### PR TITLE
fix(電子發票): 修正登入協定升版與回應解密

### DIFF
--- a/packages/connectors/src/einvoice.selfcheck.ts
+++ b/packages/connectors/src/einvoice.selfcheck.ts
@@ -1,15 +1,30 @@
 // Run with: npx tsx packages/connectors/src/einvoice.selfcheck.ts
 // Exercises the private official App endpoint contract without sending credentials.
 import assert from "node:assert/strict";
-import { EInvoiceClient } from "./tw-einvoice-api";
+import forge from "node-forge";
+import { EInvoiceClient, RSA_PUBLIC_KEY } from "./tw-einvoice-api";
 
+const OUTDATED_PROTOCOL_VERSION = "6.800.2";
+const REQUIRED_PROTOCOL_VERSION = "7.9000.40";
 const requests: Array<{ url: string; init: RequestInit }> = [];
 
 (globalThis as unknown as { fetch: typeof fetch }).fetch = (async (url: string, init: RequestInit) => {
   requests.push({ url, init });
 
   if (url.endsWith("User/Login")) {
-    return json(
+    const requestHeaders = new Headers(init.headers);
+    // Simulate the service's forced-upgrade response whenever the client is not
+    // using the protocol version advertised by the service.
+    if (requestHeaders.get("AppVersion") !== REQUIRED_PROTOCOL_VERSION) {
+      return json({
+        Result: null,
+        ReturnCode: "6608",
+        Message: "請立即更新。",
+        Info: JSON.stringify({ VersionNumber: REQUIRED_PROTOCOL_VERSION })
+      });
+    }
+
+    return encryptedJson(
       {
         Result: {
           User: {
@@ -18,8 +33,7 @@ const requests: Array<{ url: string; init: RequestInit }> = [];
             MobileBarcode: "/ABCD123"
           }
         }
-      },
-      "single"
+      }
     );
   }
 
@@ -27,7 +41,7 @@ const requests: Array<{ url: string; init: RequestInit }> = [];
 }) as typeof fetch;
 
 async function main() {
-  const client = new EInvoiceClient();
+  const client = new EInvoiceClient({ appVersion: OUTDATED_PROTOCOL_VERSION });
   await client.login({ mobile: "0912345678", password: "test-password" });
 
   assert.equal(client.currentUser?.mobile, "0912345678");
@@ -42,26 +56,47 @@ async function main() {
     endDate: "2026/07/31"
   });
 
-  const loginHeaders = new Headers(requests[0]?.init.headers);
-  assert.equal(loginHeaders.get("AppVersion"), "6.800.2");
+  const outdatedLoginHeaders = new Headers(requests[0]?.init.headers);
+  assert.equal(outdatedLoginHeaders.get("AppVersion"), OUTDATED_PROTOCOL_VERSION);
+  assert.equal(outdatedLoginHeaders.get("encrypt"), "single");
+
+  const loginHeaders = new Headers(requests[1]?.init.headers);
+  assert.equal(loginHeaders.get("AppVersion"), REQUIRED_PROTOCOL_VERSION);
   assert.equal(loginHeaders.get("OS"), "Android");
   assert.equal(loginHeaders.get("encrypt"), "single");
   assert.ok(loginHeaders.get("ApiKey"));
 
-  const invoiceHeaders = new Headers(requests[1]?.init.headers);
+  const invoiceHeaders = new Headers(requests[2]?.init.headers);
   assert.equal(invoiceHeaders.get("encrypt"), "mixed");
   assert.equal(invoiceHeaders.get("Token"), "test-user-token");
   assert.equal(invoiceHeaders.get("CarrierCode"), "/ABCD123");
 
   assert.match(requests[0]?.url ?? "", /UIAPAPP\/api\/User\/Login$/);
-  assert.match(requests[1]?.url ?? "", /UIAPAPP\/api\/Invoice\/ChkCarrierInv$/);
+  assert.match(requests[1]?.url ?? "", /UIAPAPP\/api\/User\/Login$/);
+  assert.match(requests[2]?.url ?? "", /UIAPAPP\/api\/Invoice\/ChkCarrierInv$/);
   console.log("einvoice.selfcheck: ok");
 }
 
-function json(body: unknown, encrypt: string) {
+function json(body: unknown, encrypt = "single") {
   return new Response(JSON.stringify(body), {
     status: 200,
     headers: { "Content-Type": "application/json", encrypt }
+  });
+}
+
+function encryptedJson(body: unknown) {
+  const keyText = forge.util.encode64(
+    forge.md.sha256.create().update(RSA_PUBLIC_KEY.slice(0, 16), "utf8").digest().getBytes()
+  );
+  const key = forge.md.sha256.create().update(keyText, "utf8").digest().getBytes();
+  const iv = forge.md.md5.create().update(keyText, "utf8").digest().getBytes();
+  const cipher = forge.cipher.createCipher("AES-CBC", key);
+  cipher.start({ iv });
+  cipher.update(forge.util.createBuffer(JSON.stringify(body), "utf8"));
+  assert.equal(cipher.finish(), true);
+  return new Response(forge.util.encode64(cipher.output.getBytes()), {
+    status: 200,
+    headers: { "Content-Type": "application/json", encrypt: "single" }
   });
 }
 

--- a/packages/connectors/src/tw-einvoice-api.ts
+++ b/packages/connectors/src/tw-einvoice-api.ts
@@ -1,7 +1,9 @@
 import forge from "node-forge";
 
 const BASE_URL = "https://invoiceapp.nat.gov.tw/UIAPAPP/api/";
-const DEFAULT_APP_VERSION = "6.800.2";
+// This is the API protocol version advertised by the service's 6608 upgrade
+// response. It is not the same as the version shown in Google Play.
+const DEFAULT_APP_VERSION = "7.9000.40";
 const DEFAULT_OS = "Android";
 const DEFAULT_API_KEY = "xkRT21hZ3uDJehRthVlDAdfzpAoPLEoKpTAKyR/eB2iMqErmM7U5IVC6G5eHD/MN";
 
@@ -60,15 +62,30 @@ export class EInvoiceClient {
 
   async post(path: string, body?: unknown) {
     const payload = this.normalizeRequestBody(path, body);
+    let data = await this.send(path, payload);
+
+    // The private App API returns a plain JSON 6608 response (while still
+    // setting `encrypt: single`) when its protocol version changes. Follow the
+    // version advertised by the service and retry login once so a future App
+    // release does not require another emergency hard-coded version update.
+    const requiredVersion = path === "User/Login" ? forcedUpgradeVersion(data) : undefined;
+    if (requiredVersion && requiredVersion !== this.headers.AppVersion) {
+      this.headers.AppVersion = requiredVersion;
+      data = await this.send(path, payload);
+    }
+
+    if (path === "User/Login") this.setCurrentUserFromLogin(data);
+    return data;
+  }
+
+  private async send(path: string, payload: unknown) {
     const { requestBody, cryptoKey, headers } = this.encryptRequest(payload);
     const res = await fetch(this.host + path, {
       method: "POST",
       headers: { ...this.headers, ...headers },
       body: requestBody
     });
-    const data = await this.readResponse(res, path, cryptoKey);
-    if (path === "User/Login") this.setCurrentUserFromLogin(data);
-    return data;
+    return this.readResponse(res, path, cryptoKey);
   }
 
   async login(params: LoginParams) {
@@ -197,6 +214,22 @@ function responseMessage(data: unknown) {
     response.Description,
     response.description
   );
+}
+
+function forcedUpgradeVersion(data: unknown) {
+  const response = asRecord(data);
+  const returnCode = firstString(response?.ReturnCode, response?.returnCode);
+  if (returnCode !== "6608") return undefined;
+
+  const rawInfo = response?.Info ?? response?.info;
+  let info = asRecord(rawInfo);
+  if (!info && typeof rawInfo === "string") {
+    const parsed = parseJson(rawInfo);
+    info = parsed.parsed ? asRecord(parsed.value) : null;
+  }
+
+  const version = firstString(info?.VersionNumber, info?.versionNumber);
+  return version && /^[0-9A-Za-z._-]{1,32}$/.test(version) ? version : undefined;
 }
 
 function asRecord(value: unknown) {


### PR DESCRIPTION
## 變更內容

- 更新電子發票 App API 協定版本為服務端公告的 `7.9000.40`
- 登入收到 `6608` 強制升版回應時，讀取 `Info.VersionNumber` 並自動重試一次
- 優先解析標示為加密但實際為明文 JSON 的維護／升版回應
- 補上強制升版重試及 AES 加密登入回應的 self-check

## 問題原因

官方服務在舊協定版本登入時，會回傳 `encrypt: single` 標頭，但內容實際是明文 JSON。舊邏輯直接嘗試 AES 解密，導致 `node-forge` 在解碼非 UTF-8 資料時拋出 `URI malformed`。

## 影響

電子發票登入可使用目前服務要求的協定版本，未來服務透過 `6608` 公告新版協定時也能自動更新並重試。

## 驗證

- `tsc -p packages/connectors/tsconfig.json`
- `einvoice.selfcheck: ok`
- 全 workspace TypeScript typecheck
- Web production build