### PR TITLE
修復個人電子發票同步，改回免 AppID 流程

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4044,8 +4044,8 @@ interface ConnectorField {
 const connectorFields: Record<ConnectorId, ConnectorField[]> = {
   einvoice: [
     { key: "mobile", label: "手機號碼", type: "text", placeholder: "0912345678" },
-    { key: "password", label: "手機條碼驗證碼", type: "password" },
-    { key: "appId", label: "財政部 AppID", type: "password", placeholder: "請填寫已申請的 AppID" },
+    { key: "password", label: "密碼", type: "password" },
+    { key: "apiKey", label: "API 金鑰（通常不需填寫）", type: "password" },
     { key: "periodsBack", label: "回溯期數", type: "number", placeholder: "1" },
     { key: "fetchDetails", label: "同步明細", type: "checkbox" }
   ],
@@ -4606,11 +4606,6 @@ function ConnectorPanel({
           )}
         </div>
       </div>
-      {connectorId === "einvoice" && (
-        <p className="mt-3 rounded-lg bg-steel/8 px-3 py-2 text-xs leading-5 text-ink/65">
-          同步使用財政部電子發票公開 API；AppID 需先向財政部申請。密碼欄請填手機條碼驗證碼（不是簡訊驗證碼）。
-        </p>
-      )}
       {demoMode && (
         <p className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
           Demo site 已停用同步；你仍可查看示範資料與介面互動。

--- a/packages/connectors/src/einvoice.selfcheck.ts
+++ b/packages/connectors/src/einvoice.selfcheck.ts
@@ -1,137 +1,67 @@
 // Run with: npx tsx packages/connectors/src/einvoice.selfcheck.ts
-// Exercises the public MOF API contract end-to-end: barcode login -> invoice headers -> details.
+// Exercises the private official App endpoint contract without sending credentials.
 import assert from "node:assert/strict";
-import { einvoiceConnector, parseInvoiceConfig } from "./index";
 import { EInvoiceClient } from "./tw-einvoice-api";
 
-const requests: URLSearchParams[] = [];
+const requests: Array<{ url: string; init: RequestInit }> = [];
 
-(globalThis as unknown as { fetch: typeof fetch }).fetch = (async (_url: string, init: RequestInit) => {
-  const body = new URLSearchParams(String(init.body));
-  requests.push(body);
+(globalThis as unknown as { fetch: typeof fetch }).fetch = (async (url: string, init: RequestInit) => {
+  requests.push({ url, init });
 
-  if (body.get("appID") === "SUSPENDED") {
-    return json({ code: 998, msg: "appID 不符合規定 (停權或尚未申請)" });
-  }
-
-  if (body.get("action") === "getBarcode") {
-    assert.equal(body.get("version"), "2.0");
-    assert.equal(body.get("phoneNo"), "0912345678");
-    assert.equal(body.get("verificationCode"), "barcode-password");
-    return json({ code: 200, msg: "執行成功", cardNo: "/ABCD123" });
-  }
-
-  if (body.get("action") === "carrierInvChk") {
-    assert.equal(body.get("version"), "0.6");
-    assert.equal(body.get("cardType"), "3J0002");
-    assert.equal(body.get("cardNo"), "/ABCD123");
-    assert.equal(body.get("cardEncrypt"), "barcode-password");
-    if (body.get("appID") === "PAGED-APP-ID") {
-      const page = body.get("page");
-      return json({
-        code: page === "1" ? 996 : 200,
-        msg: "執行成功",
-        details: [
-          {
-            invNum: page === "1" ? "BB12345678" : "CC12345678",
-            invDate: "20260709",
-            sellerName: "分頁測試商店",
-            amount: "10"
+  if (url.endsWith("User/Login")) {
+    return json(
+      {
+        Result: {
+          User: {
+            Mobile: "0912345678",
+            UserToken: "test-user-token",
+            MobileBarcode: "/ABCD123"
           }
-        ]
-      });
-    }
-    return json({
-      code: 200,
-      msg: "執行成功",
-      details: [
-        {
-          invNum: "AA12345678",
-          invDate: { year: 126, month: 6, date: 8 },
-          sellerName: "測試商店",
-          amount: "120"
         }
-      ]
-    });
+      },
+      "single"
+    );
   }
 
-  if (body.get("action") === "carrierInvDetail") {
-    assert.equal(body.get("version"), "0.5");
-    assert.equal(body.get("invNum"), "AA12345678");
-    assert.equal(body.get("invDate"), "2026/07/08");
-    return json({
-      code: 200,
-      msg: "執行成功",
-      invNum: "AA12345678",
-      details: [
-        {
-          rowNum: "1",
-          description: "咖啡",
-          quantity: "2",
-          unitPrice: "60",
-          amount: "120"
-        }
-      ]
-    });
-  }
-
-  throw new Error(`Unexpected action: ${body.get("action")}`);
+  return json({ result: [] }, "mixed");
 }) as typeof fetch;
 
 async function main() {
-  const config = parseInvoiceConfig({
-    mobile: "0912345678",
-    password: "barcode-password",
-    appId: "VALID-APP-ID",
-    periodsBack: 1,
-    fetchDetails: true
-  });
-  const result = await einvoiceConnector.sync(config, undefined);
+  const client = new EInvoiceClient();
+  await client.login({ mobile: "0912345678", password: "test-password" });
 
-  assert.equal(config.mobileBarcode, "/ABCD123", "login should persist the returned mobile barcode");
-  assert.equal(result.records.length, 1);
-  assert.equal(result.records[0]?.sourceId, "AA12345678:2026/07/08");
-  assert.equal(result.records[0]?.sellerName, "測試商店");
-  assert.equal(result.records[0]?.amount, 120);
-  assert.equal(result.invoiceLineItems?.length, 1);
-  assert.equal(result.invoiceLineItems?.[0]?.description, "咖啡");
-  assert.equal(result.invoiceLineItems?.[0]?.amount, 120);
-  assert.deepEqual(
-    requests.map((request) => request.get("action")),
-    ["getBarcode", "carrierInvChk", "carrierInvDetail"]
-  );
+  assert.equal(client.currentUser?.mobile, "0912345678");
+  assert.equal(client.currentUser?.userToken, "test-user-token");
+  assert.equal(client.currentUser?.mobileBarcode, "/ABCD123");
 
-  const paged = await new EInvoiceClient({ appId: "PAGED-APP-ID" }).checkCarrierInvoices({
+  await client.checkCarrierInvoices({
     carrierId: "/ABCD123",
-    cardEncrypt: "barcode-password",
+    carrierType: "3J0002",
+    cardEncrypt: "test-password",
     startDate: "2026/07/01",
     endDate: "2026/07/31"
   });
-  assert.equal(paged.result.length, 2, "code 996 should fetch and combine the next page");
-  assert.deepEqual(
-    requests.slice(-2).map((request) => request.get("page")),
-    ["1", "2"]
-  );
 
-  await assert.rejects(
-    new EInvoiceClient({ appId: "SUSPENDED" }).login({
-      mobile: "0912345678",
-      password: "barcode-password"
-    }),
-    /電子發票 API 998.*appID 不符合規定/
-  );
-  await assert.rejects(
-    new EInvoiceClient().login({ mobile: "0912345678", password: "barcode-password" }),
-    /尚未設定財政部電子發票 AppID/
-  );
+  const loginHeaders = new Headers(requests[0]?.init.headers);
+  assert.equal(loginHeaders.get("AppVersion"), "6.800.2");
+  assert.equal(loginHeaders.get("OS"), "Android");
+  assert.equal(loginHeaders.get("encrypt"), "single");
+  assert.ok(loginHeaders.get("ApiKey"));
 
+  const invoiceHeaders = new Headers(requests[1]?.init.headers);
+  assert.equal(invoiceHeaders.get("encrypt"), "mixed");
+  assert.equal(invoiceHeaders.get("Token"), "test-user-token");
+  assert.equal(invoiceHeaders.get("CarrierCode"), "/ABCD123");
+
+  assert.match(requests[0]?.url ?? "", /UIAPAPP\/api\/User\/Login$/);
+  assert.match(requests[1]?.url ?? "", /UIAPAPP\/api\/Invoice\/ChkCarrierInv$/);
   console.log("einvoice.selfcheck: ok");
 }
 
-function json(body: unknown) {
+function json(body: unknown, encrypt: string) {
   return new Response(JSON.stringify(body), {
     status: 200,
-    headers: { "Content-Type": "application/json" }
+    headers: { "Content-Type": "application/json", encrypt }
   });
 }
 

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -28,8 +28,6 @@ export const invoiceConfigSchema = z.object({
   records: z.array(invoiceRecordSchema).default([]),
   mobile: z.string().min(1).optional(),
   password: z.string().min(1).optional(),
-  appId: z.string().min(1).optional(),
-  /** @deprecated Use appId. Retained so existing encrypted settings can migrate without data loss. */
   apiKey: z.string().min(1).optional(),
   mobileBarcode: z.string().min(1).optional(),
   userToken: z.string().min(1).optional(),
@@ -66,12 +64,12 @@ export const einvoiceConnector: Connector<InvoiceConfig, Omit<Invoice, "id" | "c
 
 async function syncTaiwanEInvoices(config: InvoiceConfig, cursor?: string) {
   const client = new EInvoiceClient({
-    appId: config.appId,
     apiKey: config.apiKey,
     currentUser:
-      config.mobile && config.mobileBarcode
+      config.mobile && config.userToken && config.mobileBarcode
         ? {
             mobile: config.mobile,
+            userToken: config.userToken,
             mobileBarcode: config.mobileBarcode
           }
         : null
@@ -84,10 +82,12 @@ async function syncTaiwanEInvoices(config: InvoiceConfig, cursor?: string) {
         password: config.password!
       });
     } catch (error) {
-      throw new Error(
-        `電子發票登入失敗：${error instanceof Error ? error.message : "發生未知錯誤"}`
-      );
+      throw new Error(`電子發票登入失敗：${error instanceof Error ? error.message : "發生未知錯誤"}`);
     }
+  }
+
+  if (client.currentUser?.userToken) {
+    config.userToken = client.currentUser.userToken;
   }
 
   if (client.currentUser?.mobileBarcode) {

--- a/packages/connectors/src/tw-einvoice-api.ts
+++ b/packages/connectors/src/tw-einvoice-api.ts
@@ -1,264 +1,266 @@
-const BASE_URL = "https://api.einvoice.nat.gov.tw";
-const BARCODE_PATH = "/PB2CAPIVAN/Carrier/AppGetBarcode";
-const INVOICE_PATH = "/PB2CAPIVAN/invServ/InvServ";
-const MOBILE_BARCODE_TYPE = "3J0002";
-const SUCCESS_CODE = "200";
-const MORE_RESULTS_CODE = "996";
+import forge from "node-forge";
+
+const BASE_URL = "https://invoiceapp.nat.gov.tw/UIAPAPP/api/";
+const DEFAULT_APP_VERSION = "6.800.2";
+const DEFAULT_OS = "Android";
+const DEFAULT_API_KEY = "xkRT21hZ3uDJehRthVlDAdfzpAoPLEoKpTAKyR/eB2iMqErmM7U5IVC6G5eHD/MN";
+
+export const RSA_PUBLIC_KEY = `<RSAKeyValue><Modulus>wWj/ElSXlSJCJv/ELn47aYNIx8pWec6RFgVWnW836DQwQjh7pL90av6Mvv5kPjNbM4njxeLeuXx9ZuNP2A+JUhVLkU6zdqB+T2Nyj+zhUa5szkmaJm0ntXJvGN7iAwIvLPE2BcMWGlsPBFhWMoRt8goM06AUcFIzI4dL3iDpUWvm/Og/bzeel7/rb0RVbV86zv4MzqIt7PJM7mnw+SCjH59nEBsKkR96kR3Ye6iwztvAZcIGyTihFW2J0GEq+sPO09XW+oobQt62qIaisbR7rVZcY5Qcu8g6qeVzoz1n77/SeG4BZo/hLR13I874ZUZ+rdbFNoOPj9mj+WSPFIPf6Q==</Modulus><Exponent>AQAB</Exponent></RSAKeyValue>`;
 
 export type EInvoiceUser = {
   mobile?: string;
+  userToken?: string;
   mobileBarcode?: string;
   [key: string]: unknown;
 };
 
-export type LoginParams = {
-  mobile: string;
-  password: string;
-  deviceId?: string;
-};
-
-type CarrierInvoiceParams = {
-  carrierId?: string;
-  carrierType?: string;
-  cardEncrypt?: string;
-  startDate?: string;
-  endDate?: string;
-};
-
-type CarrierInvoiceDetailParams = {
-  carrierId?: string;
-  carrierType?: string;
-  cardEncrypt?: string;
-  invNum?: string;
-  invDate?: string;
-};
-
-type ApiResponse = Record<string, unknown> & {
-  code?: string | number;
-  msg?: string;
-  details?: unknown;
-};
+export type LoginParams =
+  | {
+      mobile: string;
+      password: string;
+      deviceId?: string;
+      platform?: string;
+      pushToken?: string;
+    }
+  | {
+      Id: string;
+      VerifyCode: string;
+      DeviceID?: string;
+      Platform?: string;
+      PushToken?: string;
+    };
 
 export class EInvoiceClient {
   currentUser: EInvoiceUser | null;
   host: string;
-  private appId?: string;
-  private deviceId: string;
+  private headers: Record<string, string>;
 
   constructor({
-    appId,
     apiKey,
+    appVersion,
     currentUser,
-    deviceId,
-    host
+    host,
+    os
   }: {
-    appId?: string;
-    /** @deprecated Kept as a migration fallback for configs that stored the AppID as apiKey. */
     apiKey?: string;
+    appVersion?: string;
     currentUser?: EInvoiceUser | null;
-    deviceId?: string;
     host?: string;
+    os?: string;
   } = {}) {
-    this.host = (host ?? BASE_URL).replace(/\/$/, "");
-    this.appId = appId?.trim() || apiKey?.trim() || undefined;
+    this.host = host ?? BASE_URL;
     this.currentUser = currentUser ?? null;
-    this.deviceId = deviceId?.trim() || createDeviceId();
+    this.headers = {
+      "Content-Type": "application/json",
+      ApiKey: apiKey?.trim() || DEFAULT_API_KEY,
+      AppVersion: appVersion?.trim() || DEFAULT_APP_VERSION,
+      OS: os?.trim() || DEFAULT_OS
+    };
+  }
+
+  async post(path: string, body?: unknown) {
+    const payload = this.normalizeRequestBody(path, body);
+    const { requestBody, cryptoKey, headers } = this.encryptRequest(payload);
+    const res = await fetch(this.host + path, {
+      method: "POST",
+      headers: { ...this.headers, ...headers },
+      body: requestBody
+    });
+    const data = await this.readResponse(res, path, cryptoKey);
+    if (path === "User/Login") this.setCurrentUserFromLogin(data);
+    return data;
   }
 
   async login(params: LoginParams) {
-    const appId = this.requireAppId();
-    const data = await this.post(BARCODE_PATH, {
-      version: "2.0",
-      action: "getBarcode",
-      appID: appId,
-      phoneNo: params.mobile,
-      timeStamp: unixTimestamp(10),
-      uuid: params.deviceId?.trim() || this.deviceId,
-      verificationCode: params.password
-    });
-    assertSuccessful(data, "取得手機條碼");
-
-    const mobileBarcode = readString(data.cardNo);
-    if (!mobileBarcode) {
-      throw new Error("電子發票 API 未回傳手機條碼，請確認手機號碼與驗證碼。");
+    const data = await this.post("User/Login", params);
+    if (!this.currentUser) {
+      throw new Error(responseMessage(data) || "登入回應未包含使用者資料，請確認帳號、密碼與 App 版本。");
     }
-
-    this.currentUser = { mobile: params.mobile, mobileBarcode };
     return data;
   }
 
-  async checkCarrierInvoices(params: CarrierInvoiceParams) {
-    const carrierId = requiredParam(params.carrierId, "手機條碼");
-    const cardEncrypt = requiredParam(params.cardEncrypt, "手機條碼驗證碼");
-    const startDate = requiredParam(params.startDate, "查詢起日");
-    const endDate = requiredParam(params.endDate, "查詢迄日");
-    const rows: Record<string, unknown>[] = [];
+  checkCarrierInvoices(params: unknown) {
+    return this.post("Invoice/ChkCarrierInv", params);
+  }
 
-    for (let page = 1; page <= 100; page += 1) {
-      const data = await this.post(INVOICE_PATH, {
-        version: "0.6",
-        action: "carrierInvChk",
-        appID: this.requireAppId(),
-        cardType: params.carrierType || MOBILE_BARCODE_TYPE,
-        cardNo: carrierId,
-        cardEncrypt,
-        startDate,
-        endDate,
-        onlyWinningInv: "N",
-        timeStamp: unixTimestamp(10),
-        expTimeStamp: unixTimestamp(180),
-        uuid: this.deviceId,
-        page: String(page)
-      });
-      const code = responseCode(data);
-      if (code !== SUCCESS_CODE && code !== MORE_RESULTS_CODE) {
-        throw apiError(data, "查詢發票");
-      }
+  checkCarrierInvoiceDetail(params: unknown) {
+    return this.post("Invoice/ChkCarrierInvDetail", params);
+  }
 
-      const pageRows = arrayOfRecords(data.details).map(normalizeInvoiceHeader);
-      rows.push(...pageRows);
-      if (code !== MORE_RESULTS_CODE || pageRows.length === 0) break;
+  private normalizeRequestBody(path: string, body?: unknown) {
+    if (path !== "User/Login") return body;
+    const loginBody = body as Partial<Extract<LoginParams, { mobile: string }>> &
+      Partial<Extract<LoginParams, { Id: string }>>;
+    if (!loginBody || loginBody.Id || loginBody.VerifyCode) return body;
+
+    return {
+      Id: loginBody.mobile,
+      VerifyCode: loginBody.password,
+      DeviceID: loginBody.deviceId ?? "http://OpenUDID.org",
+      Platform: loginBody.platform ?? DEFAULT_OS,
+      PushToken: loginBody.pushToken ?? ""
+    };
+  }
+
+  private encryptRequest(body?: unknown) {
+    const json = JSON.stringify(body ?? { "": "" });
+    const user = this.currentUser;
+    if (user?.mobile && user?.userToken) {
+      const cryptoKey = aesEncryptString(user.mobile, user.userToken);
+      return {
+        cryptoKey,
+        requestBody: aesEncryptString(json, cryptoKey),
+        headers: {
+          encrypt: "mixed",
+          ValidationToken: cryptoKey,
+          Token: user.userToken,
+          UUID: "http://OpenUDID.org",
+          ...(user.mobileBarcode ? { CarrierCode: user.mobileBarcode } : {})
+        }
+      };
     }
 
-    return { result: dedupeByInvoiceNumber(rows) };
+    return {
+      cryptoKey: singleResponseKey(),
+      requestBody: rsaEncrypt(json),
+      headers: { encrypt: "single" }
+    };
   }
 
-  async checkCarrierInvoiceDetail(params: CarrierInvoiceDetailParams) {
-    const data = await this.post(INVOICE_PATH, {
-      version: "0.5",
-      action: "carrierInvDetail",
-      appID: this.requireAppId(),
-      cardType: params.carrierType || MOBILE_BARCODE_TYPE,
-      cardNo: requiredParam(params.carrierId, "手機條碼"),
-      cardEncrypt: requiredParam(params.cardEncrypt, "手機條碼驗證碼"),
-      invNum: requiredParam(params.invNum, "發票號碼"),
-      invDate: officialInvoiceDate(requiredParam(params.invDate, "發票日期")),
-      timeStamp: unixTimestamp(10),
-      expTimeStamp: unixTimestamp(180),
-      uuid: this.deviceId
-    });
-    assertSuccessful(data, "查詢發票明細");
-    return { result: data };
-  }
+  private async readResponse(res: Response, path: string, cryptoKey?: string) {
+    const encrypted = res.headers.get("encrypt")?.toLowerCase();
+    const raw = await res.text();
+    const plaintextJson = parseJson(raw);
+    let data: unknown;
 
-  private async post(path: string, fields: Record<string, string>) {
-    const res = await fetch(this.host + path, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8" },
-      body: new URLSearchParams(fields).toString()
-    });
-    const text = await res.text();
-    let data: ApiResponse;
-
-    try {
-      data = JSON.parse(text) as ApiResponse;
-    } catch {
-      throw new Error(`電子發票 API 回傳格式錯誤（HTTP ${res.status}）。`);
+    // Maintenance and forced-upgrade responses can be plain JSON even when the
+    // response still advertises an encrypted mode. Parse JSON before decrypting
+    // so those errors remain readable instead of surfacing as a crypto URI error.
+    if (plaintextJson.parsed) {
+      data = plaintextJson.value;
+    } else {
+      let text = raw;
+      try {
+        if (raw && encrypted === "single") text = aesDecryptString(raw, singleResponseKey());
+        if (raw && encrypted === "mixed" && cryptoKey) text = aesDecryptString(raw, cryptoKey);
+      } catch {
+        throw new Error(`電子發票服務回傳無法解讀（${path}），可能是官方 App 協定已更新。`);
+      }
+      const decryptedJson = parseJson(text);
+      data = decryptedJson.parsed ? decryptedJson.value : text;
     }
 
     if (!res.ok) {
-      throw new Error(`電子發票 API HTTP ${res.status}${data.msg ? `：${data.msg}` : ""}`);
+      const message = responseMessage(data);
+      throw new Error(`HTTP ${res.status} - ${path}${message ? `: ${message}` : ""}`);
     }
+
     return data;
   }
 
-  private requireAppId() {
-    if (!this.appId) {
-      throw new Error("尚未設定財政部電子發票 AppID，請先在連接器設定中填寫 AppID。");
-    }
-    return this.appId;
+  private setCurrentUserFromLogin(data: unknown) {
+    const response = asRecord(data);
+    const result = asRecord(response?.result ?? response?.Result);
+    const rawUser = asRecord(result?.user ?? result?.User);
+    if (!rawUser) return;
+
+    const mobile = firstString(rawUser.mobile, rawUser.Mobile, rawUser.id, rawUser.Id);
+    const userToken = firstString(rawUser.userToken, rawUser.UserToken, rawUser.token, rawUser.Token);
+    const mobileBarcode = firstString(
+      rawUser.mobileBarcode,
+      rawUser.MobileBarcode,
+      rawUser.carrierCode,
+      rawUser.CarrierCode
+    );
+    if (mobile && userToken) this.currentUser = { ...rawUser, mobile, userToken, mobileBarcode };
   }
 }
 
-function unixTimestamp(secondsFromNow: number) {
-  return String(Math.floor(Date.now() / 1000) + secondsFromNow);
-}
-
-function createDeviceId() {
-  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
-  return `taiwan-fin-hub-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-}
-
-function responseCode(data: ApiResponse) {
-  return data.code === undefined ? "" : String(data.code);
-}
-
-function assertSuccessful(data: ApiResponse, operation: string) {
-  if (responseCode(data) !== SUCCESS_CODE) throw apiError(data, operation);
-}
-
-function apiError(data: ApiResponse, operation: string) {
-  const code = responseCode(data) || "未知代碼";
-  const message = readString(data.msg) || "未知錯誤";
-  return new Error(`電子發票 API ${code}（${operation}）：${message}`);
-}
-
-function requiredParam(value: string | undefined, label: string) {
-  const normalized = value?.trim();
-  if (!normalized) throw new Error(`缺少${label}。`);
-  return normalized;
-}
-
-function readString(value: unknown) {
-  return typeof value === "string" ? value.trim() : value == null ? "" : String(value).trim();
-}
-
-function arrayOfRecords(value: unknown) {
-  return Array.isArray(value)
-    ? value.filter((item): item is Record<string, unknown> => Boolean(item && typeof item === "object"))
-    : [];
-}
-
-function normalizeInvoiceHeader(row: Record<string, unknown>) {
-  return { ...row, invDate: normalizeOfficialDate(row.invDate) };
-}
-
-function normalizeOfficialDate(value: unknown) {
-  if (typeof value === "string") return readableInvoiceDate(value);
-  if (typeof value === "number") return formatLocalDate(new Date(value));
-  if (!value || typeof value !== "object") return "";
-
-  const date = value as Record<string, unknown>;
-  const timestamp = Number(date.time);
-  if (Number.isFinite(timestamp) && timestamp > 0) return formatLocalDate(new Date(timestamp));
-
-  const rawYear = Number(date.year);
-  const rawMonth = Number(date.month);
-  const rawDay = Number(date.date ?? date.dayOfMonth);
-  if ([rawYear, rawMonth, rawDay].every(Number.isFinite)) {
-    // The API serializes java.util.Date fields: year is years since 1900 and month is zero-based.
-    const year = rawYear < 300 ? rawYear + 1900 : rawYear;
-    const month = rawMonth >= 0 && rawMonth <= 11 ? rawMonth + 1 : rawMonth;
-    return `${year}/${String(month).padStart(2, "0")}/${String(rawDay).padStart(2, "0")}`;
+function parseJson(text: string): { parsed: boolean; value?: unknown } {
+  const trimmed = text.trim();
+  if (!trimmed || (!trimmed.startsWith("{") && !trimmed.startsWith("["))) return { parsed: false };
+  try {
+    return { parsed: true, value: JSON.parse(trimmed) };
+  } catch {
+    return { parsed: false };
   }
-  return "";
 }
 
-function formatLocalDate(date: Date) {
-  if (Number.isNaN(date.getTime())) return "";
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}/${month}/${day}`;
+function responseMessage(data: unknown) {
+  const response = asRecord(data);
+  if (!response) return typeof data === "string" ? data : "";
+  return firstString(
+    response.Message,
+    response.message,
+    response.Msg,
+    response.msg,
+    response.Description,
+    response.description
+  );
 }
 
-function officialInvoiceDate(value: string) {
-  return readableInvoiceDate(value).replace(/[-.]/g, "/").slice(0, 10);
+function asRecord(value: unknown) {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
 }
 
-function readableInvoiceDate(value: string) {
-  const normalized = value.trim();
-  if (/^\d{8}$/.test(normalized)) {
-    return `${normalized.slice(0, 4)}/${normalized.slice(4, 6)}/${normalized.slice(6, 8)}`;
+function firstString(...values: unknown[]) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
   }
-  return normalized;
+  return undefined;
 }
 
-function dedupeByInvoiceNumber(rows: Record<string, unknown>[]) {
-  const unique = new Map<string, Record<string, unknown>>();
-  rows.forEach((row, index) => {
-    const key = `${readString(row.invNum)}:${readString(row.invDate)}` || String(index);
-    unique.set(key, row);
-  });
-  return Array.from(unique.values());
+function aesEncryptString(text: string, keyText: string) {
+  const cipher = createAesCipher("encrypt", keyText);
+  cipher.update(forge.util.createBuffer(text, "utf8"));
+  cipher.finish();
+  return forge.util.encode64(cipher.output.getBytes());
+}
+
+function aesDecryptString(text: string, keyText: string) {
+  const cipher = createAesCipher("decrypt", keyText);
+  cipher.update(forge.util.createBuffer(forge.util.decode64(text), "raw"));
+  if (!cipher.finish()) throw new Error("Invalid encrypted response");
+  return cipher.output.toString();
+}
+
+function createAesCipher(direction: "encrypt" | "decrypt", keyText: string) {
+  const key = forge.md.sha256.create().update(keyText, "utf8").digest().getBytes();
+  const iv = forge.md.md5.create().update(keyText, "utf8").digest().getBytes();
+  const cipher =
+    direction === "encrypt"
+      ? forge.cipher.createCipher("AES-CBC", key)
+      : forge.cipher.createDecipher("AES-CBC", key);
+  cipher.start({ iv });
+  return cipher;
+}
+
+function rsaEncrypt(text: string) {
+  const publicKey = forge.pki.publicKeyFromPem(rsaPublicKeyPem());
+  const bytes = forge.util.encodeUtf8(text);
+  const chunks: string[] = [];
+  for (let offset = 0; offset < bytes.length; offset += 245) {
+    chunks.push(publicKey.encrypt(bytes.slice(offset, offset + 245), "RSAES-PKCS1-V1_5"));
+  }
+  return forge.util.encode64(chunks.join(""));
+}
+
+function rsaPublicKeyPem() {
+  const key = forge.pki.setRsaPublicKey(
+    new forge.jsbn.BigInteger(forge.util.bytesToHex(forge.util.decode64(rsaXmlValue("Modulus"))), 16),
+    new forge.jsbn.BigInteger(forge.util.bytesToHex(forge.util.decode64(rsaXmlValue("Exponent"))), 16)
+  );
+  return forge.pki.publicKeyToPem(key);
+}
+
+function rsaXmlValue(name: string) {
+  const match = RSA_PUBLIC_KEY.match(new RegExp(`<${name}>([^<]+)</${name}>`));
+  if (!match) throw new Error(`Missing RSA key field: ${name}`);
+  return match[1];
+}
+
+function singleResponseKey() {
+  return forge.util.encode64(
+    forge.md.sha256.create().update(RSA_PUBLIC_KEY.slice(0, 16), "utf8").digest().getBytes()
+  );
 }


### PR DESCRIPTION
## 變更內容

- 將電子發票連接器從需要 AppID 的財政部公開 API 改回官方 App 私有端點
- 恢復原有 RSA／AES 加密登入、`userToken` 與手機條碼狀態
- 將 App 版本標頭更新為 `6.800.2`
- 移除 AppID 設定欄位，恢復個人使用者只需手機號碼與驗證碼即可同步
- 優先解析明文 JSON 維護／升級訊息，避免誤做 AES 解密後出現 `URI malformed`
- 支援登入回應欄位大小寫差異，並移除可能輸出使用者資料的除錯紀錄
- 將發票自我測試改為驗證 App 私有端點、加密模式與登入狀態契約

## 問題根因

個人使用者無法向財政部申請公開 API 所需的 AppID，因此前一版改用公開 API 後實際上無法使用。舊私有端點程式另有兩個問題：App 版本已過期，以及官方回傳明文升級通知時仍依 `encrypt` 標頭嘗試解密，導致錯誤訊息變成 `URI malformed`。

## 使用者影響

電子發票設定不再要求 AppID，可恢復以統一發票兌獎 App 的手機號碼與驗證碼同步個人載具發票。這仍是未公開的 App 內部介面，未來官方改版時可能需要再次更新協定或版本。

## 驗證

- `npm run typecheck`：通過（Web、Worker、Connectors、Core、DB）
- `npm run build`：通過
- `node --import tsx packages/connectors/src/einvoice.selfcheck.ts`：通過
- 真實帳號發票歷史同步：待專案擁有者在部署介面自行輸入帳密驗證；請勿將帳密貼在 PR 或對話中
