### PR TITLE
改善 iOS 主畫面 Web App 的縮放與滑動行為

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -42,6 +42,44 @@ test("renders the mobile bottom navigation", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "更多", exact: true })).toBeVisible();
 });
 
+test("uses app-like scrolling and history only in standalone display mode", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("html")).not.toHaveClass(/is-standalone/);
+  await expect(page.locator("html")).toHaveCSS("touch-action", "auto");
+
+  await page.addInitScript(() => {
+    const nativeMatchMedia = window.matchMedia.bind(window);
+    window.matchMedia = (query: string) => {
+      if (query !== "(display-mode: standalone)") return nativeMatchMedia(query);
+      return {
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      };
+    };
+  });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.reload();
+
+  await expect(page.locator("html")).toHaveClass(/is-standalone/);
+  await expect(page.locator("html")).toHaveCSS("overflow", "hidden");
+  await expect(page.locator("body")).toHaveCSS("overflow", "hidden");
+  await expect(page.locator("#root")).toHaveCSS("touch-action", "pan-x pan-y");
+  await expect(page.locator("#root")).toHaveCSS("overflow-y", "auto");
+  await expect(page.locator("#root")).toHaveCSS("overscroll-behavior", "none");
+
+  const historyLength = await page.evaluate(() => window.history.length);
+  await page.getByRole("button", { name: "資產", exact: true }).last().click();
+  await expect(page).toHaveURL(/#\/assets$/);
+  await expect(page.getByRole("heading", { name: "資產", exact: true })).toBeVisible();
+  expect(await page.evaluate(() => window.history.length)).toBe(historyLength);
+});
+
 test("opens a primary view from its hash route", async ({ page }) => {
   await page.goto("/#/invoices");
   await expect(page.getByRole("heading", { name: "發票", exact: true })).toBeVisible();

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -50,6 +50,13 @@
   const detail = $derived(isDetail(view) ? detailLabels[view] : undefined);
   const mobileSetting = $derived(isMobileSetting(view) ? mobileSettingsLabels[view] : undefined);
 
+  const isStandalone = () => document.documentElement.classList.contains("is-standalone");
+  function scrollToTop() {
+    const options: ScrollToOptions = { top: 0, behavior: "smooth" };
+    if (isStandalone()) document.getElementById("root")?.scrollTo(options);
+    else window.scrollTo(options);
+  }
+
   onMount(() => {
     const routeView = parseViewHash(window.location.hash);
     if (routeView) view = routeView;
@@ -59,7 +66,7 @@
       const next = parseViewHash(window.location.hash);
       if (next) {
         view = next;
-        window.scrollTo({ top: 0, behavior: "smooth" });
+        scrollToTop();
       }
     };
     window.addEventListener("hashchange", handleHashChange);
@@ -72,8 +79,15 @@
   });
   function navigate(next: View) {
     view = next;
-    if (window.location.hash !== viewHash(next)) window.location.hash = viewHash(next);
-    window.scrollTo({ top: 0, behavior: "smooth" });
+    const nextHash = viewHash(next);
+    if (window.location.hash !== nextHash) {
+      if (isStandalone()) {
+        window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}${nextHash}`);
+      } else {
+        window.location.hash = nextHash;
+      }
+    }
+    scrollToTop();
   }
   function toggleMoneyVisibility() { moneyState.hidden = !moneyState.hidden; localStorage.setItem("taiwan-fin-hub-money-hidden", String(moneyState.hidden)); }
 </script>

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,6 +1,11 @@
 import { mount } from "svelte";
 import App from "./App.svelte";
 
+document.documentElement.classList.toggle(
+  "is-standalone",
+  window.matchMedia("(display-mode: standalone)").matches,
+);
+
 const target = document.getElementById("root");
 if (!target) throw new Error("Missing #root element");
 mount(App, { target });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -137,3 +137,19 @@
     font-size: 16px;
   }
 }
+
+/* Give the installed Home Screen app a fixed viewport with its own native-like scroller. */
+html.is-standalone,
+html.is-standalone body {
+  height: 100%;
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
+html.is-standalone #root {
+  height: 100dvh;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: none;
+  touch-action: pan-x pan-y;
+}


### PR DESCRIPTION
## 變更內容

- 偵測 `display-mode: standalone`，只在加入主畫面的 Web App 啟用 App 化手勢設定。
- 禁止雙指縮放，並將 standalone 模式改為固定 viewport 與獨立捲動容器。
- 停用頂端與底部 overscroll 回彈，避免捲動時露出頁面外空白。
- standalone 導覽改用 `history.replaceState`，避免建立可由邊緣滑動返回的 history 紀錄。
- 新增 E2E 測試，確認一般瀏覽器與 standalone 模式維持各自預期的捲動及導覽行為。

## 問題原因

原本由頁面 viewport 直接捲動，iOS 主畫面 Web App 到達捲動邊界時仍會出現橡皮筋回彈。此外，hash 導覽會持續新增瀏覽器 history，使邊緣滑動可以切回前一個畫面。

## 使用者影響

加入主畫面後的操作會更接近原生 App：不會縮放、不會在捲動邊界露出空白，也不會因左右邊緣滑動返回前一個分頁。一般瀏覽器模式仍保留原本的縮放與上一頁行為。

## 驗證

- `npm run test:unit -w @taiwan-fin-hub/web`
- `npm run typecheck -w @taiwan-fin-hub/web`
- `npm run build -w @taiwan-fin-hub/web`
- `npm run test:e2e -w @taiwan-fin-hub/web`
- `git diff --check`
