### PR TITLE
Fix E-Invoice sync with the new App protocol

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4045,7 +4045,6 @@ const connectorFields: Record<ConnectorId, ConnectorField[]> = {
   einvoice: [
     { key: "mobile", label: "手機號碼", type: "text", placeholder: "0912345678" },
     { key: "password", label: "密碼", type: "password" },
-    { key: "apiKey", label: "API 金鑰（通常不需填寫）", type: "password" },
     { key: "periodsBack", label: "回溯期數", type: "number", placeholder: "1" },
     { key: "fetchDetails", label: "同步明細", type: "checkbox" }
   ],
@@ -4402,7 +4401,9 @@ function ConnectorPanel({
   const fields = connectorFields[connectorId];
   const [values, setValues] = useState<Record<string, string | boolean>>(() => {
     const defaults: Record<string, string | boolean> = {};
-    if (connectorId === "einvoice") defaults.fetchDetails = true;
+    if (connectorId === "einvoice") {
+      defaults.fetchDetails = true;
+    }
     return defaults;
   });
   const [otp, setOtp] = useState("");
@@ -4523,9 +4524,10 @@ function ConnectorPanel({
     },
     onSuccess: (_data, target) => {
       invalidateAfterSync(target ?? "default");
-      queryClient.invalidateQueries({ queryKey: ["sync-jobs"] });
     },
-    onError: (mutationError) => setError(messageFromError(mutationError))
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["sync-jobs"] });
+    }
   });
   const syncErrorMessage = sync.isError ? messageFromError(sync.error) : "";
   const otpRequired = connectorId === "tdcc" && (otpForced || /OTP/i.test(syncErrorMessage));
@@ -4631,6 +4633,7 @@ function ConnectorPanel({
       )}
       <SyncJobStatus
         job={syncJob}
+        currentError={syncErrorMessage}
         loading={syncJobs.isLoading}
         updating={updateSyncJob.isPending}
         onToggle={(enabled) => updateSyncJob.mutate({ enabled })}
@@ -4702,6 +4705,7 @@ function ConnectorPanel({
 
 function SyncJobStatus({
   job,
+  currentError,
   loading,
   updating,
   onToggle,
@@ -4709,6 +4713,7 @@ function SyncJobStatus({
   onInterval
 }: {
   job?: SyncJobRow;
+  currentError?: string;
   loading: boolean;
   updating: boolean;
   onToggle: (enabled: boolean) => void;
@@ -4792,8 +4797,10 @@ function SyncJobStatus({
           </button>
         )}
       </div>
-      {job?.lastError && (
-        <p className="mt-1 text-xs text-coral">{job.lastError}</p>
+      {(currentError || job?.lastError) && (
+        <p className="mt-1 text-xs text-coral">
+          {currentError ? `本次同步：${currentError}` : `上次同步：${job?.lastError}`}
+        </p>
       )}
     </div>
   );

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,5 +1,6 @@
 import {
   einvoiceConnector,
+  EInvoiceProtocolUnavailableError,
   parseConnectorConfig,
   parseCathaybkConfig,
   parseEsunConfig,
@@ -26,7 +27,6 @@ import {
 } from "@taiwan-fin-hub/core";
 import {
   getConnectorSettings,
-  updateConnectorPublicConfig,
   upsertConnectorSettings
 } from "@taiwan-fin-hub/db";
 import { Hono, type Context } from "hono";
@@ -929,42 +929,54 @@ api.put("/connectors/:connectorId/settings", async (c) => {
 
   const now = new Date().toISOString();
   const encryptionKey = configEncryptionKey(c.env);
-  const publicConfigJson = Object.keys(publicConfig).length > 0 ? JSON.stringify(publicConfig) : null;
-
-  if (hasSensitive) {
-    let parsedConfig: unknown;
-    try {
-      const existing = await getConnectorSettings(c.env.DB, connectorId);
-      const storedPublic = existing?.public_config ? JSON.parse(existing.public_config) : {};
-      parsedConfig = parseConnectorConfig(connectorId, { ...storedPublic, ...rawConfig });
-    } catch {
-      return c.json(
-        {
-          success: false,
-          error: {
-            code: "INVALID_CONNECTOR_CONFIG",
-            message: "Connector config does not match the expected shape."
-          }
-        },
-        400
-      );
-    }
-    const encryptedConfig = await encryptJson(parsedConfig, encryptionKey);
-    await upsertConnectorSettings(c.env.DB, {
-      id: crypto.randomUUID(),
-      connectorId,
-      encryptedConfig,
-      publicConfig: publicConfigJson,
-      now
-    });
-  } else {
-    const existing = await getConnectorSettings(c.env.DB, connectorId);
-    if (!existing) {
-      return c.json({ success: false, error: { code: "CONNECTOR_CONFIG_MISSING", message: "Cannot update public config before credentials are set." } }, 400);
-    }
-    const mergedPublic = { ...JSON.parse(existing.public_config ?? "{}"), ...publicConfig };
-    await updateConnectorPublicConfig(c.env.DB, connectorId, JSON.stringify(mergedPublic), now);
+  const existing = await getConnectorSettings(c.env.DB, connectorId);
+  if (!hasSensitive && !existing) {
+    return c.json({ success: false, error: { code: "CONNECTOR_CONFIG_MISSING", message: "Cannot update public config before credentials are set." } }, 400);
   }
+
+  let parsedConfig: unknown;
+  let mergedPublic: Record<string, unknown>;
+  try {
+    const storedConfig = existing
+      ? await decryptJson<Record<string, unknown>>(existing.encrypted_config, encryptionKey)
+      : {};
+    const storedPublic = existing?.public_config ? JSON.parse(existing.public_config) : {};
+    const mergedConfig: Record<string, unknown> = {
+      ...storedConfig,
+      ...storedPublic,
+      ...rawConfig
+    };
+
+    if (connectorId === "einvoice" && einvoiceCredentialsChanged(storedConfig, rawConfig)) {
+      for (const key of [
+        "userToken", "mobileBarcode", "sid", "token", "iv", "svrCode", "loginAppId",
+        "loginLiat", "loginSsMe", "ltoken", "hkey", "serverTimeOffset"
+      ]) delete mergedConfig[key];
+    }
+
+    parsedConfig = parseConnectorConfig(connectorId, mergedConfig);
+    mergedPublic = { ...storedPublic, ...publicConfig };
+  } catch {
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: "INVALID_CONNECTOR_CONFIG",
+          message: "Connector config does not match the expected shape."
+        }
+      },
+      400
+    );
+  }
+
+  const encryptedConfig = await encryptJson(parsedConfig, encryptionKey);
+  await upsertConnectorSettings(c.env.DB, {
+    id: existing?.id ?? crypto.randomUUID(),
+    connectorId,
+    encryptedConfig,
+    publicConfig: Object.keys(mergedPublic).length > 0 ? JSON.stringify(mergedPublic) : null,
+    now
+  });
 
   return c.json({
     connectorId,
@@ -1132,6 +1144,9 @@ async function syncRouteResponse(
     if (error instanceof NeedsUserActionError) {
       return jsonError("USER_ACTION_REQUIRED", error.message, 400);
     }
+    if (error instanceof EInvoiceProtocolUnavailableError) {
+      return jsonError("CONNECTOR_PROTOCOL_UNAVAILABLE", error.message, 503);
+    }
     throw error;
   }
 }
@@ -1146,7 +1161,7 @@ async function syncEinvoice(
   const settings = await requireConnectorSettings(env.DB, connectorId);
   const config = await decryptJson<unknown>(settings.encrypted_config, configEncryptionKey(env));
   const parsedConfig = parseInvoiceConfig({ ...(config as Record<string, unknown>), ...overrides });
-  const originalInvoiceConfig = invoiceConfigSnapshot(config as { fetchDetails?: boolean; userToken?: string; mobileBarcode?: string });
+  const originalInvoiceConfig = invoiceConfigSnapshot(config as Record<string, unknown>);
   console.log(`[sync] ${connectorId}/${scope}: starting trigger=${trigger} (cursor=${settings.sync_cursor ?? "none"})`);
   const result = await einvoiceConnector.sync(parsedConfig, settings.sync_cursor ?? undefined);
   const invoiceLineItems = result.invoiceLineItems ?? [];
@@ -1542,6 +1557,9 @@ async function withManualSyncLock(
     const outcome = await task();
     await markManualSyncSuccess(env.DB, connectorId, scope);
     return outcome;
+  } catch (error) {
+    await markManualSyncFailure(env.DB, connectorId, scope, error);
+    throw error;
   } finally {
     await releaseSyncJobLock(env.DB, canonicalSyncLockRowId(connectorId), runId);
   }
@@ -1696,10 +1714,10 @@ async function completeSyncJob(db: D1Database, job: SyncJobRow, outcome: SyncOut
 
 async function failSyncJob(db: D1Database, job: SyncJobRow, error: unknown) {
   const now = new Date();
-  const status: SyncStatus = error instanceof NeedsUserActionError ? "needs_user_action" : "failed";
+  const status: SyncStatus = isUserActionError(error) ? "needs_user_action" : "failed";
   const enabled = status === "needs_user_action" ? 0 : 1;
   const nextRunAt = status === "failed"
-    ? new Date(now.getTime() + 60 * 60 * 1000).toISOString()
+    ? new Date(now.getTime() + job.interval_minutes * 60 * 1000).toISOString()
     : job.next_run_at;
 
   await db
@@ -1740,12 +1758,39 @@ async function markManualSyncSuccess(db: D1Database, connectorId: ConnectorId, s
     .run();
 }
 
+async function markManualSyncFailure(
+  db: D1Database,
+  connectorId: ConnectorId,
+  scope: SyncScope,
+  error: unknown
+) {
+  const status: SyncStatus = isUserActionError(error) ? "needs_user_action" : "failed";
+  const now = new Date().toISOString();
+  await db
+    .prepare(
+      `UPDATE sync_jobs
+       SET last_status = ?,
+           last_error = ?,
+           last_run_at = ?,
+           enabled = CASE WHEN ? = 'needs_user_action' THEN 0 ELSE enabled END,
+           updated_at = ?
+       WHERE connector_id = ?
+         AND scope = ?`
+    )
+    .bind(status, safeErrorMessage(error), now, status, now, connectorId, scope)
+    .run();
+}
+
 function canonicalSyncLockRowId(connectorId: ConnectorId) {
   return `${connectorId}:all`;
 }
 
 function isUserActionError(error: unknown) {
-  if (error instanceof NeedsUserActionError || error instanceof TdccOtpExpiredError) return true;
+  if (
+    error instanceof NeedsUserActionError ||
+    error instanceof TdccOtpExpiredError ||
+    error instanceof EInvoiceProtocolUnavailableError
+  ) return true;
   const message = error instanceof Error ? error.message : String(error);
   return /OTP|verification|requires.*login|requires.*session|requires.*user action/i.test(message);
 }
@@ -1753,6 +1798,19 @@ function isUserActionError(error: unknown) {
 function safeErrorMessage(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
   return message.replace(/\s+/g, " ").slice(0, 300);
+}
+
+function einvoiceCredentialsChanged(
+  storedConfig: Record<string, unknown>,
+  submittedConfig: Record<string, unknown>
+) {
+  return ["mobile", "password", "apiKey"].some(
+    (key) =>
+      key in submittedConfig &&
+      submittedConfig[key] !== undefined &&
+      submittedConfig[key] !== "" &&
+      submittedConfig[key] !== storedConfig[key]
+  );
 }
 
 api.onError((error) => {
@@ -1778,23 +1836,18 @@ function stableId(...parts: string[]) {
   return parts.join(":");
 }
 
-function invoiceConfigSnapshot(config: { fetchDetails?: boolean; userToken?: string; mobileBarcode?: string }) {
-  return {
-    fetchDetails: config.fetchDetails,
-    mobileBarcode: config.mobileBarcode,
-    userToken: config.userToken
-  };
+function invoiceConfigSnapshot(config: Record<string, unknown>) {
+  return Object.fromEntries([
+    "protocol", "fetchDetails", "mobileBarcode", "userToken", "loginClientCode", "sid", "token", "iv", "svrCode",
+    "loginAppId", "loginLiat", "loginSsMe", "ltoken", "hkey", "serverTimeOffset"
+  ].map((key) => [key, config[key]]));
 }
 
 function invoiceConfigChanged(
-  before: { fetchDetails?: boolean; userToken?: string; mobileBarcode?: string },
-  after: { fetchDetails?: boolean; userToken?: string; mobileBarcode?: string }
+  before: Record<string, unknown>,
+  after: Record<string, unknown>
 ) {
-  return (
-    before.fetchDetails !== after.fetchDetails ||
-    before.userToken !== after.userToken ||
-    before.mobileBarcode !== after.mobileBarcode
-  );
+  return Object.keys(before).some((key) => before[key] !== after[key]);
 }
 
 function invoiceLineItemStatement(

--- a/packages/connectors/src/einvoice-v2.selfcheck.ts
+++ b/packages/connectors/src/einvoice-v2.selfcheck.ts
@@ -1,0 +1,154 @@
+// Run with: npx tsx packages/connectors/src/einvoice-v2.selfcheck.ts
+// Uses only synthetic session data and a local fake fetch implementation.
+import assert from "node:assert/strict";
+import {
+  decryptLoginData,
+  encryptLoginData,
+  EInvoiceV2Client
+} from "./tw-einvoice-v2";
+import { einvoiceConnector, parseInvoiceConfig } from "./index";
+
+const requests: Array<{ url: string; init: RequestInit }> = [];
+const syntheticSession = {
+  sid: "123456789012345678",
+  token: "t".repeat(64),
+  skey: "synthetic-skey",
+  iv: "synthetic-iv",
+  ltoken: "synthetic-ltoken",
+  hkey: "synthetic-hkey",
+  carrier_code: "/ABCD123456",
+  liat: 1_783_947_541,
+  ssme: "synthetic-signing-secret",
+  appid: "synthetic-app-id"
+};
+const syntheticServerNow = Math.floor(Date.now() / 1000) + 123;
+
+const fakeFetch: typeof fetch = async (input, init) => {
+  const url = String(input);
+  const requestInit = init ?? {};
+  requests.push({ url, init: requestInit });
+
+  if (url.endsWith("/mid/v1/login")) {
+    const body = JSON.parse(String(requestInit.body ?? "{}")) as { ldata?: string };
+    assert.equal(typeof body.ldata, "string");
+    const login = await decryptLoginData(body.ldata!);
+    assert.equal(login.type, 0);
+    assert.equal(login.account, "0912345678");
+    assert.equal(login.password, "synthetic-password");
+    assert.equal(login.carrier_code, "");
+    assert.equal(login.pdid, "a:synthetic-android-id");
+    const device = login.device as Record<string, unknown>;
+    assert.equal(typeof login.ckey, "string");
+    assert.equal((login.ckey as string).length, 8);
+    assert.equal(device.os, "a");
+    assert.equal(device.os_version, "15");
+    assert.equal(device.pdid, "a:synthetic-android-id");
+    assert.equal(device.appver, "6.800.2");
+    assert.equal(device.lang, "zh");
+    assert.equal(device.ccs, "tw");
+    return json({ result: 0, payload: await encryptLoginData({ ...syntheticSession, now: syntheticServerNow }) });
+  }
+
+  if (url.endsWith("/einvoice/carriers/query-invoices-header")) {
+    const claims = readJwtClaims(requestInit);
+    assert.equal(claims.comms.appid, syntheticSession.appid);
+    assert.equal(claims.comms.liat, syntheticSession.liat);
+    assert.equal(claims.comms.keyType, "2");
+    assert.equal(claims.reqdata.action, "carrierInvChk");
+    assert.equal(claims.reqdata.cardNo, syntheticSession.carrier_code);
+    assert.equal(claims.reqdata.onlyWinningInv, "A");
+    return json({
+      result: 0,
+      payload: {
+        data: [{
+          invNum: "AA-12345678",
+          invDate: { year: "115", month: "7", date: "1", time: String(Date.parse("2026-07-01T04:34:56.000Z")) },
+          amount: "120",
+          sellerName: "測試商店"
+        }]
+      }
+    });
+  }
+
+  if (url.endsWith("/einvoice/carriers/query-invoices-details")) {
+    const claims = readJwtClaims(requestInit);
+    assert.equal(claims.reqdata.action, "carrierInvDetail");
+    assert.equal(claims.reqdata.invNum, "AA-12345678");
+    assert.equal(claims.reqdata.invDate, "2026/07/01");
+    return json({ result: 0, payload: { details: [{ rowNum: "1", itemName: "測試品項", quantity: "2", unitPrice: "60", amount: "120" }] } });
+  }
+
+  throw new Error(`unexpected fake URL: ${url}`);
+};
+
+async function main() {
+  const client = new EInvoiceV2Client({
+    middleHost: "https://fake-middle.test",
+    bigHost: "https://fake-big.test",
+    androidId: "synthetic-android-id",
+    fetchImpl: fakeFetch
+  });
+
+  const session = await client.login({
+    mobile: "0912345678",
+    password: "synthetic-password",
+    androidId: "synthetic-android-id"
+  });
+  assert.equal(session.sid, syntheticSession.sid);
+  assert.equal(session.loginAppId, syntheticSession.appid);
+  assert.equal(session.loginSsMe, syntheticSession.ssme);
+  assert.equal(session.carrierCode, syntheticSession.carrier_code);
+  assert.ok((session.serverTimeOffset ?? 0) >= 122 && (session.serverTimeOffset ?? 0) <= 123);
+
+  await client.queryCarrierInvoices(session, "2026-07-01", "2026-07-31");
+  await client.queryCarrierInvoiceDetail(session, "AA-12345678", "2026/07/01");
+  assert.equal(requests.length, 3);
+
+  const loginHeaders = new Headers(requests[0].init.headers);
+  assert.equal(loginHeaders.get("Content-Type"), "application/json; charset=utf-8");
+  assert.equal(loginHeaders.get("appver"), "6.800.2");
+  const invoiceHeaders = new Headers(requests[1].init.headers);
+  assert.equal(invoiceHeaders.get("Content-Type"), "application/x-www-form-urlencoded; charset=utf-8");
+  assert.equal(new URL(requests[2].url).pathname, "/einvoice/carriers/query-invoices-details");
+
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = fakeFetch;
+  const connectorConfig = parseInvoiceConfig({
+    protocol: "v2",
+    mobile: "0912345678",
+    password: "synthetic-password",
+    androidId: "synthetic-android-id",
+    periodsBack: 1,
+    fetchDetails: true
+  });
+  const syncResult = await einvoiceConnector.sync(connectorConfig);
+  assert.equal(syncResult.records.length, 1);
+  assert.equal(syncResult.invoiceLineItems?.length, 1);
+  assert.equal(connectorConfig.sid, syntheticSession.sid);
+  assert.equal(connectorConfig.loginAppId, syntheticSession.appid);
+  assert.equal(typeof connectorConfig.loginClientCode, "string");
+  assert.equal(connectorConfig.loginClientCode?.length, 8);
+  console.log("einvoice-v2.selfcheck: ok");
+}
+
+function json(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" }
+  });
+}
+
+function readJwtClaims(init: RequestInit) {
+  const form = new URLSearchParams(String(init.body ?? ""));
+  const token = form.get("einvoiceJwt");
+  assert.ok(token);
+  const parts = token.split(".");
+  assert.equal(parts.length, 3);
+  const header = JSON.parse(Buffer.from(parts[0], "base64url").toString("utf8")) as Record<string, unknown>;
+  assert.deepEqual(header, { alg: "HS256", typ: "JWT", ver: "1.0" });
+  return JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8")) as {
+    comms: Record<string, unknown>;
+    reqdata: Record<string, unknown>;
+  };
+}
+
+main();

--- a/packages/connectors/src/einvoice.selfcheck.ts
+++ b/packages/connectors/src/einvoice.selfcheck.ts
@@ -2,7 +2,11 @@
 // Exercises the private official App endpoint contract without sending credentials.
 import assert from "node:assert/strict";
 import forge from "node-forge";
-import { EInvoiceClient, RSA_PUBLIC_KEY } from "./tw-einvoice-api";
+import {
+  EInvoiceClient,
+  EInvoiceProtocolUnavailableError,
+  RSA_PUBLIC_KEY
+} from "./tw-einvoice-api";
 
 const OUTDATED_PROTOCOL_VERSION = "6.800.2";
 const REQUIRED_PROTOCOL_VERSION = "7.9000.40";
@@ -13,6 +17,13 @@ const requests: Array<{ url: string; init: RequestInit }> = [];
 
   if (url.endsWith("User/Login")) {
     const requestHeaders = new Headers(init.headers);
+    if (requestHeaders.get("ApiKey") === "protocol-unavailable") {
+      return json({
+        Result: null,
+        ReturnCode: 6603,
+        Message: "目前系統繁忙，請稍後再試。"
+      });
+    }
     // Simulate the service's forced-upgrade response whenever the client is not
     // using the protocol version advertised by the service.
     if (requestHeaders.get("AppVersion") !== REQUIRED_PROTOCOL_VERSION) {
@@ -74,6 +85,15 @@ async function main() {
   assert.match(requests[0]?.url ?? "", /UIAPAPP\/api\/User\/Login$/);
   assert.match(requests[1]?.url ?? "", /UIAPAPP\/api\/User\/Login$/);
   assert.match(requests[2]?.url ?? "", /UIAPAPP\/api\/Invoice\/ChkCarrierInv$/);
+
+  const protocolClient = new EInvoiceClient({ apiKey: "protocol-unavailable" });
+  await assert.rejects(
+    () => protocolClient.login({ mobile: "0912345678", password: "test-password" }),
+    (error: unknown) =>
+      error instanceof EInvoiceProtocolUnavailableError &&
+      /代碼 6603/.test(error.message) &&
+      /不是帳號密碼錯誤/.test(error.message)
+  );
   console.log("einvoice.selfcheck: ok");
 }
 

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -1,7 +1,11 @@
 import type { Connector, Invoice, InvoiceLineItem } from "@taiwan-fin-hub/core";
 import { z } from "zod";
-import { currentPeriodIndex, getDetailItems, getInvoices, periodFromIndex } from "./invoice-data";
-import { EInvoiceClient } from "./tw-einvoice-api";
+import { currentPeriodIndex, periodFromIndex } from "./invoice-data";
+import { EInvoiceV2Client, type EInvoiceV2Session } from "./tw-einvoice-v2";
+
+export { EInvoiceProtocolUnavailableError } from "./tw-einvoice-api";
+export { EInvoiceV2Client, decryptLoginData, encryptLoginData, signInvoiceJwt } from "./tw-einvoice-v2";
+export type { EInvoiceV2Options, EInvoiceV2Session } from "./tw-einvoice-v2";
 
 export { tdccConnector, createTdccConnector, tdccConfigSchema, parseTdccConfig, syncTdccTradeHistory, TdccOtpExpiredError } from "./tdcc";
 export type { TdccConfig, TdccHolding, TdccCashBalance, TdccCashMovement, TdccClient } from "./tdcc";
@@ -26,11 +30,26 @@ const invoiceRecordSchema = z.object({
 
 export const invoiceConfigSchema = z.object({
   records: z.array(invoiceRecordSchema).default([]),
+  protocol: z.enum(["legacy", "v2"]).default("v2").transform(() => "v2" as const),
   mobile: z.string().min(1).optional(),
   password: z.string().min(1).optional(),
   apiKey: z.string().min(1).optional(),
   mobileBarcode: z.string().min(1).optional(),
   userToken: z.string().min(1).optional(),
+  androidId: z.string().min(1).optional(),
+  ptoken: z.string().optional(),
+  loginClientCode: z.string().optional(),
+  loginType: z.number().int().min(0).max(9).default(0),
+  sid: z.string().optional(),
+  token: z.string().optional(),
+  iv: z.string().optional(),
+  svrCode: z.string().optional(),
+  loginAppId: z.string().optional(),
+  loginLiat: z.number().int().optional(),
+  loginSsMe: z.string().optional(),
+  ltoken: z.string().optional(),
+  hkey: z.string().optional(),
+  serverTimeOffset: z.number().int().optional(),
   periodsBack: z.number().int().min(1).max(24).default(1),
   fetchDetails: z.boolean().default(true)
 });
@@ -63,41 +82,57 @@ export const einvoiceConnector: Connector<InvoiceConfig, Omit<Invoice, "id" | "c
 };
 
 async function syncTaiwanEInvoices(config: InvoiceConfig, cursor?: string) {
-  const client = new EInvoiceClient({
-    apiKey: config.apiKey,
-    currentUser:
-      config.mobile && config.userToken && config.mobileBarcode
-        ? {
-            mobile: config.mobile,
-            userToken: config.userToken,
-            mobileBarcode: config.mobileBarcode
-          }
-        : null
-  });
+  return syncTaiwanEInvoicesV2(config, cursor);
+}
 
-  if (!client.currentUser) {
+async function syncTaiwanEInvoicesV2(config: InvoiceConfig, cursor?: string) {
+  if (!config.mobile || !config.password) {
+    throw new Error("新版電子發票需要手機號碼與密碼。");
+  }
+
+  const client = new EInvoiceV2Client({
+    androidId: config.androidId,
+    loginClientCode: config.loginClientCode,
+    ptoken: config.ptoken
+  });
+  let session: EInvoiceV2Session;
+  if (config.sid && config.token && config.loginAppId && config.loginLiat != null && config.loginSsMe) {
+    session = {
+      sid: config.sid,
+      token: config.token,
+      iv: config.iv,
+      svrCode: config.svrCode,
+      clientCode: config.loginClientCode,
+      loginAppId: config.loginAppId,
+      loginLiat: config.loginLiat,
+      loginSsMe: config.loginSsMe,
+      ltoken: config.ltoken,
+      hkey: config.hkey,
+      serverTimeOffset: config.serverTimeOffset,
+      carrierCode: config.mobileBarcode
+    };
+  } else {
     try {
-      await client.login({
-        mobile: config.mobile!,
-        password: config.password!
+      session = await client.login({
+        mobile: config.mobile,
+        password: config.password,
+        androidId: config.androidId,
+        loginClientCode: config.loginClientCode,
+        ptoken: config.ptoken,
+        loginType: config.loginType,
+        carrierCode: config.mobileBarcode
       });
     } catch (error) {
       throw new Error(`電子發票登入失敗：${error instanceof Error ? error.message : "發生未知錯誤"}`);
     }
+    Object.assign(config, session);
+    config.loginClientCode = session.clientCode ?? config.loginClientCode;
+    config.mobileBarcode = session.carrierCode ?? config.mobileBarcode;
   }
 
-  if (client.currentUser?.userToken) {
-    config.userToken = client.currentUser.userToken;
-  }
-
-  if (client.currentUser?.mobileBarcode) {
-    config.mobileBarcode = client.currentUser.mobileBarcode;
-  }
-
-  const carrierId = config.mobileBarcode ?? client.currentUser?.mobileBarcode;
-  if (!carrierId) {
-    throw new Error("電子發票登入未回傳手機條碼。");
-  }
+  const carrierCode = config.mobileBarcode ?? session.carrierCode;
+  if (!carrierCode) throw new Error("新版電子發票登入未回傳手機條碼。");
+  session.carrierCode = carrierCode;
 
   const now = new Date();
   const currentIndex = currentPeriodIndex(now);
@@ -108,30 +143,16 @@ async function syncTaiwanEInvoices(config: InvoiceConfig, cursor?: string) {
 
   for (const periodIndex of periodIndexes) {
     const period = periodFromIndex(periodIndex, now);
-    const payload = await client.checkCarrierInvoices({
-      carrierId,
-      carrierType: "3J0002",
-      cardEncrypt: config.password,
-      startDate: period.startDate,
-      endDate: period.endDate
-    });
-
-    const invoices = getInvoices(payload);
+    const payload = await client.queryCarrierInvoices(session, period.startDate, period.endDate);
+    const invoices = getV2Invoices(payload);
     for (const invoice of invoices) {
-      let detail: unknown;
-      let detailItems: ReturnType<typeof getDetailItems> = [];
       const sourceId = invoiceSourceId(invoice.invNum, invoice.invDate, invoice.id);
-
-      if (config.fetchDetails && invoice.invNum && invoice.invDate) {
+      let detail: unknown;
+      let detailItems: ReturnType<typeof getV2DetailItems> = [];
+      if (config.fetchDetails && invoice.invNum && invoice.detailInvDate) {
         try {
-          detail = await client.checkCarrierInvoiceDetail({
-            carrierId,
-            carrierType: "3J0002",
-            cardEncrypt: config.password,
-            invNum: invoice.invNum,
-            invDate: invoice.invDate
-          });
-          detailItems = getDetailItems(detail);
+          detail = await client.queryCarrierInvoiceDetail(session, invoice.invNum, invoice.detailInvDate);
+          detailItems = getV2DetailItems(detail);
           detailItems.forEach((item, index) => {
             invoiceLineItems.push({
               invoiceSourceId: sourceId,
@@ -146,24 +167,16 @@ async function syncTaiwanEInvoices(config: InvoiceConfig, cursor?: string) {
           });
         } catch (error) {
           detailErrorCount += 1;
-          detail = {
-            error: error instanceof Error ? error.message : "Unable to fetch invoice detail."
-          };
+          detail = { error: error instanceof Error ? error.message : "Unable to fetch invoice detail." };
         }
       }
-
       records.push({
         sourceId,
         invoiceNumber: invoice.invNum || undefined,
         invoiceDate: normalizeInvoiceDate(invoice.invDate),
         sellerName: invoice.sellerName,
         amount: Math.max(0, Math.trunc(invoice.amount)),
-        raw: {
-          invoice,
-          period,
-          detail,
-          detailItems
-        }
+        raw: { invoice, period, detail, detailItems }
       });
     }
   }
@@ -179,6 +192,108 @@ async function syncTaiwanEInvoices(config: InvoiceConfig, cursor?: string) {
       periodsBack: config.periodsBack
     })
   };
+}
+
+function getV2Invoices(payload: unknown) {
+  const rows = findArray(payload, [
+    "invoices", "invoice", "invoiceList", "invList", "headers", "header", "invoiceHeaders", "details", "result", "data", "list"
+  ]);
+  return rows
+    .filter((item): item is Record<string, unknown> => Boolean(item && typeof item === "object"))
+    .map((item, index) => {
+      const invoiceDate = parseV2InvoiceDate(item.invDate ?? item.invoiceDate ?? item.date);
+      return {
+        id: firstStringValue(item.invNum, item.invoiceNumber, item.id) || `v2-${index}`,
+        invNum: firstStringValue(item.invNum, item.invoiceNumber),
+        invDate: invoiceDate.iso,
+        detailInvDate: invoiceDate.apiDate,
+        sellerName: firstStringValue(item.sellerName, item.seller, item.sellerNameE) || "未知商店",
+        amount: parseNumericValue(item.amount, item.total, item.totalAmount),
+        randomNumber: firstStringValue(item.randomNumber),
+        invPeriod: firstStringValue(item.invPeriod, item.invTerm),
+        sellerID: firstStringValue(item.sellerID, item.sellerBan),
+        encrypt: firstStringValue(item.encrypt),
+        isQrCode: item.isQrCode === true || item.isScanInv === true,
+        isBuyerType: item.isBuyerType === true || item.isBuyerType === "Y"
+      };
+    });
+}
+
+function parseV2InvoiceDate(value: unknown) {
+  if (typeof value === "string" && value.trim()) {
+    const iso = normalizeInvoiceDate(value);
+    return { iso, apiDate: formatTaipeiApiDate(new Date(iso)) };
+  }
+
+  const record = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+  const epoch = Number(record?.time);
+  if (Number.isFinite(epoch) && epoch > 0) {
+    const date = new Date(epoch);
+    return { iso: date.toISOString(), apiDate: formatTaipeiApiDate(date) };
+  }
+
+  const rocYear = Number(record?.year);
+  const month = Number(record?.month);
+  const day = Number(record?.date);
+  if (Number.isFinite(rocYear) && Number.isFinite(month) && Number.isFinite(day)) {
+    const year = rocYear < 1911 ? rocYear + 1911 : rocYear;
+    const apiDate = `${year}/${String(month).padStart(2, "0")}/${String(day).padStart(2, "0")}`;
+    return { iso: normalizeInvoiceDate(apiDate), apiDate };
+  }
+
+  return { iso: "", apiDate: "" };
+}
+
+function formatTaipeiApiDate(date: Date) {
+  if (Number.isNaN(date.getTime())) return "";
+  const taipei = new Date(date.getTime() + 8 * 60 * 60 * 1000);
+  return `${taipei.getUTCFullYear()}/${String(taipei.getUTCMonth() + 1).padStart(2, "0")}/${String(taipei.getUTCDate()).padStart(2, "0")}`;
+}
+
+function getV2DetailItems(payload: unknown) {
+  const rows = findArray(payload, ["details", "items", "itemList", "invoiceDetails", "result", "data", "list"]);
+  return rows
+    .filter((item): item is Record<string, unknown> => Boolean(item && typeof item === "object"))
+    .map((item, index) => ({
+      id: firstStringValue(item.rowNum, item.id) || String(index),
+      amount: firstStringValue(item.amount, item.subtotal),
+      description: firstStringValue(item.description, item.itemName, item.name) || "未命名品項",
+      quantity: firstStringValue(item.quantity, item.qty),
+      unitPrice: firstStringValue(item.unitPrice, item.price)
+    }));
+}
+
+function findArray(value: unknown, keys: string[], depth = 0): unknown[] {
+  if (depth > 5 || value == null) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value !== "object") return [];
+  const record = value as Record<string, unknown>;
+  for (const key of keys) {
+    if (Array.isArray(record[key])) return record[key] as unknown[];
+  }
+  for (const child of Object.values(record)) {
+    const found = findArray(child, keys, depth + 1);
+    if (found.length) return found;
+  }
+  return [];
+}
+
+function firstStringValue(...values: unknown[]) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value;
+    if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  }
+  return "";
+}
+
+function parseNumericValue(...values: unknown[]) {
+  for (const value of values) {
+    const parsed = Number(String(value ?? "").replace(/,/g, ""));
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return 0;
 }
 
 function parseOptionalNumber(value: string) {

--- a/packages/connectors/src/tw-einvoice-api.ts
+++ b/packages/connectors/src/tw-einvoice-api.ts
@@ -32,6 +32,15 @@ export type LoginParams =
       PushToken?: string;
     };
 
+export class EInvoiceProtocolUnavailableError extends Error {
+  constructor(
+    message = "財政部電子發票服務拒絕目前的 App 登入協定（代碼 6603）。這不是帳號密碼錯誤，也不是暫時忙碌；重複同步不會恢復，需改用新版協定或財政部正式 AppID API。"
+  ) {
+    super(message);
+    this.name = "EInvoiceProtocolUnavailableError";
+  }
+}
+
 export class EInvoiceClient {
   currentUser: EInvoiceUser | null;
   host: string;
@@ -91,7 +100,14 @@ export class EInvoiceClient {
   async login(params: LoginParams) {
     const data = await this.post("User/Login", params);
     if (!this.currentUser) {
-      throw new Error(responseMessage(data) || "登入回應未包含使用者資料，請確認帳號、密碼與 App 版本。");
+      const returnCode = responseReturnCode(data);
+      const message = responseMessage(data);
+      if (returnCode === "6603" || message === "目前系統繁忙，請稍後再試。") {
+        throw new EInvoiceProtocolUnavailableError();
+      }
+      throw new Error(
+        `${returnCode ? `代碼 ${returnCode}：` : ""}${message || "登入回應未包含使用者資料，請確認帳號、密碼與 App 版本。"}`
+      );
     }
     return data;
   }
@@ -214,6 +230,14 @@ function responseMessage(data: unknown) {
     response.Description,
     response.description
   );
+}
+
+function responseReturnCode(data: unknown) {
+  const response = asRecord(data);
+  const value = response?.ReturnCode ?? response?.returnCode;
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return undefined;
 }
 
 function forcedUpgradeVersion(data: unknown) {

--- a/packages/connectors/src/tw-einvoice-v2.ts
+++ b/packages/connectors/src/tw-einvoice-v2.ts
@@ -1,0 +1,460 @@
+/**
+ * Transport used by the 2026 Taiwan e-invoice app protocol.
+ *
+ * The app deliberately keeps the middle API payload opaque (ldata) and the
+ * invoice API payload signed (einvoiceJwt).  This module contains only the
+ * protocol primitives and a small client; it does not log credentials or
+ * tokens.  Hosts and app metadata remain overridable so a future app update
+ * can be accommodated without changing the connector shape.
+ */
+
+export type EInvoiceV2Session = {
+  sid: string;
+  token: string;
+  iv?: string;
+  svrCode?: string;
+  clientCode?: string;
+  loginAppId: string;
+  loginLiat: number;
+  loginSsMe: string;
+  ltoken?: string;
+  hkey?: string;
+  carrierCode?: string;
+  /** Difference between the service `now` and this worker's Unix clock. */
+  serverTimeOffset?: number;
+};
+
+export type EInvoiceV2Options = {
+  middleHost?: string;
+  bigHost?: string;
+  appVersion?: string;
+  appBuild?: number;
+  language?: string;
+  ccs?: string;
+  androidId?: string;
+  ptoken?: string;
+  loginClientCode?: string;
+  loginType?: number;
+  osVersion?: string;
+  userAgent?: string;
+  fetchImpl?: typeof fetch;
+};
+
+export type EInvoiceV2LoginOptions = EInvoiceV2Options & {
+  mobile: string;
+  password: string;
+  carrierCode?: string;
+};
+
+const PROD_MIDDLE_HOST = "https://uia.einvoice.nat.gov.tw";
+const PROD_BIG_HOST = "https://upi.einvoice.nat.gov.tw";
+const DEFAULT_APP_VERSION = "6.800.2";
+const DEFAULT_APP_BUILD = 66;
+const DEFAULT_USER_AGENT = "okhttp/5.3.0";
+const ALPHANUMERIC = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+function cryptoApi() {
+  const value = globalThis.crypto;
+  if (!value?.subtle || !value.getRandomValues) {
+    throw new Error("此執行環境缺少 WebCrypto，無法建立新版電子發票登入封包。");
+  }
+  return value;
+}
+
+function base64(bytes: Uint8Array) {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return globalThis.btoa(binary);
+}
+
+function base64Url(bytes: Uint8Array) {
+  return base64(bytes).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function utf8(value: string) {
+  return new TextEncoder().encode(value);
+}
+
+// TypeScript's DOM lib currently models Uint8Array with ArrayBufferLike while
+// WebCrypto's overload still asks for ArrayBuffer. The runtime accepts both;
+// keep the conversion in one place for Node and Cloudflare builds.
+function cryptoSource(value: Uint8Array) {
+  return value as unknown as BufferSource;
+}
+
+function swapPairs(value: string) {
+  let output = "";
+  for (let index = 0; index < value.length; index += 2) {
+    output += value[index + 1] ?? "";
+    output += value[index] ?? "";
+  }
+  return output;
+}
+
+function randomAlphaNumeric(length: number) {
+  const random = new Uint32Array(length);
+  cryptoApi().getRandomValues(random);
+  return Array.from(random, (value) => ALPHANUMERIC[value % ALPHANUMERIC.length]).join("");
+}
+
+async function sha256(value: string) {
+  return new Uint8Array(await cryptoApi().subtle.digest("SHA-256", cryptoSource(utf8(value))));
+}
+
+async function aesGcmEncrypt(plainText: string, key: Uint8Array, iv: Uint8Array) {
+  const cryptoKey = await cryptoApi().subtle.importKey("raw", cryptoSource(key), "AES-GCM", false, ["encrypt"]);
+  return new Uint8Array(
+    await cryptoApi().subtle.encrypt({ name: "AES-GCM", iv: cryptoSource(iv), tagLength: 128 }, cryptoKey, cryptoSource(utf8(plainText)))
+  );
+}
+
+async function aesGcmDecrypt(cipherText: Uint8Array, key: Uint8Array, iv: Uint8Array) {
+  const cryptoKey = await cryptoApi().subtle.importKey("raw", cryptoSource(key), "AES-GCM", false, ["decrypt"]);
+  return new TextDecoder().decode(
+    await cryptoApi().subtle.decrypt({ name: "AES-GCM", iv: cryptoSource(iv), tagLength: 128 }, cryptoKey, cryptoSource(cipherText))
+  );
+}
+
+type LDataCryptoContext = { key: Uint8Array; iv: Uint8Array };
+
+async function encryptLoginDataWithContext(data: Record<string, unknown>) {
+  const json = JSON.stringify(data);
+  const a = randomAlphaNumeric(16);
+  const b = randomAlphaNumeric(16);
+  const seed = `${swapPairs(b)}${swapPairs(a)}${[...a].reverse().join("")}${[...b].reverse().join("")}`;
+  const key = await sha256(seed);
+  const iv = utf8(`${a.slice(-6)}${b.slice(-6)}`);
+  const cipherText = await aesGcmEncrypt(json, key, iv);
+  return { value: `${a}|${base64(cipherText)}|${b}`, context: { key, iv } satisfies LDataCryptoContext };
+}
+
+async function decryptLDataCiphertext(value: string, context: LDataCryptoContext) {
+  const binary = globalThis.atob(value);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return JSON.parse(await aesGcmDecrypt(bytes, context.key, context.iv)) as Record<string, unknown>;
+}
+
+/** AppCrypto.lDataEncrypt: random 16+16 seed, SHA-256 key, AES-GCM payload. */
+export async function encryptLoginData(data: Record<string, unknown>) {
+  let step = "json";
+  try {
+    step = "random";
+    return (await encryptLoginDataWithContext(data)).value;
+  } catch (error) {
+    throw new Error(`新版電子發票登入封包建立失敗（${step}）：${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+/** Decrypts the ldata response returned in the middle API payload. */
+export async function decryptLoginData(value: string) {
+  const parts = value.split("|");
+  if (parts.length !== 3 || parts[0].length !== 16 || parts[2].length !== 16) {
+    throw new Error("新版電子發票登入回應的 ldata 格式無效。");
+  }
+  const [a, encoded, b] = parts;
+  const seed = `${swapPairs(b)}${swapPairs(a)}${[...a].reverse().join("")}${[...b].reverse().join("")}`;
+  const key = await sha256(seed);
+  const iv = utf8(`${a.slice(-6)}${b.slice(-6)}`);
+  return decryptLDataCiphertext(encoded, { key, iv });
+}
+
+function jsonHeaders(options: EInvoiceV2Options) {
+  return {
+    Accept: "application/json",
+    "Content-Type": "application/json; charset=utf-8",
+    "User-Agent": options.userAgent ?? DEFAULT_USER_AGENT,
+    appver: options.appVersion ?? DEFAULT_APP_VERSION,
+    appbn: String(options.appBuild ?? DEFAULT_APP_BUILD),
+    platform: "android",
+    version: options.appVersion ?? DEFAULT_APP_VERSION
+  };
+}
+
+function formHeaders(options: EInvoiceV2Options) {
+  return {
+    Accept: "application/json",
+    "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+    "User-Agent": options.userAgent ?? DEFAULT_USER_AGENT,
+    appver: options.appVersion ?? DEFAULT_APP_VERSION,
+    appbn: String(options.appBuild ?? DEFAULT_APP_BUILD),
+    platform: "android",
+    version: options.appVersion ?? DEFAULT_APP_VERSION
+  };
+}
+
+function stringValue(value: unknown) {
+  return typeof value === "string" ? value : value == null ? "" : String(value);
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+}
+
+function unwrapBody(body: unknown) {
+  const root = recordValue(body);
+  if (!root) return body;
+  return root.payload ?? root.data ?? root.result ?? root;
+}
+
+async function decodeMiddleBody(body: unknown, context?: LDataCryptoContext) {
+  const value = unwrapBody(body);
+  if (typeof value !== "string") return value;
+  if (context && !value.includes("|")) {
+    try {
+      return await decryptLDataCiphertext(value, context);
+    } catch {
+      // Fall through to the compatibility decoder for plain service messages.
+    }
+  }
+  try {
+    return await decryptLoginData(value);
+  } catch {
+    // A few service errors are returned as a plain message string.
+    return value;
+  }
+}
+
+function sessionFromLoginData(data: unknown, fallback: Partial<EInvoiceV2Session>) {
+  const value = recordValue(data) ?? {};
+  const agree = recordValue(value.agree_ver);
+  const serverNow = Number(value.now);
+  const serverTimeOffset = Number.isFinite(serverNow)
+    ? Math.trunc(serverNow - Date.now() / 1000)
+    : fallback.serverTimeOffset;
+  const session: EInvoiceV2Session = {
+    sid: stringValue(value.sid ?? fallback.sid),
+    token: stringValue(value.token ?? fallback.token),
+    iv: stringValue(value.iv ?? fallback.iv) || undefined,
+    svrCode: stringValue(value.svrCode ?? value.svr_code ?? fallback.svrCode) || undefined,
+    clientCode: stringValue(value.clientCode ?? fallback.clientCode) || undefined,
+    loginAppId: stringValue(value.appid ?? value.loginAppId ?? fallback.loginAppId),
+    loginLiat: Number(value.liat ?? fallback.loginLiat ?? 0),
+    loginSsMe: stringValue(value.ssme ?? value.loginSsMe ?? fallback.loginSsMe),
+    ltoken: stringValue(value.ltoken ?? fallback.ltoken) || undefined,
+    hkey: stringValue(value.hkey ?? value.skey ?? fallback.hkey) || undefined,
+    carrierCode: stringValue(value.carrier_code ?? value.carrierCode ?? fallback.carrierCode) || undefined,
+    serverTimeOffset
+  };
+  if (agree?.eula != null) (session as EInvoiceV2Session & { agreedEulaVersion?: number }).agreedEulaVersion = Number(agree.eula);
+  if (!session.sid || !session.token || !session.loginAppId || !session.loginSsMe || !Number.isFinite(session.loginLiat)) {
+    throw new Error(`新版電子發票登入成功回應缺少必要 session 欄位（回應欄位：${Object.keys(value).join(",") || "無"}）。`);
+  }
+  return session;
+}
+
+function accessToken(session: EInvoiceV2Session) {
+  // ApiCrypto.getAcToken: sid[14..17] + sid[0..3] selects token[5..30].
+  if (session.sid.length !== 18 || session.token.length < 44) return "";
+  const indexes = [14, 15, 16, 17, 0, 1, 2, 3];
+  return `${session.sid}|${indexes.map((index) => session.token.charAt((session.sid.charCodeAt(index) % 26) + 5)).join("")}`;
+}
+
+export function createInvoiceJwt(
+  request: Record<string, unknown>,
+  session: Pick<EInvoiceV2Session, "loginLiat" | "loginAppId" | "loginSsMe" | "carrierCode">,
+  now = Math.floor(Date.now() / 1000) - 10
+) {
+  const header = { alg: "HS256", typ: "JWT", ver: "1.0" };
+  const claims = {
+    comms: {
+      iat: now,
+      exp: now + 40,
+      liat: session.loginLiat,
+      appid: session.loginAppId,
+      barcode: session.carrierCode ?? "",
+      keyType: "2"
+    },
+    reqdata: request
+  };
+  const encodedHeader = base64Url(utf8(JSON.stringify(header)));
+  const encodedClaims = base64Url(utf8(JSON.stringify(claims)));
+  return {
+    signingInput: `${encodedHeader}.${encodedClaims}`,
+    secret: session.loginSsMe
+  };
+}
+
+function correctedInvoiceTimestamp(session: Pick<EInvoiceV2Session, "serverTimeOffset">) {
+  return Math.floor(Date.now() / 1000) + (session.serverTimeOffset ?? 0) - 10;
+}
+
+export async function signInvoiceJwt(
+  request: Record<string, unknown>,
+  session: Pick<EInvoiceV2Session, "loginLiat" | "loginAppId" | "loginSsMe" | "carrierCode">,
+  now?: number
+) {
+  const { signingInput, secret } = createInvoiceJwt(request, session, now);
+  const key = await cryptoApi().subtle.importKey("raw", cryptoSource(utf8(secret)), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const signature = new Uint8Array(await cryptoApi().subtle.sign("HMAC", key, cryptoSource(utf8(signingInput))));
+  return `${signingInput}.${base64Url(signature)}`;
+}
+
+export class EInvoiceV2Client {
+  private readonly options: Required<Pick<EInvoiceV2Options, "middleHost" | "bigHost">> & EInvoiceV2Options;
+  private readonly fetcher: typeof fetch;
+
+  constructor(options: EInvoiceV2Options = {}) {
+    this.options = {
+      middleHost: options.middleHost ?? PROD_MIDDLE_HOST,
+      bigHost: options.bigHost ?? PROD_BIG_HOST,
+      ...options
+    };
+    // Cloudflare's global fetch is Web-IDL bound; storing the bare function and
+    // invoking it as a class member causes an Illegal invocation error.
+    this.fetcher = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  }
+
+  async login(params: EInvoiceV2LoginOptions) {
+    const androidId = params.androidId ?? "taiwan-fin-hub";
+    const ptoken = params.ptoken ?? "";
+    const loginClientCode = params.loginClientCode ?? this.options.loginClientCode ?? randomAlphaNumeric(8);
+    const inner = {
+      type: params.loginType ?? 0,
+      account: params.mobile,
+      password: params.password,
+      carrier_code: params.carrierCode ?? "",
+      ckey: loginClientCode,
+      device: {
+        os: "a",
+        os_version: params.osVersion ?? "15",
+        model: "Android",
+        pdid: `a:${androidId}`,
+        ptoken,
+        appver: params.appVersion ?? DEFAULT_APP_VERSION,
+        appbn: params.appBuild ?? DEFAULT_APP_BUILD,
+        lang: params.language ?? "zh",
+        ccs: params.ccs ?? "tw"
+      },
+      ts: Math.floor(Date.now() / 1000),
+      pdid: `a:${androidId}`
+    };
+    const encrypted = await encryptLoginDataWithContext(inner);
+    const body = await this.middleRequest("/mid/v1/login", { ldata: encrypted.value });
+    const data = await decodeMiddleBody(body, encrypted.context);
+    try {
+      return sessionFromLoginData(data, { clientCode: loginClientCode, carrierCode: params.carrierCode });
+    } catch (error) {
+      throw new Error(`${error instanceof Error ? error.message : String(error)}；外層回應形狀：${responseShape(body)}`);
+    }
+  }
+
+  async loginToken(session: Pick<EInvoiceV2Session, "ltoken"> & Partial<EInvoiceV2Session>, options: EInvoiceV2Options = {}) {
+    if (!session.ltoken) throw new Error("新版電子發票 session 沒有 ltoken，無法使用 token 登入。");
+    const androidId = options.androidId ?? "taiwan-fin-hub";
+    const inner = {
+      ltoken: session.ltoken,
+      ckey: options.loginClientCode ?? session.clientCode ?? this.options.loginClientCode ?? randomAlphaNumeric(8),
+      device: {
+        os: "a", os_version: options.osVersion ?? "15", model: "Android", pdid: `a:${androidId}`,
+        ptoken: options.ptoken ?? "", appver: options.appVersion ?? DEFAULT_APP_VERSION,
+        appbn: options.appBuild ?? DEFAULT_APP_BUILD, lang: options.language ?? "zh", ccs: options.ccs ?? "tw"
+      },
+      ts: Math.floor(Date.now() / 1000),
+      pdid: `a:${androidId}`
+    };
+    const encrypted = await encryptLoginDataWithContext(inner);
+    const body = await this.middleRequest("/mid/v1/logintoken", { ldata: encrypted.value });
+    return sessionFromLoginData(await decodeMiddleBody(body, encrypted.context), session);
+  }
+
+  async queryCarrierInvoices(session: EInvoiceV2Session, startDate: string, endDate: string, page = 1) {
+    const request = {
+      version: "1.0",
+      cardType: "3J0002",
+      cardNo: session.carrierCode ?? "",
+      action: "carrierInvChk",
+      startDate,
+      endDate,
+      onlyWinningInv: "A",
+      page
+    };
+    return this.bigRequest("/einvoice/carriers/query-invoices-header", await signInvoiceJwt(request, session, correctedInvoiceTimestamp(session)));
+  }
+
+  async queryCarrierInvoiceDetail(session: EInvoiceV2Session, invNum: string, invDate: string) {
+    const request = {
+      version: "1.0",
+      cardType: "3J0002",
+      cardNo: session.carrierCode ?? "",
+      action: "carrierInvDetail",
+      invNum,
+      invDate
+    };
+    return this.bigRequest("/einvoice/carriers/query-invoices-details", await signInvoiceJwt(request, session, correctedInvoiceTimestamp(session)));
+  }
+
+  async queryInvoiceDetail(
+    session: EInvoiceV2Session,
+    invNum: string,
+    invDate: string,
+    randomNumber = "",
+    invPeriod = "",
+    sellerID = "",
+    encrypt = "",
+    isQrCode = false,
+    isBuyerType = false
+  ) {
+    const request = {
+      version: "1.0", action: "qryInvDetail", invNum, invDate, randomNumber,
+      type: randomNumber ? (isQrCode ? "QRCode" : "Barcode") : "NoRandomNumber",
+      invTerm: invPeriod, sellerID, encrypt,
+      isBuyerType: isBuyerType ? "Y" : "N"
+    };
+    return this.bigRequest("/einvoice/invoices/query-details", await signInvoiceJwt(request, session, correctedInvoiceTimestamp(session)));
+  }
+
+  private async middleRequest(path: string, body: Record<string, unknown>) {
+    const response = await this.fetcher(`${this.options.middleHost}${path}`, {
+      method: "POST", headers: jsonHeaders(this.options), body: JSON.stringify(body)
+    });
+    return readJsonResponse(response, path);
+  }
+
+  private async bigRequest(path: string, jwt: string) {
+    const form = new URLSearchParams({ einvoiceJwt: jwt });
+    const response = await this.fetcher(`${this.options.bigHost}${path}`, {
+      method: "POST", headers: formHeaders(this.options), body: form.toString()
+    });
+    return readJsonResponse(response, path);
+  }
+}
+
+async function readJsonResponse(response: Response, path: string) {
+  const text = await response.text();
+  let body: unknown;
+  try { body = text ? JSON.parse(text) : {}; } catch { body = text; }
+  if (!response.ok) {
+    const root = recordValue(body);
+    const message = stringValue(root?.message ?? root?.msg ?? root?.description ?? root?.error);
+    throw new Error(`新版電子發票 ${path} HTTP ${response.status}${message ? `：${message}` : ""}`);
+  }
+  const root = recordValue(body);
+  if (typeof root?.result === "number" && root.result !== 0) {
+    const payload = recordValue(root.payload);
+    const encryptedPayload = typeof root.payload === "string" ? await tryDecryptErrorPayload(root.payload) : undefined;
+    const decodedPayload = recordValue(encryptedPayload);
+    const message = stringValue(
+      root.message ?? root.msg ?? root.description ?? root.error ??
+      payload?.message ?? payload?.msg ?? payload?.description ?? payload?.error ??
+      decodedPayload?.message ?? decodedPayload?.msg ?? decodedPayload?.description ?? decodedPayload?.error ??
+      (typeof root.payload === "string" ? root.payload : undefined)
+    );
+    throw new Error(`新版電子發票 ${path} 回應錯誤（代碼 ${root.result}）${message ? `：${message}` : ""}`);
+  }
+  return body;
+}
+
+async function tryDecryptErrorPayload(value: string) {
+  try {
+    return await decryptLoginData(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function responseShape(body: unknown) {
+  const root = recordValue(body);
+  if (!root) return typeof body;
+  const payload = root.payload;
+  return `keys=${Object.keys(root).join(",") || "無"}, payload=${typeof payload}${typeof payload === "string" ? `(${payload.length} chars)` : ""}`;
+}


### PR DESCRIPTION
## What changed

- implement the current E-Invoice App login, session, encryption, JWT, invoice header, and detail protocol
- force E-Invoice sync to use the new protocol and remove obsolete protocol/API-key controls from the UI
- parse the new API's ROC-date object so July invoices and detail rows are stored with valid dates
- persist refreshed session data and improve manual/automatic sync failure reporting
- add synthetic self-check coverage for the new protocol and legacy-unavailable response

## Why

The legacy private App endpoint now returns code 6603 as a generic busy response. The replacement protocol returns `invDate` as an object, which the previous mapper treated as an invalid string and caused current-month invoices to be stored without dates.

## Impact

E-Invoice sync now works with the current App protocol only. Current-month invoices and their line items are imported correctly, while users no longer need to choose a protocol.

## Validation

- `npm run build --workspaces`
- `npx tsx packages/connectors/src/einvoice-v2.selfcheck.ts`
- `npx tsx packages/connectors/src/einvoice.selfcheck.ts`
- live sync against the configured D1: 13 July invoices and 36 detail rows
