### PR TITLE
設定 Svelte 前端格式化並統一程式碼格式

### DIFF
--- a/apps/web/.prettierignore
+++ b/apps/web/.prettierignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+playwright-report
+test-results

--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -5,7 +5,17 @@ test.beforeEach(async ({ page }) => {
     const path = new URL(route.request().url()).pathname;
     let body: unknown;
     if (path === "/api/runtime") body = { demoMode: true };
-    else if (path === "/api/summary") body = { totalAssetsTwd: 0, totalLiabilitiesTwd: 0, netWorthTwd: 0, monthlyIncomeTwd: 0, monthlyExpenseTwd: 0, accounts: 0, investments: 0, transactions: 0 };
+    else if (path === "/api/summary")
+      body = {
+        totalAssetsTwd: 0,
+        totalLiabilitiesTwd: 0,
+        netWorthTwd: 0,
+        monthlyIncomeTwd: 0,
+        monthlyExpenseTwd: 0,
+        accounts: 0,
+        investments: 0,
+        transactions: 0,
+      };
     else if (path === "/api/bank") body = { accounts: [], transactions: [] };
     else if (path === "/api/investments") body = [];
     else if (path === "/api/investment-transactions") body = [];
@@ -15,34 +25,53 @@ test.beforeEach(async ({ page }) => {
     else if (path === "/api/history/net-worth") body = [];
     else if (path === "/api/sync-jobs") body = [];
     else if (path === "/api/classification/rules") body = [];
-    else if (path.includes("/connectors/") && path.endsWith("/settings")) body = { configured: false, publicConfig: {} };
+    else if (path.includes("/connectors/") && path.endsWith("/settings"))
+      body = { configured: false, publicConfig: {} };
     else throw new Error(`Unexpected API request in E2E mock: ${path}`);
-    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
   });
 });
 
-test("loads the responsive shell and changes primary views", async ({ page }) => {
+test("loads the responsive shell and changes primary views", async ({
+  page,
+}) => {
   await page.goto("/");
   await expect(page.getByText("Taiwan Fin Hub").first()).toBeVisible();
-  await expect(page.getByRole("heading", { name: "總覽", exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "總覽", exact: true }),
+  ).toBeVisible();
 
   await page.getByRole("button", { name: "資產" }).first().click();
-  await expect(page.getByRole("heading", { name: "資產", exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "資產", exact: true }),
+  ).toBeVisible();
   await expect(page).toHaveURL(/#\/assets$/);
 
   await page.goBack();
-  await expect(page.getByRole("heading", { name: "總覽", exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "總覽", exact: true }),
+  ).toBeVisible();
 });
 
 test("renders the mobile bottom navigation", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");
-  await expect(page.getByRole("navigation", { name: "主要導覽" })).toBeVisible();
+  await expect(
+    page.getByRole("navigation", { name: "主要導覽" }),
+  ).toBeVisible();
   await page.getByRole("button", { name: "更多" }).click();
-  await expect(page.getByRole("heading", { name: "更多", exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "更多", exact: true }),
+  ).toBeVisible();
 });
 
-test("uses app-like scrolling and history only in standalone display mode", async ({ page }) => {
+test("uses app-like scrolling and history only in standalone display mode", async ({
+  page,
+}) => {
   await page.goto("/");
   await expect(page.locator("html")).not.toHaveClass(/is-standalone/);
   await expect(page.locator("html")).toHaveCSS("touch-action", "auto");
@@ -50,7 +79,8 @@ test("uses app-like scrolling and history only in standalone display mode", asyn
   await page.addInitScript(() => {
     const nativeMatchMedia = window.matchMedia.bind(window);
     window.matchMedia = (query: string) => {
-      if (query !== "(display-mode: standalone)") return nativeMatchMedia(query);
+      if (query !== "(display-mode: standalone)")
+        return nativeMatchMedia(query);
       return {
         matches: true,
         media: query,
@@ -76,11 +106,15 @@ test("uses app-like scrolling and history only in standalone display mode", asyn
   const historyLength = await page.evaluate(() => window.history.length);
   await page.getByRole("button", { name: "資產", exact: true }).last().click();
   await expect(page).toHaveURL(/#\/assets$/);
-  await expect(page.getByRole("heading", { name: "資產", exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "資產", exact: true }),
+  ).toBeVisible();
   expect(await page.evaluate(() => window.history.length)).toBe(historyLength);
 });
 
 test("opens a primary view from its hash route", async ({ page }) => {
   await page.goto("/#/invoices");
-  await expect(page.getByRole("heading", { name: "發票", exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "發票", exact: true }),
+  ).toBeVisible();
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "svelte-check --tsconfig ./tsconfig.json && vite build",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "typecheck": "svelte-check --tsconfig ./tsconfig.json",
     "dev": "vite",
     "test:unit": "vitest run",
@@ -28,6 +30,8 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.4.2",
     "jsdom": "^29.1.1",
+    "prettier": "^3.9.5",
+    "prettier-plugin-svelte": "^4.1.1",
     "svelte-check": "^4.7.2",
     "tailwindcss": "^4.3.2",
     "vite": "^8.1.4",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -7,12 +7,12 @@ export default defineConfig({
   use: {
     baseURL: "http://127.0.0.1:4173",
     trace: "on-first-retry",
-    ...devices["Desktop Chrome"]
+    ...devices["Desktop Chrome"],
   },
   webServer: {
     command: "npm run dev -- --host 127.0.0.1 --port 4173",
     url: "http://127.0.0.1:4173",
     reuseExistingServer: true,
-    timeout: 120_000
-  }
+    timeout: 120_000,
+  },
 });

--- a/apps/web/prettier.config.js
+++ b/apps/web/prettier.config.js
@@ -1,0 +1,4 @@
+/** @type {import("prettier").Config} */
+export default {
+  plugins: ["prettier-plugin-svelte"],
+};

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -1,6 +1,16 @@
 <script lang="ts">
   import { onMount, type Component } from "svelte";
-  import { BarChart3, Wallet, History, FileText, Settings, Ellipsis, Eye, EyeOff, RefreshCw } from "@lucide/svelte";
+  import {
+    BarChart3,
+    Wallet,
+    History,
+    FileText,
+    Settings,
+    Ellipsis,
+    Eye,
+    EyeOff,
+    RefreshCw,
+  } from "@lucide/svelte";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
   import { parseViewHash, viewHash } from "./app/navigation";
   import Button from "./components/ui/Button.svelte";
@@ -16,41 +26,115 @@
   import SettingsView from "./features/settings/Settings.svelte";
   import { createApiClient } from "./lib/api";
   import { moneyState } from "./lib/format.svelte";
-  import type { DetailView, MobileSettingsView, PrimaryView, RuntimeInfo, View } from "./lib/types";
+  import type {
+    DetailView,
+    MobileSettingsView,
+    PrimaryView,
+    RuntimeInfo,
+    View,
+  } from "./lib/types";
   import "./styles.css";
 
   const api = createApiClient();
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: 30_000 } } });
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 30_000 } },
+  });
   let view = $state<View>("overview");
   let runtime = $state<RuntimeInfo>({ demoMode: false });
 
-  const navItems: { view: PrimaryView; label: string; shortLabel: string; description: string; icon: Component }[] = [
-    { view: "overview", label: "總覽", shortLabel: "總覽", description: "淨資產、同步健康度與近期財務活動。", icon: BarChart3 },
-    { view: "assets", label: "資產", shortLabel: "資產", description: "銀行、信用卡、投資與其他資產集中管理。", icon: Wallet },
-    { view: "activity", label: "活動", shortLabel: "活動", description: "銀行、刷卡、投資與發票的統一時間軸。", icon: History },
-    { view: "invoices", label: "發票", shortLabel: "發票", description: "搜尋電子發票、商家與品項明細。", icon: FileText },
-    { view: "settings", label: "設定", shortLabel: "設定", description: "設定連接器、同步資料與匯率。", icon: Settings }
+  const navItems: {
+    view: PrimaryView;
+    label: string;
+    shortLabel: string;
+    description: string;
+    icon: Component;
+  }[] = [
+    {
+      view: "overview",
+      label: "總覽",
+      shortLabel: "總覽",
+      description: "淨資產、同步健康度與近期財務活動。",
+      icon: BarChart3,
+    },
+    {
+      view: "assets",
+      label: "資產",
+      shortLabel: "資產",
+      description: "銀行、信用卡、投資與其他資產集中管理。",
+      icon: Wallet,
+    },
+    {
+      view: "activity",
+      label: "活動",
+      shortLabel: "活動",
+      description: "銀行、刷卡、投資與發票的統一時間軸。",
+      icon: History,
+    },
+    {
+      view: "invoices",
+      label: "發票",
+      shortLabel: "發票",
+      description: "搜尋電子發票、商家與品項明細。",
+      icon: FileText,
+    },
+    {
+      view: "settings",
+      label: "設定",
+      shortLabel: "設定",
+      description: "設定連接器、同步資料與匯率。",
+      icon: Settings,
+    },
   ];
   const mobilePrimaryViews: PrimaryView[] = ["overview", "assets", "activity"];
-  const detailLabels: Record<DetailView, { label: string; description: string }> = {
+  const detailLabels: Record<
+    DetailView,
+    { label: string; description: string }
+  > = {
     bank: { label: "銀行帳戶", description: "帳戶餘額、現金流與交易分類。" },
     cards: { label: "信用卡", description: "信用卡帳戶、帳單與刷卡紀錄。" },
     investments: { label: "投資", description: "投資持倉與交易紀錄。" },
-    "manual-assets": { label: "其他資產", description: "保險、不動產、交通工具與估值紀錄。" }
+    "manual-assets": {
+      label: "其他資產",
+      description: "保險、不動產、交通工具與估值紀錄。",
+    },
   };
-  const mobileSettingsLabels: Record<MobileSettingsView, { label: string; description: string }> = {
-    "data-sources": { label: "資料來源與連接器", description: "管理來源狀態、憑證、自動同步與重新驗證。" },
-    "exchange-rates": { label: "匯率", description: "管理資產換算使用的參考匯率。" },
-    "classification-rules": { label: "分類規則", description: "讓銀行交易依條件自動分類。" }
+  const mobileSettingsLabels: Record<
+    MobileSettingsView,
+    { label: string; description: string }
+  > = {
+    "data-sources": {
+      label: "資料來源與連接器",
+      description: "管理來源狀態、憑證、自動同步與重新驗證。",
+    },
+    "exchange-rates": {
+      label: "匯率",
+      description: "管理資產換算使用的參考匯率。",
+    },
+    "classification-rules": {
+      label: "分類規則",
+      description: "讓銀行交易依條件自動分類。",
+    },
   };
   const isDetail = (v: View): v is DetailView => Object.hasOwn(detailLabels, v);
-  const isMobileSetting = (v: View): v is MobileSettingsView => Object.hasOwn(mobileSettingsLabels, v);
-  const primaryView = $derived(view === "more" || isMobileSetting(view) ? "settings" : isDetail(view) ? "assets" : view as PrimaryView);
-  const currentView = $derived(navItems.find((item) => item.view === primaryView) ?? navItems[0]!);
+  const isMobileSetting = (v: View): v is MobileSettingsView =>
+    Object.hasOwn(mobileSettingsLabels, v);
+  const primaryView = $derived(
+    view === "more" || isMobileSetting(view)
+      ? "settings"
+      : isDetail(view)
+        ? "assets"
+        : (view as PrimaryView),
+  );
+  const currentView = $derived(
+    navItems.find((item) => item.view === primaryView) ?? navItems[0]!,
+  );
   const detail = $derived(isDetail(view) ? detailLabels[view] : undefined);
-  const mobileSetting = $derived(isMobileSetting(view) ? mobileSettingsLabels[view] : undefined);
+  const mobileSetting = $derived(
+    isMobileSetting(view) ? mobileSettingsLabels[view] : undefined,
+  );
 
-  const isStandalone = () => document.documentElement.classList.contains("is-standalone");
+  const isStandalone = () =>
+    document.documentElement.classList.contains("is-standalone");
   function scrollToTop() {
     const options: ScrollToOptions = { top: 0, behavior: "smooth" };
     if (isStandalone()) document.getElementById("root")?.scrollTo(options);
@@ -60,7 +144,12 @@
   onMount(() => {
     const routeView = parseViewHash(window.location.hash);
     if (routeView) view = routeView;
-    else window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}${viewHash(view)}`);
+    else
+      window.history.replaceState(
+        null,
+        "",
+        `${window.location.pathname}${window.location.search}${viewHash(view)}`,
+      );
 
     const handleHashChange = () => {
       const next = parseViewHash(window.location.hash);
@@ -71,10 +160,12 @@
     };
     window.addEventListener("hashchange", handleHashChange);
 
-    void api.get<RuntimeInfo>("/api/runtime")
-      .then((info) => runtime = info)
-      .catch(() => runtime = { demoMode: false });
-    moneyState.hidden = localStorage.getItem("taiwan-fin-hub-money-hidden") === "true";
+    void api
+      .get<RuntimeInfo>("/api/runtime")
+      .then((info) => (runtime = info))
+      .catch(() => (runtime = { demoMode: false }));
+    moneyState.hidden =
+      localStorage.getItem("taiwan-fin-hub-money-hidden") === "true";
     return () => window.removeEventListener("hashchange", handleHashChange);
   });
   function navigate(next: View) {
@@ -82,58 +173,146 @@
     const nextHash = viewHash(next);
     if (window.location.hash !== nextHash) {
       if (isStandalone()) {
-        window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}${nextHash}`);
+        window.history.replaceState(
+          null,
+          "",
+          `${window.location.pathname}${window.location.search}${nextHash}`,
+        );
       } else {
         window.location.hash = nextHash;
       }
     }
     scrollToTop();
   }
-  function toggleMoneyVisibility() { moneyState.hidden = !moneyState.hidden; localStorage.setItem("taiwan-fin-hub-money-hidden", String(moneyState.hidden)); }
+  function toggleMoneyVisibility() {
+    moneyState.hidden = !moneyState.hidden;
+    localStorage.setItem(
+      "taiwan-fin-hub-money-hidden",
+      String(moneyState.hidden),
+    );
+  }
 </script>
 
 <QueryClientProvider client={queryClient}>
-  <div class="min-h-screen bg-paper text-ink xl:grid xl:grid-cols-[240px_minmax(0,1fr)]">
-    <aside class="hidden border-r border-white/10 bg-ink px-6 py-7 text-white xl:sticky xl:top-0 xl:flex xl:h-screen xl:flex-col">
-      <div class="px-2"><h1 class="text-xl font-semibold tracking-normal">Taiwan Fin Hub</h1><p class="mt-2 text-xs font-semibold uppercase tracking-[0.16em] text-steel/90">Wealth OS</p></div>
+  <div
+    class="min-h-screen bg-paper text-ink xl:grid xl:grid-cols-[240px_minmax(0,1fr)]"
+  >
+    <aside
+      class="hidden border-r border-white/10 bg-ink px-6 py-7 text-white xl:sticky xl:top-0 xl:flex xl:h-screen xl:flex-col"
+    >
+      <div class="px-2">
+        <h1 class="text-xl font-semibold tracking-normal">Taiwan Fin Hub</h1>
+        <p
+          class="mt-2 text-xs font-semibold uppercase tracking-[0.16em] text-steel/90"
+        >
+          Wealth OS
+        </p>
+      </div>
       <nav class="mt-6 grid gap-1">
         {#each navItems as item (item.view)}
           {@const NavIcon = item.icon}
-          <button class={`flex min-h-11 items-center gap-3 rounded-lg px-3 text-left text-sm font-medium transition ${primaryView === item.view ? "bg-white/10 text-white" : "text-white/65 hover:bg-white/5 hover:text-white"}`} aria-current={primaryView === item.view ? "page" : undefined} onclick={() => navigate(item.view)}>
+          <button
+            class={`flex min-h-11 items-center gap-3 rounded-lg px-3 text-left text-sm font-medium transition ${primaryView === item.view ? "bg-white/10 text-white" : "text-white/65 hover:bg-white/5 hover:text-white"}`}
+            aria-current={primaryView === item.view ? "page" : undefined}
+            onclick={() => navigate(item.view)}
+          >
             <NavIcon class="size-[22px] shrink-0 stroke-[1.8]" />{item.label}
           </button>
         {/each}
       </nav>
     </aside>
 
-    <div class:min-w-0={true} class:pb-20={!mobileSetting} class:pb-5={!!mobileSetting}>
-      <div class="no-scrollbar hidden border-b border-ink/10 bg-white px-4 py-2 md:flex md:gap-1 md:overflow-x-auto xl:hidden">
+    <div
+      class:min-w-0={true}
+      class:pb-20={!mobileSetting}
+      class:pb-5={!!mobileSetting}
+    >
+      <div
+        class="no-scrollbar hidden border-b border-ink/10 bg-white px-4 py-2 md:flex md:gap-1 md:overflow-x-auto xl:hidden"
+      >
         {#each navItems as item (item.view)}
           {@const NavIcon = item.icon}
-          <button class={`flex min-h-10 items-center gap-2 rounded-lg px-3 text-sm font-medium ${primaryView === item.view ? "bg-ink text-white" : "text-ink/60 hover:bg-ink/5"}`} onclick={() => navigate(item.view)}><NavIcon class="size-4" />{item.label}</button>
+          <button
+            class={`flex min-h-10 items-center gap-2 rounded-lg px-3 text-sm font-medium ${primaryView === item.view ? "bg-ink text-white" : "text-ink/60 hover:bg-ink/5"}`}
+            onclick={() => navigate(item.view)}
+            ><NavIcon class="size-4" />{item.label}</button
+          >
         {/each}
       </div>
-      <header class="sticky top-0 z-20 border-b border-ink/10 bg-white/95 backdrop-blur-sm xl:static xl:bg-transparent xl:backdrop-blur-0">
-        <div class="mx-auto flex max-w-[1440px] flex-col gap-3 px-4 py-4 sm:px-6 xl:px-8 xl:py-6">
+      <header
+        class="sticky top-0 z-20 border-b border-ink/10 bg-white/95 backdrop-blur-sm xl:static xl:bg-transparent xl:backdrop-blur-0"
+      >
+        <div
+          class="mx-auto flex max-w-[1440px] flex-col gap-3 px-4 py-4 sm:px-6 xl:px-8 xl:py-6"
+        >
           <div class="flex items-center justify-between gap-3">
             <div class="min-w-0">
               {#if mobileSetting}
-                <div class="flex items-center gap-2 md:block"><button aria-label="返回更多" class="flex size-10 shrink-0 items-center justify-center rounded-full text-xl text-ink hover:bg-ink/5 md:hidden" onclick={() => navigate("more")}>←</button><h1 class="truncate text-2xl font-semibold tracking-tight xl:text-3xl">{mobileSetting.label}</h1></div>
+                <div class="flex items-center gap-2 md:block">
+                  <button
+                    aria-label="返回更多"
+                    class="flex size-10 shrink-0 items-center justify-center rounded-full text-xl text-ink hover:bg-ink/5 md:hidden"
+                    onclick={() => navigate("more")}>←</button
+                  >
+                  <h1
+                    class="truncate text-2xl font-semibold tracking-tight xl:text-3xl"
+                  >
+                    {mobileSetting.label}
+                  </h1>
+                </div>
               {:else}
-                {#if detail}<button class="mb-1 inline-flex items-center gap-1 text-xs font-medium text-steel" onclick={() => navigate("assets")}>← 返回資產</button>{/if}
-                <h1 class="truncate text-2xl font-semibold tracking-tight xl:text-3xl"><span class="md:hidden">{view === "more" ? "更多" : primaryView === "overview" ? "資產總覽" : primaryView === "activity" ? "所有活動" : currentView.label}</span><span class="hidden md:inline">{detail?.label ?? currentView.label}</span></h1>
+                {#if detail}<button
+                    class="mb-1 inline-flex items-center gap-1 text-xs font-medium text-steel"
+                    onclick={() => navigate("assets")}>← 返回資產</button
+                  >{/if}
+                <h1
+                  class="truncate text-2xl font-semibold tracking-tight xl:text-3xl"
+                >
+                  <span class="md:hidden"
+                    >{view === "more"
+                      ? "更多"
+                      : primaryView === "overview"
+                        ? "資產總覽"
+                        : primaryView === "activity"
+                          ? "所有活動"
+                          : currentView.label}</span
+                  ><span class="hidden md:inline"
+                    >{detail?.label ?? currentView.label}</span
+                  >
+                </h1>
               {/if}
-              <p class="mt-1 hidden text-sm text-ink/55 md:block">{detail?.description ?? mobileSetting?.description ?? currentView.description}</p>
+              <p class="mt-1 hidden text-sm text-ink/55 md:block">
+                {detail?.description ??
+                  mobileSetting?.description ??
+                  currentView.description}
+              </p>
             </div>
             <div class="flex shrink-0 items-center gap-2">
-              <Button class={mobileSetting ? "hidden" : "rounded-full"} aria-label={moneyState.hidden ? "顯示金額" : "隱藏金額"} onclick={toggleMoneyVisibility} size="icon" variant="secondary"><Icon icon={moneyState.hidden ? Eye : EyeOff} size="lg" /></Button>
-              {#if primaryView === "settings"}<Button class="hidden md:inline-flex" onclick={() => queryClient.invalidateQueries()} variant="primary"><Icon icon={RefreshCw} size="sm" />同步資料</Button>{/if}
+              <Button
+                class={mobileSetting ? "hidden" : "rounded-full"}
+                aria-label={moneyState.hidden ? "顯示金額" : "隱藏金額"}
+                onclick={toggleMoneyVisibility}
+                size="icon"
+                variant="secondary"
+                ><Icon
+                  icon={moneyState.hidden ? Eye : EyeOff}
+                  size="lg"
+                /></Button
+              >
+              {#if primaryView === "settings"}<Button
+                  class="hidden md:inline-flex"
+                  onclick={() => queryClient.invalidateQueries()}
+                  variant="primary"
+                  ><Icon icon={RefreshCw} size="sm" />同步資料</Button
+                >{/if}
             </div>
           </div>
         </div>
       </header>
 
-      <main class="mx-auto max-w-[1440px] px-4 pb-5 pt-0 sm:px-6 md:py-5 xl:px-8 xl:py-6">
+      <main
+        class="mx-auto max-w-[1440px] px-4 pb-5 pt-0 sm:px-6 md:py-5 xl:px-8 xl:py-6"
+      >
         {#if view === "overview"}<Overview {api} {navigate} />
         {:else if view === "assets"}<Assets {api} {navigate} />
         {:else if view === "activity"}<Activity {api} {navigate} />
@@ -142,18 +321,47 @@
         {:else if view === "cards"}<Cards {api} />
         {:else if view === "bank"}<Bank {api} {navigate} />
         {:else if view === "manual-assets"}<ManualAssets {api} />
-        {:else}<SettingsView {api} demoMode={runtime.demoMode} mobileView={view === "more" ? "more" : isMobileSetting(view) ? view : undefined} {navigate} />{/if}
+        {:else}<SettingsView
+            {api}
+            demoMode={runtime.demoMode}
+            mobileView={view === "more"
+              ? "more"
+              : isMobileSetting(view)
+                ? view
+                : undefined}
+            {navigate}
+          />{/if}
       </main>
-      <footer class="mx-auto hidden max-w-[1440px] border-t border-ink/8 px-4 py-6 sm:px-6 md:block xl:px-8"><p class="text-xs leading-relaxed text-ink/35"><strong class="font-medium text-ink/50">免責聲明：</strong>本程式僅供個人研究與自用，未與臺灣集中保管結算所、財政部、金融監督管理委員會、各銀行或任何金融機構合作，亦未獲前述機構授權或背書。本程式所呈現的資料以您自行提供之憑證取得，作者不保證資料的即時性、正確性與完整性，亦不對因使用本程式所產生的任何直接或間接損失負責。請勿將本程式用於任何商業用途。</p></footer>
+      <footer
+        class="mx-auto hidden max-w-[1440px] border-t border-ink/8 px-4 py-6 sm:px-6 md:block xl:px-8"
+      >
+        <p class="text-xs leading-relaxed text-ink/35">
+          <strong class="font-medium text-ink/50">免責聲明：</strong
+          >本程式僅供個人研究與自用，未與臺灣集中保管結算所、財政部、金融監督管理委員會、各銀行或任何金融機構合作，亦未獲前述機構授權或背書。本程式所呈現的資料以您自行提供之憑證取得，作者不保證資料的即時性、正確性與完整性，亦不對因使用本程式所產生的任何直接或間接損失負責。請勿將本程式用於任何商業用途。
+        </p>
+      </footer>
     </div>
 
     {#if !mobileSetting}
-      <nav aria-label="主要導覽" class="fixed inset-x-0 bottom-0 z-50 grid grid-cols-4 gap-1 border-t border-ink/10 bg-ink px-2 pb-[max(env(safe-area-inset-bottom),0.5rem)] pt-2 text-white shadow-[0_-8px_28px_rgba(31,41,51,0.12)] md:hidden">
+      <nav
+        aria-label="主要導覽"
+        class="fixed inset-x-0 bottom-0 z-50 grid grid-cols-4 gap-1 border-t border-ink/10 bg-ink px-2 pb-[max(env(safe-area-inset-bottom),0.5rem)] pt-2 text-white shadow-[0_-8px_28px_rgba(31,41,51,0.12)] md:hidden"
+      >
         {#each mobilePrimaryViews as mobileView (mobileView)}
-          {@const item = navItems.find((candidate) => candidate.view === mobileView)!}{@const NavIcon = item.icon}
-          <button class={`flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-xl px-1 text-[11px] font-medium transition ${primaryView === item.view ? "bg-white/10 text-white" : "text-white/65"}`} onclick={() => navigate(item.view)}><NavIcon class="size-5" />{item.shortLabel}</button>
+          {@const item = navItems.find(
+            (candidate) => candidate.view === mobileView,
+          )!}{@const NavIcon = item.icon}
+          <button
+            class={`flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-xl px-1 text-[11px] font-medium transition ${primaryView === item.view ? "bg-white/10 text-white" : "text-white/65"}`}
+            onclick={() => navigate(item.view)}
+            ><NavIcon class="size-5" />{item.shortLabel}</button
+          >
         {/each}
-        <button class={`flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-xl px-1 text-[11px] font-medium transition ${view === "more" || !mobilePrimaryViews.includes(primaryView) ? "bg-white/10 text-white" : "text-white/65"}`} onclick={() => navigate("more")}><Ellipsis class="size-5" />更多</button>
+        <button
+          class={`flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-xl px-1 text-[11px] font-medium transition ${view === "more" || !mobilePrimaryViews.includes(primaryView) ? "bg-white/10 text-white" : "text-white/65"}`}
+          onclick={() => navigate("more")}
+          ><Ellipsis class="size-5" />更多</button
+        >
       </nav>
     {/if}
   </div>

--- a/apps/web/src/app/navigation.ts
+++ b/apps/web/src/app/navigation.ts
@@ -13,12 +13,12 @@ const views = new Set<View>([
   "data-sources",
   "exchange-rates",
   "classification-rules",
-  "more"
+  "more",
 ]);
 
 export function parseViewHash(hash: string): View | null {
   const candidate = hash.replace(/^#\/?/, "");
-  return views.has(candidate as View) ? candidate as View : null;
+  return views.has(candidate as View) ? (candidate as View) : null;
 }
 
 export function viewHash(view: View) {

--- a/apps/web/src/components/ui/Badge.svelte
+++ b/apps/web/src/components/ui/Badge.svelte
@@ -1,13 +1,28 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { cn } from "../../lib/utils";
-  let { children, class: className = "", variant = "default" }: { children?: Snippet; class?: string; variant?: "default" | "secondary" | "outline" | "destructive" | "success" } = $props();
+  let {
+    children,
+    class: className = "",
+    variant = "default",
+  }: {
+    children?: Snippet;
+    class?: string;
+    variant?: "default" | "secondary" | "outline" | "destructive" | "success";
+  } = $props();
   const variants = {
     default: "border-transparent bg-primary text-primary-foreground",
     secondary: "border-transparent bg-secondary text-secondary-foreground",
     outline: "border-border text-foreground",
     destructive: "border-transparent bg-destructive/10 text-destructive",
-    success: "border-transparent bg-moss/10 text-moss"
+    success: "border-transparent bg-moss/10 text-moss",
   };
 </script>
-<span class={cn("inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2", variants[variant], className)}>{@render children?.()}</span>
+
+<span
+  class={cn(
+    "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+    variants[variant],
+    className,
+  )}>{@render children?.()}</span
+>

--- a/apps/web/src/components/ui/Button.svelte
+++ b/apps/web/src/components/ui/Button.svelte
@@ -1,23 +1,61 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { cn } from "../../lib/utils";
-  let { children, class: className = "", variant = "default", size = "default", disabled = false, type = "button", ...rest }: {
-    children?: Snippet; class?: string; variant?: "default" | "primary" | "secondary" | "outline" | "ghost" | "link" | "destructive";
-    size?: "sm" | "default" | "lg" | "touch" | "icon"; disabled?: boolean; type?: "button" | "submit" | "reset";
+  let {
+    children,
+    class: className = "",
+    variant = "default",
+    size = "default",
+    disabled = false,
+    type = "button",
+    ...rest
+  }: {
+    children?: Snippet;
+    class?: string;
+    variant?:
+      | "default"
+      | "primary"
+      | "secondary"
+      | "outline"
+      | "ghost"
+      | "link"
+      | "destructive";
+    size?: "sm" | "default" | "lg" | "touch" | "icon";
+    disabled?: boolean;
+    type?: "button" | "submit" | "reset";
     [key: string]: unknown;
   } = $props();
   const variants = {
     default: "bg-ink text-white shadow-xs hover:bg-ink/90",
     primary: "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
-    secondary: "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-    outline: "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
+    secondary:
+      "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+    outline:
+      "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
     ghost: "text-foreground/70 hover:bg-accent hover:text-accent-foreground",
     link: "text-primary underline-offset-4 hover:underline",
-    destructive: "bg-destructive text-destructive-foreground shadow-xs hover:bg-destructive/90"
+    destructive:
+      "bg-destructive text-destructive-foreground shadow-xs hover:bg-destructive/90",
   };
-  const sizes = { sm: "h-9 rounded-md px-3 [&_svg]:size-4", default: "h-10 px-4 py-2 [&_svg]:size-4", lg: "h-11 rounded-md px-8 [&_svg]:size-5", touch: "min-h-11 px-4 [&_svg]:size-5", icon: "size-10 p-0 [&_svg]:size-4" };
+  const sizes = {
+    sm: "h-9 rounded-md px-3 [&_svg]:size-4",
+    default: "h-10 px-4 py-2 [&_svg]:size-4",
+    lg: "h-11 rounded-md px-8 [&_svg]:size-5",
+    touch: "min-h-11 px-4 [&_svg]:size-5",
+    icon: "size-10 p-0 [&_svg]:size-4",
+  };
 </script>
 
-<button {...rest} {disabled} {type} class={cn("inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0", variants[variant], sizes[size], className)}>
+<button
+  {...rest}
+  {disabled}
+  {type}
+  class={cn(
+    "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+    variants[variant],
+    sizes[size],
+    className,
+  )}
+>
   {@render children?.()}
 </button>

--- a/apps/web/src/components/ui/Button.test.ts
+++ b/apps/web/src/components/ui/Button.test.ts
@@ -5,7 +5,9 @@ import Button from "./Button.svelte";
 describe("Button", () => {
   it("renders the primary variant and forwards clicks", async () => {
     const onclick = vi.fn();
-    const { getByRole } = render(Button, { props: { variant: "primary", onclick } });
+    const { getByRole } = render(Button, {
+      props: { variant: "primary", onclick },
+    });
     const button = getByRole("button");
 
     expect(button).toHaveClass("bg-primary");
@@ -15,7 +17,9 @@ describe("Button", () => {
 
   it("prevents interaction when disabled", () => {
     const onclick = vi.fn();
-    const { getByRole } = render(Button, { props: { disabled: true, onclick } });
+    const { getByRole } = render(Button, {
+      props: { disabled: true, onclick },
+    });
     expect(getByRole("button")).toBeDisabled();
   });
 });

--- a/apps/web/src/components/ui/Card.svelte
+++ b/apps/web/src/components/ui/Card.svelte
@@ -1,8 +1,21 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { cn } from "../../lib/utils";
-  let { children, class: className = "", as = "div" }: { children?: Snippet; class?: string; as?: "div" | "section" | "article" } = $props();
-  const classes = $derived(cn("rounded-xl border border-border bg-card text-card-foreground shadow-xs", className));
+  let {
+    children,
+    class: className = "",
+    as = "div",
+  }: {
+    children?: Snippet;
+    class?: string;
+    as?: "div" | "section" | "article";
+  } = $props();
+  const classes = $derived(
+    cn(
+      "rounded-xl border border-border bg-card text-card-foreground shadow-xs",
+      className,
+    ),
+  );
 </script>
 
 {#if as === "section"}

--- a/apps/web/src/components/ui/CardContent.svelte
+++ b/apps/web/src/components/ui/CardContent.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { cn } from "../../lib/utils";
-  let { children, class: className = "" }: { children?: Snippet; class?: string } = $props();
+  let {
+    children,
+    class: className = "",
+  }: { children?: Snippet; class?: string } = $props();
 </script>
+
 <div class={cn("p-5 pt-0", className)}>{@render children?.()}</div>

--- a/apps/web/src/components/ui/CardDescription.svelte
+++ b/apps/web/src/components/ui/CardDescription.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { cn } from "../../lib/utils";
-  let { children, class: className = "" }: { children?: Snippet; class?: string } = $props();
+  let {
+    children,
+    class: className = "",
+  }: { children?: Snippet; class?: string } = $props();
 </script>
-<p class={cn("text-sm text-muted-foreground", className)}>{@render children?.()}</p>
+
+<p class={cn("text-sm text-muted-foreground", className)}>
+  {@render children?.()}
+</p>

--- a/apps/web/src/components/ui/CardHeader.svelte
+++ b/apps/web/src/components/ui/CardHeader.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { cn } from "../../lib/utils";
-  let { children, class: className = "" }: { children?: Snippet; class?: string } = $props();
+  let {
+    children,
+    class: className = "",
+  }: { children?: Snippet; class?: string } = $props();
 </script>
-<div class={cn("flex flex-col space-y-1.5 p-5", className)}>{@render children?.()}</div>
+
+<div class={cn("flex flex-col space-y-1.5 p-5", className)}>
+  {@render children?.()}
+</div>

--- a/apps/web/src/components/ui/CardTitle.svelte
+++ b/apps/web/src/components/ui/CardTitle.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { cn } from "../../lib/utils";
-  let { children, class: className = "" }: { children?: Snippet; class?: string } = $props();
+  let {
+    children,
+    class: className = "",
+  }: { children?: Snippet; class?: string } = $props();
 </script>
-<h3 class={cn("font-semibold leading-none tracking-tight", className)}>{@render children?.()}</h3>
+
+<h3 class={cn("font-semibold leading-none tracking-tight", className)}>
+  {@render children?.()}
+</h3>

--- a/apps/web/src/components/ui/Checkbox.svelte
+++ b/apps/web/src/components/ui/Checkbox.svelte
@@ -1,5 +1,18 @@
 <script lang="ts">
   import { cn } from "../../lib/utils";
-  let { class: className = "", checked = false, ...rest }: { class?: string; checked?: boolean; [key: string]: unknown } = $props();
+  let {
+    class: className = "",
+    checked = false,
+    ...rest
+  }: { class?: string; checked?: boolean; [key: string]: unknown } = $props();
 </script>
-<input {...rest} type="checkbox" {checked} class={cn("size-4 shrink-0 rounded border border-primary accent-primary shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50", className)} />
+
+<input
+  {...rest}
+  type="checkbox"
+  {checked}
+  class={cn(
+    "size-4 shrink-0 rounded border border-primary accent-primary shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+    className,
+  )}
+/>

--- a/apps/web/src/components/ui/EmptyState.svelte
+++ b/apps/web/src/components/ui/EmptyState.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   let { title, body }: { title: string; body: string } = $props();
 </script>
-<section class="rounded-xl border border-dashed border-ink/20 bg-white p-8 text-center shadow-xs">
+
+<section
+  class="rounded-xl border border-dashed border-ink/20 bg-white p-8 text-center shadow-xs"
+>
   <h2 class="text-lg font-semibold">{title}</h2>
   <p class="mt-2 text-sm text-ink/65">{body}</p>
 </section>

--- a/apps/web/src/components/ui/Icon.svelte
+++ b/apps/web/src/components/ui/Icon.svelte
@@ -1,7 +1,27 @@
 <script lang="ts">
   import type { Component } from "svelte";
-  let { icon: Icon, size = "md", class: className = "", label }: { icon: Component; size?: "sm" | "md" | "lg" | "nav" | "empty"; class?: string; label?: string } = $props();
-  const sizes = { sm: "size-4", md: "size-[18px]", lg: "size-5", nav: "size-[22px]", empty: "size-9" };
+  let {
+    icon: Icon,
+    size = "md",
+    class: className = "",
+    label,
+  }: {
+    icon: Component;
+    size?: "sm" | "md" | "lg" | "nav" | "empty";
+    class?: string;
+    label?: string;
+  } = $props();
+  const sizes = {
+    sm: "size-4",
+    md: "size-[18px]",
+    lg: "size-5",
+    nav: "size-[22px]",
+    empty: "size-9",
+  };
 </script>
 
-<Icon aria-hidden={label ? undefined : "true"} aria-label={label} class={`shrink-0 stroke-[1.8] ${sizes[size]} ${className}`} />
+<Icon
+  aria-hidden={label ? undefined : "true"}
+  aria-label={label}
+  class={`shrink-0 stroke-[1.8] ${sizes[size]} ${className}`}
+/>

--- a/apps/web/src/components/ui/Input.svelte
+++ b/apps/web/src/components/ui/Input.svelte
@@ -1,5 +1,24 @@
 <script lang="ts">
   import { cn } from "../../lib/utils";
-  let { class: className = "", value = $bindable(), type = "text", ...rest }: { class?: string; value?: string | number; type?: string; [key: string]: unknown } = $props();
+  let {
+    class: className = "",
+    value = $bindable(),
+    type = "text",
+    ...rest
+  }: {
+    class?: string;
+    value?: string | number;
+    type?: string;
+    [key: string]: unknown;
+  } = $props();
 </script>
-<input {...rest} {type} bind:value class={cn("flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50", className)} />
+
+<input
+  {...rest}
+  {type}
+  bind:value
+  class={cn(
+    "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+    className,
+  )}
+/>

--- a/apps/web/src/components/ui/Select.svelte
+++ b/apps/web/src/components/ui/Select.svelte
@@ -1,6 +1,24 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { cn } from "../../lib/utils";
-  let { children, class: className = "", value = $bindable(), ...rest }: { children?: Snippet; class?: string; value?: string | number; [key: string]: unknown } = $props();
+  let {
+    children,
+    class: className = "",
+    value = $bindable(),
+    ...rest
+  }: {
+    children?: Snippet;
+    class?: string;
+    value?: string | number;
+    [key: string]: unknown;
+  } = $props();
 </script>
-<select {...rest} bind:value class={cn("flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50", className)}>{@render children?.()}</select>
+
+<select
+  {...rest}
+  bind:value
+  class={cn(
+    "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+    className,
+  )}>{@render children?.()}</select
+>

--- a/apps/web/src/components/ui/TabsList.svelte
+++ b/apps/web/src/components/ui/TabsList.svelte
@@ -1,6 +1,18 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { cn } from "../../lib/utils";
-  let { children, class: className = "" }: { children?: Snippet; class?: string } = $props();
+  let {
+    children,
+    class: className = "",
+  }: { children?: Snippet; class?: string } = $props();
 </script>
-<div role="tablist" class={cn("inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground", className)}>{@render children?.()}</div>
+
+<div
+  role="tablist"
+  class={cn(
+    "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+    className,
+  )}
+>
+  {@render children?.()}
+</div>

--- a/apps/web/src/components/ui/TabsTrigger.svelte
+++ b/apps/web/src/components/ui/TabsTrigger.svelte
@@ -1,6 +1,31 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { cn } from "../../lib/utils";
-  let { children, class: className = "", active = false, disabled = false, ...rest }: { children?: Snippet; class?: string; active?: boolean; disabled?: boolean; [key: string]: unknown } = $props();
+  let {
+    children,
+    class: className = "",
+    active = false,
+    disabled = false,
+    ...rest
+  }: {
+    children?: Snippet;
+    class?: string;
+    active?: boolean;
+    disabled?: boolean;
+    [key: string]: unknown;
+  } = $props();
 </script>
-<button {...rest} role="tab" aria-selected={active} {disabled} class={cn("inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50", active ? "bg-background text-foreground shadow-xs" : "hover:text-foreground", className)}>{@render children?.()}</button>
+
+<button
+  {...rest}
+  role="tab"
+  aria-selected={active}
+  {disabled}
+  class={cn(
+    "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+    active
+      ? "bg-background text-foreground shadow-xs"
+      : "hover:text-foreground",
+    className,
+  )}>{@render children?.()}</button
+>

--- a/apps/web/src/components/ui/Textarea.svelte
+++ b/apps/web/src/components/ui/Textarea.svelte
@@ -1,6 +1,16 @@
 <script lang="ts">
   import { cn } from "../../lib/utils";
-  let { class: className = "", value = $bindable(), ...rest }: { class?: string; value?: string; [key: string]: unknown } = $props();
+  let {
+    class: className = "",
+    value = $bindable(),
+    ...rest
+  }: { class?: string; value?: string; [key: string]: unknown } = $props();
 </script>
 
-<textarea {...rest} bind:value class={cn("flex min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50", className)}></textarea>
+<textarea
+  {...rest}
+  bind:value
+  class={cn(
+    "flex min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+    className,
+  )}></textarea>

--- a/apps/web/src/components/ui/chart/ChartContainer.svelte
+++ b/apps/web/src/components/ui/chart/ChartContainer.svelte
@@ -11,11 +11,16 @@
     children,
     class: className,
     ...rest
-  }: HTMLAttributes<HTMLDivElement> & { config: ChartConfig; children?: Snippet } = $props();
+  }: HTMLAttributes<HTMLDivElement> & {
+    config: ChartConfig;
+    children?: Snippet;
+  } = $props();
   const chartId = `chart-${uid.replace(/:/g, "")}`;
 
   setChartContext({
-    get config() { return config; }
+    get config() {
+      return config;
+    },
   });
 </script>
 
@@ -29,7 +34,7 @@
     "[&_.lc-axis-grid]:stroke-ink/10 [&_.lc-highlight-line]:stroke-steel/30",
     "[&_.lc-highlight-point]:stroke-white [&_.lc-highlight-point]:stroke-2",
     "[&_.lc-path]:transition-opacity [&_.lc-text-svg]:overflow-visible",
-    className
+    className,
   )}
   {...rest}
 >

--- a/apps/web/src/components/ui/chart/ChartStyle.svelte
+++ b/apps/web/src/components/ui/chart/ChartStyle.svelte
@@ -4,16 +4,24 @@
   let { id, config }: { id: string; config: ChartConfig } = $props();
 
   const themeContents = $derived.by(() => {
-    const colorConfig = Object.entries(config).filter(([, item]) => item.theme || item.color);
+    const colorConfig = Object.entries(config).filter(
+      ([, item]) => item.theme || item.color,
+    );
     if (colorConfig.length === 0) return "";
 
-    return Object.entries(CHART_THEMES).map(([theme, prefix]) => {
-      const variables = colorConfig.map(([key, item]) => {
-        const color = item.theme?.[theme as keyof typeof item.theme] ?? item.color;
-        return color ? `  --color-${key}: ${color};` : "";
-      }).filter(Boolean).join("\n");
-      return `${prefix} [data-chart="${id}"] {\n${variables}\n}`;
-    }).join("\n");
+    return Object.entries(CHART_THEMES)
+      .map(([theme, prefix]) => {
+        const variables = colorConfig
+          .map(([key, item]) => {
+            const color =
+              item.theme?.[theme as keyof typeof item.theme] ?? item.color;
+            return color ? `  --color-${key}: ${color};` : "";
+          })
+          .filter(Boolean)
+          .join("\n");
+        return `${prefix} [data-chart="${id}"] {\n${variables}\n}`;
+      })
+      .join("\n");
   });
 </script>
 

--- a/apps/web/src/components/ui/chart/ChartTooltip.svelte
+++ b/apps/web/src/components/ui/chart/ChartTooltip.svelte
@@ -9,7 +9,7 @@
     titleFormatter,
     valueFormatter = (value: unknown) => String(value ?? ""),
     hideItemLabel = false,
-    indicator = "dot"
+    indicator = "dot",
   }: {
     class?: string;
     labelFormatter?: (value: unknown) => string;
@@ -21,24 +21,51 @@
 
   const chart = useChart();
   const context = getChartContext();
-  const visibleSeries = $derived(context.tooltip.series.filter((series) => series.visible));
-  const header = $derived(context.tooltip.data ? context.x(context.tooltip.data) : undefined);
+  const visibleSeries = $derived(
+    context.tooltip.series.filter((series) => series.visible),
+  );
+  const header = $derived(
+    context.tooltip.data ? context.x(context.tooltip.data) : undefined,
+  );
 </script>
 
 <TooltipPrimitive.Root variant="none" portal={true}>
-  <div class={cn("grid min-w-40 gap-2 rounded-lg border border-ink/10 bg-white/95 px-3 py-2 text-xs text-ink shadow-xl backdrop-blur-sm", className)}>
-    <p class="font-semibold">{titleFormatter ? titleFormatter(context.tooltip.data, header) : labelFormatter(header)}</p>
+  <div
+    class={cn(
+      "grid min-w-40 gap-2 rounded-lg border border-ink/10 bg-white/95 px-3 py-2 text-xs text-ink shadow-xl backdrop-blur-sm",
+      className,
+    )}
+  >
+    <p class="font-semibold">
+      {titleFormatter
+        ? titleFormatter(context.tooltip.data, header)
+        : labelFormatter(header)}
+    </p>
     <div class="grid gap-1.5">
       {#each visibleSeries as series (series.key)}
         {@const itemConfig = chart.config[series.key]}
         {@const color = series.color ?? itemConfig?.color ?? "#3e6f7c"}
-        <div class={cn("grid items-center gap-2", hideItemLabel ? "grid-cols-[auto_auto] justify-between" : "grid-cols-[auto_minmax(0,1fr)_auto]")}>
+        <div
+          class={cn(
+            "grid items-center gap-2",
+            hideItemLabel
+              ? "grid-cols-[auto_auto] justify-between"
+              : "grid-cols-[auto_minmax(0,1fr)_auto]",
+          )}
+        >
           <span
-            class={cn("shrink-0 rounded-sm", indicator === "line" ? "h-0.5 w-3" : "size-2.5")}
+            class={cn(
+              "shrink-0 rounded-sm",
+              indicator === "line" ? "h-0.5 w-3" : "size-2.5",
+            )}
             style={`background-color: ${color}`}
           ></span>
-          {#if !hideItemLabel}<span class="text-ink/55">{itemConfig?.label ?? series.label ?? series.key}</span>{/if}
-          <span class="font-semibold tabular-nums">{valueFormatter(series.value, series.key)}</span>
+          {#if !hideItemLabel}<span class="text-ink/55"
+              >{itemConfig?.label ?? series.label ?? series.key}</span
+            >{/if}
+          <span class="font-semibold tabular-nums"
+            >{valueFormatter(series.value, series.key)}</span
+          >
         </div>
       {/each}
     </div>

--- a/apps/web/src/components/ui/chart/chart-utils.ts
+++ b/apps/web/src/components/ui/chart/chart-utils.ts
@@ -2,13 +2,16 @@ import { getContext, setContext, type Component } from "svelte";
 
 export const CHART_THEMES = { light: "", dark: ".dark" } as const;
 
-export type ChartConfig = Record<string, {
-  label?: string;
-  icon?: Component;
-} & (
-  | { color?: string; theme?: never }
-  | { color?: never; theme: Record<keyof typeof CHART_THEMES, string> }
-)>;
+export type ChartConfig = Record<
+  string,
+  {
+    label?: string;
+    icon?: Component;
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof CHART_THEMES, string> }
+  )
+>;
 
 type ChartContextValue = { config: ChartConfig };
 const chartContextKey = Symbol("chart-context");

--- a/apps/web/src/features/activity/Activity.svelte
+++ b/apps/web/src/features/activity/Activity.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
   import { SvelteDate } from "svelte/reactivity";
-  import { createMutation, createQuery, useQueryClient } from "@tanstack/svelte-query";
-  import { Search, Building2, CreditCard, FileText, TrendingUp } from "@lucide/svelte";
+  import {
+    createMutation,
+    createQuery,
+    useQueryClient,
+  } from "@tanstack/svelte-query";
+  import {
+    Search,
+    Building2,
+    CreditCard,
+    FileText,
+    TrendingUp,
+  } from "@lucide/svelte";
   import Card from "../../components/ui/Card.svelte";
   import CardHeader from "../../components/ui/CardHeader.svelte";
   import CardContent from "../../components/ui/CardContent.svelte";
@@ -16,11 +26,27 @@
   import ActivityCategoryChart from "./ActivityCategoryChart.svelte";
   import type { ApiClient } from "../../lib/api";
   import { queryKeys } from "../../lib/api";
-  import { bankQuery, exchangeRatesQuery, investmentTransactionsQuery, invoicesQuery } from "../../lib/queries";
+  import {
+    bankQuery,
+    exchangeRatesQuery,
+    investmentTransactionsQuery,
+    invoicesQuery,
+  } from "../../lib/queries";
   import type { ActivityItem, View } from "../../lib/types";
-  import { buildActivityCategorySlices, activityCashAmountTwd } from "../../lib/activity-chart";
-  import { formatCompactTwd, formatCurrency, formatDate, formatNumber, normalizeFinancialDate, rateMap } from "../../lib/format.svelte";
-  let { api, navigate }: { api: ApiClient; navigate: (view: View) => void } = $props();
+  import {
+    buildActivityCategorySlices,
+    activityCashAmountTwd,
+  } from "../../lib/activity-chart";
+  import {
+    formatCompactTwd,
+    formatCurrency,
+    formatDate,
+    formatNumber,
+    normalizeFinancialDate,
+    rateMap,
+  } from "../../lib/format.svelte";
+  let { api, navigate }: { api: ApiClient; navigate: (view: View) => void } =
+    $props();
   const bank = createQuery(bankQuery(() => api));
   const invoices = createQuery(invoicesQuery(() => api));
   const trades = createQuery(investmentTransactionsQuery(() => api));
@@ -29,111 +55,609 @@
   let source = $state<"all" | "bank" | "card" | "invoice">("all");
   let search = $state("");
   let selectedMonth = $state(new Date().toISOString().slice(0, 7));
-  let selectedCategory = $state<{ flow: "income" | "expense"; category: string } | null>(null);
-  let pending = $state<{ item: ActivityItem; categoryId: string; addRule: boolean; pattern: string; operator: "contains" | "equals" } | null>(null);
-  const categories: Record<string, string> = { salary: "薪資", transfer: "轉帳", food: "餐飲", transport: "交通", shopping: "購物", housing: "居住", health: "醫療", education: "教育", entertainment: "娛樂", investment: "投資", insurance: "保險", fee: "費用", tax: "稅務", other: "其他" };
+  let selectedCategory = $state<{
+    flow: "income" | "expense";
+    category: string;
+  } | null>(null);
+  let pending = $state<{
+    item: ActivityItem;
+    categoryId: string;
+    addRule: boolean;
+    pattern: string;
+    operator: "contains" | "equals";
+  } | null>(null);
+  const categories: Record<string, string> = {
+    salary: "薪資",
+    transfer: "轉帳",
+    food: "餐飲",
+    transport: "交通",
+    shopping: "購物",
+    housing: "居住",
+    health: "醫療",
+    education: "教育",
+    entertainment: "娛樂",
+    investment: "投資",
+    insurance: "保險",
+    fee: "費用",
+    tax: "稅務",
+    other: "其他",
+  };
   const rateValues = $derived(rateMap($rates.data));
-  const bankAccounts = $derived(new Map(($bank.data?.accounts ?? []).map((account) => [account.id, account])));
-  const rawItems = $derived<ActivityItem[]>([
-    ...($bank.data?.transactions ?? []).map((t) => {
-      const account = bankAccounts.get(t.accountId);
-      const isCard = account?.accountType === "credit" || t.accountType === "credit";
-      return { id: t.id, source: isCard ? "card" as const : "bank" as const, date: t.postedDate ?? t.authorizedAt ?? "", title: t.description ?? t.counterparty ?? "銀行交易", subtitle: t.institutionName ?? account?.institutionName ?? t.accountName ?? account?.accountName ?? "", amount: t.amount, currency: t.currency, category: t.classification?.label ?? "其他", categoryId: t.classification?.categoryId ?? "other", transactionId: t.id, status: t.status };
-    }),
-    ...($invoices.data ?? []).map((i) => ({ id: i.id, source: "invoice" as const, date: i.invoiceDate, title: i.sellerName ?? "電子發票", subtitle: i.invoiceNumber ?? "", amount: i.amount, currency: "TWD", category: "發票", status: "已開立" })),
-    ...($trades.data ?? []).map((t) => ({ id: t.id, source: "investment" as const, date: normalizeFinancialDate(t.tradeDate ?? t.postedDate), title: t.name ?? t.symbol ?? "投資交易", subtitle: [t.transactionName ?? t.transactionCode, t.quantity != null ? `${formatNumber(t.quantity)} 股` : undefined].filter(Boolean).join(" · "), amount: t.price === 1 ? undefined : t.amount, currency: t.currency, category: "投資", status: "已完成" }))
-  ].sort((a, b) => b.date.localeCompare(a.date)));
-  const months = $derived([...new Set(rawItems.map((i) => i.date.slice(0, 7)).filter(Boolean).concat([new Date().toISOString().slice(0, 7)]))].sort((a, b) => b.localeCompare(a)).slice(0, 12));
-  const monthlyCashItems = $derived(rawItems.filter((item) => item.date.startsWith(selectedMonth) && (item.source === "bank" || item.source === "card")));
-  const incomeSlices = $derived(buildActivityCategorySlices(monthlyCashItems, "income", rateValues));
-  const expenseSlices = $derived(buildActivityCategorySlices(monthlyCashItems, "expense", rateValues));
-  const incomeTotal = $derived(incomeSlices.reduce((sum, slice) => sum + slice.amount, 0));
-  const expenseTotal = $derived(expenseSlices.reduce((sum, slice) => sum + slice.amount, 0));
+  const bankAccounts = $derived(
+    new Map(
+      ($bank.data?.accounts ?? []).map((account) => [account.id, account]),
+    ),
+  );
+  const rawItems = $derived<ActivityItem[]>(
+    [
+      ...($bank.data?.transactions ?? []).map((t) => {
+        const account = bankAccounts.get(t.accountId);
+        const isCard =
+          account?.accountType === "credit" || t.accountType === "credit";
+        return {
+          id: t.id,
+          source: isCard ? ("card" as const) : ("bank" as const),
+          date: t.postedDate ?? t.authorizedAt ?? "",
+          title: t.description ?? t.counterparty ?? "銀行交易",
+          subtitle:
+            t.institutionName ??
+            account?.institutionName ??
+            t.accountName ??
+            account?.accountName ??
+            "",
+          amount: t.amount,
+          currency: t.currency,
+          category: t.classification?.label ?? "其他",
+          categoryId: t.classification?.categoryId ?? "other",
+          transactionId: t.id,
+          status: t.status,
+        };
+      }),
+      ...($invoices.data ?? []).map((i) => ({
+        id: i.id,
+        source: "invoice" as const,
+        date: i.invoiceDate,
+        title: i.sellerName ?? "電子發票",
+        subtitle: i.invoiceNumber ?? "",
+        amount: i.amount,
+        currency: "TWD",
+        category: "發票",
+        status: "已開立",
+      })),
+      ...($trades.data ?? []).map((t) => ({
+        id: t.id,
+        source: "investment" as const,
+        date: normalizeFinancialDate(t.tradeDate ?? t.postedDate),
+        title: t.name ?? t.symbol ?? "投資交易",
+        subtitle: [
+          t.transactionName ?? t.transactionCode,
+          t.quantity != null ? `${formatNumber(t.quantity)} 股` : undefined,
+        ]
+          .filter(Boolean)
+          .join(" · "),
+        amount: t.price === 1 ? undefined : t.amount,
+        currency: t.currency,
+        category: "投資",
+        status: "已完成",
+      })),
+    ].sort((a, b) => b.date.localeCompare(a.date)),
+  );
+  const months = $derived(
+    [
+      ...new Set(
+        rawItems
+          .map((i) => i.date.slice(0, 7))
+          .filter(Boolean)
+          .concat([new Date().toISOString().slice(0, 7)]),
+      ),
+    ]
+      .sort((a, b) => b.localeCompare(a))
+      .slice(0, 12),
+  );
+  const monthlyCashItems = $derived(
+    rawItems.filter(
+      (item) =>
+        item.date.startsWith(selectedMonth) &&
+        (item.source === "bank" || item.source === "card"),
+    ),
+  );
+  const incomeSlices = $derived(
+    buildActivityCategorySlices(monthlyCashItems, "income", rateValues),
+  );
+  const expenseSlices = $derived(
+    buildActivityCategorySlices(monthlyCashItems, "expense", rateValues),
+  );
+  const incomeTotal = $derived(
+    incomeSlices.reduce((sum, slice) => sum + slice.amount, 0),
+  );
+  const expenseTotal = $derived(
+    expenseSlices.reduce((sum, slice) => sum + slice.amount, 0),
+  );
   const currentMonth = new Date().toISOString().slice(0, 7);
   const selectedMonthLabel = $derived(`${Number(selectedMonth.slice(5))} 月`);
-  const pendingCount = $derived(rawItems.filter((item) => (item.source === "bank" || item.source === "card") && (item.status === "pending" || item.categoryId === "other")).length);
+  const pendingCount = $derived(
+    rawItems.filter(
+      (item) =>
+        (item.source === "bank" || item.source === "card") &&
+        (item.status === "pending" || item.categoryId === "other"),
+    ).length,
+  );
   const cashFlowMonths = Array.from({ length: 6 }, (_, index) => {
     const date = new SvelteDate();
     date.setMonth(date.getMonth() - (5 - index));
     return date.toISOString().slice(0, 7);
   });
-  const cashFlow = $derived(cashFlowMonths.map((month) => {
-    const items = rawItems.filter((item) => item.date.startsWith(month) && (item.source === "bank" || item.source === "card"));
+  const cashFlow = $derived(
+    cashFlowMonths.map((month) => {
+      const items = rawItems.filter(
+        (item) =>
+          item.date.startsWith(month) &&
+          (item.source === "bank" || item.source === "card"),
+      );
+      return {
+        month,
+        income: items.reduce(
+          (sum, item) =>
+            sum + Math.max(activityCashAmountTwd(item, rateValues), 0),
+          0,
+        ),
+        expense: Math.abs(
+          items.reduce(
+            (sum, item) =>
+              sum + Math.min(activityCashAmountTwd(item, rateValues), 0),
+            0,
+          ),
+        ),
+      };
+    }),
+  );
+  const maxCashFlow = $derived(
+    Math.max(...cashFlow.flatMap((point) => [point.income, point.expense]), 1),
+  );
+  const filtered = $derived(
+    rawItems.filter((item) => {
+      const amount = activityCashAmountTwd(item, rateValues);
+      const matchesFlow =
+        !selectedCategory ||
+        (selectedCategory.flow === "income" ? amount > 0 : amount < 0);
+      return (
+        (source === "all" || item.source === source) &&
+        item.date.startsWith(selectedMonth) &&
+        (!search.trim() ||
+          `${item.title} ${item.subtitle} ${item.category}`
+            .toLowerCase()
+            .includes(search.toLowerCase())) &&
+        (!selectedCategory ||
+          (item.category === selectedCategory.category && matchesFlow))
+      );
+    }),
+  );
+  const categoryMutation = createMutation({
+    mutationFn: async (payload: {
+      transactionId: string;
+      categoryId: string;
+      addRule: boolean;
+      pattern: string;
+      operator: "contains" | "equals";
+    }) => {
+      await api.put(
+        `/api/classification/overrides/bank_transaction/${payload.transactionId}`,
+        { categoryId: payload.categoryId },
+      );
+      if (payload.addRule)
+        await api.post("/api/classification/rules", {
+          categoryId: payload.categoryId,
+          targetType: "bank_transaction",
+          field: "any_text",
+          operator: payload.operator,
+          pattern: payload.pattern.trim(),
+          priority: 200,
+          description: "由活動頁建立",
+        });
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.bank });
+      qc.invalidateQueries({ queryKey: queryKeys.classificationRules });
+      pending = null;
+    },
+  });
+  function openCategory(item: ActivityItem, categoryId: string) {
+    if (item.transactionId && categoryId !== item.categoryId)
+      pending = {
+        item,
+        categoryId,
+        addRule: false,
+        pattern: item.title,
+        operator: "contains",
+      };
+  }
+  function chooseCategory(flow: "income" | "expense", category: string) {
+    selectedCategory =
+      selectedCategory?.flow === flow && selectedCategory.category === category
+        ? null
+        : { flow, category };
+  }
+  function chooseMonth(month: string) {
+    selectedMonth = month;
+    selectedCategory = null;
+  }
+  function sourceLabel(source: ActivityItem["source"]) {
     return {
-      month,
-      income: items.reduce((sum, item) => sum + Math.max(activityCashAmountTwd(item, rateValues), 0), 0),
-      expense: Math.abs(items.reduce((sum, item) => sum + Math.min(activityCashAmountTwd(item, rateValues), 0), 0))
-    };
-  }));
-  const maxCashFlow = $derived(Math.max(...cashFlow.flatMap((point) => [point.income, point.expense]), 1));
-  const filtered = $derived(rawItems.filter((item) => {
-    const amount = activityCashAmountTwd(item, rateValues);
-    const matchesFlow = !selectedCategory || (selectedCategory.flow === "income" ? amount > 0 : amount < 0);
-    return (source === "all" || item.source === source)
-      && item.date.startsWith(selectedMonth)
-      && (!search.trim() || `${item.title} ${item.subtitle} ${item.category}`.toLowerCase().includes(search.toLowerCase()))
-      && (!selectedCategory || (item.category === selectedCategory.category && matchesFlow));
-  }));
-  const categoryMutation = createMutation({ mutationFn: async (payload: { transactionId: string; categoryId: string; addRule: boolean; pattern: string; operator: "contains" | "equals" }) => { await api.put(`/api/classification/overrides/bank_transaction/${payload.transactionId}`, { categoryId: payload.categoryId }); if (payload.addRule) await api.post("/api/classification/rules", { categoryId: payload.categoryId, targetType: "bank_transaction", field: "any_text", operator: payload.operator, pattern: payload.pattern.trim(), priority: 200, description: "由活動頁建立" }); }, onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.bank }); qc.invalidateQueries({ queryKey: queryKeys.classificationRules }); pending = null; } });
-  function openCategory(item: ActivityItem, categoryId: string) { if (item.transactionId && categoryId !== item.categoryId) pending = { item, categoryId, addRule: false, pattern: item.title, operator: "contains" }; }
-  function chooseCategory(flow: "income" | "expense", category: string) { selectedCategory = selectedCategory?.flow === flow && selectedCategory.category === category ? null : { flow, category }; }
-  function chooseMonth(month: string) { selectedMonth = month; selectedCategory = null; }
-  function sourceLabel(source: ActivityItem["source"]) { return { bank: "銀行", card: "信用卡", investment: "投資", invoice: "發票" }[source]; }
-  function renderedAmount(item: ActivityItem) { return item.source === "card" ? -Math.abs(item.amount ?? 0) : item.amount; }
-  function countMatches() { if (!pending) return 0; return ($bank.data?.transactions ?? []).filter((t) => `${t.description ?? ""} ${t.counterparty ?? ""}`.toLowerCase().includes(pending!.pattern.toLowerCase())).length; }
+      bank: "銀行",
+      card: "信用卡",
+      investment: "投資",
+      invoice: "發票",
+    }[source];
+  }
+  function renderedAmount(item: ActivityItem) {
+    return item.source === "card" ? -Math.abs(item.amount ?? 0) : item.amount;
+  }
+  function countMatches() {
+    if (!pending) return 0;
+    return ($bank.data?.transactions ?? []).filter((t) =>
+      `${t.description ?? ""} ${t.counterparty ?? ""}`
+        .toLowerCase()
+        .includes(pending!.pattern.toLowerCase()),
+    ).length;
+  }
 </script>
 
-{#if $bank.isPending || $invoices.isPending || $trades.isPending}<EmptyState title="載入活動中" body="正在整理銀行、投資與發票資料。" />{:else}
+{#if $bank.isPending || $invoices.isPending || $trades.isPending}<EmptyState
+    title="載入活動中"
+    body="正在整理銀行、投資與發票資料。"
+  />{:else}
   <div class="grid min-w-0 max-w-full gap-5 overflow-x-clip">
-    <div class="hidden min-w-0 grid-cols-2 gap-3 md:grid md:grid-cols-4 md:gap-4">
-      <Card><CardContent class="p-5"><p class="text-xs font-semibold text-ink/50">{selectedMonthLabel}收入</p><p class="mt-2 truncate text-2xl font-bold text-moss">+{formatCurrency(incomeTotal)}</p><p class="mt-1 text-xs text-ink/45">銀行與信用卡活動</p></CardContent></Card>
-      <Card><CardContent class="p-5"><p class="text-xs font-semibold text-ink/50">{selectedMonthLabel}支出</p><p class="mt-2 truncate text-2xl font-bold text-coral">−{formatCurrency(expenseTotal)}</p><p class="mt-1 text-xs text-ink/45">不重複計入發票</p></CardContent></Card>
-      <Card><CardContent class="p-5"><p class="text-xs font-semibold text-ink/50">{selectedMonthLabel}淨流入</p><p class={`mt-2 truncate text-2xl font-bold ${incomeTotal >= expenseTotal ? "text-moss" : "text-coral"}`}>{formatCurrency(incomeTotal - expenseTotal)}</p><p class="mt-1 text-xs text-ink/45">收入 − 支出</p></CardContent></Card>
-      <Card><CardContent class="p-5"><p class="text-xs font-semibold text-ink/50">待分類</p><p class="mt-2 text-2xl font-bold">{pendingCount} 筆</p><p class="mt-1 text-xs text-ink/45">銀行交易</p></CardContent></Card>
+    <div
+      class="hidden min-w-0 grid-cols-2 gap-3 md:grid md:grid-cols-4 md:gap-4"
+    >
+      <Card
+        ><CardContent class="p-5"
+          ><p class="text-xs font-semibold text-ink/50">
+            {selectedMonthLabel}收入
+          </p>
+          <p class="mt-2 truncate text-2xl font-bold text-moss">
+            +{formatCurrency(incomeTotal)}
+          </p>
+          <p class="mt-1 text-xs text-ink/45">銀行與信用卡活動</p></CardContent
+        ></Card
+      >
+      <Card
+        ><CardContent class="p-5"
+          ><p class="text-xs font-semibold text-ink/50">
+            {selectedMonthLabel}支出
+          </p>
+          <p class="mt-2 truncate text-2xl font-bold text-coral">
+            −{formatCurrency(expenseTotal)}
+          </p>
+          <p class="mt-1 text-xs text-ink/45">不重複計入發票</p></CardContent
+        ></Card
+      >
+      <Card
+        ><CardContent class="p-5"
+          ><p class="text-xs font-semibold text-ink/50">
+            {selectedMonthLabel}淨流入
+          </p>
+          <p
+            class={`mt-2 truncate text-2xl font-bold ${incomeTotal >= expenseTotal ? "text-moss" : "text-coral"}`}
+          >
+            {formatCurrency(incomeTotal - expenseTotal)}
+          </p>
+          <p class="mt-1 text-xs text-ink/45">收入 − 支出</p></CardContent
+        ></Card
+      >
+      <Card
+        ><CardContent class="p-5"
+          ><p class="text-xs font-semibold text-ink/50">待分類</p>
+          <p class="mt-2 text-2xl font-bold">{pendingCount} 筆</p>
+          <p class="mt-1 text-xs text-ink/45">銀行交易</p></CardContent
+        ></Card
+      >
     </div>
 
     <section class="grid min-w-0 gap-3">
-      <div class="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div class="min-w-0"><h2 class="text-lg font-semibold">每月分類比例</h2><p class="mt-1 text-xs text-ink/45">收入與支出分開計算，發票不重複列入</p></div>
-        <Select aria-label="選擇活動月份" class="h-11 w-full min-w-0 font-semibold sm:w-auto sm:shrink-0" value={selectedMonth} onchange={(event: Event) => chooseMonth((event.currentTarget as HTMLSelectElement).value)}>{#each months as month (month)}<option value={month}>{month.slice(0, 4)} 年 {Number(month.slice(5))} 月</option>{/each}</Select>
+      <div
+        class="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <div class="min-w-0">
+          <h2 class="text-lg font-semibold">每月分類比例</h2>
+          <p class="mt-1 text-xs text-ink/45">
+            收入與支出分開計算，發票不重複列入
+          </p>
+        </div>
+        <Select
+          aria-label="選擇活動月份"
+          class="h-11 w-full min-w-0 font-semibold sm:w-auto sm:shrink-0"
+          value={selectedMonth}
+          onchange={(event: Event) =>
+            chooseMonth((event.currentTarget as HTMLSelectElement).value)}
+          >{#each months as month (month)}<option value={month}
+              >{month.slice(0, 4)} 年 {Number(month.slice(5))} 月</option
+            >{/each}</Select
+        >
       </div>
       <div class="grid min-w-0 gap-3 lg:grid-cols-2">
-        <ActivityCategoryChart flow="income" slices={incomeSlices} selectedCategory={selectedCategory?.flow === "income" ? selectedCategory.category : undefined} onSelect={(category) => chooseCategory("income", category)} />
-        <ActivityCategoryChart flow="expense" slices={expenseSlices} selectedCategory={selectedCategory?.flow === "expense" ? selectedCategory.category : undefined} onSelect={(category) => chooseCategory("expense", category)} />
+        <ActivityCategoryChart
+          flow="income"
+          slices={incomeSlices}
+          selectedCategory={selectedCategory?.flow === "income"
+            ? selectedCategory.category
+            : undefined}
+          onSelect={(category) => chooseCategory("income", category)}
+        />
+        <ActivityCategoryChart
+          flow="expense"
+          slices={expenseSlices}
+          selectedCategory={selectedCategory?.flow === "expense"
+            ? selectedCategory.category
+            : undefined}
+          onSelect={(category) => chooseCategory("expense", category)}
+        />
       </div>
     </section>
 
     <Card class="hidden md:block">
-      <CardHeader class="flex-row items-center justify-between"><h2 class="text-lg font-semibold">現金流趨勢</h2><Badge variant="secondary">6 個月　收入／支出</Badge></CardHeader>
+      <CardHeader class="flex-row items-center justify-between"
+        ><h2 class="text-lg font-semibold">現金流趨勢</h2>
+        <Badge variant="secondary">6 個月　收入／支出</Badge></CardHeader
+      >
       <CardContent>
         <div class="grid grid-cols-6 gap-3">
           {#each cashFlow as point (point.month)}
-            <button aria-pressed={selectedMonth === point.month} class={`grid min-w-0 rounded-xl px-2 pb-2 pt-3 transition ${selectedMonth === point.month ? "bg-steel/10 ring-2 ring-steel/30" : "hover:bg-paper"}`} onclick={() => chooseMonth(point.month)}>
-              <div class="flex h-28 items-end justify-center gap-2"><span class="w-1/3 rounded-t-lg bg-emerald-700" style={`height:${Math.max(8, point.income / maxCashFlow * 100)}%`}></span><span class="w-1/3 rounded-t-lg bg-coral" style={`height:${Math.max(8, point.expense / maxCashFlow * 100)}%`}></span></div>
-              <span class="mt-2 text-xs font-semibold">{Number(point.month.slice(5))} 月</span><span class="mt-1 truncate text-[10px] text-moss">+{formatCompactTwd(point.income)}</span><span class="truncate text-[10px] text-coral">−{formatCompactTwd(point.expense)}</span>
+            <button
+              aria-pressed={selectedMonth === point.month}
+              class={`grid min-w-0 rounded-xl px-2 pb-2 pt-3 transition ${selectedMonth === point.month ? "bg-steel/10 ring-2 ring-steel/30" : "hover:bg-paper"}`}
+              onclick={() => chooseMonth(point.month)}
+            >
+              <div class="flex h-28 items-end justify-center gap-2">
+                <span
+                  class="w-1/3 rounded-t-lg bg-emerald-700"
+                  style={`height:${Math.max(8, (point.income / maxCashFlow) * 100)}%`}
+                ></span><span
+                  class="w-1/3 rounded-t-lg bg-coral"
+                  style={`height:${Math.max(8, (point.expense / maxCashFlow) * 100)}%`}
+                ></span>
+              </div>
+              <span class="mt-2 text-xs font-semibold"
+                >{Number(point.month.slice(5))} 月</span
+              ><span class="mt-1 truncate text-[10px] text-moss"
+                >+{formatCompactTwd(point.income)}</span
+              ><span class="truncate text-[10px] text-coral"
+                >−{formatCompactTwd(point.expense)}</span
+              >
             </button>
           {/each}
         </div>
-        <div class="mt-3 flex items-center justify-between text-xs text-ink/45"><span><span class="text-emerald-700">■</span> 收入　<span class="text-coral">■</span> 支出</span><button class="font-semibold text-steel" onclick={() => chooseMonth(currentMonth)}>回到本月</button></div>
+        <div class="mt-3 flex items-center justify-between text-xs text-ink/45">
+          <span
+            ><span class="text-emerald-700">■</span> 收入　<span
+              class="text-coral">■</span
+            > 支出</span
+          ><button
+            class="font-semibold text-steel"
+            onclick={() => chooseMonth(currentMonth)}>回到本月</button
+          >
+        </div>
       </CardContent>
     </Card>
 
     <Card class="min-w-0 max-w-full overflow-hidden">
       <CardHeader class="min-w-0 gap-3 border-b border-ink/8">
-        <div class="flex min-w-0 flex-col gap-3 md:flex-row md:items-center md:justify-between"><div class="min-w-0"><h2 class="truncate text-lg font-semibold">{selectedCategory ? `${selectedMonthLabel} · ${selectedCategory.category}` : `${selectedMonthLabel}所有活動`}</h2><p class="text-xs text-ink/45">銀行、信用卡、投資與發票</p></div><div class="relative md:w-80"><Search class="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-muted-foreground" /><Input class="h-11 pl-9" placeholder="搜尋商家、帳戶、品項或分類" bind:value={search} /></div></div>
-        {#if selectedCategory}<div class="flex items-center justify-between rounded-lg bg-steel/10 px-3 py-2 text-sm"><span><strong>{selectedCategory.category}</strong> · {selectedCategory.flow === "income" ? "收入" : "支出"}</span><button class="min-h-8 px-2 text-xs font-semibold text-steel" onclick={() => selectedCategory = null}>顯示全部</button></div>{/if}
-        <TabsList class="grid h-auto w-full grid-cols-4">{#each [{key:"all",label:"全部"},{key:"bank",label:"銀行"},{key:"card",label:"信用卡"},{key:"invoice",label:"發票"}] as filter (filter.key)}<TabsTrigger class={`min-h-9 min-w-0 px-1 text-xs md:text-sm ${source === filter.key ? "bg-ink text-white" : ""}`} active={source === filter.key} onclick={() => { source = filter.key as typeof source; selectedCategory = null; }}>{filter.label}</TabsTrigger>{/each}</TabsList>
+        <div
+          class="flex min-w-0 flex-col gap-3 md:flex-row md:items-center md:justify-between"
+        >
+          <div class="min-w-0">
+            <h2 class="truncate text-lg font-semibold">
+              {selectedCategory
+                ? `${selectedMonthLabel} · ${selectedCategory.category}`
+                : `${selectedMonthLabel}所有活動`}
+            </h2>
+            <p class="text-xs text-ink/45">銀行、信用卡、投資與發票</p>
+          </div>
+          <div class="relative md:w-80">
+            <Search
+              class="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-muted-foreground"
+            /><Input
+              class="h-11 pl-9"
+              placeholder="搜尋商家、帳戶、品項或分類"
+              bind:value={search}
+            />
+          </div>
+        </div>
+        {#if selectedCategory}<div
+            class="flex items-center justify-between rounded-lg bg-steel/10 px-3 py-2 text-sm"
+          >
+            <span
+              ><strong>{selectedCategory.category}</strong> · {selectedCategory.flow ===
+              "income"
+                ? "收入"
+                : "支出"}</span
+            ><button
+              class="min-h-8 px-2 text-xs font-semibold text-steel"
+              onclick={() => (selectedCategory = null)}>顯示全部</button
+            >
+          </div>{/if}
+        <TabsList class="grid h-auto w-full grid-cols-4"
+          >{#each [{ key: "all", label: "全部" }, { key: "bank", label: "銀行" }, { key: "card", label: "信用卡" }, { key: "invoice", label: "發票" }] as filter (filter.key)}<TabsTrigger
+              class={`min-h-9 min-w-0 px-1 text-xs md:text-sm ${source === filter.key ? "bg-ink text-white" : ""}`}
+              active={source === filter.key}
+              onclick={() => {
+                source = filter.key as typeof source;
+                selectedCategory = null;
+              }}>{filter.label}</TabsTrigger
+            >{/each}</TabsList
+        >
       </CardHeader>
       <CardContent class="min-w-0 p-0">
         <div class="min-w-0 divide-y divide-ink/8 md:hidden">
-          {#if filtered.length === 0}<p class="p-8 text-center text-sm text-ink/50">沒有符合條件的活動。</p>{:else}{#each filtered.slice(0, 100) as item (item.source + "-" + item.id)}{@const amount = renderedAmount(item)}<div class="flex min-w-0 items-center gap-3 px-4 py-3"><span class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-steel/10 text-steel">{#if item.source === "bank"}<Building2 class="size-5" />{:else if item.source === "card"}<CreditCard class="size-5" />{:else if item.source === "invoice"}<FileText class="size-5" />{:else}<TrendingUp class="size-5" />{/if}</span><div class="min-w-0 flex-1"><p class="truncate text-sm font-semibold">{item.title}</p><p class="mt-0.5 truncate text-xs text-ink/45">{sourceLabel(item.source)} · {formatDate(item.date)}</p>{#if item.transactionId}<Select aria-label={`更新 ${item.title} 分類`} class="mt-1 h-8 max-w-36 px-2 py-1 text-xs font-medium text-steel" value={item.categoryId} onchange={(e: Event) => openCategory(item, (e.currentTarget as HTMLSelectElement).value)}>{#each Object.entries(categories) as [key, label] (key)}<option value={key}>{label}</option>{/each}</Select>{/if}</div><p class={`max-w-[42%] shrink-0 truncate text-sm font-semibold tabular-nums ${(amount ?? 0) < 0 ? "text-coral" : item.source !== "invoice" ? "text-moss" : ""}`}>{amount == null ? "—" : `${amount >= 0 && item.source !== "invoice" ? "+" : ""}${formatCurrency(amount, item.currency)}`}</p></div>{/each}{/if}
+          {#if filtered.length === 0}<p
+              class="p-8 text-center text-sm text-ink/50"
+            >
+              沒有符合條件的活動。
+            </p>{:else}{#each filtered.slice(0, 100) as item (item.source + "-" + item.id)}{@const amount =
+                renderedAmount(item)}
+              <div class="flex min-w-0 items-center gap-3 px-4 py-3">
+                <span
+                  class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-steel/10 text-steel"
+                  >{#if item.source === "bank"}<Building2
+                      class="size-5"
+                    />{:else if item.source === "card"}<CreditCard
+                      class="size-5"
+                    />{:else if item.source === "invoice"}<FileText
+                      class="size-5"
+                    />{:else}<TrendingUp class="size-5" />{/if}</span
+                >
+                <div class="min-w-0 flex-1">
+                  <p class="truncate text-sm font-semibold">{item.title}</p>
+                  <p class="mt-0.5 truncate text-xs text-ink/45">
+                    {sourceLabel(item.source)} · {formatDate(item.date)}
+                  </p>
+                  {#if item.transactionId}<Select
+                      aria-label={`更新 ${item.title} 分類`}
+                      class="mt-1 h-8 max-w-36 px-2 py-1 text-xs font-medium text-steel"
+                      value={item.categoryId}
+                      onchange={(e: Event) =>
+                        openCategory(
+                          item,
+                          (e.currentTarget as HTMLSelectElement).value,
+                        )}
+                      >{#each Object.entries(categories) as [key, label] (key)}<option
+                          value={key}>{label}</option
+                        >{/each}</Select
+                    >{/if}
+                </div>
+                <p
+                  class={`max-w-[42%] shrink-0 truncate text-sm font-semibold tabular-nums ${(amount ?? 0) < 0 ? "text-coral" : item.source !== "invoice" ? "text-moss" : ""}`}
+                >
+                  {amount == null
+                    ? "—"
+                    : `${amount >= 0 && item.source !== "invoice" ? "+" : ""}${formatCurrency(amount, item.currency)}`}
+                </p>
+              </div>{/each}{/if}
         </div>
         <div class="hidden overflow-x-auto md:block">
-          <table class="w-full min-w-[820px] text-left text-sm"><thead class="bg-paper text-xs font-semibold text-ink/45"><tr><th class="px-5 py-3">日期</th><th class="px-4 py-3">來源</th><th class="px-4 py-3">說明／商家</th><th class="px-4 py-3">分類</th><th class="px-4 py-3 text-right">金額</th><th class="px-5 py-3">狀態</th></tr></thead><tbody class="divide-y divide-ink/8">{#if filtered.length === 0}<tr><td class="px-5 py-8 text-center text-ink/50" colspan="6">沒有符合條件的活動。</td></tr>{:else}{#each filtered.slice(0, 100) as item (item.source + "-" + item.id)}{@const amount = renderedAmount(item)}<tr><td class="whitespace-nowrap px-5 py-3 text-ink/55">{formatDate(item.date)}</td><td class="px-4 py-3">{sourceLabel(item.source)}</td><td class="max-w-xs px-4 py-3"><p class="truncate font-semibold">{item.title}</p><p class="truncate text-xs text-ink/40">{item.subtitle}</p></td><td class="px-4 py-3">{#if item.transactionId}<Select aria-label={`更新 ${item.title} 分類`} class="h-9 w-auto px-2 text-sm font-medium text-steel" value={item.categoryId} onchange={(e: Event) => openCategory(item, (e.currentTarget as HTMLSelectElement).value)}>{#each Object.entries(categories) as [key, label] (key)}<option value={key}>{label}</option>{/each}</Select>{:else}{item.category}{/if}</td><td class={`whitespace-nowrap px-4 py-3 text-right font-semibold tabular-nums ${(amount ?? 0) < 0 ? "text-coral" : item.source !== "invoice" ? "text-moss" : ""}`}>{amount == null ? "—" : formatCurrency(amount, item.currency)}</td><td class="whitespace-nowrap px-5 py-3 text-ink/55">{item.status === "pending" ? "待入帳" : item.status === "posted" ? "已入帳" : item.status}</td></tr>{/each}{/if}</tbody></table>
+          <table class="w-full min-w-[820px] text-left text-sm">
+            <thead class="bg-paper text-xs font-semibold text-ink/45"
+              ><tr
+                ><th class="px-5 py-3">日期</th><th class="px-4 py-3">來源</th
+                ><th class="px-4 py-3">說明／商家</th><th class="px-4 py-3"
+                  >分類</th
+                ><th class="px-4 py-3 text-right">金額</th><th class="px-5 py-3"
+                  >狀態</th
+                ></tr
+              ></thead
+            ><tbody class="divide-y divide-ink/8"
+              >{#if filtered.length === 0}<tr
+                  ><td class="px-5 py-8 text-center text-ink/50" colspan="6"
+                    >沒有符合條件的活動。</td
+                  ></tr
+                >{:else}{#each filtered.slice(0, 100) as item (item.source + "-" + item.id)}{@const amount =
+                    renderedAmount(item)}<tr
+                    ><td class="whitespace-nowrap px-5 py-3 text-ink/55"
+                      >{formatDate(item.date)}</td
+                    ><td class="px-4 py-3">{sourceLabel(item.source)}</td><td
+                      class="max-w-xs px-4 py-3"
+                      ><p class="truncate font-semibold">{item.title}</p>
+                      <p class="truncate text-xs text-ink/40">
+                        {item.subtitle}
+                      </p></td
+                    ><td class="px-4 py-3"
+                      >{#if item.transactionId}<Select
+                          aria-label={`更新 ${item.title} 分類`}
+                          class="h-9 w-auto px-2 text-sm font-medium text-steel"
+                          value={item.categoryId}
+                          onchange={(e: Event) =>
+                            openCategory(
+                              item,
+                              (e.currentTarget as HTMLSelectElement).value,
+                            )}
+                          >{#each Object.entries(categories) as [key, label] (key)}<option
+                              value={key}>{label}</option
+                            >{/each}</Select
+                        >{:else}{item.category}{/if}</td
+                    ><td
+                      class={`whitespace-nowrap px-4 py-3 text-right font-semibold tabular-nums ${(amount ?? 0) < 0 ? "text-coral" : item.source !== "invoice" ? "text-moss" : ""}`}
+                      >{amount == null
+                        ? "—"
+                        : formatCurrency(amount, item.currency)}</td
+                    ><td class="whitespace-nowrap px-5 py-3 text-ink/55"
+                      >{item.status === "pending"
+                        ? "待入帳"
+                        : item.status === "posted"
+                          ? "已入帳"
+                          : item.status}</td
+                    ></tr
+                  >{/each}{/if}</tbody
+            >
+          </table>
         </div>
       </CardContent>
     </Card>
-    <div class="flex justify-end"><Button variant="ghost" onclick={() => navigate("invoices")}>查看完整發票明細 →</Button></div>
-    {#if pending}<div aria-modal="true" class="fixed inset-0 z-[70] flex items-end bg-ink/45 md:items-center md:justify-center md:p-6" role="dialog"><div class="max-h-[88vh] w-full overflow-y-auto rounded-t-2xl bg-white p-5 shadow-2xl md:max-w-lg md:rounded-2xl md:p-6"><h2 class="text-xl font-semibold">更新活動分類</h2><p class="mt-1 text-sm text-ink/50">{pending.item.title} → {categories[pending.categoryId] ?? pending.categoryId}</p><label class="mt-5 flex cursor-pointer items-start gap-3 rounded-xl border border-ink/10 bg-paper p-4"><Checkbox class="mt-1" checked={pending.addRule} onchange={(e: Event) => pending!.addRule = (e.currentTarget as HTMLInputElement).checked} /><span><span class="block font-semibold">同時新增分類規則</span><span class="mt-1 block text-xs text-ink/50">符合規則的活動之後會自動套用。</span></span></label>{#if pending.addRule}<div class="mt-4 grid gap-3 rounded-xl border border-steel/20 bg-steel/5 p-4"><Select bind:value={pending.operator}><option value="contains">交易文字包含</option><option value="equals">交易文字完全等於</option></Select><Input bind:value={pending.pattern} /><p class="text-xs font-semibold text-steel">將更新 {countMatches()} 筆過去活動</p></div>{/if}<div class="mt-5 grid grid-cols-2 gap-3"><Button variant="secondary" onclick={() => pending = null}>取消</Button><Button disabled={$categoryMutation.isPending || (pending.addRule && !pending.pattern.trim())} onclick={() => $categoryMutation.mutate({ transactionId: pending!.item.transactionId!, categoryId: pending!.categoryId, addRule: pending!.addRule, pattern: pending!.pattern, operator: pending!.operator })}>{$categoryMutation.isPending ? "更新中…" : "更新分類"}</Button></div>{#if $categoryMutation.isError}<p class="mt-3 text-sm text-coral">更新失敗。</p>{/if}</div></div>{/if}
+    <div class="flex justify-end">
+      <Button variant="ghost" onclick={() => navigate("invoices")}
+        >查看完整發票明細 →</Button
+      >
+    </div>
+    {#if pending}<div
+        aria-modal="true"
+        class="fixed inset-0 z-[70] flex items-end bg-ink/45 md:items-center md:justify-center md:p-6"
+        role="dialog"
+      >
+        <div
+          class="max-h-[88vh] w-full overflow-y-auto rounded-t-2xl bg-white p-5 shadow-2xl md:max-w-lg md:rounded-2xl md:p-6"
+        >
+          <h2 class="text-xl font-semibold">更新活動分類</h2>
+          <p class="mt-1 text-sm text-ink/50">
+            {pending.item.title} → {categories[pending.categoryId] ??
+              pending.categoryId}
+          </p>
+          <label
+            class="mt-5 flex cursor-pointer items-start gap-3 rounded-xl border border-ink/10 bg-paper p-4"
+            ><Checkbox
+              class="mt-1"
+              checked={pending.addRule}
+              onchange={(e: Event) =>
+                (pending!.addRule = (
+                  e.currentTarget as HTMLInputElement
+                ).checked)}
+            /><span
+              ><span class="block font-semibold">同時新增分類規則</span><span
+                class="mt-1 block text-xs text-ink/50"
+                >符合規則的活動之後會自動套用。</span
+              ></span
+            ></label
+          >{#if pending.addRule}<div
+              class="mt-4 grid gap-3 rounded-xl border border-steel/20 bg-steel/5 p-4"
+            >
+              <Select bind:value={pending.operator}
+                ><option value="contains">交易文字包含</option><option
+                  value="equals">交易文字完全等於</option
+                ></Select
+              ><Input bind:value={pending.pattern} />
+              <p class="text-xs font-semibold text-steel">
+                將更新 {countMatches()} 筆過去活動
+              </p>
+            </div>{/if}
+          <div class="mt-5 grid grid-cols-2 gap-3">
+            <Button variant="secondary" onclick={() => (pending = null)}
+              >取消</Button
+            ><Button
+              disabled={$categoryMutation.isPending ||
+                (pending.addRule && !pending.pattern.trim())}
+              onclick={() =>
+                $categoryMutation.mutate({
+                  transactionId: pending!.item.transactionId!,
+                  categoryId: pending!.categoryId,
+                  addRule: pending!.addRule,
+                  pattern: pending!.pattern,
+                  operator: pending!.operator,
+                })}
+              >{$categoryMutation.isPending ? "更新中…" : "更新分類"}</Button
+            >
+          </div>
+          {#if $categoryMutation.isError}<p class="mt-3 text-sm text-coral">
+              更新失敗。
+            </p>{/if}
+        </div>
+      </div>{/if}
   </div>
 {/if}

--- a/apps/web/src/features/activity/ActivityCategoryChart.svelte
+++ b/apps/web/src/features/activity/ActivityCategoryChart.svelte
@@ -3,15 +3,22 @@
   import Card from "../../components/ui/Card.svelte";
   import CardContent from "../../components/ui/CardContent.svelte";
   import CardHeader from "../../components/ui/CardHeader.svelte";
-  import { ChartContainer, ChartTooltip, type ChartConfig } from "../../components/ui/chart";
+  import {
+    ChartContainer,
+    ChartTooltip,
+    type ChartConfig,
+  } from "../../components/ui/chart";
   import { formatCompactTwd, formatCurrency } from "../../lib/format.svelte";
-  import type { ActivityCategorySlice, ActivityFlow } from "../../lib/activity-chart";
+  import type {
+    ActivityCategorySlice,
+    ActivityFlow,
+  } from "../../lib/activity-chart";
 
   let {
     flow,
     slices,
     selectedCategory,
-    onSelect
+    onSelect,
   }: {
     flow: ActivityFlow;
     slices: ActivityCategorySlice[];
@@ -21,35 +28,51 @@
 
   const title = $derived(flow === "income" ? "收入分類" : "支出分類");
   const total = $derived(slices.reduce((sum, slice) => sum + slice.amount, 0));
-  const chartConfig: ChartConfig = { default: { label: "金額", color: "#3e6f7c" } };
+  const chartConfig: ChartConfig = {
+    default: { label: "金額", color: "#3e6f7c" },
+  };
 </script>
 
 {#snippet tooltip()}
   <ChartTooltip
     titleFormatter={(data) => {
       const slice = data as ActivityCategorySlice | undefined;
-      return slice ? `${slice.category} · ${slice.percentage.toFixed(1)}%` : title;
+      return slice
+        ? `${slice.category} · ${slice.percentage.toFixed(1)}%`
+        : title;
     }}
     valueFormatter={(value) => formatCurrency(Number(value))}
     hideItemLabel={true}
   />
 {/snippet}
 
-<Card class={`min-w-0 overflow-hidden ${flow === "income" ? "border-moss/20" : "border-coral/20"}`}>
+<Card
+  class={`min-w-0 overflow-hidden ${flow === "income" ? "border-moss/20" : "border-coral/20"}`}
+>
   <CardHeader class="flex-row items-start justify-between gap-3 pb-2">
     <div class="min-w-0">
-      <h3 class={`font-semibold ${flow === "income" ? "text-moss" : "text-coral"}`}>{title}</h3>
+      <h3
+        class={`font-semibold ${flow === "income" ? "text-moss" : "text-coral"}`}
+      >
+        {title}
+      </h3>
       <p class="mt-1 text-xs text-ink/45">點選分類查看該月活動</p>
     </div>
-    <p class={`shrink-0 text-base font-bold tabular-nums sm:text-lg ${flow === "income" ? "text-moss" : "text-coral"}`}>
+    <p
+      class={`shrink-0 text-base font-bold tabular-nums sm:text-lg ${flow === "income" ? "text-moss" : "text-coral"}`}
+    >
       {flow === "income" ? "+" : "−"}{formatCurrency(total)}
     </p>
   </CardHeader>
   <CardContent class="pt-2">
     {#if slices.length === 0}
-      <div class="rounded-xl bg-paper p-6 text-center text-sm text-ink/45">此月份沒有{flow === "income" ? "收入" : "支出"}活動</div>
+      <div class="rounded-xl bg-paper p-6 text-center text-sm text-ink/45">
+        此月份沒有{flow === "income" ? "收入" : "支出"}活動
+      </div>
     {:else}
-      <div class="grid min-w-0 gap-4 sm:grid-cols-[150px_minmax(0,1fr)] sm:items-center">
+      <div
+        class="grid min-w-0 gap-4 sm:grid-cols-[150px_minmax(0,1fr)] sm:items-center"
+      >
         <div class="relative mx-auto size-36">
           <ChartContainer config={chartConfig} class="size-36 min-h-36">
             <PieChart
@@ -61,14 +84,19 @@
               innerRadius={0.62}
               cornerRadius={3}
               padAngle={0.025}
-              tooltip={tooltip}
-              onArcClick={(_, detail) => onSelect((detail.data as ActivityCategorySlice).category)}
+              {tooltip}
+              onArcClick={(_, detail) =>
+                onSelect((detail.data as ActivityCategorySlice).category)}
               props={{ arc: { stroke: "white", strokeWidth: 2 } }}
             />
           </ChartContainer>
-          <div class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+          <div
+            class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center"
+          >
             <span class="text-[11px] text-ink/40">合計</span>
-            <span class="mt-0.5 text-sm font-bold tabular-nums">{formatCompactTwd(total)}</span>
+            <span class="mt-0.5 text-sm font-bold tabular-nums"
+              >{formatCompactTwd(total)}</span
+            >
           </div>
         </div>
         <div class="grid min-w-0 gap-1.5">
@@ -78,11 +106,20 @@
               class={`grid min-h-11 min-w-0 grid-cols-[12px_minmax(0,1fr)_auto] items-center gap-2 rounded-lg px-2 text-left transition ${selectedCategory === slice.category ? "bg-steel/10 ring-1 ring-steel/20" : "hover:bg-paper"}`}
               onclick={() => onSelect(slice.category)}
             >
-              <span class="size-2.5 rounded-full" style={`background-color:${slice.color}`}></span>
-              <span class="truncate text-sm font-semibold">{slice.category}</span>
+              <span
+                class="size-2.5 rounded-full"
+                style={`background-color:${slice.color}`}
+              ></span>
+              <span class="truncate text-sm font-semibold"
+                >{slice.category}</span
+              >
               <span class="text-right">
-                <span class="block text-xs font-bold tabular-nums">{slice.percentage.toFixed(1)}%</span>
-                <span class="block text-[10px] text-ink/40 tabular-nums">{formatCurrency(slice.amount)}</span>
+                <span class="block text-xs font-bold tabular-nums"
+                  >{slice.percentage.toFixed(1)}%</span
+                >
+                <span class="block text-[10px] text-ink/40 tabular-nums"
+                  >{formatCurrency(slice.amount)}</span
+                >
               </span>
             </button>
           {/each}

--- a/apps/web/src/features/assets/Assets.svelte
+++ b/apps/web/src/features/assets/Assets.svelte
@@ -9,11 +9,23 @@
   import TabsList from "../../components/ui/TabsList.svelte";
   import TabsTrigger from "../../components/ui/TabsTrigger.svelte";
   import type { ApiClient } from "../../lib/api";
-  import { bankQuery, exchangeRatesQuery, investmentsQuery, manualAssetsQuery } from "../../lib/queries";
+  import {
+    bankQuery,
+    exchangeRatesQuery,
+    investmentsQuery,
+    manualAssetsQuery,
+  } from "../../lib/queries";
   import type { AssetSection, BankAccountRow, View } from "../../lib/types";
-  import { formatBankAccountName, formatCurrency, formatDate, formatNumber, rateMap } from "../../lib/format.svelte";
+  import {
+    formatBankAccountName,
+    formatCurrency,
+    formatDate,
+    formatNumber,
+    rateMap,
+  } from "../../lib/format.svelte";
 
-  let { api, navigate }: { api: ApiClient; navigate: (view: View) => void } = $props();
+  let { api, navigate }: { api: ApiClient; navigate: (view: View) => void } =
+    $props();
   const bank = createQuery(bankQuery(() => api));
   const investments = createQuery(investmentsQuery(() => api));
   const manual = createQuery(manualAssetsQuery(() => api));
@@ -22,104 +34,295 @@
   let section = $state<AssetSection>("all");
   const bankData = $derived($bank.data ?? { accounts: [], transactions: [] });
   const rateValues = $derived(rateMap($rates.data));
-  const toTwd = (value: number, currency: string) => currency === "TWD" ? value : value * (rateValues[currency] ?? 0);
-  const deposits = $derived(bankData.accounts.filter((account) => account.accountType !== "credit"));
-  const cards = $derived(bankData.accounts.filter((account) => account.accountType === "credit"));
-  const bankTotal = $derived(deposits.reduce((sum, account) => sum + toTwd(account.balance ?? 0, account.currency), 0));
-  const investmentTotal = $derived(($investments.data ?? []).reduce((sum, item) => sum + toTwd((item.marketValue ?? 0) + (item.cashBalance ?? 0), item.currency), 0));
-  const manualTotal = $derived(($manual.data ?? []).reduce((sum, item) => sum + (item.value ?? 0), 0));
-  const cardDebt = $derived(cards.reduce((sum, account) => sum + Math.abs(toTwd(account.balance ?? 0, account.currency)), 0));
+  const toTwd = (value: number, currency: string) =>
+    currency === "TWD" ? value : value * (rateValues[currency] ?? 0);
+  const deposits = $derived(
+    bankData.accounts.filter((account) => account.accountType !== "credit"),
+  );
+  const cards = $derived(
+    bankData.accounts.filter((account) => account.accountType === "credit"),
+  );
+  const bankTotal = $derived(
+    deposits.reduce(
+      (sum, account) => sum + toTwd(account.balance ?? 0, account.currency),
+      0,
+    ),
+  );
+  const investmentTotal = $derived(
+    ($investments.data ?? []).reduce(
+      (sum, item) =>
+        sum +
+        toTwd((item.marketValue ?? 0) + (item.cashBalance ?? 0), item.currency),
+      0,
+    ),
+  );
+  const manualTotal = $derived(
+    ($manual.data ?? []).reduce((sum, item) => sum + (item.value ?? 0), 0),
+  );
+  const cardDebt = $derived(
+    cards.reduce(
+      (sum, account) =>
+        sum + Math.abs(toTwd(account.balance ?? 0, account.currency)),
+      0,
+    ),
+  );
   const grossAssets = $derived(bankTotal + investmentTotal + manualTotal);
   const netWorth = $derived(grossAssets - cardDebt);
   const groupedBanks = $derived.by(() => {
-    const groups = deposits.reduce<Record<string, BankAccountRow[]>>((result, account) => {
-      const institution = account.institutionName ?? account.connectorId;
-      (result[institution] ??= []).push(account);
-      return result;
-    }, {});
-    return Object.entries(groups).map(([institution, accounts]) => ({
-      institution,
-      accounts: [...accounts].sort((a, b) => toTwd(b.balance ?? 0, b.currency) - toTwd(a.balance ?? 0, a.currency)),
-      totalTwd: accounts.reduce((sum, account) => sum + toTwd(account.balance ?? 0, account.currency), 0),
-      foreignCurrencies: [...new Set(accounts.map((account) => account.currency).filter((currency) => currency !== "TWD"))]
-    })).sort((a, b) => b.totalTwd - a.totalTwd || a.institution.localeCompare(b.institution, "zh-TW"));
+    const groups = deposits.reduce<Record<string, BankAccountRow[]>>(
+      (result, account) => {
+        const institution = account.institutionName ?? account.connectorId;
+        (result[institution] ??= []).push(account);
+        return result;
+      },
+      {},
+    );
+    return Object.entries(groups)
+      .map(([institution, accounts]) => ({
+        institution,
+        accounts: [...accounts].sort(
+          (a, b) =>
+            toTwd(b.balance ?? 0, b.currency) -
+            toTwd(a.balance ?? 0, a.currency),
+        ),
+        totalTwd: accounts.reduce(
+          (sum, account) => sum + toTwd(account.balance ?? 0, account.currency),
+          0,
+        ),
+        foreignCurrencies: [
+          ...new Set(
+            accounts
+              .map((account) => account.currency)
+              .filter((currency) => currency !== "TWD"),
+          ),
+        ],
+      }))
+      .sort(
+        (a, b) =>
+          b.totalTwd - a.totalTwd ||
+          a.institution.localeCompare(b.institution, "zh-TW"),
+      );
   });
   const tabs: { key: AssetSection; label: string }[] = [
-    { key: "all", label: "全部" }, { key: "bank", label: "銀行" }, { key: "cards", label: "信用卡" },
-    { key: "investments", label: "投資" }, { key: "manual-assets", label: "其他資產" }
+    { key: "all", label: "全部" },
+    { key: "bank", label: "銀行" },
+    { key: "cards", label: "信用卡" },
+    { key: "investments", label: "投資" },
+    { key: "manual-assets", label: "其他資產" },
   ];
-  const loading = $derived($bank.isPending || $investments.isPending || $manual.isPending);
-  const failed = $derived($bank.isError || $investments.isError || $manual.isError);
-  const mobileSummary = $derived(section === "bank"
-    ? { label: "銀行與現金", value: bankTotal, detail: `${deposits.length} 個帳戶` }
-    : section === "cards"
-      ? { label: "信用卡負債", value: cardDebt, detail: `${cards.length} 張卡片 · 目前未繳` }
-      : section === "investments"
-        ? { label: "投資市值", value: investmentTotal, detail: `${$investments.data?.length ?? 0} 個持倉 · TDCC` }
-        : section === "manual-assets"
-          ? { label: "其他資產", value: manualTotal, detail: "房產、保險與交通工具" }
-          : { label: "全部資產", value: netWorth, detail: "淨資產 · 已扣除信用卡負債" });
+  const loading = $derived(
+    $bank.isPending || $investments.isPending || $manual.isPending,
+  );
+  const failed = $derived(
+    $bank.isError || $investments.isError || $manual.isError,
+  );
+  const mobileSummary = $derived(
+    section === "bank"
+      ? {
+          label: "銀行與現金",
+          value: bankTotal,
+          detail: `${deposits.length} 個帳戶`,
+        }
+      : section === "cards"
+        ? {
+            label: "信用卡負債",
+            value: cardDebt,
+            detail: `${cards.length} 張卡片 · 目前未繳`,
+          }
+        : section === "investments"
+          ? {
+              label: "投資市值",
+              value: investmentTotal,
+              detail: `${$investments.data?.length ?? 0} 個持倉 · TDCC`,
+            }
+          : section === "manual-assets"
+            ? {
+                label: "其他資產",
+                value: manualTotal,
+                detail: "房產、保險與交通工具",
+              }
+            : {
+                label: "全部資產",
+                value: netWorth,
+                detail: "淨資產 · 已扣除信用卡負債",
+              },
+  );
 </script>
 
 {#if loading}
-  <EmptyState title="載入資產中" body="正在彙整銀行、信用卡、投資與其他資產。" />
+  <EmptyState
+    title="載入資產中"
+    body="正在彙整銀行、信用卡、投資與其他資產。"
+  />
 {:else if failed}
-  <EmptyState title="無法載入資產" body="請稍後再試，或確認 Worker API 是否可用。" />
+  <EmptyState
+    title="無法載入資產"
+    body="請稍後再試，或確認 Worker API 是否可用。"
+  />
 {:else}
   <div class="grid min-w-0 max-w-full gap-5">
     <section class="rounded-2xl bg-ink p-5 text-white shadow-xs md:hidden">
-      <p class="text-xs font-semibold tracking-wide text-white/60">{mobileSummary.label}</p>
-      <p class="mt-2 break-words text-3xl font-bold tracking-tight tabular-nums">{formatCurrency(mobileSummary.value)}</p>
+      <p class="text-xs font-semibold tracking-wide text-white/60">
+        {mobileSummary.label}
+      </p>
+      <p
+        class="mt-2 break-words text-3xl font-bold tracking-tight tabular-nums"
+      >
+        {formatCurrency(mobileSummary.value)}
+      </p>
       <p class="mt-2 text-xs text-white/60">{mobileSummary.detail}</p>
     </section>
 
     <div class="hidden gap-4 md:grid md:grid-cols-2 xl:grid-cols-4">
-      {#each [
-        { label: "資產總額", value: grossAssets, detail: "不含信用卡負債", tone: "" },
-        { label: "銀行與現金", value: bankTotal, detail: `${deposits.length} 個帳戶`, tone: "text-moss" },
-        { label: "投資", value: investmentTotal, detail: `${$investments.data?.length ?? 0} 個持倉`, tone: "text-steel" },
-        { label: "信用卡負債", value: -cardDebt, detail: `${cards.length} 張卡片`, tone: "text-coral" }
-      ] as item (item.label)}
-        <Card><CardContent class="p-5"><p class="text-xs font-semibold text-ink/50">{item.label}</p><p class={`mt-2 text-2xl font-bold tracking-tight tabular-nums ${item.tone}`}>{formatCurrency(item.value)}</p><p class="mt-1 text-xs text-ink/45">{item.detail}</p></CardContent></Card>
+      {#each [{ label: "資產總額", value: grossAssets, detail: "不含信用卡負債", tone: "" }, { label: "銀行與現金", value: bankTotal, detail: `${deposits.length} 個帳戶`, tone: "text-moss" }, { label: "投資", value: investmentTotal, detail: `${$investments.data?.length ?? 0} 個持倉`, tone: "text-steel" }, { label: "信用卡負債", value: -cardDebt, detail: `${cards.length} 張卡片`, tone: "text-coral" }] as item (item.label)}
+        <Card
+          ><CardContent class="p-5"
+            ><p class="text-xs font-semibold text-ink/50">{item.label}</p>
+            <p
+              class={`mt-2 text-2xl font-bold tracking-tight tabular-nums ${item.tone}`}
+            >
+              {formatCurrency(item.value)}
+            </p>
+            <p class="mt-1 text-xs text-ink/45">{item.detail}</p></CardContent
+          ></Card
+        >
       {/each}
     </div>
 
     <TabsList class="grid h-auto w-full grid-cols-5 bg-card shadow-xs">
       {#each tabs as tab (tab.key)}
-        <TabsTrigger class={`min-h-10 min-w-0 px-1 text-xs sm:text-sm ${section === tab.key ? "bg-ink text-white" : ""}`} active={section === tab.key} onclick={() => section = tab.key}>{tab.label}</TabsTrigger>
+        <TabsTrigger
+          class={`min-h-10 min-w-0 px-1 text-xs sm:text-sm ${section === tab.key ? "bg-ink text-white" : ""}`}
+          active={section === tab.key}
+          onclick={() => (section = tab.key)}>{tab.label}</TabsTrigger
+        >
       {/each}
     </TabsList>
 
     {#if section === "all"}
       <div class="grid gap-3 xl:hidden">
         <Card>
-          <CardHeader class="flex-row items-center justify-between py-4"><div><h2 class="text-lg font-semibold">銀行與現金</h2><p class="mt-1 text-xs text-ink/45">各銀行彙整，外幣換算為 TWD</p></div><button class="text-xs font-semibold text-steel" onclick={() => section = "bank"}>總額 {formatCurrency(bankTotal)}</button></CardHeader>
+          <CardHeader class="flex-row items-center justify-between py-4"
+            ><div>
+              <h2 class="text-lg font-semibold">銀行與現金</h2>
+              <p class="mt-1 text-xs text-ink/45">各銀行彙整，外幣換算為 TWD</p>
+            </div>
+            <button
+              class="text-xs font-semibold text-steel"
+              onclick={() => (section = "bank")}
+              >總額 {formatCurrency(bankTotal)}</button
+            ></CardHeader
+          >
           <CardContent class="pt-0">
             <div class="divide-y divide-ink/8">
               {#each groupedBanks as group (group.institution)}
-                <button class="flex min-h-16 w-full items-center justify-between gap-3 py-3 text-left" onclick={() => section = "bank"}>
-                  <div class="flex min-w-0 items-center gap-3"><span class="flex size-9 shrink-0 items-center justify-center rounded-xl bg-steel/10 text-steel"><Building2 class="size-4" /></span><div class="min-w-0"><h3 class="truncate font-semibold">{group.institution}</h3><p class="mt-1 truncate text-xs text-ink/45">{group.accounts.length} 個帳戶{group.foreignCurrencies.length ? ` · 含 ${group.foreignCurrencies.join("、")}` : ""}</p></div></div>
-                  <p class="shrink-0 font-bold tabular-nums text-steel">{formatCurrency(group.totalTwd)}</p>
+                <button
+                  class="flex min-h-16 w-full items-center justify-between gap-3 py-3 text-left"
+                  onclick={() => (section = "bank")}
+                >
+                  <div class="flex min-w-0 items-center gap-3">
+                    <span
+                      class="flex size-9 shrink-0 items-center justify-center rounded-xl bg-steel/10 text-steel"
+                      ><Building2 class="size-4" /></span
+                    >
+                    <div class="min-w-0">
+                      <h3 class="truncate font-semibold">
+                        {group.institution}
+                      </h3>
+                      <p class="mt-1 truncate text-xs text-ink/45">
+                        {group.accounts.length} 個帳戶{group.foreignCurrencies
+                          .length
+                          ? ` · 含 ${group.foreignCurrencies.join("、")}`
+                          : ""}
+                      </p>
+                    </div>
+                  </div>
+                  <p class="shrink-0 font-bold tabular-nums text-steel">
+                    {formatCurrency(group.totalTwd)}
+                  </p>
                 </button>
               {/each}
             </div>
           </CardContent>
         </Card>
-        <Card><CardHeader class="flex-row items-center justify-between"><h2 class="text-lg font-semibold">投資</h2><span class="text-sm font-bold tabular-nums text-steel">{formatCurrency(investmentTotal)}</span></CardHeader><CardContent><button class="flex w-full items-center justify-between gap-4 text-left" onclick={() => section = "investments"}><div><p class="font-semibold">主要投資帳戶</p><p class="text-xs text-ink/45">{$investments.data?.length ?? 0} 個持倉 · TDCC</p></div><span class="text-xs font-semibold text-steel">查看持倉 →</span></button></CardContent></Card>
-        <Card><CardHeader class="flex-row items-center justify-between"><h2 class="text-lg font-semibold">其他資產</h2><span class="font-bold tabular-nums text-moss">{formatCurrency(manualTotal)}</span></CardHeader><CardContent class="pt-0"><button class="text-left text-xs text-ink/45" onclick={() => section = "manual-assets"}>保險、房產、交通工具 · 更新估值 →</button></CardContent></Card>
+        <Card
+          ><CardHeader class="flex-row items-center justify-between"
+            ><h2 class="text-lg font-semibold">投資</h2>
+            <span class="text-sm font-bold tabular-nums text-steel"
+              >{formatCurrency(investmentTotal)}</span
+            ></CardHeader
+          ><CardContent
+            ><button
+              class="flex w-full items-center justify-between gap-4 text-left"
+              onclick={() => (section = "investments")}
+              ><div>
+                <p class="font-semibold">主要投資帳戶</p>
+                <p class="text-xs text-ink/45">
+                  {$investments.data?.length ?? 0} 個持倉 · TDCC
+                </p>
+              </div>
+              <span class="text-xs font-semibold text-steel">查看持倉 →</span
+              ></button
+            ></CardContent
+          ></Card
+        >
+        <Card
+          ><CardHeader class="flex-row items-center justify-between"
+            ><h2 class="text-lg font-semibold">其他資產</h2>
+            <span class="font-bold tabular-nums text-moss"
+              >{formatCurrency(manualTotal)}</span
+            ></CardHeader
+          ><CardContent class="pt-0"
+            ><button
+              class="text-left text-xs text-ink/45"
+              onclick={() => (section = "manual-assets")}
+              >保險、房產、交通工具 · 更新估值 →</button
+            ></CardContent
+          ></Card
+        >
       </div>
 
-      <div class="hidden gap-5 xl:grid xl:grid-cols-[minmax(0,2fr)_minmax(300px,0.8fr)]">
+      <div
+        class="hidden gap-5 xl:grid xl:grid-cols-[minmax(0,2fr)_minmax(300px,0.8fr)]"
+      >
         <div class="grid content-start gap-5">
           <Card>
-            <CardHeader class="flex-row items-center justify-between border-b border-ink/8"><div><h2 class="text-lg font-semibold">銀行帳戶</h2><p class="text-xs text-ink/45">{deposits.length} 個帳戶</p></div><Button size="sm" variant="ghost" onclick={() => navigate("bank")}>查看交易 →</Button></CardHeader>
+            <CardHeader
+              class="flex-row items-center justify-between border-b border-ink/8"
+              ><div>
+                <h2 class="text-lg font-semibold">銀行帳戶</h2>
+                <p class="text-xs text-ink/45">{deposits.length} 個帳戶</p>
+              </div>
+              <Button size="sm" variant="ghost" onclick={() => navigate("bank")}
+                >查看交易 →</Button
+              ></CardHeader
+            >
             <div class="divide-y divide-ink/8">
               {#each groupedBanks as group (group.institution)}
                 <div class="p-4">
-                  <div class="mb-2 flex items-center justify-between gap-3"><h3 class="font-semibold">{group.institution}</h3><div class="flex items-center gap-3"><span class="text-xs font-bold tabular-nums text-steel">{formatCurrency(group.totalTwd)}</span><span class="text-xs font-medium text-moss">已同步</span></div></div>
+                  <div class="mb-2 flex items-center justify-between gap-3">
+                    <h3 class="font-semibold">{group.institution}</h3>
+                    <div class="flex items-center gap-3">
+                      <span class="text-xs font-bold tabular-nums text-steel"
+                        >{formatCurrency(group.totalTwd)}</span
+                      ><span class="text-xs font-medium text-moss">已同步</span>
+                    </div>
+                  </div>
                   <div class="grid gap-2">
                     {#each group.accounts as account (account.id)}
-                      <div class="flex items-center justify-between gap-4 text-sm"><span class="min-w-0 truncate text-ink/60">{account.accountName ?? formatBankAccountName(account)}</span><span class="shrink-0 font-semibold tabular-nums">{formatCurrency(account.balance ?? 0, account.currency)}</span></div>
+                      <div
+                        class="flex items-center justify-between gap-4 text-sm"
+                      >
+                        <span class="min-w-0 truncate text-ink/60"
+                          >{account.accountName ??
+                            formatBankAccountName(account)}</span
+                        ><span class="shrink-0 font-semibold tabular-nums"
+                          >{formatCurrency(
+                            account.balance ?? 0,
+                            account.currency,
+                          )}</span
+                        >
+                      </div>
                     {/each}
                   </div>
                 </div>
@@ -127,34 +330,240 @@
             </div>
           </Card>
           <Card>
-            <CardHeader class="flex-row items-center justify-between border-b border-ink/8"><div><h2 class="text-lg font-semibold">投資持倉</h2><p class="text-xs text-ink/45">市值 {formatCurrency(investmentTotal)}</p></div><Button size="sm" variant="ghost" onclick={() => navigate("investments")}>查看全部 →</Button></CardHeader>
+            <CardHeader
+              class="flex-row items-center justify-between border-b border-ink/8"
+              ><div>
+                <h2 class="text-lg font-semibold">投資持倉</h2>
+                <p class="text-xs text-ink/45">
+                  市值 {formatCurrency(investmentTotal)}
+                </p>
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                onclick={() => navigate("investments")}>查看全部 →</Button
+              ></CardHeader
+            >
             <div class="divide-y divide-ink/8">
               {#each ($investments.data ?? []).slice(0, 5) as item (item.id)}
-                <div class="grid grid-cols-[64px_minmax(0,1fr)_auto] items-center gap-3 px-5 py-3 text-sm"><span class="font-semibold text-steel">{item.symbol ?? item.assetType.toUpperCase()}</span><span class="min-w-0 truncate font-medium">{item.name}</span><span class="font-semibold tabular-nums">{formatCurrency((item.marketValue ?? 0) + (item.cashBalance ?? 0), item.currency)}</span></div>
+                <div
+                  class="grid grid-cols-[64px_minmax(0,1fr)_auto] items-center gap-3 px-5 py-3 text-sm"
+                >
+                  <span class="font-semibold text-steel"
+                    >{item.symbol ?? item.assetType.toUpperCase()}</span
+                  ><span class="min-w-0 truncate font-medium">{item.name}</span
+                  ><span class="font-semibold tabular-nums"
+                    >{formatCurrency(
+                      (item.marketValue ?? 0) + (item.cashBalance ?? 0),
+                      item.currency,
+                    )}</span
+                  >
+                </div>
               {/each}
             </div>
           </Card>
         </div>
         <div class="grid content-start gap-5">
-          <Card><CardHeader class="flex-row items-center justify-between"><h2 class="text-lg font-semibold">信用卡</h2><Button size="sm" variant="ghost" onclick={() => navigate("cards")}>查看交易 →</Button></CardHeader><CardContent><div class="rounded-xl bg-ink p-4 text-white"><p class="text-xs text-white/60">目前負債</p><p class="mt-2 text-2xl font-bold tabular-nums">{formatCurrency(cardDebt)}</p><p class="mt-2 text-xs text-white/55">{cards.length} 張卡片</p></div></CardContent></Card>
-          <Card><CardHeader class="flex-row items-center justify-between"><h2 class="text-lg font-semibold">其他資產</h2><Button size="sm" variant="ghost" onclick={() => navigate("manual-assets")}>更新估值</Button></CardHeader><CardContent><p class="text-2xl font-bold tabular-nums text-moss">{formatCurrency(manualTotal)}</p><p class="mt-2 text-xs text-ink/45">保險、不動產、交通工具與其他</p></CardContent></Card>
+          <Card
+            ><CardHeader class="flex-row items-center justify-between"
+              ><h2 class="text-lg font-semibold">信用卡</h2>
+              <Button
+                size="sm"
+                variant="ghost"
+                onclick={() => navigate("cards")}>查看交易 →</Button
+              ></CardHeader
+            ><CardContent
+              ><div class="rounded-xl bg-ink p-4 text-white">
+                <p class="text-xs text-white/60">目前負債</p>
+                <p class="mt-2 text-2xl font-bold tabular-nums">
+                  {formatCurrency(cardDebt)}
+                </p>
+                <p class="mt-2 text-xs text-white/55">{cards.length} 張卡片</p>
+              </div></CardContent
+            ></Card
+          >
+          <Card
+            ><CardHeader class="flex-row items-center justify-between"
+              ><h2 class="text-lg font-semibold">其他資產</h2>
+              <Button
+                size="sm"
+                variant="ghost"
+                onclick={() => navigate("manual-assets")}>更新估值</Button
+              ></CardHeader
+            ><CardContent
+              ><p class="text-2xl font-bold tabular-nums text-moss">
+                {formatCurrency(manualTotal)}
+              </p>
+              <p class="mt-2 text-xs text-ink/45">
+                保險、不動產、交通工具與其他
+              </p></CardContent
+            ></Card
+          >
         </div>
       </div>
     {:else if section === "bank"}
       <Card>
-        <CardHeader class="flex-row items-center justify-between"><div><h2 class="flex items-center gap-2 text-lg font-semibold"><Building2 class="size-5 text-steel" />銀行帳戶</h2><p class="mt-1 text-xs text-ink/45">依銀行分組，總額由大到小排列</p></div><Button size="sm" variant="ghost" onclick={() => navigate("bank")}>查看所有交易 →</Button></CardHeader>
+        <CardHeader class="flex-row items-center justify-between"
+          ><div>
+            <h2 class="flex items-center gap-2 text-lg font-semibold">
+              <Building2 class="size-5 text-steel" />銀行帳戶
+            </h2>
+            <p class="mt-1 text-xs text-ink/45">依銀行分組，總額由大到小排列</p>
+          </div>
+          <Button size="sm" variant="ghost" onclick={() => navigate("bank")}
+            >查看所有交易 →</Button
+          ></CardHeader
+        >
         <div class="divide-y divide-ink/8">
           {#each groupedBanks as group (group.institution)}
-            <section class="px-5 py-4"><div class="flex items-center justify-between gap-3"><div><h3 class="font-semibold">{group.institution}</h3><p class="mt-1 text-xs text-ink/45">{group.accounts.length} 個帳戶</p></div><p class="font-bold tabular-nums text-steel">{formatCurrency(group.totalTwd)}</p></div><div class="mt-3 grid gap-2 md:grid-cols-2">{#each group.accounts as account (account.id)}<div class="rounded-xl border border-ink/8 p-3"><div class="flex items-start justify-between gap-3"><div class="min-w-0"><p class="truncate text-sm font-semibold">{account.accountName ?? formatBankAccountName(account)}</p><p class="mt-1 text-xs text-ink/45">{account.currency} · {account.asOfAt ? `更新 ${formatDate(account.asOfAt)}` : "尚未同步"}</p></div><p class="shrink-0 font-bold tabular-nums">{formatCurrency(account.balance ?? 0, account.currency)}</p></div></div>{/each}</div></section>
+            <section class="px-5 py-4">
+              <div class="flex items-center justify-between gap-3">
+                <div>
+                  <h3 class="font-semibold">{group.institution}</h3>
+                  <p class="mt-1 text-xs text-ink/45">
+                    {group.accounts.length} 個帳戶
+                  </p>
+                </div>
+                <p class="font-bold tabular-nums text-steel">
+                  {formatCurrency(group.totalTwd)}
+                </p>
+              </div>
+              <div class="mt-3 grid gap-2 md:grid-cols-2">
+                {#each group.accounts as account (account.id)}<div
+                    class="rounded-xl border border-ink/8 p-3"
+                  >
+                    <div class="flex items-start justify-between gap-3">
+                      <div class="min-w-0">
+                        <p class="truncate text-sm font-semibold">
+                          {account.accountName ??
+                            formatBankAccountName(account)}
+                        </p>
+                        <p class="mt-1 text-xs text-ink/45">
+                          {account.currency} · {account.asOfAt
+                            ? `更新 ${formatDate(account.asOfAt)}`
+                            : "尚未同步"}
+                        </p>
+                      </div>
+                      <p class="shrink-0 font-bold tabular-nums">
+                        {formatCurrency(account.balance ?? 0, account.currency)}
+                      </p>
+                    </div>
+                  </div>{/each}
+              </div>
+            </section>
           {/each}
         </div>
       </Card>
     {:else if section === "cards"}
-      <Card><CardHeader class="flex-row items-center justify-between"><div><h2 class="text-lg font-semibold">信用卡帳戶</h2><p class="mt-1 text-xs text-ink/45">目前負債 {formatCurrency(cardDebt)}</p></div><Button size="sm" variant="ghost" onclick={() => navigate("cards")}>查看刷卡紀錄 →</Button></CardHeader><CardContent>{#if cards.length === 0}<p class="py-8 text-center text-sm text-ink/45">尚無信用卡資料。</p>{:else}<div class="grid gap-3 md:grid-cols-2">{#each cards as card, index (card.id)}<button class={`w-full rounded-2xl p-4 text-left text-white ${index % 2 === 0 ? "bg-ink" : "bg-steel"}`} onclick={() => navigate("cards")}><div class="flex items-start justify-between"><div><p class="font-semibold">{card.institutionName ?? card.connectorId}</p><p class="mt-2 text-xs text-white/65">{card.accountName ?? formatBankAccountName(card)}</p></div><CreditCard class="size-5 text-white/70" /></div><p class="mt-5 text-2xl font-bold tabular-nums">{formatCurrency(Math.abs(card.balance ?? 0), card.currency)}</p></button>{/each}</div>{/if}</CardContent></Card>
+      <Card
+        ><CardHeader class="flex-row items-center justify-between"
+          ><div>
+            <h2 class="text-lg font-semibold">信用卡帳戶</h2>
+            <p class="mt-1 text-xs text-ink/45">
+              目前負債 {formatCurrency(cardDebt)}
+            </p>
+          </div>
+          <Button size="sm" variant="ghost" onclick={() => navigate("cards")}
+            >查看刷卡紀錄 →</Button
+          ></CardHeader
+        ><CardContent
+          >{#if cards.length === 0}<p
+              class="py-8 text-center text-sm text-ink/45"
+            >
+              尚無信用卡資料。
+            </p>{:else}<div class="grid gap-3 md:grid-cols-2">
+              {#each cards as card, index (card.id)}<button
+                  class={`w-full rounded-2xl p-4 text-left text-white ${index % 2 === 0 ? "bg-ink" : "bg-steel"}`}
+                  onclick={() => navigate("cards")}
+                  ><div class="flex items-start justify-between">
+                    <div>
+                      <p class="font-semibold">
+                        {card.institutionName ?? card.connectorId}
+                      </p>
+                      <p class="mt-2 text-xs text-white/65">
+                        {card.accountName ?? formatBankAccountName(card)}
+                      </p>
+                    </div>
+                    <CreditCard class="size-5 text-white/70" />
+                  </div>
+                  <p class="mt-5 text-2xl font-bold tabular-nums">
+                    {formatCurrency(Math.abs(card.balance ?? 0), card.currency)}
+                  </p></button
+                >{/each}
+            </div>{/if}</CardContent
+        ></Card
+      >
     {:else if section === "investments"}
-      <Card><CardHeader class="flex-row items-center justify-between"><div><h2 class="text-lg font-semibold">投資持倉</h2><p class="mt-1 text-xs text-ink/45">市值 {formatCurrency(investmentTotal)}</p></div><Button size="sm" variant="ghost" onclick={() => navigate("investments")}>交易紀錄 →</Button></CardHeader><CardContent><div class="divide-y divide-ink/8">{#each $investments.data ?? [] as item (item.id)}<button class="flex min-h-16 w-full items-center justify-between gap-3 py-3 text-left" onclick={() => navigate("investments")}><div class="min-w-0"><p class="truncate font-semibold">{item.symbol ? `${item.symbol} ` : ""}{item.name}</p><p class="mt-1 text-xs text-ink/45">{formatNumber(item.quantity ?? 0)} 單位 · {item.assetType.toUpperCase()}</p></div><p class="shrink-0 font-bold tabular-nums text-steel">{formatCurrency((item.marketValue ?? 0) + (item.cashBalance ?? 0), item.currency)}</p></button>{/each}</div></CardContent></Card>
+      <Card
+        ><CardHeader class="flex-row items-center justify-between"
+          ><div>
+            <h2 class="text-lg font-semibold">投資持倉</h2>
+            <p class="mt-1 text-xs text-ink/45">
+              市值 {formatCurrency(investmentTotal)}
+            </p>
+          </div>
+          <Button
+            size="sm"
+            variant="ghost"
+            onclick={() => navigate("investments")}>交易紀錄 →</Button
+          ></CardHeader
+        ><CardContent
+          ><div class="divide-y divide-ink/8">
+            {#each $investments.data ?? [] as item (item.id)}<button
+                class="flex min-h-16 w-full items-center justify-between gap-3 py-3 text-left"
+                onclick={() => navigate("investments")}
+                ><div class="min-w-0">
+                  <p class="truncate font-semibold">
+                    {item.symbol ? `${item.symbol} ` : ""}{item.name}
+                  </p>
+                  <p class="mt-1 text-xs text-ink/45">
+                    {formatNumber(item.quantity ?? 0)} 單位 · {item.assetType.toUpperCase()}
+                  </p>
+                </div>
+                <p class="shrink-0 font-bold tabular-nums text-steel">
+                  {formatCurrency(
+                    (item.marketValue ?? 0) + (item.cashBalance ?? 0),
+                    item.currency,
+                  )}
+                </p></button
+              >{/each}
+          </div></CardContent
+        ></Card
+      >
     {:else}
-      <Card><CardHeader class="flex-row items-center justify-between"><div><h2 class="text-lg font-semibold">其他資產</h2><p class="mt-1 text-xs text-ink/45">合計 {formatCurrency(manualTotal)}</p></div><Button size="sm" variant="ghost" onclick={() => navigate("manual-assets")}>＋ 新增資產</Button></CardHeader><CardContent><div class="divide-y divide-ink/8">{#each $manual.data ?? [] as item (item.id)}<button class="flex min-h-16 w-full items-center justify-between gap-3 py-3 text-left" onclick={() => navigate("manual-assets")}><div class="min-w-0"><p class="truncate font-semibold">{item.name}</p><p class="mt-1 truncate text-xs text-ink/45">{item.category} · {item.date ? `${formatDate(item.date)} 更新` : "查看估值歷史"}</p></div><p class="shrink-0 font-bold tabular-nums text-moss">{formatCurrency(item.value ?? 0)}</p></button>{/each}</div></CardContent></Card>
+      <Card
+        ><CardHeader class="flex-row items-center justify-between"
+          ><div>
+            <h2 class="text-lg font-semibold">其他資產</h2>
+            <p class="mt-1 text-xs text-ink/45">
+              合計 {formatCurrency(manualTotal)}
+            </p>
+          </div>
+          <Button
+            size="sm"
+            variant="ghost"
+            onclick={() => navigate("manual-assets")}>＋ 新增資產</Button
+          ></CardHeader
+        ><CardContent
+          ><div class="divide-y divide-ink/8">
+            {#each $manual.data ?? [] as item (item.id)}<button
+                class="flex min-h-16 w-full items-center justify-between gap-3 py-3 text-left"
+                onclick={() => navigate("manual-assets")}
+                ><div class="min-w-0">
+                  <p class="truncate font-semibold">{item.name}</p>
+                  <p class="mt-1 truncate text-xs text-ink/45">
+                    {item.category} · {item.date
+                      ? `${formatDate(item.date)} 更新`
+                      : "查看估值歷史"}
+                  </p>
+                </div>
+                <p class="shrink-0 font-bold tabular-nums text-moss">
+                  {formatCurrency(item.value ?? 0)}
+                </p></button
+              >{/each}
+          </div></CardContent
+        ></Card
+      >
     {/if}
   </div>
 {/if}

--- a/apps/web/src/features/assets/Bank.svelte
+++ b/apps/web/src/features/assets/Bank.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { SvelteDate } from "svelte/reactivity";
-  import { createMutation, createQuery, useQueryClient } from "@tanstack/svelte-query";
+  import {
+    createMutation,
+    createQuery,
+    useQueryClient,
+  } from "@tanstack/svelte-query";
   import { Search } from "@lucide/svelte";
   import Card from "../../components/ui/Card.svelte";
   import CardHeader from "../../components/ui/CardHeader.svelte";
@@ -13,8 +17,16 @@
   import { queryKeys } from "../../lib/api";
   import { bankQuery, exchangeRatesQuery } from "../../lib/queries";
   import type { BankTransactionRow, View } from "../../lib/types";
-  import { formatBankAccountName, formatCurrency, formatCurrencyTotals, formatDate, rateMap, transactionValueTwd } from "../../lib/format.svelte";
-  let { api, navigate }: { api: ApiClient; navigate: (view: View) => void } = $props();
+  import {
+    formatBankAccountName,
+    formatCurrency,
+    formatCurrencyTotals,
+    formatDate,
+    rateMap,
+    transactionValueTwd,
+  } from "../../lib/format.svelte";
+  let { api, navigate }: { api: ApiClient; navigate: (view: View) => void } =
+    $props();
   const bank = createQuery(bankQuery(() => api));
   const rates = createQuery(exchangeRatesQuery(() => api));
   const qc = useQueryClient();
@@ -23,19 +35,279 @@
   let flow = $state<"all" | "inflow" | "outflow">("all");
   let range = $state<"month" | "threeMonths" | "year" | "all">("month");
   let selected = $state<BankTransactionRow | null>(null);
-  let ruleForm = $state({ pattern: "", operator: "contains" as "contains" | "equals" });
+  let ruleForm = $state({
+    pattern: "",
+    operator: "contains" as "contains" | "equals",
+  });
   const rateValues = $derived(rateMap($rates.data));
   const accounts = $derived($bank.data?.accounts ?? []);
   const transactions = $derived($bank.data?.transactions ?? []);
-  const filtered = $derived(transactions.filter((t) => (account === "all" || t.accountId === account) && (flow === "all" || (flow === "inflow" ? t.amount >= 0 : t.amount < 0)) && (!search.trim() || `${t.description ?? ""} ${t.counterparty ?? ""} ${t.institutionName ?? ""}`.toLowerCase().includes(search.toLowerCase())) && inRange(t)));
-  const totals = $derived(accounts.reduce<Record<string, number>>((s, a) => { const c = a.currency || "TWD"; s[c] = (s[c] ?? 0) + (a.balance ?? 0); return s; }, {}));
-  const cashFlow = $derived({ inflow: filtered.filter((t) => t.amount >= 0).reduce((s, t) => s + transactionValueTwd(t, rateValues), 0), outflow: filtered.filter((t) => t.amount < 0).reduce((s, t) => s + transactionValueTwd(t, rateValues), 0) });
-  const override = createMutation({ mutationFn: async ({ id, categoryId }: { id: string; categoryId: string }) => api.put(`/api/classification/overrides/bank_transaction/${id}`, { categoryId }), onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.bank }); selected = null; } });
-  const clearOverride = createMutation({ mutationFn: (id: string) => api.delete(`/api/classification/overrides/bank_transaction/${id}`), onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.bank }); selected = null; } });
-  const addRule = createMutation({ mutationFn: async ({ categoryId, pattern, operator }: { categoryId: string; pattern: string; operator: string }) => api.post("/api/classification/rules", { categoryId, targetType: "bank_transaction", field: "any_text", operator, pattern, priority: 200 }), onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.bank }); qc.invalidateQueries({ queryKey: queryKeys.classificationRules }); selected = null; } });
-  const categoryLabels: Record<string, string> = { salary: "薪資", transfer: "轉帳", food: "餐飲", transport: "交通", shopping: "購物", housing: "居住", health: "醫療", education: "教育", entertainment: "娛樂", investment: "投資", insurance: "保險", fee: "費用", tax: "稅務", other: "其他" };
-  function inRange(t: BankTransactionRow) { if (range === "all") return true; const date = new Date(t.postedDate ?? t.authorizedAt ?? ""); const months = range === "month" ? 1 : range === "threeMonths" ? 3 : 12; const start = new SvelteDate(); start.setMonth(start.getMonth() - months + 1); return date >= start; }
-  function selectTransaction(t: BankTransactionRow) { selected = t; ruleForm = { pattern: t.description ?? t.counterparty ?? "", operator: "contains" }; }
+  const filtered = $derived(
+    transactions.filter(
+      (t) =>
+        (account === "all" || t.accountId === account) &&
+        (flow === "all" ||
+          (flow === "inflow" ? t.amount >= 0 : t.amount < 0)) &&
+        (!search.trim() ||
+          `${t.description ?? ""} ${t.counterparty ?? ""} ${t.institutionName ?? ""}`
+            .toLowerCase()
+            .includes(search.toLowerCase())) &&
+        inRange(t),
+    ),
+  );
+  const totals = $derived(
+    accounts.reduce<Record<string, number>>((s, a) => {
+      const c = a.currency || "TWD";
+      s[c] = (s[c] ?? 0) + (a.balance ?? 0);
+      return s;
+    }, {}),
+  );
+  const cashFlow = $derived({
+    inflow: filtered
+      .filter((t) => t.amount >= 0)
+      .reduce((s, t) => s + transactionValueTwd(t, rateValues), 0),
+    outflow: filtered
+      .filter((t) => t.amount < 0)
+      .reduce((s, t) => s + transactionValueTwd(t, rateValues), 0),
+  });
+  const override = createMutation({
+    mutationFn: async ({
+      id,
+      categoryId,
+    }: {
+      id: string;
+      categoryId: string;
+    }) =>
+      api.put(`/api/classification/overrides/bank_transaction/${id}`, {
+        categoryId,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.bank });
+      selected = null;
+    },
+  });
+  const clearOverride = createMutation({
+    mutationFn: (id: string) =>
+      api.delete(`/api/classification/overrides/bank_transaction/${id}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.bank });
+      selected = null;
+    },
+  });
+  const addRule = createMutation({
+    mutationFn: async ({
+      categoryId,
+      pattern,
+      operator,
+    }: {
+      categoryId: string;
+      pattern: string;
+      operator: string;
+    }) =>
+      api.post("/api/classification/rules", {
+        categoryId,
+        targetType: "bank_transaction",
+        field: "any_text",
+        operator,
+        pattern,
+        priority: 200,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.bank });
+      qc.invalidateQueries({ queryKey: queryKeys.classificationRules });
+      selected = null;
+    },
+  });
+  const categoryLabels: Record<string, string> = {
+    salary: "薪資",
+    transfer: "轉帳",
+    food: "餐飲",
+    transport: "交通",
+    shopping: "購物",
+    housing: "居住",
+    health: "醫療",
+    education: "教育",
+    entertainment: "娛樂",
+    investment: "投資",
+    insurance: "保險",
+    fee: "費用",
+    tax: "稅務",
+    other: "其他",
+  };
+  function inRange(t: BankTransactionRow) {
+    if (range === "all") return true;
+    const date = new Date(t.postedDate ?? t.authorizedAt ?? "");
+    const months = range === "month" ? 1 : range === "threeMonths" ? 3 : 12;
+    const start = new SvelteDate();
+    start.setMonth(start.getMonth() - months + 1);
+    return date >= start;
+  }
+  function selectTransaction(t: BankTransactionRow) {
+    selected = t;
+    ruleForm = {
+      pattern: t.description ?? t.counterparty ?? "",
+      operator: "contains",
+    };
+  }
 </script>
 
-{#if $bank.isPending}<EmptyState title="載入銀行資料中" body="正在讀取帳戶與交易。" />{:else}<div class="grid gap-5"><div class="grid grid-cols-2 gap-3 md:grid-cols-4"><div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs"><p class="text-xs text-ink/45">帳戶數</p><p class="mt-2 text-xl font-bold">{accounts.length}</p></div><div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs"><p class="text-xs text-ink/45">帳戶餘額</p><p class="mt-2 text-xl font-bold">{formatCurrencyTotals(totals)}</p></div><div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs"><p class="text-xs text-ink/45">本期收入</p><p class="mt-2 text-xl font-bold text-moss">{formatCurrency(cashFlow.inflow)}</p></div><div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs"><p class="text-xs text-ink/45">本期支出</p><p class="mt-2 text-xl font-bold text-coral">{formatCurrency(Math.abs(cashFlow.outflow))}</p></div></div><Card><CardHeader class="gap-3"><div class="flex flex-wrap items-center justify-between gap-3"><div><h2 class="text-lg font-semibold">銀行交易</h2><p class="text-xs text-ink/45">共 {filtered.length} 筆符合條件</p></div><label class="flex min-h-10 items-center gap-2 rounded-md border border-input bg-background px-3 shadow-xs focus-within:ring-2 focus-within:ring-ring"><Search class="size-4 text-steel" /><Input class="h-auto w-48 border-0 bg-transparent p-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0" placeholder="搜尋交易" bind:value={search} /></label></div><div class="flex flex-wrap gap-2"><Select class="w-auto" bind:value={account}><option value="all">全部帳戶</option>{#each accounts as a (a.id)}<option value={a.id}>{a.institutionName ?? a.accountName ?? a.id}</option>{/each}</Select><Select class="w-auto" bind:value={flow}><option value="all">全部流向</option><option value="inflow">收入</option><option value="outflow">支出</option></Select><Select class="w-auto" bind:value={range}><option value="month">本月</option><option value="threeMonths">近三個月</option><option value="year">今年</option><option value="all">全部</option></Select></div></CardHeader><CardContent class="p-0"><div class="divide-y divide-ink/8">{#if filtered.length === 0}<p class="p-8 text-center text-sm text-ink/50">沒有符合條件的交易。</p>{:else}{#each filtered.slice(0, 200) as t (t.id)}<button class="flex w-full items-center justify-between gap-3 px-5 py-3 text-left hover:bg-paper" onclick={() => selectTransaction(t)}><div class="min-w-0"><p class="truncate text-sm font-semibold">{t.description ?? t.counterparty ?? "銀行交易"}</p><p class="mt-1 truncate text-xs text-ink/40">{formatBankAccountName(t)} · {formatDate(t.postedDate ?? t.authorizedAt)} · {t.classification?.label ?? "其他"}</p></div><p class={`shrink-0 text-sm font-bold tabular-nums ${t.amount < 0 ? "text-coral" : "text-moss"}`}>{t.amount >= 0 ? "+" : ""}{formatCurrency(t.amount, t.currency)}</p></button>{/each}{/if}</div></CardContent></Card><div class="flex justify-end"><Button variant="ghost" onclick={() => navigate("settings")}>管理匯率與分類規則 →</Button></div>{#if selected}<div class="fixed inset-0 z-[70] flex items-end bg-ink/45 md:items-center md:justify-center md:p-6"><div class="w-full rounded-t-2xl bg-white p-5 shadow-2xl md:max-w-lg md:rounded-2xl"><div class="flex items-start justify-between"><div><p class="text-xs font-semibold text-steel">交易分類</p><h2 class="mt-1 text-xl font-semibold">{selected.description ?? selected.counterparty ?? "銀行交易"}</h2><p class="mt-1 text-sm text-ink/50">目前分類：{selected.classification?.label ?? "其他"}</p></div><Button aria-label="關閉" class="rounded-full text-xl" size="icon" variant="ghost" onclick={() => selected = null}>×</Button></div><Select class="mt-5" onchange={(e: Event) => $override.mutate({ id: selected!.id, categoryId: (e.currentTarget as HTMLSelectElement).value })}>{#each Object.entries(categoryLabels) as [key, label] (key)}<option value={key} selected={key === (selected.classification?.categoryId ?? "other")}>{label}</option>{/each}</Select>{#if selected.classification?.source === "override"}<Button class="mt-3" size="sm" variant="secondary" onclick={() => $clearOverride.mutate(selected!.id)}>清除分類覆寫</Button>{/if}<div class="mt-4 rounded-xl border border-steel/20 bg-steel/5 p-4"><p class="text-sm font-semibold">建立規則</p><Input class="mt-2" bind:value={ruleForm.pattern} /><div class="mt-3 flex gap-2"><Select class="w-auto" bind:value={ruleForm.operator}><option value="contains">包含</option><option value="equals">完全等於</option></Select><Button size="sm" onclick={() => $addRule.mutate({ categoryId: selected?.classification?.categoryId ?? "other", ...ruleForm })}>新增規則</Button></div></div></div></div>{/if}</div>{/if}
+{#if $bank.isPending}<EmptyState
+    title="載入銀行資料中"
+    body="正在讀取帳戶與交易。"
+  />{:else}<div class="grid gap-5">
+    <div class="grid grid-cols-2 gap-3 md:grid-cols-4">
+      <div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs">
+        <p class="text-xs text-ink/45">帳戶數</p>
+        <p class="mt-2 text-xl font-bold">{accounts.length}</p>
+      </div>
+      <div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs">
+        <p class="text-xs text-ink/45">帳戶餘額</p>
+        <p class="mt-2 text-xl font-bold">{formatCurrencyTotals(totals)}</p>
+      </div>
+      <div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs">
+        <p class="text-xs text-ink/45">本期收入</p>
+        <p class="mt-2 text-xl font-bold text-moss">
+          {formatCurrency(cashFlow.inflow)}
+        </p>
+      </div>
+      <div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs">
+        <p class="text-xs text-ink/45">本期支出</p>
+        <p class="mt-2 text-xl font-bold text-coral">
+          {formatCurrency(Math.abs(cashFlow.outflow))}
+        </p>
+      </div>
+    </div>
+    <Card
+      ><CardHeader class="gap-3"
+        ><div class="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 class="text-lg font-semibold">銀行交易</h2>
+            <p class="text-xs text-ink/45">共 {filtered.length} 筆符合條件</p>
+          </div>
+          <label
+            class="flex min-h-10 items-center gap-2 rounded-md border border-input bg-background px-3 shadow-xs focus-within:ring-2 focus-within:ring-ring"
+            ><Search class="size-4 text-steel" /><Input
+              class="h-auto w-48 border-0 bg-transparent p-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+              placeholder="搜尋交易"
+              bind:value={search}
+            /></label
+          >
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <Select class="w-auto" bind:value={account}
+            ><option value="all">全部帳戶</option
+            >{#each accounts as a (a.id)}<option value={a.id}
+                >{a.institutionName ?? a.accountName ?? a.id}</option
+              >{/each}</Select
+          ><Select class="w-auto" bind:value={flow}
+            ><option value="all">全部流向</option><option value="inflow"
+              >收入</option
+            ><option value="outflow">支出</option></Select
+          ><Select class="w-auto" bind:value={range}
+            ><option value="month">本月</option><option value="threeMonths"
+              >近三個月</option
+            ><option value="year">今年</option><option value="all">全部</option
+            ></Select
+          >
+        </div></CardHeader
+      ><CardContent class="p-0"
+        ><div class="divide-y divide-ink/8">
+          {#if filtered.length === 0}<p
+              class="p-8 text-center text-sm text-ink/50"
+            >
+              沒有符合條件的交易。
+            </p>{:else}{#each filtered.slice(0, 200) as t (t.id)}<button
+                class="flex w-full items-center justify-between gap-3 px-5 py-3 text-left hover:bg-paper"
+                onclick={() => selectTransaction(t)}
+                ><div class="min-w-0">
+                  <p class="truncate text-sm font-semibold">
+                    {t.description ?? t.counterparty ?? "銀行交易"}
+                  </p>
+                  <p class="mt-1 truncate text-xs text-ink/40">
+                    {formatBankAccountName(t)} · {formatDate(
+                      t.postedDate ?? t.authorizedAt,
+                    )} · {t.classification?.label ?? "其他"}
+                  </p>
+                </div>
+                <p
+                  class={`shrink-0 text-sm font-bold tabular-nums ${t.amount < 0 ? "text-coral" : "text-moss"}`}
+                >
+                  {t.amount >= 0 ? "+" : ""}{formatCurrency(
+                    t.amount,
+                    t.currency,
+                  )}
+                </p></button
+              >{/each}{/if}
+        </div></CardContent
+      ></Card
+    >
+    <div class="flex justify-end">
+      <Button variant="ghost" onclick={() => navigate("settings")}
+        >管理匯率與分類規則 →</Button
+      >
+    </div>
+    {#if selected}<div
+        class="fixed inset-0 z-[70] flex items-end bg-ink/45 md:items-center md:justify-center md:p-6"
+      >
+        <div
+          class="w-full rounded-t-2xl bg-white p-5 shadow-2xl md:max-w-lg md:rounded-2xl"
+        >
+          <div class="flex items-start justify-between">
+            <div>
+              <p class="text-xs font-semibold text-steel">交易分類</p>
+              <h2 class="mt-1 text-xl font-semibold">
+                {selected.description ?? selected.counterparty ?? "銀行交易"}
+              </h2>
+              <p class="mt-1 text-sm text-ink/50">
+                目前分類：{selected.classification?.label ?? "其他"}
+              </p>
+            </div>
+            <Button
+              aria-label="關閉"
+              class="rounded-full text-xl"
+              size="icon"
+              variant="ghost"
+              onclick={() => (selected = null)}>×</Button
+            >
+          </div>
+          <Select
+            class="mt-5"
+            onchange={(e: Event) =>
+              $override.mutate({
+                id: selected!.id,
+                categoryId: (e.currentTarget as HTMLSelectElement).value,
+              })}
+            >{#each Object.entries(categoryLabels) as [key, label] (key)}<option
+                value={key}
+                selected={key ===
+                  (selected.classification?.categoryId ?? "other")}
+                >{label}</option
+              >{/each}</Select
+          >{#if selected.classification?.source === "override"}<Button
+              class="mt-3"
+              size="sm"
+              variant="secondary"
+              onclick={() => $clearOverride.mutate(selected!.id)}
+              >清除分類覆寫</Button
+            >{/if}
+          <div class="mt-4 rounded-xl border border-steel/20 bg-steel/5 p-4">
+            <p class="text-sm font-semibold">建立規則</p>
+            <Input class="mt-2" bind:value={ruleForm.pattern} />
+            <div class="mt-3 flex gap-2">
+              <Select class="w-auto" bind:value={ruleForm.operator}
+                ><option value="contains">包含</option><option value="equals"
+                  >完全等於</option
+                ></Select
+              ><Button
+                size="sm"
+                onclick={() =>
+                  $addRule.mutate({
+                    categoryId: selected?.classification?.categoryId ?? "other",
+                    ...ruleForm,
+                  })}>新增規則</Button
+              >
+            </div>
+          </div>
+        </div>
+      </div>{/if}
+  </div>{/if}

--- a/apps/web/src/features/assets/Cards.svelte
+++ b/apps/web/src/features/assets/Cards.svelte
@@ -9,19 +9,126 @@
   import type { ApiClient } from "../../lib/api";
   import { bankQuery, creditCardBillsQuery } from "../../lib/queries";
   import type { CreditCardBillRow } from "../../lib/types";
-  import { formatBankAccountName, formatCurrency, formatDate } from "../../lib/format.svelte";
+  import {
+    formatBankAccountName,
+    formatCurrency,
+    formatDate,
+  } from "../../lib/format.svelte";
   let { api }: { api: ApiClient } = $props();
   const bank = createQuery(bankQuery(() => api));
   const bills = createQuery(creditCardBillsQuery(() => api));
   let search = $state("");
-  const cards = $derived(($bank.data?.accounts ?? []).filter((a) => a.accountType === "credit"));
+  const cards = $derived(
+    ($bank.data?.accounts ?? []).filter((a) => a.accountType === "credit"),
+  );
   const cardsById = $derived(new Map(cards.map((card) => [card.id, card])));
-  const filteredBills = $derived(($bills.data ?? []).filter((b) => `${b.accountSourceId ?? ""} ${b.billingPeriod}`.toLowerCase().includes(search.toLowerCase())));
-  const outstanding = $derived(Math.abs(cards.reduce((s, c) => s + (c.balance ?? 0), 0)));
+  const filteredBills = $derived(
+    ($bills.data ?? []).filter((b) =>
+      `${b.accountSourceId ?? ""} ${b.billingPeriod}`
+        .toLowerCase()
+        .includes(search.toLowerCase()),
+    ),
+  );
+  const outstanding = $derived(
+    Math.abs(cards.reduce((s, c) => s + (c.balance ?? 0), 0)),
+  );
   function billAccountName(bill: CreditCardBillRow) {
     const card = cardsById.get(bill.accountId);
     return card?.accountName ?? card?.institutionName ?? "信用卡帳戶";
   }
 </script>
 
-{#if $bank.isPending}<EmptyState title="載入信用卡中" body="正在讀取信用卡資料。" />{:else}<div class="grid min-w-0 gap-5"><div class="grid grid-cols-2 gap-3 md:grid-cols-3"><div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs"><p class="text-xs text-ink/45">信用卡數</p><p class="mt-2 text-xl font-bold">{cards.length}</p></div><div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs"><p class="text-xs text-ink/45">目前已用金額</p><p class="mt-2 text-xl font-bold text-coral">{formatCurrency(outstanding)}</p></div><div class="hidden rounded-xl border border-ink/10 bg-white p-4 shadow-xs md:block"><p class="text-xs text-ink/45">帳單筆數</p><p class="mt-2 text-xl font-bold">{filteredBills.length}</p></div></div><Card><CardHeader><h2 class="text-lg font-semibold">信用卡帳戶</h2></CardHeader><CardContent class="grid gap-3 md:grid-cols-2">{#if cards.length === 0}<p class="py-8 text-center text-sm text-ink/45">尚無信用卡資料。</p>{:else}{#each cards as card, i (card.id)}<div class={`rounded-2xl p-4 text-white ${i % 2 === 0 ? "bg-ink" : "bg-steel"}`}><div class="flex items-start justify-between"><div><p class="font-semibold">{card.institutionName ?? card.connectorId}</p><p class="mt-2 text-xs text-white/65">{card.accountName ?? formatBankAccountName(card)}</p></div><CreditCard class="size-5 text-white/70" /></div><p class="mt-5 text-2xl font-bold">{card.balance == null ? "尚無餘額" : formatCurrency(Math.abs(card.balance), card.currency)}</p><p class="mt-2 text-xs text-white/60">{card.statementClosingDate ? `結帳日 ${formatDate(card.statementClosingDate)}` : "查看帳單與待入帳紀錄"}</p></div>{/each}{/if}</CardContent></Card><Card class="min-w-0 max-w-full overflow-hidden"><CardHeader class="flex-row items-center justify-between"><h2 class="text-lg font-semibold">信用卡帳單</h2><div class="relative w-44"><Search class="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-muted-foreground" /><Input class="pl-9" placeholder="搜尋帳單" bind:value={search} /></div></CardHeader><CardContent class="min-w-0 p-0"><div class="max-w-full overflow-x-auto"><table class="w-full min-w-[680px] text-left text-sm"><thead class="border-y border-ink/8 bg-paper text-xs text-ink/50"><tr><th class="px-5 py-3">帳戶</th><th class="px-5 py-3">帳期</th><th class="px-5 py-3 text-right">帳單金額</th><th class="px-5 py-3">繳款期限</th><th class="px-5 py-3">狀態</th></tr></thead><tbody class="divide-y divide-ink/8">{#each filteredBills as bill (bill.id)}<tr><td class="px-5 py-3 font-medium">{billAccountName(bill)}</td><td class="px-5 py-3">{bill.billingPeriod}</td><td class="px-5 py-3 text-right font-semibold">{bill.statementAmount == null ? "-" : formatCurrency(bill.statementAmount, bill.currency)}</td><td class="px-5 py-3">{bill.paymentDueDate ? formatDate(bill.paymentDueDate) : "—"}</td><td class="px-5 py-3">{bill.isPaid ? "已繳" : "待繳"}</td></tr>{/each}</tbody></table></div></CardContent></Card></div>{/if}
+{#if $bank.isPending}<EmptyState
+    title="載入信用卡中"
+    body="正在讀取信用卡資料。"
+  />{:else}<div class="grid min-w-0 gap-5">
+    <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
+      <div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs">
+        <p class="text-xs text-ink/45">信用卡數</p>
+        <p class="mt-2 text-xl font-bold">{cards.length}</p>
+      </div>
+      <div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs">
+        <p class="text-xs text-ink/45">目前已用金額</p>
+        <p class="mt-2 text-xl font-bold text-coral">
+          {formatCurrency(outstanding)}
+        </p>
+      </div>
+      <div
+        class="hidden rounded-xl border border-ink/10 bg-white p-4 shadow-xs md:block"
+      >
+        <p class="text-xs text-ink/45">帳單筆數</p>
+        <p class="mt-2 text-xl font-bold">{filteredBills.length}</p>
+      </div>
+    </div>
+    <Card
+      ><CardHeader><h2 class="text-lg font-semibold">信用卡帳戶</h2></CardHeader
+      ><CardContent class="grid gap-3 md:grid-cols-2"
+        >{#if cards.length === 0}<p
+            class="py-8 text-center text-sm text-ink/45"
+          >
+            尚無信用卡資料。
+          </p>{:else}{#each cards as card, i (card.id)}<div
+              class={`rounded-2xl p-4 text-white ${i % 2 === 0 ? "bg-ink" : "bg-steel"}`}
+            >
+              <div class="flex items-start justify-between">
+                <div>
+                  <p class="font-semibold">
+                    {card.institutionName ?? card.connectorId}
+                  </p>
+                  <p class="mt-2 text-xs text-white/65">
+                    {card.accountName ?? formatBankAccountName(card)}
+                  </p>
+                </div>
+                <CreditCard class="size-5 text-white/70" />
+              </div>
+              <p class="mt-5 text-2xl font-bold">
+                {card.balance == null
+                  ? "尚無餘額"
+                  : formatCurrency(Math.abs(card.balance), card.currency)}
+              </p>
+              <p class="mt-2 text-xs text-white/60">
+                {card.statementClosingDate
+                  ? `結帳日 ${formatDate(card.statementClosingDate)}`
+                  : "查看帳單與待入帳紀錄"}
+              </p>
+            </div>{/each}{/if}</CardContent
+      ></Card
+    ><Card class="min-w-0 max-w-full overflow-hidden"
+      ><CardHeader class="flex-row items-center justify-between"
+        ><h2 class="text-lg font-semibold">信用卡帳單</h2>
+        <div class="relative w-44">
+          <Search
+            class="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-muted-foreground"
+          /><Input class="pl-9" placeholder="搜尋帳單" bind:value={search} />
+        </div></CardHeader
+      ><CardContent class="min-w-0 p-0"
+        ><div class="max-w-full overflow-x-auto">
+          <table class="w-full min-w-[680px] text-left text-sm">
+            <thead class="border-y border-ink/8 bg-paper text-xs text-ink/50"
+              ><tr
+                ><th class="px-5 py-3">帳戶</th><th class="px-5 py-3">帳期</th
+                ><th class="px-5 py-3 text-right">帳單金額</th><th
+                  class="px-5 py-3">繳款期限</th
+                ><th class="px-5 py-3">狀態</th></tr
+              ></thead
+            ><tbody class="divide-y divide-ink/8"
+              >{#each filteredBills as bill (bill.id)}<tr
+                  ><td class="px-5 py-3 font-medium">{billAccountName(bill)}</td
+                  ><td class="px-5 py-3">{bill.billingPeriod}</td><td
+                    class="px-5 py-3 text-right font-semibold"
+                    >{bill.statementAmount == null
+                      ? "-"
+                      : formatCurrency(bill.statementAmount, bill.currency)}</td
+                  ><td class="px-5 py-3"
+                    >{bill.paymentDueDate
+                      ? formatDate(bill.paymentDueDate)
+                      : "—"}</td
+                  ><td class="px-5 py-3">{bill.isPaid ? "已繳" : "待繳"}</td
+                  ></tr
+                >{/each}</tbody
+            >
+          </table>
+        </div></CardContent
+      ></Card
+    >
+  </div>{/if}

--- a/apps/web/src/features/assets/Investments.svelte
+++ b/apps/web/src/features/assets/Investments.svelte
@@ -8,27 +8,173 @@
   import Input from "../../components/ui/Input.svelte";
   import Select from "../../components/ui/Select.svelte";
   import type { ApiClient } from "../../lib/api";
-  import { exchangeRatesQuery, investmentsQuery, investmentTransactionsQuery } from "../../lib/queries";
+  import {
+    exchangeRatesQuery,
+    investmentsQuery,
+    investmentTransactionsQuery,
+  } from "../../lib/queries";
   import type { InvestmentTransactionRow } from "../../lib/types";
-  import { formatCurrency, formatDate, formatNumber, rateMap } from "../../lib/format.svelte";
+  import {
+    formatCurrency,
+    formatDate,
+    formatNumber,
+    rateMap,
+  } from "../../lib/format.svelte";
   let { api }: { api: ApiClient } = $props();
   const investments = createQuery(investmentsQuery(() => api));
   const trades = createQuery(investmentTransactionsQuery(() => api));
   const rates = createQuery(exchangeRatesQuery(() => api));
   let search = $state("");
   let tradeType = $state("all");
-  const positions = $derived(($investments.data ?? []).filter((p) => `${p.symbol ?? ""} ${p.name}`.toLowerCase().includes(search.toLowerCase())));
+  const positions = $derived(
+    ($investments.data ?? []).filter((p) =>
+      `${p.symbol ?? ""} ${p.name}`
+        .toLowerCase()
+        .includes(search.toLowerCase()),
+    ),
+  );
   const rateValues = $derived(rateMap($rates.data));
-  const total = $derived(($investments.data ?? []).reduce((s, p) => {
-    const value = (p.marketValue ?? 0) + (p.cashBalance ?? 0);
-    return s + (p.currency === "TWD" ? value : value * (rateValues[p.currency] ?? 0));
-  }, 0));
-  const filteredTrades = $derived(($trades.data ?? []).filter((t) => (tradeType === "all" || t.assetType === tradeType) && `${t.symbol ?? ""} ${t.name ?? ""} ${t.transactionName ?? ""}`.toLowerCase().includes(search.toLowerCase())).slice(0, 100));
+  const total = $derived(
+    ($investments.data ?? []).reduce((s, p) => {
+      const value = (p.marketValue ?? 0) + (p.cashBalance ?? 0);
+      return (
+        s +
+        (p.currency === "TWD" ? value : value * (rateValues[p.currency] ?? 0))
+      );
+    }, 0),
+  );
+  const filteredTrades = $derived(
+    ($trades.data ?? [])
+      .filter(
+        (t) =>
+          (tradeType === "all" || t.assetType === tradeType) &&
+          `${t.symbol ?? ""} ${t.name ?? ""} ${t.transactionName ?? ""}`
+            .toLowerCase()
+            .includes(search.toLowerCase()),
+      )
+      .slice(0, 100),
+  );
   function tradeDisplay(t: InvestmentTransactionRow) {
-    if (t.amount != null && t.price != null && t.price !== 1) return formatCurrency(t.amount, t.currency);
+    if (t.amount != null && t.price != null && t.price !== 1)
+      return formatCurrency(t.amount, t.currency);
     if (t.quantity != null) return `${formatNumber(t.quantity)} 股`;
     return "金額未提供";
   }
 </script>
 
-{#if $investments.isPending}<EmptyState title="載入投資中" body="正在讀取投資持倉。" />{:else}<div class="grid gap-5"><div class="grid grid-cols-2 gap-3 md:grid-cols-3"><div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs"><p class="text-xs text-ink/45">持倉市值</p><p class="mt-2 text-xl font-bold">{formatCurrency(total)}</p></div><div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs"><p class="text-xs text-ink/45">持倉數</p><p class="mt-2 text-xl font-bold">{positions.length}</p></div><div class="hidden rounded-xl border border-ink/10 bg-white p-4 shadow-xs md:block"><p class="text-xs text-ink/45">交易筆數</p><p class="mt-2 text-xl font-bold">{$trades.data?.length ?? 0}</p></div></div><Card><CardHeader class="gap-3"><div class="flex flex-wrap items-center justify-between gap-3"><h2 class="text-lg font-semibold">投資持倉</h2><div class="relative w-52"><Search class="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-muted-foreground" /><Input class="pl-9" placeholder="搜尋股票／基金" bind:value={search} /></div></div></CardHeader><CardContent class="p-0"><div class="hidden overflow-x-auto md:block"><table class="w-full text-left text-sm"><thead class="border-y border-ink/8 bg-paper text-xs text-ink/50"><tr><th class="px-5 py-3">名稱</th><th class="px-5 py-3">類型</th><th class="px-5 py-3">數量</th><th class="px-5 py-3 text-right">市值</th><th class="px-5 py-3">日期</th></tr></thead><tbody class="divide-y divide-ink/8">{#each positions as p (p.id)}<tr><td class="px-5 py-3 font-semibold">{p.symbol ? `${p.symbol} ` : ""}{p.name}</td><td class="px-5 py-3">{p.assetType.toUpperCase()}</td><td class="px-5 py-3">{p.quantity == null ? "-" : formatNumber(p.quantity)}</td><td class="px-5 py-3 text-right font-semibold">{formatCurrency((p.marketValue ?? 0) + (p.cashBalance ?? 0), p.currency)}</td><td class="px-5 py-3 text-xs text-ink/50">{formatDate(p.asOfDate)}</td></tr>{/each}</tbody></table></div><div class="divide-y divide-ink/8 md:hidden">{#each positions as p (p.id)}<div class="flex items-center justify-between gap-3 px-4 py-3"><div class="min-w-0"><p class="truncate font-semibold">{p.symbol ? `${p.symbol} ` : ""}{p.name}</p><p class="mt-1 text-xs text-ink/45">{p.quantity ?? 0} 單位 · {p.assetType.toUpperCase()}</p></div><p class="shrink-0 font-bold text-steel">{formatCurrency((p.marketValue ?? 0) + (p.cashBalance ?? 0), p.currency)}</p></div>{/each}</div></CardContent></Card><Card><CardHeader class="flex-row items-center justify-between"><h2 class="text-lg font-semibold">交易紀錄</h2><Select class="w-36" bind:value={tradeType}><option value="all">全部類型</option><option value="stock">股票</option><option value="etf">ETF</option><option value="fund">基金</option></Select></CardHeader><CardContent class="p-0"><div class="divide-y divide-ink/8">{#each filteredTrades as t (t.id)}<div class="flex items-center justify-between gap-3 px-5 py-3 text-sm"><div class="min-w-0"><p class="truncate font-semibold">{t.name ?? t.symbol ?? "投資交易"}</p><p class="text-xs text-ink/45">{t.transactionName ?? t.transactionCode ?? ""} · {formatDate(t.tradeDate ?? t.postedDate)}</p></div><span class="shrink-0 font-semibold text-ink/65">{tradeDisplay(t)}</span></div>{/each}</div></CardContent></Card></div>{/if}
+{#if $investments.isPending}<EmptyState
+    title="載入投資中"
+    body="正在讀取投資持倉。"
+  />{:else}<div class="grid gap-5">
+    <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
+      <div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs">
+        <p class="text-xs text-ink/45">持倉市值</p>
+        <p class="mt-2 text-xl font-bold">{formatCurrency(total)}</p>
+      </div>
+      <div class="rounded-xl border border-ink/10 bg-white p-4 shadow-xs">
+        <p class="text-xs text-ink/45">持倉數</p>
+        <p class="mt-2 text-xl font-bold">{positions.length}</p>
+      </div>
+      <div
+        class="hidden rounded-xl border border-ink/10 bg-white p-4 shadow-xs md:block"
+      >
+        <p class="text-xs text-ink/45">交易筆數</p>
+        <p class="mt-2 text-xl font-bold">{$trades.data?.length ?? 0}</p>
+      </div>
+    </div>
+    <Card
+      ><CardHeader class="gap-3"
+        ><div class="flex flex-wrap items-center justify-between gap-3">
+          <h2 class="text-lg font-semibold">投資持倉</h2>
+          <div class="relative w-52">
+            <Search
+              class="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-muted-foreground"
+            /><Input
+              class="pl-9"
+              placeholder="搜尋股票／基金"
+              bind:value={search}
+            />
+          </div>
+        </div></CardHeader
+      ><CardContent class="p-0"
+        ><div class="hidden overflow-x-auto md:block">
+          <table class="w-full text-left text-sm">
+            <thead class="border-y border-ink/8 bg-paper text-xs text-ink/50"
+              ><tr
+                ><th class="px-5 py-3">名稱</th><th class="px-5 py-3">類型</th
+                ><th class="px-5 py-3">數量</th><th class="px-5 py-3 text-right"
+                  >市值</th
+                ><th class="px-5 py-3">日期</th></tr
+              ></thead
+            ><tbody class="divide-y divide-ink/8"
+              >{#each positions as p (p.id)}<tr
+                  ><td class="px-5 py-3 font-semibold"
+                    >{p.symbol ? `${p.symbol} ` : ""}{p.name}</td
+                  ><td class="px-5 py-3">{p.assetType.toUpperCase()}</td><td
+                    class="px-5 py-3"
+                    >{p.quantity == null ? "-" : formatNumber(p.quantity)}</td
+                  ><td class="px-5 py-3 text-right font-semibold"
+                    >{formatCurrency(
+                      (p.marketValue ?? 0) + (p.cashBalance ?? 0),
+                      p.currency,
+                    )}</td
+                  ><td class="px-5 py-3 text-xs text-ink/50"
+                    >{formatDate(p.asOfDate)}</td
+                  ></tr
+                >{/each}</tbody
+            >
+          </table>
+        </div>
+        <div class="divide-y divide-ink/8 md:hidden">
+          {#each positions as p (p.id)}<div
+              class="flex items-center justify-between gap-3 px-4 py-3"
+            >
+              <div class="min-w-0">
+                <p class="truncate font-semibold">
+                  {p.symbol ? `${p.symbol} ` : ""}{p.name}
+                </p>
+                <p class="mt-1 text-xs text-ink/45">
+                  {p.quantity ?? 0} 單位 · {p.assetType.toUpperCase()}
+                </p>
+              </div>
+              <p class="shrink-0 font-bold text-steel">
+                {formatCurrency(
+                  (p.marketValue ?? 0) + (p.cashBalance ?? 0),
+                  p.currency,
+                )}
+              </p>
+            </div>{/each}
+        </div></CardContent
+      ></Card
+    ><Card
+      ><CardHeader class="flex-row items-center justify-between"
+        ><h2 class="text-lg font-semibold">交易紀錄</h2>
+        <Select class="w-36" bind:value={tradeType}
+          ><option value="all">全部類型</option><option value="stock"
+            >股票</option
+          ><option value="etf">ETF</option><option value="fund">基金</option
+          ></Select
+        ></CardHeader
+      ><CardContent class="p-0"
+        ><div class="divide-y divide-ink/8">
+          {#each filteredTrades as t (t.id)}<div
+              class="flex items-center justify-between gap-3 px-5 py-3 text-sm"
+            >
+              <div class="min-w-0">
+                <p class="truncate font-semibold">
+                  {t.name ?? t.symbol ?? "投資交易"}
+                </p>
+                <p class="text-xs text-ink/45">
+                  {t.transactionName ?? t.transactionCode ?? ""} · {formatDate(
+                    t.tradeDate ?? t.postedDate,
+                  )}
+                </p>
+              </div>
+              <span class="shrink-0 font-semibold text-ink/65"
+                >{tradeDisplay(t)}</span
+              >
+            </div>{/each}
+        </div></CardContent
+      ></Card
+    >
+  </div>{/if}

--- a/apps/web/src/features/assets/ManualAssets.svelte
+++ b/apps/web/src/features/assets/ManualAssets.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { toStore } from "svelte/store";
-  import { createMutation, createQuery, useQueryClient } from "@tanstack/svelte-query";
+  import {
+    createMutation,
+    createQuery,
+    useQueryClient,
+  } from "@tanstack/svelte-query";
   import { Pencil, Plus, Trash2 } from "@lucide/svelte";
   import Card from "../../components/ui/Card.svelte";
   import CardHeader from "../../components/ui/CardHeader.svelte";
@@ -12,9 +16,16 @@
   import Textarea from "../../components/ui/Textarea.svelte";
   import type { ApiClient } from "../../lib/api";
   import { queryKeys } from "../../lib/api";
-  import { manualAssetHistoryQuery, manualAssetsQuery } from "../../lib/queries";
+  import {
+    manualAssetHistoryQuery,
+    manualAssetsQuery,
+  } from "../../lib/queries";
   import type { ManualAssetRow } from "../../lib/types";
-  import { formatCurrency, formatDate, todayStr } from "../../lib/format.svelte";
+  import {
+    formatCurrency,
+    formatDate,
+    todayStr,
+  } from "../../lib/format.svelte";
 
   let { api }: { api: ApiClient } = $props();
   const qc = useQueryClient();
@@ -26,34 +37,127 @@
   let historyDate = $state(todayStr());
   let editingHistoryDate = $state<string | null>(null);
   let editingHistoryValue = $state("");
-  let form = $state({ name: "", category: "real_estate", value: "", date: todayStr(), note: "" });
-  const categories = { real_estate: "不動產", insurance: "保險", vehicle: "交通工具", other: "其他" };
-  const total = $derived(($assets.data ?? []).reduce((s, a) => s + (a.value ?? 0), 0));
+  let form = $state({
+    name: "",
+    category: "real_estate",
+    value: "",
+    date: todayStr(),
+    note: "",
+  });
+  const categories = {
+    real_estate: "不動產",
+    insurance: "保險",
+    vehicle: "交通工具",
+    other: "其他",
+  };
+  const total = $derived(
+    ($assets.data ?? []).reduce((s, a) => s + (a.value ?? 0), 0),
+  );
 
-  const add = createMutation({ mutationFn: () => api.post<{ id: string }>("/api/manual-assets", { ...form, value: Number(form.value) }), onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.manualAssets }); qc.invalidateQueries({ queryKey: queryKeys.netWorthHistory }); adding = false; reset(); } });
-  const update = createMutation({ mutationFn: () => api.put(`/api/manual-assets/${editing!.id}`, { name: form.name, category: form.category, note: form.note || undefined }), onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.manualAssets }); editing = null; reset(); } });
-  const remove = createMutation({ mutationFn: (id: string) => api.delete(`/api/manual-assets/${id}`), onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.manualAssets }); qc.invalidateQueries({ queryKey: queryKeys.netWorthHistory }); } });
-  const history = createQuery(toStore(() => manualAssetHistoryQuery(() => api, expandedAssetId)));
+  const add = createMutation({
+    mutationFn: () =>
+      api.post<{ id: string }>("/api/manual-assets", {
+        ...form,
+        value: Number(form.value),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.manualAssets });
+      qc.invalidateQueries({ queryKey: queryKeys.netWorthHistory });
+      adding = false;
+      reset();
+    },
+  });
+  const update = createMutation({
+    mutationFn: () =>
+      api.put(`/api/manual-assets/${editing!.id}`, {
+        name: form.name,
+        category: form.category,
+        note: form.note || undefined,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.manualAssets });
+      editing = null;
+      reset();
+    },
+  });
+  const remove = createMutation({
+    mutationFn: (id: string) => api.delete(`/api/manual-assets/${id}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.manualAssets });
+      qc.invalidateQueries({ queryKey: queryKeys.netWorthHistory });
+    },
+  });
+  const history = createQuery(
+    toStore(() => manualAssetHistoryQuery(() => api, expandedAssetId)),
+  );
   const addHistory = createMutation({
-    mutationFn: ({ assetId, value, date }: { assetId: string; value: number; date: string }) => api.post(`/api/manual-assets/${assetId}/history`, { value, date }),
-    onSuccess: () => { invalidateHistory(); historyValue = ""; historyDate = todayStr(); }
+    mutationFn: ({
+      assetId,
+      value,
+      date,
+    }: {
+      assetId: string;
+      value: number;
+      date: string;
+    }) => api.post(`/api/manual-assets/${assetId}/history`, { value, date }),
+    onSuccess: () => {
+      invalidateHistory();
+      historyValue = "";
+      historyDate = todayStr();
+    },
   });
   const editHistory = createMutation({
-    mutationFn: ({ assetId, value, date }: { assetId: string; value: number; date: string }) => api.post(`/api/manual-assets/${assetId}/history`, { value, date }),
-    onSuccess: () => { invalidateHistory(); editingHistoryDate = null; editingHistoryValue = ""; }
+    mutationFn: ({
+      assetId,
+      value,
+      date,
+    }: {
+      assetId: string;
+      value: number;
+      date: string;
+    }) => api.post(`/api/manual-assets/${assetId}/history`, { value, date }),
+    onSuccess: () => {
+      invalidateHistory();
+      editingHistoryDate = null;
+      editingHistoryValue = "";
+    },
   });
   const deleteHistory = createMutation({
-    mutationFn: ({ assetId, date }: { assetId: string; date: string }) => api.delete(`/api/manual-assets/${assetId}/history/${date}`),
-    onSuccess: invalidateHistory
+    mutationFn: ({ assetId, date }: { assetId: string; date: string }) =>
+      api.delete(`/api/manual-assets/${assetId}/history/${date}`),
+    onSuccess: invalidateHistory,
   });
 
-  function reset() { form = { name: "", category: "real_estate", value: "", date: todayStr(), note: "" }; }
-  function startEdit(asset: ManualAssetRow) { editing = asset; form = { name: asset.name, category: asset.category, value: String(asset.value ?? ""), date: asset.date ?? todayStr(), note: asset.note ?? "" }; }
-  function submit() { if (!form.name.trim() || !form.value) return; editing ? $update.mutate() : $add.mutate(); }
+  function reset() {
+    form = {
+      name: "",
+      category: "real_estate",
+      value: "",
+      date: todayStr(),
+      note: "",
+    };
+  }
+  function startEdit(asset: ManualAssetRow) {
+    editing = asset;
+    form = {
+      name: asset.name,
+      category: asset.category,
+      value: String(asset.value ?? ""),
+      date: asset.date ?? todayStr(),
+      note: asset.note ?? "",
+    };
+  }
+  function submit() {
+    if (!form.name.trim() || !form.value) return;
+    editing ? $update.mutate() : $add.mutate();
+  }
   function invalidateHistory() {
     qc.invalidateQueries({ queryKey: queryKeys.manualAssets });
     qc.invalidateQueries({ queryKey: queryKeys.netWorthHistory });
-    if (expandedAssetId) qc.invalidateQueries({ queryKey: queryKeys.manualAssetHistory(expandedAssetId) });
+    if (expandedAssetId)
+      qc.invalidateQueries({
+        queryKey: queryKeys.manualAssetHistory(expandedAssetId),
+      });
   }
   function toggleHistory(id: string) {
     expandedAssetId = expandedAssetId === id ? null : id;
@@ -67,7 +171,20 @@
   <EmptyState title="載入其他資產中" body="正在讀取估值紀錄。" />
 {:else}
   <div class="grid gap-5">
-    <div class="flex items-end justify-between"><div><p class="text-sm text-ink/50">其他資產總額</p><p class="mt-1 text-3xl font-bold">{formatCurrency(total)}</p></div><Button variant="primary" onclick={() => { adding = true; editing = null; reset(); }}><Plus class="size-4" />新增資產</Button></div>
+    <div class="flex items-end justify-between">
+      <div>
+        <p class="text-sm text-ink/50">其他資產總額</p>
+        <p class="mt-1 text-3xl font-bold">{formatCurrency(total)}</p>
+      </div>
+      <Button
+        variant="primary"
+        onclick={() => {
+          adding = true;
+          editing = null;
+          reset();
+        }}><Plus class="size-4" />新增資產</Button
+      >
+    </div>
     <Card>
       <CardHeader><h2 class="text-lg font-semibold">資產清單</h2></CardHeader>
       <CardContent class="p-0">
@@ -78,23 +195,129 @@
             {#each $assets.data ?? [] as asset (asset.id)}
               <div class="px-5 py-4">
                 <div class="flex items-center justify-between gap-3">
-                  <button class="min-w-0 flex-1 text-left" onclick={() => toggleHistory(asset.id)} aria-expanded={expandedAssetId === asset.id}>
+                  <button
+                    class="min-w-0 flex-1 text-left"
+                    onclick={() => toggleHistory(asset.id)}
+                    aria-expanded={expandedAssetId === asset.id}
+                  >
                     <p class="truncate font-semibold">{asset.name}</p>
-                    <p class="mt-1 text-xs text-ink/45">{categories[asset.category as keyof typeof categories] ?? asset.category} · {asset.date ? formatDate(asset.date) : "尚未估值"}{asset.note ? ` · ${asset.note}` : ""}</p>
+                    <p class="mt-1 text-xs text-ink/45">
+                      {categories[asset.category as keyof typeof categories] ??
+                        asset.category} · {asset.date
+                        ? formatDate(asset.date)
+                        : "尚未估值"}{asset.note ? ` · ${asset.note}` : ""}
+                    </p>
                   </button>
-                  <div class="flex items-center gap-3"><p class="font-bold tabular-nums">{formatCurrency(asset.value ?? 0)}</p><button class="rounded-sm p-1 text-ink/40 hover:text-steel" aria-label="編輯資產" onclick={() => startEdit(asset)}><Pencil class="size-4" /></button><button class="rounded-sm p-1 text-ink/40 hover:text-coral" aria-label="刪除資產" onclick={() => $remove.mutate(asset.id)}><Trash2 class="size-4" /></button></div>
+                  <div class="flex items-center gap-3">
+                    <p class="font-bold tabular-nums">
+                      {formatCurrency(asset.value ?? 0)}
+                    </p>
+                    <button
+                      class="rounded-sm p-1 text-ink/40 hover:text-steel"
+                      aria-label="編輯資產"
+                      onclick={() => startEdit(asset)}
+                      ><Pencil class="size-4" /></button
+                    ><button
+                      class="rounded-sm p-1 text-ink/40 hover:text-coral"
+                      aria-label="刪除資產"
+                      onclick={() => $remove.mutate(asset.id)}
+                      ><Trash2 class="size-4" /></button
+                    >
+                  </div>
                 </div>
                 {#if expandedAssetId === asset.id}
                   <div class="mt-4 rounded-lg bg-paper/70 p-3">
-                    <div class="flex items-center justify-between"><h3 class="text-sm font-semibold">估值歷史</h3><span class="text-xs text-ink/45">{($history.data ?? []).length} 筆</span></div>
-                    {#if $history.isPending}<p class="mt-3 text-sm text-ink/45">載入歷史中…</p>{:else if ($history.data ?? []).length === 0}<p class="mt-3 text-sm text-ink/45">尚無歷史紀錄。</p>{:else}
+                    <div class="flex items-center justify-between">
+                      <h3 class="text-sm font-semibold">估值歷史</h3>
+                      <span class="text-xs text-ink/45"
+                        >{($history.data ?? []).length} 筆</span
+                      >
+                    </div>
+                    {#if $history.isPending}<p class="mt-3 text-sm text-ink/45">
+                        載入歷史中…
+                      </p>{:else if ($history.data ?? []).length === 0}<p
+                        class="mt-3 text-sm text-ink/45"
+                      >
+                        尚無歷史紀錄。
+                      </p>{:else}
                       <div class="mt-2 divide-y divide-ink/8">
                         {#each $history.data ?? [] as entry (entry.date)}
-                          <div class="flex items-center justify-between gap-3 py-2 text-sm"><span>{formatDate(entry.date)}</span>{#if editingHistoryDate === entry.date}<div class="flex items-center gap-2"><Input class="h-8 w-28 px-2 py-1" type="number" bind:value={editingHistoryValue} /><Button size="sm" variant="ghost" onclick={() => $editHistory.mutate({ assetId: asset.id, value: Number(editingHistoryValue), date: entry.date })}>儲存</Button><Button size="sm" variant="ghost" onclick={() => editingHistoryDate = null}>取消</Button></div>{:else}<div class="flex items-center gap-2"><span class="font-medium">{formatCurrency(entry.value)}</span><Button size="sm" variant="ghost" onclick={() => { editingHistoryDate = entry.date; editingHistoryValue = String(entry.value); }}>編輯</Button><Button class="text-coral hover:text-coral" size="sm" variant="ghost" onclick={() => $deleteHistory.mutate({ assetId: asset.id, date: entry.date })}>刪除</Button></div>{/if}</div>
+                          <div
+                            class="flex items-center justify-between gap-3 py-2 text-sm"
+                          >
+                            <span>{formatDate(entry.date)}</span
+                            >{#if editingHistoryDate === entry.date}<div
+                                class="flex items-center gap-2"
+                              >
+                                <Input
+                                  class="h-8 w-28 px-2 py-1"
+                                  type="number"
+                                  bind:value={editingHistoryValue}
+                                /><Button
+                                  size="sm"
+                                  variant="ghost"
+                                  onclick={() =>
+                                    $editHistory.mutate({
+                                      assetId: asset.id,
+                                      value: Number(editingHistoryValue),
+                                      date: entry.date,
+                                    })}>儲存</Button
+                                ><Button
+                                  size="sm"
+                                  variant="ghost"
+                                  onclick={() => (editingHistoryDate = null)}
+                                  >取消</Button
+                                >
+                              </div>{:else}<div class="flex items-center gap-2">
+                                <span class="font-medium"
+                                  >{formatCurrency(entry.value)}</span
+                                ><Button
+                                  size="sm"
+                                  variant="ghost"
+                                  onclick={() => {
+                                    editingHistoryDate = entry.date;
+                                    editingHistoryValue = String(entry.value);
+                                  }}>編輯</Button
+                                ><Button
+                                  class="text-coral hover:text-coral"
+                                  size="sm"
+                                  variant="ghost"
+                                  onclick={() =>
+                                    $deleteHistory.mutate({
+                                      assetId: asset.id,
+                                      date: entry.date,
+                                    })}>刪除</Button
+                                >
+                              </div>{/if}
+                          </div>
                         {/each}
                       </div>
                     {/if}
-                    <div class="mt-3 flex flex-wrap items-end gap-2 border-t border-ink/8 pt-3"><label class="grid gap-1 text-xs text-ink/55">估值<Input class="w-32" type="number" bind:value={historyValue} /></label><label class="grid gap-1 text-xs text-ink/55">日期<Input type="date" bind:value={historyDate} /></label><Button size="sm" disabled={!historyValue || $addHistory.isPending} onclick={() => $addHistory.mutate({ assetId: asset.id, value: Number(historyValue), date: historyDate })}><Plus class="size-4" />新增估值</Button></div>
+                    <div
+                      class="mt-3 flex flex-wrap items-end gap-2 border-t border-ink/8 pt-3"
+                    >
+                      <label class="grid gap-1 text-xs text-ink/55"
+                        >估值<Input
+                          class="w-32"
+                          type="number"
+                          bind:value={historyValue}
+                        /></label
+                      ><label class="grid gap-1 text-xs text-ink/55"
+                        >日期<Input
+                          type="date"
+                          bind:value={historyDate}
+                        /></label
+                      ><Button
+                        size="sm"
+                        disabled={!historyValue || $addHistory.isPending}
+                        onclick={() =>
+                          $addHistory.mutate({
+                            assetId: asset.id,
+                            value: Number(historyValue),
+                            date: historyDate,
+                          })}><Plus class="size-4" />新增估值</Button
+                      >
+                    </div>
                   </div>
                 {/if}
               </div>
@@ -103,6 +326,60 @@
         </div>
       </CardContent>
     </Card>
-    {#if adding || editing}<div class="fixed inset-0 z-[70] flex items-end bg-ink/45 md:items-center md:justify-center md:p-6"><div class="w-full rounded-t-2xl bg-white p-5 shadow-2xl md:max-w-lg md:rounded-2xl"><div class="flex items-center justify-between"><h2 class="text-xl font-semibold">{editing ? "編輯資產" : "新增資產"}</h2><Button aria-label="關閉" class="rounded-full text-xl" size="icon" variant="ghost" onclick={() => { adding = false; editing = null; }}>×</Button></div><div class="mt-5 grid gap-3"><label class="grid gap-1 text-sm">名稱<Input bind:value={form.name} /></label><label class="grid gap-1 text-sm">類別<Select bind:value={form.category}>{#each Object.entries(categories) as [key, label] (key)}<option value={key}>{label}</option>{/each}</Select></label><label class="grid gap-1 text-sm">目前估值<Input type="number" bind:value={form.value} /></label><label class="grid gap-1 text-sm">估值日期<Input type="date" bind:value={form.date} /></label><label class="grid gap-1 text-sm">備註<Textarea rows="2" bind:value={form.note} /></label></div><div class="mt-5 grid grid-cols-2 gap-3"><Button variant="secondary" onclick={() => { adding = false; editing = null; }}>取消</Button><Button disabled={$add.isPending || $update.isPending} onclick={submit}>{$add.isPending || $update.isPending ? "儲存中…" : "儲存"}</Button></div></div></div>{/if}
+    {#if adding || editing}<div
+        class="fixed inset-0 z-[70] flex items-end bg-ink/45 md:items-center md:justify-center md:p-6"
+      >
+        <div
+          class="w-full rounded-t-2xl bg-white p-5 shadow-2xl md:max-w-lg md:rounded-2xl"
+        >
+          <div class="flex items-center justify-between">
+            <h2 class="text-xl font-semibold">
+              {editing ? "編輯資產" : "新增資產"}
+            </h2>
+            <Button
+              aria-label="關閉"
+              class="rounded-full text-xl"
+              size="icon"
+              variant="ghost"
+              onclick={() => {
+                adding = false;
+                editing = null;
+              }}>×</Button
+            >
+          </div>
+          <div class="mt-5 grid gap-3">
+            <label class="grid gap-1 text-sm"
+              >名稱<Input bind:value={form.name} /></label
+            ><label class="grid gap-1 text-sm"
+              >類別<Select bind:value={form.category}
+                >{#each Object.entries(categories) as [key, label] (key)}<option
+                    value={key}>{label}</option
+                  >{/each}</Select
+              ></label
+            ><label class="grid gap-1 text-sm"
+              >目前估值<Input type="number" bind:value={form.value} /></label
+            ><label class="grid gap-1 text-sm"
+              >估值日期<Input type="date" bind:value={form.date} /></label
+            ><label class="grid gap-1 text-sm"
+              >備註<Textarea rows="2" bind:value={form.note} /></label
+            >
+          </div>
+          <div class="mt-5 grid grid-cols-2 gap-3">
+            <Button
+              variant="secondary"
+              onclick={() => {
+                adding = false;
+                editing = null;
+              }}>取消</Button
+            ><Button
+              disabled={$add.isPending || $update.isPending}
+              onclick={submit}
+              >{$add.isPending || $update.isPending
+                ? "儲存中…"
+                : "儲存"}</Button
+            >
+          </div>
+        </div>
+      </div>{/if}
   </div>
 {/if}

--- a/apps/web/src/features/invoices/Invoices.svelte
+++ b/apps/web/src/features/invoices/Invoices.svelte
@@ -13,15 +13,36 @@
   let search = $state("");
   let expanded = $state<Record<string, boolean>>({});
   const all = $derived($invoices.data ?? []);
-  const filtered = $derived(all.filter((invoice) => `${invoice.sellerName ?? ""} ${invoice.invoiceNumber ?? ""} ${invoice.items.map((item) => item.description).join(" ")}`.toLowerCase().includes(search.trim().toLowerCase())).sort((a, b) => b.invoiceDate.localeCompare(a.invoiceDate)));
-  const months = $derived([...new Set(filtered.map((invoice) => invoice.invoiceDate.slice(0, 7)))].sort((a, b) => b.localeCompare(a)));
+  const filtered = $derived(
+    all
+      .filter((invoice) =>
+        `${invoice.sellerName ?? ""} ${invoice.invoiceNumber ?? ""} ${invoice.items.map((item) => item.description).join(" ")}`
+          .toLowerCase()
+          .includes(search.trim().toLowerCase()),
+      )
+      .sort((a, b) => b.invoiceDate.localeCompare(a.invoiceDate)),
+  );
+  const months = $derived(
+    [
+      ...new Set(filtered.map((invoice) => invoice.invoiceDate.slice(0, 7))),
+    ].sort((a, b) => b.localeCompare(a)),
+  );
   const thisMonth = new Date().toISOString().slice(0, 7);
-  const thisMonthInvoices = $derived(all.filter((invoice) => invoice.invoiceDate.startsWith(thisMonth)));
-  const thisMonthTotal = $derived(thisMonthInvoices.reduce((sum, invoice) => sum + invoice.amount, 0));
-  const allExpanded = $derived(filtered.length > 0 && filtered.every((invoice) => expanded[invoice.id]));
+  const thisMonthInvoices = $derived(
+    all.filter((invoice) => invoice.invoiceDate.startsWith(thisMonth)),
+  );
+  const thisMonthTotal = $derived(
+    thisMonthInvoices.reduce((sum, invoice) => sum + invoice.amount, 0),
+  );
+  const allExpanded = $derived(
+    filtered.length > 0 && filtered.every((invoice) => expanded[invoice.id]),
+  );
   function toggleAll() {
     if (allExpanded) expanded = {};
-    else expanded = Object.fromEntries(filtered.map((invoice) => [invoice.id, true]));
+    else
+      expanded = Object.fromEntries(
+        filtered.map((invoice) => [invoice.id, true]),
+      );
   }
 </script>
 
@@ -32,37 +53,146 @@
 {:else}
   <section class="grid gap-4">
     <div class="grid gap-3 sm:grid-cols-3">
-      <div class="rounded-xl border border-ink/10 bg-white px-4 py-3 shadow-xs"><p class="text-xs text-ink/50">本月消費</p><p class="mt-1 text-xl font-semibold tabular-nums">{formatCurrency(thisMonthTotal)}</p><p class="text-xs text-ink/40">{thisMonthInvoices.length} 張發票</p></div>
-      <div class="rounded-xl border border-ink/10 bg-white px-4 py-3 shadow-xs"><p class="text-xs text-ink/50">發票總數</p><p class="mt-1 text-xl font-semibold tabular-nums">{all.length.toLocaleString()}</p><p class="text-xs text-ink/40">張</p></div>
-      <div class="rounded-xl border border-ink/10 bg-white px-4 py-3 shadow-xs"><p class="text-xs text-ink/50">本月均消</p><p class="mt-1 text-xl font-semibold tabular-nums">{thisMonthInvoices.length > 0 ? formatCurrency(thisMonthTotal / thisMonthInvoices.length) : "—"}</p><p class="text-xs text-ink/40">每張平均</p></div>
+      <div class="rounded-xl border border-ink/10 bg-white px-4 py-3 shadow-xs">
+        <p class="text-xs text-ink/50">本月消費</p>
+        <p class="mt-1 text-xl font-semibold tabular-nums">
+          {formatCurrency(thisMonthTotal)}
+        </p>
+        <p class="text-xs text-ink/40">{thisMonthInvoices.length} 張發票</p>
+      </div>
+      <div class="rounded-xl border border-ink/10 bg-white px-4 py-3 shadow-xs">
+        <p class="text-xs text-ink/50">發票總數</p>
+        <p class="mt-1 text-xl font-semibold tabular-nums">
+          {all.length.toLocaleString()}
+        </p>
+        <p class="text-xs text-ink/40">張</p>
+      </div>
+      <div class="rounded-xl border border-ink/10 bg-white px-4 py-3 shadow-xs">
+        <p class="text-xs text-ink/50">本月均消</p>
+        <p class="mt-1 text-xl font-semibold tabular-nums">
+          {thisMonthInvoices.length > 0
+            ? formatCurrency(thisMonthTotal / thisMonthInvoices.length)
+            : "—"}
+        </p>
+        <p class="text-xs text-ink/40">每張平均</p>
+      </div>
     </div>
 
     <div class="flex gap-2">
-      <div class="relative min-w-0 flex-1"><Search class="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-muted-foreground" /><Input class="h-11 pl-9" placeholder="搜尋商店、發票號碼或品項" bind:value={search} /></div>
-      {#if filtered.length > 0}<Button class="h-11" variant="outline" onclick={toggleAll}>{allExpanded ? "全部收合" : "全部展開"}</Button>{/if}
+      <div class="relative min-w-0 flex-1">
+        <Search
+          class="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-muted-foreground"
+        /><Input
+          class="h-11 pl-9"
+          placeholder="搜尋商店、發票號碼或品項"
+          bind:value={search}
+        />
+      </div>
+      {#if filtered.length > 0}<Button
+          class="h-11"
+          variant="outline"
+          onclick={toggleAll}>{allExpanded ? "全部收合" : "全部展開"}</Button
+        >{/if}
     </div>
 
     {#if months.length === 0}
-      <EmptyState title={search.trim() ? "無符合結果" : "尚無發票記錄"} body={search.trim() ? "請調整搜尋條件。" : "同步電子發票連接器後顯示。"} />
+      <EmptyState
+        title={search.trim() ? "無符合結果" : "尚無發票記錄"}
+        body={search.trim() ? "請調整搜尋條件。" : "同步電子發票連接器後顯示。"}
+      />
     {:else}
-      <div class="overflow-hidden rounded-xl border border-ink/10 bg-white shadow-xs">
+      <div
+        class="overflow-hidden rounded-xl border border-ink/10 bg-white shadow-xs"
+      >
         {#each months as month (month)}
-          {@const group = filtered.filter((invoice) => invoice.invoiceDate.startsWith(month))}
+          {@const group = filtered.filter((invoice) =>
+            invoice.invoiceDate.startsWith(month),
+          )}
           <div>
-            <div class="flex items-center justify-between border-b border-ink/8 bg-paper px-4 py-2"><span class="text-xs font-semibold text-ink/55">{month.slice(0, 4)} 年 {Number(month.slice(5))} 月</span><span class="text-xs font-semibold tabular-nums text-ink/55">{formatCurrency(group.reduce((sum, invoice) => sum + invoice.amount, 0))}</span></div>
+            <div
+              class="flex items-center justify-between border-b border-ink/8 bg-paper px-4 py-2"
+            >
+              <span class="text-xs font-semibold text-ink/55"
+                >{month.slice(0, 4)} 年 {Number(month.slice(5))} 月</span
+              ><span class="text-xs font-semibold tabular-nums text-ink/55"
+                >{formatCurrency(
+                  group.reduce((sum, invoice) => sum + invoice.amount, 0),
+                )}</span
+              >
+            </div>
             <div class="divide-y divide-ink/8">
               {#each group as invoice (invoice.id)}
                 <div>
-                  <button class={`flex w-full items-center gap-3 px-4 py-3 text-left transition ${expanded[invoice.id] ? "bg-blue-50" : "hover:bg-ink/3"}`} onclick={() => expanded[invoice.id] = !expanded[invoice.id]}>
-                    <div class="min-w-0 flex-1"><p class="truncate text-sm font-medium">{invoice.sellerName ?? "未知商家"}</p><p class="text-xs text-ink/45">{formatDate(invoice.invoiceDate)}{invoice.invoiceNumber ? ` · ${invoice.invoiceNumber}` : ""}</p></div>
-                    <div class="flex shrink-0 items-center gap-2 text-right"><div><p class="text-sm font-semibold tabular-nums">{formatCurrency(invoice.amount)}</p>{#if invoice.items.length > 0}<p class="text-xs text-ink/40">{invoice.items.length} 項</p>{/if}</div><ChevronDown class={`size-4 text-ink/30 transition-transform ${expanded[invoice.id] ? "rotate-180" : ""}`} /></div>
+                  <button
+                    class={`flex w-full items-center gap-3 px-4 py-3 text-left transition ${expanded[invoice.id] ? "bg-blue-50" : "hover:bg-ink/3"}`}
+                    onclick={() =>
+                      (expanded[invoice.id] = !expanded[invoice.id])}
+                  >
+                    <div class="min-w-0 flex-1">
+                      <p class="truncate text-sm font-medium">
+                        {invoice.sellerName ?? "未知商家"}
+                      </p>
+                      <p class="text-xs text-ink/45">
+                        {formatDate(invoice.invoiceDate)}{invoice.invoiceNumber
+                          ? ` · ${invoice.invoiceNumber}`
+                          : ""}
+                      </p>
+                    </div>
+                    <div class="flex shrink-0 items-center gap-2 text-right">
+                      <div>
+                        <p class="text-sm font-semibold tabular-nums">
+                          {formatCurrency(invoice.amount)}
+                        </p>
+                        {#if invoice.items.length > 0}<p
+                            class="text-xs text-ink/40"
+                          >
+                            {invoice.items.length} 項
+                          </p>{/if}
+                      </div>
+                      <ChevronDown
+                        class={`size-4 text-ink/30 transition-transform ${expanded[invoice.id] ? "rotate-180" : ""}`}
+                      />
+                    </div>
                   </button>
                   {#if expanded[invoice.id]}
                     <div class="border-t border-ink/8 bg-paper/60">
                       {#if invoice.items.length > 0}
-                        <div class="divide-y divide-ink/6">{#each invoice.items as item (item.id)}<div class="flex items-start gap-3 px-5 py-2.5"><div class="min-w-0 flex-1"><p class="text-sm text-ink/80">{item.description}</p>{#if item.quantity != null || item.unitPrice != null}<p class="mt-0.5 text-xs text-ink/45">{item.quantity != null ? `${item.quantity.toLocaleString()} × ` : ""}{item.unitPrice != null ? formatCurrency(item.unitPrice) : ""}</p>{/if}</div><p class="shrink-0 text-sm font-medium tabular-nums">{formatCurrency(item.amount)}</p></div>{/each}</div>
-                      {:else}<p class="px-5 py-3 text-xs text-ink/40">無品項記錄</p>{/if}
-                      <div class="flex items-center justify-between border-t border-ink/8 px-5 py-2.5"><p class="text-xs font-semibold text-ink/50">合計</p><p class="text-sm font-bold tabular-nums">{formatCurrency(invoice.amount)}</p></div>
+                        <div class="divide-y divide-ink/6">
+                          {#each invoice.items as item (item.id)}<div
+                              class="flex items-start gap-3 px-5 py-2.5"
+                            >
+                              <div class="min-w-0 flex-1">
+                                <p class="text-sm text-ink/80">
+                                  {item.description}
+                                </p>
+                                {#if item.quantity != null || item.unitPrice != null}<p
+                                    class="mt-0.5 text-xs text-ink/45"
+                                  >
+                                    {item.quantity != null
+                                      ? `${item.quantity.toLocaleString()} × `
+                                      : ""}{item.unitPrice != null
+                                      ? formatCurrency(item.unitPrice)
+                                      : ""}
+                                  </p>{/if}
+                              </div>
+                              <p
+                                class="shrink-0 text-sm font-medium tabular-nums"
+                              >
+                                {formatCurrency(item.amount)}
+                              </p>
+                            </div>{/each}
+                        </div>
+                      {:else}<p class="px-5 py-3 text-xs text-ink/40">
+                          無品項記錄
+                        </p>{/if}
+                      <div
+                        class="flex items-center justify-between border-t border-ink/8 px-5 py-2.5"
+                      >
+                        <p class="text-xs font-semibold text-ink/50">合計</p>
+                        <p class="text-sm font-bold tabular-nums">
+                          {formatCurrency(invoice.amount)}
+                        </p>
+                      </div>
                     </div>
                   {/if}
                 </div>

--- a/apps/web/src/features/overview/NetWorthHistoryChart.svelte
+++ b/apps/web/src/features/overview/NetWorthHistoryChart.svelte
@@ -7,8 +7,16 @@
   import CardHeader from "../../components/ui/CardHeader.svelte";
   import TabsList from "../../components/ui/TabsList.svelte";
   import TabsTrigger from "../../components/ui/TabsTrigger.svelte";
-  import { ChartContainer, ChartTooltip, type ChartConfig } from "../../components/ui/chart";
-  import { formatCompactTwd, formatCurrency, formatDate } from "../../lib/format.svelte";
+  import {
+    ChartContainer,
+    ChartTooltip,
+    type ChartConfig,
+  } from "../../components/ui/chart";
+  import {
+    formatCompactTwd,
+    formatCurrency,
+    formatDate,
+  } from "../../lib/format.svelte";
   import {
     buildNetWorthChartData,
     getAvailableNetWorthAssets,
@@ -17,11 +25,14 @@
     type NetWorthAssetType,
     type NetWorthChartPoint,
     type NetWorthDisplayMode,
-    type NetWorthTimeframe
+    type NetWorthTimeframe,
   } from "../../lib/net-worth-chart";
   import type { NetWorthHistoryRow } from "../../lib/types";
 
-  let { data = [], loading = false }: { data?: NetWorthHistoryRow[]; loading?: boolean } = $props();
+  let {
+    data = [],
+    loading = false,
+  }: { data?: NetWorthHistoryRow[]; loading?: boolean } = $props();
 
   const storageKey = "taiwan-fin-hub-net-worth-chart-included-assets";
   const timeframes: NetWorthTimeframe[] = ["1M", "3M", "6M", "1Y", "ALL"];
@@ -30,26 +41,52 @@
     stock: { label: "股票/ETF", color: "#6574cd" },
     fund: { label: "基金", color: "#9b6bb0" },
     deposit: { label: "存款", color: "#3e6f7c" },
-    manual: { label: "其他資產", color: "#b5853f" }
+    manual: { label: "其他資產", color: "#b5853f" },
   };
 
-  let includedAssets = $state<NetWorthAssetType[]>([...NET_WORTH_DEFAULT_ASSETS]);
+  let includedAssets = $state<NetWorthAssetType[]>([
+    ...NET_WORTH_DEFAULT_ASSETS,
+  ]);
   let timeframe = $state<NetWorthTimeframe>("1Y");
   let displayMode = $state<NetWorthDisplayMode>("sum");
 
   const availableAssets = $derived(getAvailableNetWorthAssets(data));
-  const chartData = $derived(buildNetWorthChartData(data, includedAssets, timeframe));
+  const chartData = $derived(
+    buildNetWorthChartData(data, includedAssets, timeframe),
+  );
   const firstValue = $derived(chartData[0]?.selectedTotal ?? 0);
   const latestValue = $derived(chartData.at(-1)?.selectedTotal ?? 0);
   const changeValue = $derived(latestValue - firstValue);
-  const changePercent = $derived(firstValue === 0 ? 0 : changeValue / Math.abs(firstValue) * 100);
+  const changePercent = $derived(
+    firstValue === 0 ? 0 : (changeValue / Math.abs(firstValue)) * 100,
+  );
   const chartSeries = $derived(
     displayMode === "sum"
-      ? [{ key: "selectedTotal", label: "淨資產", value: "selectedTotal", color: "var(--color-selectedTotal)" }]
-      : [...NET_WORTH_ASSET_SERIES
-          .filter(({ key }) => includedAssets.includes(key))
-          .map(({ key, label }) => ({ key, label, value: key, color: `var(--color-${key})` })),
-        { key: "selectedTotal", label: "總和", value: "selectedTotal", color: "var(--color-selectedTotal)", props: { strokeDasharray: "6 4", strokeWidth: 2.5 } }]
+      ? [
+          {
+            key: "selectedTotal",
+            label: "淨資產",
+            value: "selectedTotal",
+            color: "var(--color-selectedTotal)",
+          },
+        ]
+      : [
+          ...NET_WORTH_ASSET_SERIES.filter(({ key }) =>
+            includedAssets.includes(key),
+          ).map(({ key, label }) => ({
+            key,
+            label,
+            value: key,
+            color: `var(--color-${key})`,
+          })),
+          {
+            key: "selectedTotal",
+            label: "總和",
+            value: "selectedTotal",
+            color: "var(--color-selectedTotal)",
+            props: { strokeDasharray: "6 4", strokeWidth: 2.5 },
+          },
+        ],
   );
 
   onMount(() => {
@@ -57,10 +94,12 @@
       const saved = JSON.parse(localStorage.getItem(storageKey) ?? "null");
       if (!Array.isArray(saved)) return;
       const valid = saved.filter((value): value is NetWorthAssetType =>
-        ["stock", "fund", "deposit", "manual"].includes(value)
+        ["stock", "fund", "deposit", "manual"].includes(value),
       );
       if (valid.length) includedAssets = valid;
-    } catch { /* keep defaults */ }
+    } catch {
+      /* keep defaults */
+    }
   });
 
   function toggleAsset(asset: NetWorthAssetType) {
@@ -80,14 +119,18 @@
   function formatAxisDate(value: unknown) {
     const date = value instanceof Date ? value : new Date(String(value));
     if (Number.isNaN(date.getTime())) return "";
-    return new Intl.DateTimeFormat("zh-TW", { month: "numeric", day: "numeric" }).format(date);
+    return new Intl.DateTimeFormat("zh-TW", {
+      month: "numeric",
+      day: "numeric",
+    }).format(date);
   }
 </script>
 
 {#snippet chartTooltip()}
   <ChartTooltip
     indicator={displayMode === "sum" ? "dot" : "line"}
-    labelFormatter={(value) => formatDate(value instanceof Date ? value.toISOString() : String(value))}
+    labelFormatter={(value) =>
+      formatDate(value instanceof Date ? value.toISOString() : String(value))}
     valueFormatter={(value) => formatCurrency(Number(value))}
   />
 {/snippet}
@@ -96,8 +139,13 @@
   <CardHeader class="gap-3 p-4 md:p-5">
     <div class="flex flex-wrap items-center justify-between gap-3">
       <div class="flex flex-wrap items-center gap-3">
-        <h2 class="flex items-center gap-2 text-base font-semibold"><TrendingUp class="size-4 text-steel" />資產走勢</h2>
-        <div class="flex flex-wrap items-center gap-1.5" aria-label="資產類型篩選">
+        <h2 class="flex items-center gap-2 text-base font-semibold">
+          <TrendingUp class="size-4 text-steel" />資產走勢
+        </h2>
+        <div
+          class="flex flex-wrap items-center gap-1.5"
+          aria-label="資產類型篩選"
+        >
           <span class="text-xs font-medium text-ink/40">包含</span>
           {#each NET_WORTH_ASSET_SERIES as option (option.key)}
             {@const active = includedAssets.includes(option.key)}
@@ -107,25 +155,45 @@
               disabled={!available}
               aria-pressed={active}
               onclick={() => toggleAsset(option.key)}
-            ><span class="size-2 rounded-full" style={`background:${option.color}`}></span>{option.label}</button>
+              ><span
+                class="size-2 rounded-full"
+                style={`background:${option.color}`}
+              ></span>{option.label}</button
+            >
           {/each}
         </div>
         <TabsList class="h-8 border border-border p-0.5 text-xs">
           {#each [{ key: "sum", label: "總和" }, { key: "breakdown", label: "分類" }] as option (option.key)}
-            <TabsTrigger class="h-7 px-2 py-0.5 text-xs" active={displayMode === option.key} onclick={() => displayMode = option.key as NetWorthDisplayMode}>{option.label}</TabsTrigger>
+            <TabsTrigger
+              class="h-7 px-2 py-0.5 text-xs"
+              active={displayMode === option.key}
+              onclick={() => (displayMode = option.key as NetWorthDisplayMode)}
+              >{option.label}</TabsTrigger
+            >
           {/each}
         </TabsList>
       </div>
       <div class="flex items-center gap-2">
         {#if chartData.length > 0}
-          <span class={`inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs font-semibold ${changeValue >= 0 ? "bg-emerald-50 text-emerald-600" : "bg-red-50 text-red-500"}`}>
-            {#if changeValue >= 0}<ArrowUpRight class="size-3.5" />{:else}<ArrowDownLeft class="size-3.5" />{/if}
+          <span
+            class={`inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs font-semibold ${changeValue >= 0 ? "bg-emerald-50 text-emerald-600" : "bg-red-50 text-red-500"}`}
+          >
+            {#if changeValue >= 0}<ArrowUpRight
+                class="size-3.5"
+              />{:else}<ArrowDownLeft class="size-3.5" />{/if}
             {changePercent >= 0 ? "+" : ""}{changePercent.toFixed(1)}%
           </span>
         {/if}
-        <TabsList class="grid h-8 grid-cols-5 border border-border p-0.5 text-xs">
+        <TabsList
+          class="grid h-8 grid-cols-5 border border-border p-0.5 text-xs"
+        >
           {#each timeframes as option (option)}
-            <TabsTrigger class="h-7 px-2 py-0.5 text-xs" active={timeframe === option} onclick={() => timeframe = option}>{option === "ALL" ? "全部" : option}</TabsTrigger>
+            <TabsTrigger
+              class="h-7 px-2 py-0.5 text-xs"
+              active={timeframe === option}
+              onclick={() => (timeframe = option)}
+              >{option === "ALL" ? "全部" : option}</TabsTrigger
+            >
           {/each}
         </TabsList>
       </div>
@@ -133,11 +201,20 @@
   </CardHeader>
   <CardContent class="min-w-0 overflow-hidden px-3 pb-4 sm:px-5 sm:pb-5">
     {#if loading}
-      <div class="flex h-64 items-center justify-center text-sm text-ink/45">載入趨勢中…</div>
+      <div class="flex h-64 items-center justify-center text-sm text-ink/45">
+        載入趨勢中…
+      </div>
     {:else if chartData.length === 0}
-      <div class="flex h-64 items-center justify-center rounded-lg bg-ink/2 text-sm text-ink/45">尚無淨資產歷史資料。</div>
+      <div
+        class="flex h-64 items-center justify-center rounded-lg bg-ink/2 text-sm text-ink/45"
+      >
+        尚無淨資產歷史資料。
+      </div>
     {:else}
-      <ChartContainer config={chartConfig} class="h-52 min-h-52 w-full min-w-0 sm:h-56 sm:min-h-56">
+      <ChartContainer
+        config={chartConfig}
+        class="h-52 min-h-52 w-full min-w-0 sm:h-56 sm:min-h-56"
+      >
         <LineChart
           data={chartData}
           x={xValue}
@@ -149,19 +226,38 @@
           grid={false}
           tooltip={chartTooltip}
           props={{
-            xAxis: { format: formatAxisDate, tickSpacing: 72, tickMarks: false },
-            yAxis: { format: (value: unknown) => formatCompactTwd(Number(value)), tickSpacing: 52, tickMarks: false, grid: true },
+            xAxis: {
+              format: formatAxisDate,
+              tickSpacing: 72,
+              tickMarks: false,
+            },
+            yAxis: {
+              format: (value: unknown) => formatCompactTwd(Number(value)),
+              tickSpacing: 52,
+              tickMarks: false,
+              grid: true,
+            },
             spline: { strokeWidth: 2.5 },
-            highlight: { points: true, lines: true }
+            highlight: { points: true, lines: true },
           }}
         />
       </ChartContainer>
-      <div class="mt-2 flex min-w-0 flex-wrap items-center gap-3 border-t border-ink/8 pt-3">
+      <div
+        class="mt-2 flex min-w-0 flex-wrap items-center gap-3 border-t border-ink/8 pt-3"
+      >
         {#if displayMode === "breakdown"}
           <div class="flex flex-wrap gap-x-4 gap-y-2 text-xs text-ink/55">
-            <span class="inline-flex items-center gap-1.5"><span class="w-4 border-t-2 border-dashed border-ink"></span>總和</span>
-            {#each NET_WORTH_ASSET_SERIES.filter(({ key }) => includedAssets.includes(key)) as item (item.key)}
-              <span class="inline-flex items-center gap-1.5"><span class="size-2 rounded-full" style={`background:${item.color}`}></span>{item.label}</span>
+            <span class="inline-flex items-center gap-1.5"
+              ><span class="w-4 border-t-2 border-dashed border-ink"
+              ></span>總和</span
+            >
+            {#each NET_WORTH_ASSET_SERIES.filter( ({ key }) => includedAssets.includes(key) ) as item (item.key)}
+              <span class="inline-flex items-center gap-1.5"
+                ><span
+                  class="size-2 rounded-full"
+                  style={`background:${item.color}`}
+                ></span>{item.label}</span
+              >
             {/each}
           </div>
         {:else}

--- a/apps/web/src/features/overview/Overview.svelte
+++ b/apps/web/src/features/overview/Overview.svelte
@@ -7,12 +7,30 @@
   import CardContent from "../../components/ui/CardContent.svelte";
   import EmptyState from "../../components/ui/EmptyState.svelte";
   import type { ApiClient } from "../../lib/api";
-  import { bankQuery, exchangeRatesQuery, investmentsQuery, investmentTransactionsQuery, invoicesQuery, manualAssetsQuery, netWorthHistoryQuery, syncJobsQuery } from "../../lib/queries";
+  import {
+    bankQuery,
+    exchangeRatesQuery,
+    investmentsQuery,
+    investmentTransactionsQuery,
+    invoicesQuery,
+    manualAssetsQuery,
+    netWorthHistoryQuery,
+    syncJobsQuery,
+  } from "../../lib/queries";
   import type { View } from "../../lib/types";
-  import { formatBankAccountName, formatCompactTwd, formatCurrency, formatDate, normalizeFinancialDate, rateMap, transactionValueTwd } from "../../lib/format.svelte";
+  import {
+    formatBankAccountName,
+    formatCompactTwd,
+    formatCurrency,
+    formatDate,
+    normalizeFinancialDate,
+    rateMap,
+    transactionValueTwd,
+  } from "../../lib/format.svelte";
   import NetWorthHistoryChart from "./NetWorthHistoryChart.svelte";
 
-  let { api, navigate }: { api: ApiClient; navigate: (view: View) => void } = $props();
+  let { api, navigate }: { api: ApiClient; navigate: (view: View) => void } =
+    $props();
 
   const bank = createQuery(bankQuery(() => api));
   const investments = createQuery(investmentsQuery(() => api));
@@ -25,95 +43,218 @@
 
   const bankData = $derived($bank.data ?? { accounts: [], transactions: [] });
   const rateValues = $derived(rateMap($rates.data));
-  const toTwd = (value: number, currency: string) => currency === "TWD" ? value : value * (rateValues[currency] ?? 0);
-  const deposits = $derived(bankData.accounts.filter((account) => account.accountType !== "credit"));
-  const cards = $derived(bankData.accounts.filter((account) => account.accountType === "credit"));
-  const depositTotal = $derived(deposits.reduce((sum, account) => sum + toTwd(account.balance ?? 0, account.currency), 0));
-  const cardDebt = $derived(cards.reduce((sum, account) => sum + Math.abs(toTwd(account.balance ?? 0, account.currency)), 0));
-  const investmentTotal = $derived(($investments.data ?? []).reduce((sum, item) => sum + toTwd((item.marketValue ?? 0) + (item.cashBalance ?? 0), item.currency), 0));
-  const manualTotal = $derived(($manualAssets.data ?? []).reduce((sum, item) => sum + (item.value ?? 0), 0));
+  const toTwd = (value: number, currency: string) =>
+    currency === "TWD" ? value : value * (rateValues[currency] ?? 0);
+  const deposits = $derived(
+    bankData.accounts.filter((account) => account.accountType !== "credit"),
+  );
+  const cards = $derived(
+    bankData.accounts.filter((account) => account.accountType === "credit"),
+  );
+  const depositTotal = $derived(
+    deposits.reduce(
+      (sum, account) => sum + toTwd(account.balance ?? 0, account.currency),
+      0,
+    ),
+  );
+  const cardDebt = $derived(
+    cards.reduce(
+      (sum, account) =>
+        sum + Math.abs(toTwd(account.balance ?? 0, account.currency)),
+      0,
+    ),
+  );
+  const investmentTotal = $derived(
+    ($investments.data ?? []).reduce(
+      (sum, item) =>
+        sum +
+        toTwd((item.marketValue ?? 0) + (item.cashBalance ?? 0), item.currency),
+      0,
+    ),
+  );
+  const manualTotal = $derived(
+    ($manualAssets.data ?? []).reduce(
+      (sum, item) => sum + (item.value ?? 0),
+      0,
+    ),
+  );
   const gross = $derived(depositTotal + investmentTotal + manualTotal);
   const netWorth = $derived(gross - cardDebt);
-  const pct = (value: number) => gross > 0 ? Math.round(value / gross * 100) : 0;
+  const pct = (value: number) =>
+    gross > 0 ? Math.round((value / gross) * 100) : 0;
   const allocation = $derived([
-    { label: "投資", value: investmentTotal, bar: "bg-steel", text: "text-steel", detail: `${$investments.data?.length ?? 0} 個持倉` },
-    { label: "存款", value: depositTotal, bar: "bg-moss", text: "text-moss", detail: `${deposits.length} 個帳戶` },
-    { label: "其他", value: manualTotal, bar: "bg-coral", text: "text-coral", detail: "保險、房產" }
+    {
+      label: "投資",
+      value: investmentTotal,
+      bar: "bg-steel",
+      text: "text-steel",
+      detail: `${$investments.data?.length ?? 0} 個持倉`,
+    },
+    {
+      label: "存款",
+      value: depositTotal,
+      bar: "bg-moss",
+      text: "text-moss",
+      detail: `${deposits.length} 個帳戶`,
+    },
+    {
+      label: "其他",
+      value: manualTotal,
+      bar: "bg-coral",
+      text: "text-coral",
+      detail: "保險、房產",
+    },
   ]);
   const monthKey = new Date().toISOString().slice(0, 7);
-  const monthlyBank = $derived(bankData.transactions.filter((transaction) =>
-    (transaction.postedDate ?? transaction.authorizedAt ?? "").startsWith(monthKey) && transaction.accountType !== "credit"
-  ));
-  const monthlyIncome = $derived(monthlyBank.reduce((sum, transaction) => sum + Math.max(transactionValueTwd(transaction, rateValues), 0), 0));
-  const monthlyExpense = $derived(Math.abs(monthlyBank.reduce((sum, transaction) => sum + Math.min(transactionValueTwd(transaction, rateValues), 0), 0)));
-  const unhealthy = $derived(($jobs.data ?? []).filter((job) => job.lastStatus === "failed" || job.lastStatus === "needs_user_action"));
+  const monthlyBank = $derived(
+    bankData.transactions.filter(
+      (transaction) =>
+        (transaction.postedDate ?? transaction.authorizedAt ?? "").startsWith(
+          monthKey,
+        ) && transaction.accountType !== "credit",
+    ),
+  );
+  const monthlyIncome = $derived(
+    monthlyBank.reduce(
+      (sum, transaction) =>
+        sum + Math.max(transactionValueTwd(transaction, rateValues), 0),
+      0,
+    ),
+  );
+  const monthlyExpense = $derived(
+    Math.abs(
+      monthlyBank.reduce(
+        (sum, transaction) =>
+          sum + Math.min(transactionValueTwd(transaction, rateValues), 0),
+        0,
+      ),
+    ),
+  );
+  const unhealthy = $derived(
+    ($jobs.data ?? []).filter(
+      (job) =>
+        job.lastStatus === "failed" || job.lastStatus === "needs_user_action",
+    ),
+  );
   const sourceCount = $derived(Math.max(($jobs.data ?? []).length, 4));
   const healthyCount = $derived(Math.max(sourceCount - unhealthy.length, 0));
   const accountRows = $derived(bankData.accounts.slice(0, 4));
-  const recent = $derived.by(() => [
-    ...bankData.transactions.map((transaction) => ({
-      id: `bank-${transaction.id}`,
-      date: transaction.postedDate ?? transaction.authorizedAt ?? "",
-      title: transaction.description ?? transaction.counterparty ?? "銀行交易",
-      detail: transaction.institutionName ?? "銀行",
-      amount: transaction.amount,
-      currency: transaction.currency
-    })),
-    ...($trades.data ?? []).map((trade) => ({
-      id: `trade-${trade.id}`,
-      date: normalizeFinancialDate(trade.tradeDate ?? trade.postedDate),
-      title: trade.name ?? trade.transactionName ?? "投資交易",
-      detail: trade.brokerName ?? "投資",
-      amount: trade.price === 1 ? undefined : trade.amount,
-      currency: trade.currency
-    })),
-    ...($invoices.data ?? []).map((invoice) => ({
-      id: `invoice-${invoice.id}`,
-      date: invoice.invoiceDate,
-      title: invoice.sellerName ?? "電子發票",
-      detail: "電子發票",
-      amount: -Math.abs(invoice.amount),
-      currency: "TWD"
-    }))
-  ].sort((a, b) => b.date.localeCompare(a.date)).slice(0, 4));
-  const missingRates = $derived([...new Set(bankData.accounts.map((account) => account.currency).filter((currency) => currency !== "TWD" && !rateValues[currency]))]);
-  const loading = $derived($bank.isPending || $investments.isPending || $manualAssets.isPending);
-  const failed = $derived($bank.isError || $investments.isError || $manualAssets.isError);
+  const recent = $derived.by(() =>
+    [
+      ...bankData.transactions.map((transaction) => ({
+        id: `bank-${transaction.id}`,
+        date: transaction.postedDate ?? transaction.authorizedAt ?? "",
+        title:
+          transaction.description ?? transaction.counterparty ?? "銀行交易",
+        detail: transaction.institutionName ?? "銀行",
+        amount: transaction.amount,
+        currency: transaction.currency,
+      })),
+      ...($trades.data ?? []).map((trade) => ({
+        id: `trade-${trade.id}`,
+        date: normalizeFinancialDate(trade.tradeDate ?? trade.postedDate),
+        title: trade.name ?? trade.transactionName ?? "投資交易",
+        detail: trade.brokerName ?? "投資",
+        amount: trade.price === 1 ? undefined : trade.amount,
+        currency: trade.currency,
+      })),
+      ...($invoices.data ?? []).map((invoice) => ({
+        id: `invoice-${invoice.id}`,
+        date: invoice.invoiceDate,
+        title: invoice.sellerName ?? "電子發票",
+        detail: "電子發票",
+        amount: -Math.abs(invoice.amount),
+        currency: "TWD",
+      })),
+    ]
+      .sort((a, b) => b.date.localeCompare(a.date))
+      .slice(0, 4),
+  );
+  const missingRates = $derived([
+    ...new Set(
+      bankData.accounts
+        .map((account) => account.currency)
+        .filter((currency) => currency !== "TWD" && !rateValues[currency]),
+    ),
+  ]);
+  const loading = $derived(
+    $bank.isPending || $investments.isPending || $manualAssets.isPending,
+  );
+  const failed = $derived(
+    $bank.isError || $investments.isError || $manualAssets.isError,
+  );
 </script>
 
 {#if loading}
   <EmptyState title="載入總覽中" body="正在讀取最新紀錄。" />
 {:else if failed}
-  <EmptyState title="無法載入總覽" body="請稍後再試，或確認 Worker API 是否可用。" />
+  <EmptyState
+    title="無法載入總覽"
+    body="請稍後再試，或確認 Worker API 是否可用。"
+  />
 {:else}
   <div class="grid min-w-0 gap-4 md:gap-5">
     {#if missingRates.length}
-      <div class="flex items-center justify-between gap-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-        <span>帳戶含外幣（{missingRates.join("、")}）尚未設定匯率，TWD 總額可能不準確。</span>
-        <button class="shrink-0 font-semibold underline underline-offset-2" onclick={() => navigate("settings")}>前往設定</button>
+      <div
+        class="flex items-center justify-between gap-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+      >
+        <span
+          >帳戶含外幣（{missingRates.join("、")}）尚未設定匯率，TWD
+          總額可能不準確。</span
+        >
+        <button
+          class="shrink-0 font-semibold underline underline-offset-2"
+          onclick={() => navigate("settings")}>前往設定</button
+        >
       </div>
     {/if}
 
     <div class="grid gap-4 xl:grid-cols-[minmax(0,1.8fr)_minmax(300px,1fr)]">
       <section class="rounded-2xl bg-ink p-5 text-white shadow-xs md:p-6">
         <p class="text-xs font-semibold text-white/55">全部資產</p>
-        <p class="mt-3 text-4xl font-bold tracking-tight tabular-nums md:text-[40px]">{formatCurrency(netWorth)}</p>
-        <p class="mt-3 text-sm font-semibold text-emerald-300">淨資產 · 已扣除 {formatCurrency(cardDebt)} 信用卡負債</p>
+        <p
+          class="mt-3 text-4xl font-bold tracking-tight tabular-nums md:text-[40px]"
+        >
+          {formatCurrency(netWorth)}
+        </p>
+        <p class="mt-3 text-sm font-semibold text-emerald-300">
+          淨資產 · 已扣除 {formatCurrency(cardDebt)} 信用卡負債
+        </p>
         <div class="mt-5 flex h-3 overflow-hidden rounded-full bg-white/10">
           {#each allocation as item (item.label)}
-            <span class={`h-full ${item.bar}`} style={`width:${pct(item.value)}%`}></span>
+            <span
+              class={`h-full ${item.bar}`}
+              style={`width:${pct(item.value)}%`}
+            ></span>
           {/each}
         </div>
-        <p class="mt-3 hidden text-xs text-white/65 md:block">{allocation.map((item) => `${item.label} ${pct(item.value)}%`).join("　")}</p>
+        <p class="mt-3 hidden text-xs text-white/65 md:block">
+          {allocation
+            .map((item) => `${item.label} ${pct(item.value)}%`)
+            .join("　")}
+        </p>
       </section>
 
       <Card class="hidden xl:block">
         <CardContent class="pt-6">
           <h2 class="text-lg font-semibold">同步健康度</h2>
-          <p class="mt-3 text-3xl font-bold">{healthyCount} / {sourceCount} 來源正常</p>
-          <Badge class="mt-3" variant={unhealthy.length ? "destructive" : "success"}>{unhealthy.length ? `${unhealthy.length} 個來源需要處理` : "所有來源同步正常"}</Badge>
+          <p class="mt-3 text-3xl font-bold">
+            {healthyCount} / {sourceCount} 來源正常
+          </p>
+          <Badge
+            class="mt-3"
+            variant={unhealthy.length ? "destructive" : "success"}
+            >{unhealthy.length
+              ? `${unhealthy.length} 個來源需要處理`
+              : "所有來源同步正常"}</Badge
+          >
           <p class="mt-2 text-xs text-ink/45">銀行與發票使用最近同步紀錄</p>
-          <Button class="mt-4" variant="secondary" size="sm" onclick={() => navigate("settings")}>前往同步設定</Button>
+          <Button
+            class="mt-4"
+            variant="secondary"
+            size="sm"
+            onclick={() => navigate("settings")}>前往同步設定</Button
+          >
         </CardContent>
       </Card>
     </div>
@@ -122,40 +263,81 @@
       {#each allocation as item (item.label)}
         <Card>
           <CardContent class="p-3 md:p-5">
-            <p class="text-xs font-semibold text-ink/50 md:mt-0">{item.label === "其他" ? "其他資產" : item.label}</p>
-            <p class={`mt-2 text-xl font-bold tabular-nums md:hidden ${item.text}`}>{formatCompactTwd(item.value)}</p>
-            <p class="mt-1 text-[11px] text-ink/40 md:hidden">佔全部資產 {pct(item.value)}%</p>
-            <p class={`mt-2 hidden text-2xl font-bold tabular-nums md:block ${item.text}`}>{formatCurrency(item.value)}</p>
-            <p class="mt-1 hidden text-xs text-ink/40 md:block">{item.detail}</p>
+            <p class="text-xs font-semibold text-ink/50 md:mt-0">
+              {item.label === "其他" ? "其他資產" : item.label}
+            </p>
+            <p
+              class={`mt-2 text-xl font-bold tabular-nums md:hidden ${item.text}`}
+            >
+              {formatCompactTwd(item.value)}
+            </p>
+            <p class="mt-1 text-[11px] text-ink/40 md:hidden">
+              佔全部資產 {pct(item.value)}%
+            </p>
+            <p
+              class={`mt-2 hidden text-2xl font-bold tabular-nums md:block ${item.text}`}
+            >
+              {formatCurrency(item.value)}
+            </p>
+            <p class="mt-1 hidden text-xs text-ink/40 md:block">
+              {item.detail}
+            </p>
           </CardContent>
         </Card>
       {/each}
       <Card class="hidden md:block">
         <CardContent class="p-5">
           <p class="text-xs font-semibold text-ink/50">本月淨流入</p>
-          <p class={`mt-2 text-2xl font-bold tracking-tight tabular-nums ${monthlyIncome >= monthlyExpense ? "text-moss" : "text-coral"}`}>{formatCurrency(monthlyIncome - monthlyExpense)}</p>
+          <p
+            class={`mt-2 text-2xl font-bold tracking-tight tabular-nums ${monthlyIncome >= monthlyExpense ? "text-moss" : "text-coral"}`}
+          >
+            {formatCurrency(monthlyIncome - monthlyExpense)}
+          </p>
           <p class="mt-1 text-xs text-ink/45">收入 − 支出</p>
         </CardContent>
       </Card>
     </div>
 
-    <div class="xl:hidden"><NetWorthHistoryChart data={$history.data ?? []} loading={$history.isPending} /></div>
+    <div class="xl:hidden">
+      <NetWorthHistoryChart
+        data={$history.data ?? []}
+        loading={$history.isPending}
+      />
+    </div>
 
     <div class="grid gap-4 xl:grid-cols-[minmax(0,1.8fr)_minmax(300px,1fr)]">
-      <div class="hidden min-w-0 xl:block"><NetWorthHistoryChart data={$history.data ?? []} loading={$history.isPending} /></div>
+      <div class="hidden min-w-0 xl:block">
+        <NetWorthHistoryChart
+          data={$history.data ?? []}
+          loading={$history.isPending}
+        />
+      </div>
       <Card>
         <CardHeader class="flex-row items-center justify-between">
           <h2 class="text-lg font-semibold">資產配置</h2>
-          <Button variant="ghost" size="sm" onclick={() => navigate("assets")}>查看全部 →</Button>
+          <Button variant="ghost" size="sm" onclick={() => navigate("assets")}
+            >查看全部 →</Button
+          >
         </CardHeader>
         <CardContent class="grid gap-5">
           {#each allocation as item (item.label)}
             <div>
               <div class="flex items-center justify-between gap-3">
-                <div><span class="text-sm font-semibold">{item.label}</span><span class="ml-2 text-xs text-ink/40">{item.detail}</span></div>
-                <span class={`text-sm font-bold tabular-nums ${item.text}`}>{formatCurrency(item.value)}</span>
+                <div>
+                  <span class="text-sm font-semibold">{item.label}</span><span
+                    class="ml-2 text-xs text-ink/40">{item.detail}</span
+                  >
+                </div>
+                <span class={`text-sm font-bold tabular-nums ${item.text}`}
+                  >{formatCurrency(item.value)}</span
+                >
               </div>
-              <div class="mt-2 h-2 overflow-hidden rounded-full bg-ink/10"><span class={`block h-full rounded-full ${item.bar}`} style={`width:${pct(item.value)}%`}></span></div>
+              <div class="mt-2 h-2 overflow-hidden rounded-full bg-ink/10">
+                <span
+                  class={`block h-full rounded-full ${item.bar}`}
+                  style={`width:${pct(item.value)}%`}
+                ></span>
+              </div>
             </div>
           {/each}
         </CardContent>
@@ -165,20 +347,41 @@
     {#if unhealthy.length > 0}
       <section class="rounded-2xl bg-amber-50 p-5 text-amber-900 md:hidden">
         <p class="font-semibold">{unhealthy.length} 個來源需要更新</p>
-        <button class="mt-3 text-sm font-semibold" onclick={() => navigate("settings")}>立即處理 →</button>
+        <button
+          class="mt-3 text-sm font-semibold"
+          onclick={() => navigate("settings")}>立即處理 →</button
+        >
       </section>
     {/if}
 
-    <div class="hidden gap-5 xl:grid xl:grid-cols-[minmax(0,1.8fr)_minmax(300px,1fr)]">
+    <div
+      class="hidden gap-5 xl:grid xl:grid-cols-[minmax(0,1.8fr)_minmax(300px,1fr)]"
+    >
       <Card>
-        <CardHeader class="flex-row items-center justify-between"><h2 class="text-lg font-semibold">銀行與信用卡</h2><Button variant="ghost" size="sm" onclick={() => navigate("assets")}>查看資產 →</Button></CardHeader>
+        <CardHeader class="flex-row items-center justify-between"
+          ><h2 class="text-lg font-semibold">銀行與信用卡</h2>
+          <Button variant="ghost" size="sm" onclick={() => navigate("assets")}
+            >查看資產 →</Button
+          ></CardHeader
+        >
         <CardContent class="grid gap-4">
           {#each accountRows as account (account.id)}
-            <div class="grid grid-cols-[120px_minmax(0,1fr)_auto_auto] gap-3 text-sm">
-              <span class="font-semibold">{account.institutionName ?? account.connectorId}</span>
-              <span class="truncate text-ink/45">{account.accountName ?? formatBankAccountName(account)}</span>
-              <span class={`font-semibold tabular-nums ${account.accountType === "credit" ? "text-coral" : ""}`}>{formatCurrency(account.balance ?? 0, account.currency)}</span>
-              <span class="text-xs text-ink/40">{account.asOfAt ? formatDate(account.asOfAt) : "—"}</span>
+            <div
+              class="grid grid-cols-[120px_minmax(0,1fr)_auto_auto] gap-3 text-sm"
+            >
+              <span class="font-semibold"
+                >{account.institutionName ?? account.connectorId}</span
+              >
+              <span class="truncate text-ink/45"
+                >{account.accountName ?? formatBankAccountName(account)}</span
+              >
+              <span
+                class={`font-semibold tabular-nums ${account.accountType === "credit" ? "text-coral" : ""}`}
+                >{formatCurrency(account.balance ?? 0, account.currency)}</span
+              >
+              <span class="text-xs text-ink/40"
+                >{account.asOfAt ? formatDate(account.asOfAt) : "—"}</span
+              >
             </div>
           {/each}
         </CardContent>
@@ -188,8 +391,16 @@
         <CardContent class="grid gap-4">
           {#each recent as item (item.id)}
             <div class="flex items-center justify-between gap-3 text-sm">
-              <div class="min-w-0"><p class="truncate font-semibold">{item.title}</p><p class="truncate text-xs text-ink/40">{item.detail}</p></div>
-              <span class={`shrink-0 font-semibold tabular-nums ${item.amount != null && item.amount < 0 ? "text-coral" : item.amount != null ? "text-moss" : "text-ink/40"}`}>{item.amount == null ? "—" : `${item.amount >= 0 ? "+" : ""}${formatCurrency(item.amount, item.currency)}`}</span>
+              <div class="min-w-0">
+                <p class="truncate font-semibold">{item.title}</p>
+                <p class="truncate text-xs text-ink/40">{item.detail}</p>
+              </div>
+              <span
+                class={`shrink-0 font-semibold tabular-nums ${item.amount != null && item.amount < 0 ? "text-coral" : item.amount != null ? "text-moss" : "text-ink/40"}`}
+                >{item.amount == null
+                  ? "—"
+                  : `${item.amount >= 0 ? "+" : ""}${formatCurrency(item.amount, item.currency)}`}</span
+              >
             </div>
           {/each}
         </CardContent>

--- a/apps/web/src/features/settings/ClassificationRulesPanel.svelte
+++ b/apps/web/src/features/settings/ClassificationRulesPanel.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { createMutation, createQuery, useQueryClient } from "@tanstack/svelte-query";
+  import {
+    createMutation,
+    createQuery,
+    useQueryClient,
+  } from "@tanstack/svelte-query";
   import Card from "../../components/ui/Card.svelte";
   import CardHeader from "../../components/ui/CardHeader.svelte";
   import CardContent from "../../components/ui/CardContent.svelte";
@@ -26,19 +30,99 @@
     insurance: "保險",
     fee: "費用",
     tax: "稅務",
-    other: "其他"
+    other: "其他",
   };
   const operatorLabels: Record<string, string> = {
     contains: "包含",
     equals: "完全等於",
     starts_with: "開頭為",
-    regex: "符合正規表示式"
+    regex: "符合正規表示式",
   };
   const rules = createQuery(classificationRulesQuery(() => api));
   const qc = useQueryClient();
-  let newRule = $state({ categoryId: "food", pattern: "", operator: "contains" });
-  const add = createMutation({ mutationFn: () => api.post("/api/classification/rules", { ...newRule, targetType: "bank_transaction", field: "any_text", priority: 200 }), onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.classificationRules }); newRule = { categoryId: "food", pattern: "", operator: "contains" }; } });
-  const toggle = createMutation({ mutationFn: (payload: { id: string; enabled: boolean }) => api.put(`/api/classification/rules/${payload.id}`, { enabled: payload.enabled }), onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.classificationRules }) });
-  const remove = createMutation({ mutationFn: (id: string) => api.delete(`/api/classification/rules/${id}`), onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.classificationRules }) });
+  let newRule = $state({
+    categoryId: "food",
+    pattern: "",
+    operator: "contains",
+  });
+  const add = createMutation({
+    mutationFn: () =>
+      api.post("/api/classification/rules", {
+        ...newRule,
+        targetType: "bank_transaction",
+        field: "any_text",
+        priority: 200,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.classificationRules });
+      newRule = { categoryId: "food", pattern: "", operator: "contains" };
+    },
+  });
+  const toggle = createMutation({
+    mutationFn: (payload: { id: string; enabled: boolean }) =>
+      api.put(`/api/classification/rules/${payload.id}`, {
+        enabled: payload.enabled,
+      }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.classificationRules }),
+  });
+  const remove = createMutation({
+    mutationFn: (id: string) => api.delete(`/api/classification/rules/${id}`),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.classificationRules }),
+  });
 </script>
-<Card><CardHeader class="flex-row items-center justify-between"><div><h2 class="text-lg font-semibold">分類規則</h2><p class="text-xs text-muted-foreground">讓銀行交易依條件自動分類</p></div><Badge variant="secondary">{$rules.data?.length ?? 0} 條</Badge></CardHeader><CardContent><div class="mb-4 grid gap-2 rounded-lg border border-border bg-muted/60 p-3 md:grid-cols-[120px_120px_1fr_auto]"><Select bind:value={newRule.categoryId}><option value="food">餐飲</option><option value="shopping">購物</option><option value="transport">交通</option><option value="other">其他</option></Select><Select bind:value={newRule.operator}><option value="contains">包含</option><option value="equals">完全等於</option></Select><Input placeholder="比對文字" bind:value={newRule.pattern} /><Button variant="primary" disabled={!newRule.pattern.trim()} onclick={() => $add.mutate()}>新增</Button></div><div class="divide-y divide-border">{#each $rules.data ?? [] as rule (rule.id)}<div class="flex items-center gap-3 py-3 text-sm"><Checkbox checked={rule.enabled} onchange={(e: Event) => $toggle.mutate({ id: rule.id, enabled: (e.currentTarget as HTMLInputElement).checked })} /><span class="min-w-0 flex-1 truncate"><strong>{categoryLabels[rule.categoryId] ?? rule.categoryId}</strong> · {operatorLabels[rule.operator] ?? rule.operator}「{rule.pattern}」</span><Button class="text-destructive hover:text-destructive" size="sm" variant="ghost" onclick={() => $remove.mutate(rule.id)}>刪除</Button></div>{/each}</div></CardContent></Card>
+
+<Card
+  ><CardHeader class="flex-row items-center justify-between"
+    ><div>
+      <h2 class="text-lg font-semibold">分類規則</h2>
+      <p class="text-xs text-muted-foreground">讓銀行交易依條件自動分類</p>
+    </div>
+    <Badge variant="secondary">{$rules.data?.length ?? 0} 條</Badge></CardHeader
+  ><CardContent
+    ><div
+      class="mb-4 grid gap-2 rounded-lg border border-border bg-muted/60 p-3 md:grid-cols-[120px_120px_1fr_auto]"
+    >
+      <Select bind:value={newRule.categoryId}
+        ><option value="food">餐飲</option><option value="shopping">購物</option
+        ><option value="transport">交通</option><option value="other"
+          >其他</option
+        ></Select
+      ><Select bind:value={newRule.operator}
+        ><option value="contains">包含</option><option value="equals"
+          >完全等於</option
+        ></Select
+      ><Input placeholder="比對文字" bind:value={newRule.pattern} /><Button
+        variant="primary"
+        disabled={!newRule.pattern.trim()}
+        onclick={() => $add.mutate()}>新增</Button
+      >
+    </div>
+    <div class="divide-y divide-border">
+      {#each $rules.data ?? [] as rule (rule.id)}<div
+          class="flex items-center gap-3 py-3 text-sm"
+        >
+          <Checkbox
+            checked={rule.enabled}
+            onchange={(e: Event) =>
+              $toggle.mutate({
+                id: rule.id,
+                enabled: (e.currentTarget as HTMLInputElement).checked,
+              })}
+          /><span class="min-w-0 flex-1 truncate"
+            ><strong
+              >{categoryLabels[rule.categoryId] ?? rule.categoryId}</strong
+            >
+            · {operatorLabels[rule.operator] ??
+              rule.operator}「{rule.pattern}」</span
+          ><Button
+            class="text-destructive hover:text-destructive"
+            size="sm"
+            variant="ghost"
+            onclick={() => $remove.mutate(rule.id)}>刪除</Button
+          >
+        </div>{/each}
+    </div></CardContent
+  ></Card
+>

--- a/apps/web/src/features/settings/ConnectorPanel.svelte
+++ b/apps/web/src/features/settings/ConnectorPanel.svelte
@@ -2,8 +2,18 @@
   import { onMount } from "svelte";
   import { SvelteDate } from "svelte/reactivity";
   import { toStore } from "svelte/store";
-  import { createMutation, createQuery, useQueryClient } from "@tanstack/svelte-query";
-  import { Database, KeyRound, RefreshCw, Save, WalletCards } from "@lucide/svelte";
+  import {
+    createMutation,
+    createQuery,
+    useQueryClient,
+  } from "@tanstack/svelte-query";
+  import {
+    Database,
+    KeyRound,
+    RefreshCw,
+    Save,
+    WalletCards,
+  } from "@lucide/svelte";
   import Card from "../../components/ui/Card.svelte";
   import Button from "../../components/ui/Button.svelte";
   import Checkbox from "../../components/ui/Checkbox.svelte";
@@ -12,12 +22,30 @@
   import type { ApiClient } from "../../lib/api";
   import { queryKeys } from "../../lib/api";
   import { connectorSettingsQuery, syncJobsQuery } from "../../lib/queries";
-  import type { ConnectorField, ConnectorId, SyncTarget } from "../../lib/types";
+  import type {
+    ConnectorField,
+    ConnectorId,
+    SyncTarget,
+  } from "../../lib/types";
   import { formatDateTime } from "../../lib/format.svelte";
 
-  let { api, connectorId, demoMode, title, fields }: { api: ApiClient; connectorId: ConnectorId; demoMode: boolean; title: string; fields: ConnectorField[] } = $props();
+  let {
+    api,
+    connectorId,
+    demoMode,
+    title,
+    fields,
+  }: {
+    api: ApiClient;
+    connectorId: ConnectorId;
+    demoMode: boolean;
+    title: string;
+    fields: ConnectorField[];
+  } = $props();
   const qc = useQueryClient();
-  const settings = createQuery(toStore(() => connectorSettingsQuery(() => api, connectorId)));
+  const settings = createQuery(
+    toStore(() => connectorSettingsQuery(() => api, connectorId)),
+  );
   const jobs = createQuery(syncJobsQuery(() => api));
   let values = $state<Record<string, string | boolean>>({});
   let error = $state("");
@@ -26,97 +54,166 @@
   let sinopacCaptchaImage = $state("");
   let sinopacCaptcha = $state("");
   let pendingSyncTarget = $state<SyncTarget>("default");
-  const job = $derived(($jobs.data ?? []).find((j) => j.connectorId === connectorId && j.scope === "all"));
-  const sinopacSessionAvailable = $derived(connectorId === "sinopac" && Boolean($settings.data?.sessionAvailable));
-  const intervalOptions = [{ label: "每小時", minutes: 60 }, { label: "每 6 小時", minutes: 360 }, { label: "每 12 小時", minutes: 720 }, { label: "每天", minutes: 1440 }, { label: "每週", minutes: 10080 }];
+  const job = $derived(
+    ($jobs.data ?? []).find(
+      (j) => j.connectorId === connectorId && j.scope === "all",
+    ),
+  );
+  const sinopacSessionAvailable = $derived(
+    connectorId === "sinopac" && Boolean($settings.data?.sessionAvailable),
+  );
+  const intervalOptions = [
+    { label: "每小時", minutes: 60 },
+    { label: "每 6 小時", minutes: 360 },
+    { label: "每 12 小時", minutes: 720 },
+    { label: "每天", minutes: 1440 },
+    { label: "每週", minutes: 10080 },
+  ];
 
-  onMount(() => settings.subscribe((result) => {
-    for (const [key, value] of Object.entries(result.data?.publicConfig ?? {})) {
-      if (values[key] === undefined) values[key] = typeof value === "boolean" ? value : String(value);
-    }
-    if (connectorId === "einvoice" && values.fetchDetails === undefined) values.fetchDetails = true;
-  }));
+  onMount(() =>
+    settings.subscribe((result) => {
+      for (const [key, value] of Object.entries(
+        result.data?.publicConfig ?? {},
+      )) {
+        if (values[key] === undefined)
+          values[key] = typeof value === "boolean" ? value : String(value);
+      }
+      if (connectorId === "einvoice" && values.fetchDetails === undefined)
+        values.fetchDetails = true;
+    }),
+  );
 
   const save = createMutation({
-    mutationFn: (config: Record<string, unknown>) => { if (!Object.keys(config).length) throw new Error("請先填寫欄位再儲存。"); return api.put(`/api/connectors/${connectorId}/settings`, { config }); },
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.connectorSettings(connectorId) }),
-    onError: (e) => error = e instanceof Error ? e.message : "儲存失敗"
+    mutationFn: (config: Record<string, unknown>) => {
+      if (!Object.keys(config).length) throw new Error("請先填寫欄位再儲存。");
+      return api.put(`/api/connectors/${connectorId}/settings`, { config });
+    },
+    onSuccess: () =>
+      qc.invalidateQueries({
+        queryKey: queryKeys.connectorSettings(connectorId),
+      }),
+    onError: (e) => (error = e instanceof Error ? e.message : "儲存失敗"),
   });
   const updateJob = createMutation({
-    mutationFn: (payload: Record<string, unknown>) => api.patch(`/api/sync-jobs/${connectorId}/all`, payload),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.syncJobs })
+    mutationFn: (payload: Record<string, unknown>) =>
+      api.patch(`/api/sync-jobs/${connectorId}/all`, payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.syncJobs }),
   });
   const sync = createMutation({
     mutationFn: (target: SyncTarget) => {
       if (demoMode) throw new Error("Demo site 已停用連接器同步。");
-      const path = connectorId === "tdcc" && target !== "default" ? `/api/connectors/${connectorId}/sync/${target}` : `/api/connectors/${connectorId}/sync`;
+      const path =
+        connectorId === "tdcc" && target !== "default"
+          ? `/api/connectors/${connectorId}/sync/${target}`
+          : `/api/connectors/${connectorId}/sync`;
       pendingSyncTarget = target;
-      return api.post(path, connectorId === "einvoice" ? { fetchDetails: true } : undefined);
+      return api.post(
+        path,
+        connectorId === "einvoice" ? { fetchDetails: true } : undefined,
+      );
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.syncJobs });
       qc.invalidateQueries({ queryKey: queryKeys.summary });
-      if (connectorId === "einvoice") qc.invalidateQueries({ queryKey: queryKeys.invoices });
-      else if (connectorId === "esun" || connectorId === "cathaybk") qc.invalidateQueries({ queryKey: queryKeys.bank });
+      if (connectorId === "einvoice")
+        qc.invalidateQueries({ queryKey: queryKeys.invoices });
+      else if (connectorId === "esun" || connectorId === "cathaybk")
+        qc.invalidateQueries({ queryKey: queryKeys.bank });
       else if (connectorId === "sinopac") {
-        qc.invalidateQueries({ queryKey: queryKeys.connectorSettings(connectorId) });
+        qc.invalidateQueries({
+          queryKey: queryKeys.connectorSettings(connectorId),
+        });
         qc.invalidateQueries({ queryKey: queryKeys.bank });
         qc.invalidateQueries({ queryKey: queryKeys.bills });
-      }
-      else {
-        if (pendingSyncTarget === "default" || pendingSyncTarget === "investments") qc.invalidateQueries({ queryKey: queryKeys.investments });
-        if (pendingSyncTarget === "default" || pendingSyncTarget === "trades") qc.invalidateQueries({ queryKey: queryKeys.investmentTransactions });
-        if (pendingSyncTarget === "default" || pendingSyncTarget === "bank") qc.invalidateQueries({ queryKey: queryKeys.bank });
+      } else {
+        if (
+          pendingSyncTarget === "default" ||
+          pendingSyncTarget === "investments"
+        )
+          qc.invalidateQueries({ queryKey: queryKeys.investments });
+        if (pendingSyncTarget === "default" || pendingSyncTarget === "trades")
+          qc.invalidateQueries({ queryKey: queryKeys.investmentTransactions });
+        if (pendingSyncTarget === "default" || pendingSyncTarget === "bank")
+          qc.invalidateQueries({ queryKey: queryKeys.bank });
       }
     },
     onError: (e) => {
       error = e instanceof Error ? e.message : "同步失敗";
-      if (connectorId === "sinopac") qc.invalidateQueries({ queryKey: queryKeys.connectorSettings(connectorId) });
-    }
+      if (connectorId === "sinopac")
+        qc.invalidateQueries({
+          queryKey: queryKeys.connectorSettings(connectorId),
+        });
+    },
   });
   const prepareSinopac = createMutation({
     mutationFn: () => {
       if (demoMode) throw new Error("Demo site 已停用連接器同步。");
-      return api.post<{ captchaImage: string; expiresAt: string }>("/api/connectors/sinopac/captcha");
+      return api.post<{ captchaImage: string; expiresAt: string }>(
+        "/api/connectors/sinopac/captcha",
+      );
     },
     onSuccess: (data) => {
       error = "";
       sinopacCaptcha = "";
       sinopacCaptchaImage = data.captchaImage;
     },
-    onError: (e) => error = e instanceof Error ? e.message : "取得驗證碼失敗"
+    onError: (e) => (error = e instanceof Error ? e.message : "取得驗證碼失敗"),
   });
   const verifySinopac = createMutation({
     mutationFn: () => {
       if (demoMode) throw new Error("Demo site 已停用連接器同步。");
-      if (!/^\d{6}$/.test(sinopacCaptcha.trim())) throw new Error("請輸入圖片中的六位數字驗證碼。");
-      return api.post("/api/connectors/sinopac/sync", { captcha: sinopacCaptcha.trim() });
+      if (!/^\d{6}$/.test(sinopacCaptcha.trim()))
+        throw new Error("請輸入圖片中的六位數字驗證碼。");
+      return api.post("/api/connectors/sinopac/sync", {
+        captcha: sinopacCaptcha.trim(),
+      });
     },
     onSuccess: () => {
       error = "";
       sinopacCaptcha = "";
       sinopacCaptchaImage = "";
-      qc.invalidateQueries({ queryKey: queryKeys.connectorSettings(connectorId) });
+      qc.invalidateQueries({
+        queryKey: queryKeys.connectorSettings(connectorId),
+      });
       qc.invalidateQueries({ queryKey: queryKeys.syncJobs });
       qc.invalidateQueries({ queryKey: queryKeys.summary });
       qc.invalidateQueries({ queryKey: queryKeys.bank });
       qc.invalidateQueries({ queryKey: queryKeys.bills });
       if (job && !job.enabled) $updateJob.mutate({ enabled: true });
     },
-    onError: (e) => error = e instanceof Error ? e.message : "驗證或同步失敗"
+    onError: (e) => (error = e instanceof Error ? e.message : "驗證或同步失敗"),
   });
-  const syncErrorMessage = $derived($sync.error instanceof Error ? $sync.error.message : "");
-  const otpRequired = $derived(connectorId === "tdcc" && (otpForced || /OTP/i.test(syncErrorMessage)));
+  const syncErrorMessage = $derived(
+    $sync.error instanceof Error ? $sync.error.message : "",
+  );
+  const otpRequired = $derived(
+    connectorId === "tdcc" && (otpForced || /OTP/i.test(syncErrorMessage)),
+  );
   const otpChannel = $derived(/SMS/i.test(syncErrorMessage) ? "sms" : "email");
   const verifyOtp = createMutation({
     mutationFn: () => {
       if (demoMode) throw new Error("Demo site 已停用連接器同步。");
       if (!otp.trim()) throw new Error("請先輸入驗證碼。");
-      const path = connectorId === "tdcc" && pendingSyncTarget !== "default" ? `/api/connectors/${connectorId}/sync/${pendingSyncTarget}` : `/api/connectors/${connectorId}/sync`;
+      const path =
+        connectorId === "tdcc" && pendingSyncTarget !== "default"
+          ? `/api/connectors/${connectorId}/sync/${pendingSyncTarget}`
+          : `/api/connectors/${connectorId}/sync`;
       return api.post(path, { otp: otp.trim(), otpChannel });
     },
-    onSuccess: () => { otp = ""; otpForced = false; $sync.reset(); qc.invalidateQueries({ queryKey: queryKeys.connectorSettings(connectorId) }); qc.invalidateQueries({ queryKey: queryKeys.syncJobs }); qc.invalidateQueries({ queryKey: queryKeys.summary }); qc.invalidateQueries({ queryKey: queryKeys.investments }); qc.invalidateQueries({ queryKey: queryKeys.investmentTransactions }); qc.invalidateQueries({ queryKey: queryKeys.bank }); },
-    onError: (e) => error = e instanceof Error ? e.message : "驗證失敗"
+    onSuccess: () => {
+      otp = "";
+      otpForced = false;
+      $sync.reset();
+      qc.invalidateQueries({
+        queryKey: queryKeys.connectorSettings(connectorId),
+      });
+      qc.invalidateQueries({ queryKey: queryKeys.syncJobs });
+      qc.invalidateQueries({ queryKey: queryKeys.summary });
+      qc.invalidateQueries({ queryKey: queryKeys.investments });
+      qc.invalidateQueries({ queryKey: queryKeys.investmentTransactions });
+      qc.invalidateQueries({ queryKey: queryKeys.bank });
+    },
+    onError: (e) => (error = e instanceof Error ? e.message : "驗證失敗"),
   });
 
   function buildConfig() {
@@ -147,54 +244,285 @@
   <div class="flex flex-wrap items-start justify-between gap-3">
     <div>
       <h2 class="text-lg font-semibold">{title}</h2>
-      <p class="text-sm text-ink/65">{$settings.data?.configured ? `已設定於 ${formatDateTime($settings.data.updatedAt)}。機密資料不會在此顯示；重新填寫欄位即可覆寫。` : "尚未設定"}</p>
+      <p class="text-sm text-ink/65">
+        {$settings.data?.configured
+          ? `已設定於 ${formatDateTime($settings.data.updatedAt)}。機密資料不會在此顯示；重新填寫欄位即可覆寫。`
+          : "尚未設定"}
+      </p>
     </div>
     <div class="flex flex-wrap gap-2">
-      <Button size="sm" onclick={() => { error = ""; $save.mutate(buildConfig()); }}><Save class="size-4" />儲存</Button>
+      <Button
+        size="sm"
+        onclick={() => {
+          error = "";
+          $save.mutate(buildConfig());
+        }}><Save class="size-4" />儲存</Button
+      >
       {#if connectorId === "tdcc"}
-        <Button size="sm" disabled={demoMode} onclick={() => $sync.mutate("investments")}><WalletCards class="size-4" />同步投資</Button>
-        <Button size="sm" disabled={demoMode} onclick={() => $sync.mutate("bank")}><RefreshCw class="size-4" />同步銀行</Button>
-        <Button size="sm" disabled={demoMode} onclick={() => $sync.mutate("trades")}><Database class="size-4" />同步交易</Button>
+        <Button
+          size="sm"
+          disabled={demoMode}
+          onclick={() => $sync.mutate("investments")}
+          ><WalletCards class="size-4" />同步投資</Button
+        >
+        <Button
+          size="sm"
+          disabled={demoMode}
+          onclick={() => $sync.mutate("bank")}
+          ><RefreshCw class="size-4" />同步銀行</Button
+        >
+        <Button
+          size="sm"
+          disabled={demoMode}
+          onclick={() => $sync.mutate("trades")}
+          ><Database class="size-4" />同步交易</Button
+        >
       {:else if connectorId === "sinopac"}
         {#if sinopacSessionAvailable}
-          <Button size="sm" disabled={demoMode || $sync.isPending || $verifySinopac.isPending} onclick={() => { error = ""; $sync.mutate("default"); }}><RefreshCw class="size-4" />{$sync.isPending ? "同步中…" : "同步"}</Button>
-          <Button size="sm" variant="outline" disabled={demoMode || $prepareSinopac.isPending || $verifySinopac.isPending} onclick={() => { error = ""; $prepareSinopac.mutate(); }}><KeyRound class="size-4" />{$prepareSinopac.isPending ? "取得中…" : "重新驗證"}</Button>
+          <Button
+            size="sm"
+            disabled={demoMode || $sync.isPending || $verifySinopac.isPending}
+            onclick={() => {
+              error = "";
+              $sync.mutate("default");
+            }}
+            ><RefreshCw class="size-4" />{$sync.isPending
+              ? "同步中…"
+              : "同步"}</Button
+          >
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={demoMode ||
+              $prepareSinopac.isPending ||
+              $verifySinopac.isPending}
+            onclick={() => {
+              error = "";
+              $prepareSinopac.mutate();
+            }}
+            ><KeyRound class="size-4" />{$prepareSinopac.isPending
+              ? "取得中…"
+              : "重新驗證"}</Button
+          >
         {:else}
-          <Button size="sm" disabled={demoMode || $prepareSinopac.isPending || $verifySinopac.isPending} onclick={() => { error = ""; $prepareSinopac.mutate(); }}><KeyRound class="size-4" />{$prepareSinopac.isPending ? "取得中…" : "取得驗證碼"}</Button>
+          <Button
+            size="sm"
+            disabled={demoMode ||
+              $prepareSinopac.isPending ||
+              $verifySinopac.isPending}
+            onclick={() => {
+              error = "";
+              $prepareSinopac.mutate();
+            }}
+            ><KeyRound class="size-4" />{$prepareSinopac.isPending
+              ? "取得中…"
+              : "取得驗證碼"}</Button
+          >
         {/if}
       {:else}
-        <Button size="sm" disabled={demoMode} onclick={() => $sync.mutate("default")}><RefreshCw class="size-4" />同步</Button>
+        <Button
+          size="sm"
+          disabled={demoMode}
+          onclick={() => $sync.mutate("default")}
+          ><RefreshCw class="size-4" />同步</Button
+        >
       {/if}
-      {#if connectorId === "tdcc"}<Button size="sm" variant="secondary" disabled={demoMode} onclick={() => otpForced = true}><KeyRound class="size-4" />輸入 OTP</Button>{/if}
+      {#if connectorId === "tdcc"}<Button
+          size="sm"
+          variant="secondary"
+          disabled={demoMode}
+          onclick={() => (otpForced = true)}
+          ><KeyRound class="size-4" />輸入 OTP</Button
+        >{/if}
     </div>
   </div>
-  {#if demoMode}<p class="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">Demo site 已停用同步；你仍可查看示範資料與介面互動。</p>{/if}
-  {#if connectorId === "tdcc"}<details class="mt-3 rounded-md border border-ink/10 bg-paper text-sm text-ink/70" open><summary class="cursor-pointer select-none px-3 py-2 font-medium text-ink/80">使用說明</summary><ol class="list-decimal space-y-1.5 px-3 pb-3 pt-1 pl-8"><li>先在手機下載並登入「集保e存摺」，確認可看到股票與基金資料。</li><li>填入身分證字號與集保 App 密碼，儲存後再按同步。</li><li>首次同步需要驗證碼，請查看手機簡訊或電子信箱。</li><li>完成後即可看到持倉；日後同步通常不需重新輸入驗證碼。</li></ol></details>{/if}
-  {#if connectorId === "sinopac"}<details class="mt-3 rounded-md border border-ink/10 bg-paper text-sm text-ink/70" open><summary class="cursor-pointer select-none px-3 py-2 font-medium text-ink/80">使用說明</summary><ol class="list-decimal space-y-1.5 px-3 pb-3 pt-1 pl-8"><li>先儲存身分證字號／統編、行動／網路銀行使用者代碼與網路密碼。</li><li>首次或銀行 session 失效時，透過行動網銀頁面取得並輸入一次圖形驗證碼。</li><li>驗證成功後會加密保存 session；信用卡總覽、近期帳單與未出帳消費皆直接由 App JSON API 同步，不解析 MMA 頁面。</li><li>後續手動與排程同步會自動續用 session，銀行強制登出時才需重新驗證。</li></ol></details>{/if}
+  {#if demoMode}<p
+      class="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+    >
+      Demo site 已停用同步；你仍可查看示範資料與介面互動。
+    </p>{/if}
+  {#if connectorId === "tdcc"}<details
+      class="mt-3 rounded-md border border-ink/10 bg-paper text-sm text-ink/70"
+      open
+    >
+      <summary
+        class="cursor-pointer select-none px-3 py-2 font-medium text-ink/80"
+        >使用說明</summary
+      >
+      <ol class="list-decimal space-y-1.5 px-3 pb-3 pt-1 pl-8">
+        <li>先在手機下載並登入「集保e存摺」，確認可看到股票與基金資料。</li>
+        <li>填入身分證字號與集保 App 密碼，儲存後再按同步。</li>
+        <li>首次同步需要驗證碼，請查看手機簡訊或電子信箱。</li>
+        <li>完成後即可看到持倉；日後同步通常不需重新輸入驗證碼。</li>
+      </ol>
+    </details>{/if}
+  {#if connectorId === "sinopac"}<details
+      class="mt-3 rounded-md border border-ink/10 bg-paper text-sm text-ink/70"
+      open
+    >
+      <summary
+        class="cursor-pointer select-none px-3 py-2 font-medium text-ink/80"
+        >使用說明</summary
+      >
+      <ol class="list-decimal space-y-1.5 px-3 pb-3 pt-1 pl-8">
+        <li>先儲存身分證字號／統編、行動／網路銀行使用者代碼與網路密碼。</li>
+        <li>
+          首次或銀行 session 失效時，透過行動網銀頁面取得並輸入一次圖形驗證碼。
+        </li>
+        <li>
+          驗證成功後會加密保存 session；信用卡總覽、近期帳單與未出帳消費皆直接由
+          App JSON API 同步，不解析 MMA 頁面。
+        </li>
+        <li>
+          後續手動與排程同步會自動續用 session，銀行強制登出時才需重新驗證。
+        </li>
+      </ol>
+    </details>{/if}
   {#if connectorId === "sinopac" && sinopacCaptchaImage}
     <div class="mt-3 rounded-md border border-ink/10 bg-paper p-3">
-      <p class="text-sm font-medium text-ink/80">請輸入圖片中的六位數字，驗證碼約兩分鐘內有效。</p>
+      <p class="text-sm font-medium text-ink/80">
+        請輸入圖片中的六位數字，驗證碼約兩分鐘內有效。
+      </p>
       <div class="mt-2 flex flex-wrap items-center gap-2">
-        <img src={sinopacCaptchaImage} alt="永豐圖形驗證碼" class="h-[70px] w-[200px] shrink-0 rounded border border-ink/25 bg-white object-fill shadow-sm" />
-        <Input class="min-w-40 flex-1" inputmode="numeric" maxlength="6" placeholder="六位數字驗證碼" bind:value={sinopacCaptcha} />
-        <Button size="sm" disabled={$verifySinopac.isPending} onclick={() => { error = ""; $verifySinopac.mutate(); }}><RefreshCw class="size-4" />{$verifySinopac.isPending ? "同步中…" : "驗證並同步"}</Button>
-        <Button size="sm" variant="outline" disabled={$prepareSinopac.isPending || $verifySinopac.isPending} onclick={() => $prepareSinopac.mutate()}>換一張</Button>
+        <img
+          src={sinopacCaptchaImage}
+          alt="永豐圖形驗證碼"
+          class="h-[70px] w-[200px] shrink-0 rounded border border-ink/25 bg-white object-fill shadow-sm"
+        />
+        <Input
+          class="min-w-40 flex-1"
+          inputmode="numeric"
+          maxlength="6"
+          placeholder="六位數字驗證碼"
+          bind:value={sinopacCaptcha}
+        />
+        <Button
+          size="sm"
+          disabled={$verifySinopac.isPending}
+          onclick={() => {
+            error = "";
+            $verifySinopac.mutate();
+          }}
+          ><RefreshCw class="size-4" />{$verifySinopac.isPending
+            ? "同步中…"
+            : "驗證並同步"}</Button
+        >
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={$prepareSinopac.isPending || $verifySinopac.isPending}
+          onclick={() => $prepareSinopac.mutate()}>換一張</Button
+        >
       </div>
     </div>
   {/if}
-  <div class="mt-3 rounded-md border border-ink/10 bg-paper px-3 py-2 text-sm text-ink/70">
-    <div class="flex flex-wrap items-center justify-between gap-2"><div class="flex flex-wrap items-center gap-x-3 gap-y-1"><span class="font-medium">自動同步：{job?.enabled ? "開" : "關"}</span>{#if connectorId === "sinopac"}<span>登入：{sinopacSessionAvailable ? "session 可自動續用" : "需要人工驗證"}</span>{/if}{#if job}<span>狀態：{job.running ? "同步中" : job.lastStatus === "success" ? "正常" : job.lastStatus === "failed" ? "失敗" : job.lastStatus === "needs_user_action" ? "需要處理" : "尚未同步"}</span>{#if job.lastRunAt}<span>上次：{formatDateTime(job.lastRunAt)}</span>{/if}{#if job.enabled}<span class="flex items-center gap-1.5"><Select class="h-8 w-auto px-2 text-xs" value={intervalOptions.find((option) => option.minutes === job.intervalMinutes)?.minutes ?? 1440} onchange={(e: Event) => $updateJob.mutate({ intervalMinutes: Number((e.currentTarget as HTMLSelectElement).value) })}>{#each intervalOptions as option (option.minutes)}<option value={option.minutes}>{option.label}</option>{/each}</Select>{#if job.intervalMinutes >= 1440 && job.nextRunAt}<Input type="time" class="h-8 w-auto text-xs" value={new Date(job.nextRunAt).toTimeString().slice(0, 5)} onchange={scheduleTime} /><span class="text-muted-foreground">同步</span>{/if}</span>{/if}{/if}</div>{#if job}<Button size="sm" variant="outline" disabled={$updateJob.isPending} onclick={() => $updateJob.mutate({ enabled: !job.enabled })}>{job.enabled ? "關閉" : "開啟"}</Button>{/if}</div>
-    {#if error || (job?.lastError && !sinopacCaptchaImage)}<p class="mt-1 text-xs text-coral">{error ? `本次同步：${error}` : `上次同步：${job?.lastError}`}</p>{/if}
+  <div
+    class="mt-3 rounded-md border border-ink/10 bg-paper px-3 py-2 text-sm text-ink/70"
+  >
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <span class="font-medium">自動同步：{job?.enabled ? "開" : "關"}</span
+        >{#if connectorId === "sinopac"}<span
+            >登入：{sinopacSessionAvailable
+              ? "session 可自動續用"
+              : "需要人工驗證"}</span
+          >{/if}{#if job}<span
+            >狀態：{job.running
+              ? "同步中"
+              : job.lastStatus === "success"
+                ? "正常"
+                : job.lastStatus === "failed"
+                  ? "失敗"
+                  : job.lastStatus === "needs_user_action"
+                    ? "需要處理"
+                    : "尚未同步"}</span
+          >{#if job.lastRunAt}<span>上次：{formatDateTime(job.lastRunAt)}</span
+            >{/if}{#if job.enabled}<span class="flex items-center gap-1.5"
+              ><Select
+                class="h-8 w-auto px-2 text-xs"
+                value={intervalOptions.find(
+                  (option) => option.minutes === job.intervalMinutes,
+                )?.minutes ?? 1440}
+                onchange={(e: Event) =>
+                  $updateJob.mutate({
+                    intervalMinutes: Number(
+                      (e.currentTarget as HTMLSelectElement).value,
+                    ),
+                  })}
+                >{#each intervalOptions as option (option.minutes)}<option
+                    value={option.minutes}>{option.label}</option
+                  >{/each}</Select
+              >{#if job.intervalMinutes >= 1440 && job.nextRunAt}<Input
+                  type="time"
+                  class="h-8 w-auto text-xs"
+                  value={new Date(job.nextRunAt).toTimeString().slice(0, 5)}
+                  onchange={scheduleTime}
+                /><span class="text-muted-foreground">同步</span>{/if}</span
+            >{/if}{/if}
+      </div>
+      {#if job}<Button
+          size="sm"
+          variant="outline"
+          disabled={$updateJob.isPending}
+          onclick={() => $updateJob.mutate({ enabled: !job.enabled })}
+          >{job.enabled ? "關閉" : "開啟"}</Button
+        >{/if}
+    </div>
+    {#if error || (job?.lastError && !sinopacCaptchaImage)}<p
+        class="mt-1 text-xs text-coral"
+      >
+        {error ? `本次同步：${error}` : `上次同步：${job?.lastError}`}
+      </p>{/if}
   </div>
   <div class="mt-4 grid gap-3">
     {#each fields as field (field.key)}
       {#if field.type === "checkbox"}
-        <label class="flex items-center gap-2 text-sm"><Checkbox checked={Boolean(values[field.key])} onchange={(e: Event) => values[field.key] = (e.currentTarget as HTMLInputElement).checked} />{field.label}</label>
+        <label class="flex items-center gap-2 text-sm"
+          ><Checkbox
+            checked={Boolean(values[field.key])}
+            onchange={(e: Event) =>
+              (values[field.key] = (
+                e.currentTarget as HTMLInputElement
+              ).checked)}
+          />{field.label}</label
+        >
       {:else}
-        <label class="grid gap-1 text-sm">{field.label}<Input type={field.type} placeholder={field.placeholder} value={String(values[field.key] ?? "")} oninput={(e: Event) => values[field.key] = (e.currentTarget as HTMLInputElement).value} /></label>
+        <label class="grid gap-1 text-sm"
+          >{field.label}<Input
+            type={field.type}
+            placeholder={field.placeholder}
+            value={String(values[field.key] ?? "")}
+            oninput={(e: Event) =>
+              (values[field.key] = (e.currentTarget as HTMLInputElement).value)}
+          /></label
+        >
       {/if}
     {/each}
   </div>
-  {#if otpRequired}<div class="mt-3 rounded-md border border-destructive/40 bg-destructive/10 p-3"><p class="text-sm font-medium text-ink/80">TDCC 需要驗證碼，請查看{otpChannel === "sms" ? "手機簡訊" : "電子信箱"}。</p><div class="mt-2 flex flex-wrap gap-2"><Input class="min-w-40 flex-1" placeholder="輸入驗證碼" bind:value={otp} /><Button size="sm" disabled={$verifyOtp.isPending} onclick={() => $verifyOtp.mutate()}><RefreshCw class="size-4" />驗證並同步</Button></div></div>{/if}
-  <p class="mt-3 text-xs text-ink/50">{connectorId === "sinopac" ? "永豐首次驗證成功後，正式同步會直接呼叫 App JSON API；只有銀行要求重新登入時才需再輸入驗證碼。" : "輸入完帳號密碼後，請先按「儲存設定」，再按「同步」。"}</p>
+  {#if otpRequired}<div
+      class="mt-3 rounded-md border border-destructive/40 bg-destructive/10 p-3"
+    >
+      <p class="text-sm font-medium text-ink/80">
+        TDCC 需要驗證碼，請查看{otpChannel === "sms"
+          ? "手機簡訊"
+          : "電子信箱"}。
+      </p>
+      <div class="mt-2 flex flex-wrap gap-2">
+        <Input
+          class="min-w-40 flex-1"
+          placeholder="輸入驗證碼"
+          bind:value={otp}
+        /><Button
+          size="sm"
+          disabled={$verifyOtp.isPending}
+          onclick={() => $verifyOtp.mutate()}
+          ><RefreshCw class="size-4" />驗證並同步</Button
+        >
+      </div>
+    </div>{/if}
+  <p class="mt-3 text-xs text-ink/50">
+    {connectorId === "sinopac"
+      ? "永豐首次驗證成功後，正式同步會直接呼叫 App JSON API；只有銀行要求重新登入時才需再輸入驗證碼。"
+      : "輸入完帳號密碼後，請先按「儲存設定」，再按「同步」。"}
+  </p>
 </Card>

--- a/apps/web/src/features/settings/ExchangeRatesPanel.svelte
+++ b/apps/web/src/features/settings/ExchangeRatesPanel.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { createMutation, createQuery, useQueryClient } from "@tanstack/svelte-query";
+  import {
+    createMutation,
+    createQuery,
+    useQueryClient,
+  } from "@tanstack/svelte-query";
   import { Save } from "@lucide/svelte";
   import Card from "../../components/ui/Card.svelte";
   import CardHeader from "../../components/ui/CardHeader.svelte";
@@ -15,12 +19,60 @@
   const bank = createQuery(bankQuery(() => api));
   const qc = useQueryClient();
   let values = $state<Record<string, string>>({});
-  const currencies = $derived([...new Set(($bank.data?.accounts ?? []).map((a) => a.currency).filter((c) => c && c !== "TWD"))]);
-  const save = createMutation({ mutationFn: (payload: Record<string, number>) => api.put("/api/exchange-rates", { rates: payload }), onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.exchangeRates }) });
-  onMount(() => rates.subscribe((result) => {
-    for (const rate of result.data ?? []) {
-      if (values[rate.currency] === undefined) values[rate.currency] = String(rate.rateTwd);
-    }
-  }));
+  const currencies = $derived([
+    ...new Set(
+      ($bank.data?.accounts ?? [])
+        .map((a) => a.currency)
+        .filter((c) => c && c !== "TWD"),
+    ),
+  ]);
+  const save = createMutation({
+    mutationFn: (payload: Record<string, number>) =>
+      api.put("/api/exchange-rates", { rates: payload }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.exchangeRates }),
+  });
+  onMount(() =>
+    rates.subscribe((result) => {
+      for (const rate of result.data ?? []) {
+        if (values[rate.currency] === undefined)
+          values[rate.currency] = String(rate.rateTwd);
+      }
+    }),
+  );
 </script>
-<Card><CardHeader><h2 class="text-lg font-semibold">匯率</h2><p class="text-xs text-muted-foreground">管理外幣換算使用的參考匯率</p></CardHeader><CardContent><div class="grid gap-3">{#if currencies.length === 0}<p class="text-sm text-muted-foreground">目前沒有外幣帳戶。</p>{:else}{#each currencies as currency (currency)}<label class="flex items-center justify-between gap-3 text-sm"><span class="font-semibold">{currency}</span><Input class="w-32 text-right" type="number" step="0.0001" bind:value={values[currency]} /></label>{/each}<Button variant="primary" disabled={$save.isPending} onclick={() => $save.mutate(Object.fromEntries(Object.entries(values).map(([k, v]) => [k, Number(v)])))}><Save class="size-4" />{$save.isPending ? "儲存中…" : "儲存匯率"}</Button>{/if}</div></CardContent></Card>
+
+<Card
+  ><CardHeader
+    ><h2 class="text-lg font-semibold">匯率</h2>
+    <p class="text-xs text-muted-foreground">
+      管理外幣換算使用的參考匯率
+    </p></CardHeader
+  ><CardContent
+    ><div class="grid gap-3">
+      {#if currencies.length === 0}<p class="text-sm text-muted-foreground">
+          目前沒有外幣帳戶。
+        </p>{:else}{#each currencies as currency (currency)}<label
+            class="flex items-center justify-between gap-3 text-sm"
+            ><span class="font-semibold">{currency}</span><Input
+              class="w-32 text-right"
+              type="number"
+              step="0.0001"
+              bind:value={values[currency]}
+            /></label
+          >{/each}<Button
+          variant="primary"
+          disabled={$save.isPending}
+          onclick={() =>
+            $save.mutate(
+              Object.fromEntries(
+                Object.entries(values).map(([k, v]) => [k, Number(v)]),
+              ),
+            )}
+          ><Save class="size-4" />{$save.isPending
+            ? "儲存中…"
+            : "儲存匯率"}</Button
+        >{/if}
+    </div></CardContent
+  ></Card
+>

--- a/apps/web/src/features/settings/Metric.svelte
+++ b/apps/web/src/features/settings/Metric.svelte
@@ -1,6 +1,27 @@
 <script lang="ts">
   import Card from "../../components/ui/Card.svelte";
   import CardContent from "../../components/ui/CardContent.svelte";
-  let { label, value, detail, tone = "neutral" }: { label: string; value: string; detail: string; tone?: "neutral" | "positive" | "negative" } = $props();
+  let {
+    label,
+    value,
+    detail,
+    tone = "neutral",
+  }: {
+    label: string;
+    value: string;
+    detail: string;
+    tone?: "neutral" | "positive" | "negative";
+  } = $props();
 </script>
-<Card><CardContent class="p-4"><p class="text-xs font-semibold text-muted-foreground">{label}</p><p class={`mt-2 text-2xl font-bold ${tone === "positive" ? "text-moss" : tone === "negative" ? "text-coral" : ""}`}>{value}</p><p class="mt-1 text-xs text-muted-foreground">{detail}</p></CardContent></Card>
+
+<Card
+  ><CardContent class="p-4"
+    ><p class="text-xs font-semibold text-muted-foreground">{label}</p>
+    <p
+      class={`mt-2 text-2xl font-bold ${tone === "positive" ? "text-moss" : tone === "negative" ? "text-coral" : ""}`}
+    >
+      {value}
+    </p>
+    <p class="mt-1 text-xs text-muted-foreground">{detail}</p></CardContent
+  ></Card
+>

--- a/apps/web/src/features/settings/MobileMore.svelte
+++ b/apps/web/src/features/settings/MobileMore.svelte
@@ -3,18 +3,134 @@
   import Card from "../../components/ui/Card.svelte";
   import CardContent from "../../components/ui/CardContent.svelte";
   import type { ApiClient } from "../../lib/api";
-  import type { BankData, ClassificationRuleRow, SyncJobRow, View } from "../../lib/types";
-  let { demoMode, jobs, rules, bank, navigate }: { api: ApiClient; demoMode: boolean; jobs: SyncJobRow[]; rules: ClassificationRuleRow[]; bank: BankData; navigate: (view: View) => void } = $props();
-  const sources = [{ id: "einvoice", label: "電子發票" }, { id: "esun", label: "玉山銀行" }, { id: "cathaybk", label: "國泰世華" }, { id: "sinopac", label: "永豐行動銀行" }, { id: "tdcc", label: "集保 e 存摺" }];
-  const unhealthy = $derived(jobs.filter((job) => job.lastStatus === "failed" || job.lastStatus === "needs_user_action"));
+  import type {
+    BankData,
+    ClassificationRuleRow,
+    SyncJobRow,
+    View,
+  } from "../../lib/types";
+  let {
+    demoMode,
+    jobs,
+    rules,
+    bank,
+    navigate,
+  }: {
+    api: ApiClient;
+    demoMode: boolean;
+    jobs: SyncJobRow[];
+    rules: ClassificationRuleRow[];
+    bank: BankData;
+    navigate: (view: View) => void;
+  } = $props();
+  const sources = [
+    { id: "einvoice", label: "電子發票" },
+    { id: "esun", label: "玉山銀行" },
+    { id: "cathaybk", label: "國泰世華" },
+    { id: "sinopac", label: "永豐行動銀行" },
+    { id: "tdcc", label: "集保 e 存摺" },
+  ];
+  const unhealthy = $derived(
+    jobs.filter(
+      (job) =>
+        job.lastStatus === "failed" || job.lastStatus === "needs_user_action",
+    ),
+  );
 </script>
+
 <div class="grid gap-4">
-  {#if demoMode}<span class="w-fit rounded-full bg-steel/10 px-3 py-1 text-xs font-semibold text-steel">Demo 資料</span>{/if}
-  <Card><CardContent class="pt-5"><p class="text-xs font-semibold text-ink/45">資料健康度</p><p class="mt-2 text-2xl font-bold">{Math.max(sources.length - unhealthy.length, 0)} / {sources.length} 來源正常</p>{#if unhealthy.length}<p class="mt-2 text-sm font-semibold text-coral">{unhealthy.length} 個來源需要處理</p>{/if}</CardContent></Card>
-  <section><h2 class="mb-2 text-sm font-semibold text-ink/50">設定與資料</h2><Card><div class="divide-y divide-ink/8">
-    <button class="flex min-h-16 w-full items-center gap-3 px-4 py-3 text-left" onclick={() => navigate("data-sources")}><span class="flex size-10 items-center justify-center rounded-xl bg-steel/10 text-steel"><Database class="size-5" /></span><span class="flex-1"><span class="block font-semibold">資料來源與連接器</span><span class="block text-xs text-ink/45">狀態、憑證、排程與重新驗證</span></span><span class="text-xs font-semibold text-steel">{sources.length} 個　›</span></button>
-    <button class="flex min-h-16 w-full items-center gap-3 px-4 py-3 text-left" onclick={() => navigate("exchange-rates")}><span class="flex size-10 items-center justify-center rounded-xl bg-steel/10 text-steel"><WalletCards class="size-5" /></span><span class="flex-1"><span class="block font-semibold">匯率</span><span class="block text-xs text-ink/45">管理外幣換算</span></span><span class="text-xs font-semibold text-steel">›</span></button>
-    <button class="flex min-h-16 w-full items-center gap-3 px-4 py-3 text-left" onclick={() => navigate("classification-rules")}><span class="flex size-10 items-center justify-center rounded-xl bg-steel/10 text-steel"><Settings class="size-5" /></span><span class="flex-1"><span class="block font-semibold">分類規則</span><span class="block text-xs text-ink/45">銀行交易自動分類</span></span><span class="text-xs font-semibold text-steel">{rules.length} 條　›</span></button>
-  </div></Card></section>
-  <section><div class="mb-2 flex items-center justify-between"><h2 class="text-sm font-semibold text-ink/50">資料來源</h2><button class="min-h-8 px-2 text-xs font-semibold text-steel" onclick={() => navigate("data-sources")}>管理</button></div><Card><div class="divide-y divide-ink/8">{#each sources as source (source.id)}{@const job = jobs.find((item) => item.connectorId === source.id)}<div class="flex items-center justify-between gap-3 px-4 py-3 text-sm"><span class="font-semibold">{source.label}</span><span class={job?.lastStatus === "failed" || job?.lastStatus === "needs_user_action" ? "text-coral" : "text-moss"}>{job?.lastStatus === "failed" || job?.lastStatus === "needs_user_action" ? "需要處理" : job?.lastSuccessAt ? "正常" : "尚未同步"}</span></div>{/each}</div></Card></section>
+  {#if demoMode}<span
+      class="w-fit rounded-full bg-steel/10 px-3 py-1 text-xs font-semibold text-steel"
+      >Demo 資料</span
+    >{/if}
+  <Card
+    ><CardContent class="pt-5"
+      ><p class="text-xs font-semibold text-ink/45">資料健康度</p>
+      <p class="mt-2 text-2xl font-bold">
+        {Math.max(sources.length - unhealthy.length, 0)} / {sources.length} 來源正常
+      </p>
+      {#if unhealthy.length}<p class="mt-2 text-sm font-semibold text-coral">
+          {unhealthy.length} 個來源需要處理
+        </p>{/if}</CardContent
+    ></Card
+  >
+  <section>
+    <h2 class="mb-2 text-sm font-semibold text-ink/50">設定與資料</h2>
+    <Card
+      ><div class="divide-y divide-ink/8">
+        <button
+          class="flex min-h-16 w-full items-center gap-3 px-4 py-3 text-left"
+          onclick={() => navigate("data-sources")}
+          ><span
+            class="flex size-10 items-center justify-center rounded-xl bg-steel/10 text-steel"
+            ><Database class="size-5" /></span
+          ><span class="flex-1"
+            ><span class="block font-semibold">資料來源與連接器</span><span
+              class="block text-xs text-ink/45">狀態、憑證、排程與重新驗證</span
+            ></span
+          ><span class="text-xs font-semibold text-steel"
+            >{sources.length} 個　›</span
+          ></button
+        >
+        <button
+          class="flex min-h-16 w-full items-center gap-3 px-4 py-3 text-left"
+          onclick={() => navigate("exchange-rates")}
+          ><span
+            class="flex size-10 items-center justify-center rounded-xl bg-steel/10 text-steel"
+            ><WalletCards class="size-5" /></span
+          ><span class="flex-1"
+            ><span class="block font-semibold">匯率</span><span
+              class="block text-xs text-ink/45">管理外幣換算</span
+            ></span
+          ><span class="text-xs font-semibold text-steel">›</span></button
+        >
+        <button
+          class="flex min-h-16 w-full items-center gap-3 px-4 py-3 text-left"
+          onclick={() => navigate("classification-rules")}
+          ><span
+            class="flex size-10 items-center justify-center rounded-xl bg-steel/10 text-steel"
+            ><Settings class="size-5" /></span
+          ><span class="flex-1"
+            ><span class="block font-semibold">分類規則</span><span
+              class="block text-xs text-ink/45">銀行交易自動分類</span
+            ></span
+          ><span class="text-xs font-semibold text-steel"
+            >{rules.length} 條　›</span
+          ></button
+        >
+      </div></Card
+    >
+  </section>
+  <section>
+    <div class="mb-2 flex items-center justify-between">
+      <h2 class="text-sm font-semibold text-ink/50">資料來源</h2>
+      <button
+        class="min-h-8 px-2 text-xs font-semibold text-steel"
+        onclick={() => navigate("data-sources")}>管理</button
+      >
+    </div>
+    <Card
+      ><div class="divide-y divide-ink/8">
+        {#each sources as source (source.id)}{@const job = jobs.find(
+            (item) => item.connectorId === source.id,
+          )}
+          <div
+            class="flex items-center justify-between gap-3 px-4 py-3 text-sm"
+          >
+            <span class="font-semibold">{source.label}</span><span
+              class={job?.lastStatus === "failed" ||
+              job?.lastStatus === "needs_user_action"
+                ? "text-coral"
+                : "text-moss"}
+              >{job?.lastStatus === "failed" ||
+              job?.lastStatus === "needs_user_action"
+                ? "需要處理"
+                : job?.lastSuccessAt
+                  ? "正常"
+                  : "尚未同步"}</span
+            >
+          </div>{/each}
+      </div></Card
+    >
+  </section>
 </div>

--- a/apps/web/src/features/settings/Settings.svelte
+++ b/apps/web/src/features/settings/Settings.svelte
@@ -1,38 +1,187 @@
 <script lang="ts">
   import { createQuery } from "@tanstack/svelte-query";
   import type { ApiClient } from "../../lib/api";
-  import { bankQuery, classificationRulesQuery, syncJobsQuery } from "../../lib/queries";
-  import type { ConnectorField, ConnectorId, MobileSettingsView, View } from "../../lib/types";
+  import {
+    bankQuery,
+    classificationRulesQuery,
+    syncJobsQuery,
+  } from "../../lib/queries";
+  import type {
+    ConnectorField,
+    ConnectorId,
+    MobileSettingsView,
+    View,
+  } from "../../lib/types";
   import Metric from "./Metric.svelte";
   import SourceCard from "./SourceCard.svelte";
   import ExchangeRatesPanel from "./ExchangeRatesPanel.svelte";
   import ClassificationRulesPanel from "./ClassificationRulesPanel.svelte";
   import ConnectorPanel from "./ConnectorPanel.svelte";
   import MobileMore from "./MobileMore.svelte";
-  let { api, demoMode, mobileView, navigate }: { api: ApiClient; demoMode: boolean; mobileView?: MobileSettingsView | "more"; navigate: (view: View) => void } = $props();
-  const sources: { id: ConnectorId; title: string; description: string }[] = [{ id: "einvoice", title: "電子發票", description: "財政部載具與品項明細" }, { id: "tdcc", title: "集保 e 存摺", description: "持倉、投資交易與銀行帳戶" }, { id: "esun", title: "玉山銀行", description: "帳戶、信用卡與交易" }, { id: "cathaybk", title: "國泰世華銀行", description: "帳戶與交易" }, { id: "sinopac", title: "永豐行動銀行", description: "App JSON API：信用卡帳務、近期帳單與未出帳消費" }];
+  let {
+    api,
+    demoMode,
+    mobileView,
+    navigate,
+  }: {
+    api: ApiClient;
+    demoMode: boolean;
+    mobileView?: MobileSettingsView | "more";
+    navigate: (view: View) => void;
+  } = $props();
+  const sources: { id: ConnectorId; title: string; description: string }[] = [
+    { id: "einvoice", title: "電子發票", description: "財政部載具與品項明細" },
+    {
+      id: "tdcc",
+      title: "集保 e 存摺",
+      description: "持倉、投資交易與銀行帳戶",
+    },
+    { id: "esun", title: "玉山銀行", description: "帳戶、信用卡與交易" },
+    { id: "cathaybk", title: "國泰世華銀行", description: "帳戶與交易" },
+    {
+      id: "sinopac",
+      title: "永豐行動銀行",
+      description: "App JSON API：信用卡帳務、近期帳單與未出帳消費",
+    },
+  ];
   const connectorFields: Record<ConnectorId, ConnectorField[]> = {
-    einvoice: [{ key: "appId", label: "App ID", type: "text" }, { key: "apiKey", label: "API Key", type: "password" }, { key: "periodsBack", label: "往回期數", type: "number", placeholder: "6" }, { key: "fetchDetails", label: "同步品項明細", type: "checkbox" }],
-    tdcc: [{ key: "identity", label: "身分證字號", type: "text" }, { key: "password", label: "集保 App 密碼", type: "password" }],
-    esun: [{ key: "username", label: "使用者名稱", type: "text" }, { key: "password", label: "密碼", type: "password" }, { key: "lookbackMonths", label: "往回月份", type: "number", placeholder: "3" }],
-    cathaybk: [{ key: "username", label: "使用者名稱", type: "text" }, { key: "password", label: "密碼", type: "password" }, { key: "lookbackMonths", label: "往回月份", type: "number", placeholder: "3" }],
-    sinopac: [{ key: "userId", label: "身分證字號／統編", type: "text" }, { key: "account", label: "行動／網路銀行使用者代碼", type: "text" }, { key: "password", label: "網路密碼", type: "password" }, { key: "lookbackMonths", label: "帳單往回月份", type: "number", placeholder: "3" }]
+    einvoice: [
+      { key: "appId", label: "App ID", type: "text" },
+      { key: "apiKey", label: "API Key", type: "password" },
+      {
+        key: "periodsBack",
+        label: "往回期數",
+        type: "number",
+        placeholder: "6",
+      },
+      { key: "fetchDetails", label: "同步品項明細", type: "checkbox" },
+    ],
+    tdcc: [
+      { key: "identity", label: "身分證字號", type: "text" },
+      { key: "password", label: "集保 App 密碼", type: "password" },
+    ],
+    esun: [
+      { key: "username", label: "使用者名稱", type: "text" },
+      { key: "password", label: "密碼", type: "password" },
+      {
+        key: "lookbackMonths",
+        label: "往回月份",
+        type: "number",
+        placeholder: "3",
+      },
+    ],
+    cathaybk: [
+      { key: "username", label: "使用者名稱", type: "text" },
+      { key: "password", label: "密碼", type: "password" },
+      {
+        key: "lookbackMonths",
+        label: "往回月份",
+        type: "number",
+        placeholder: "3",
+      },
+    ],
+    sinopac: [
+      { key: "userId", label: "身分證字號／統編", type: "text" },
+      { key: "account", label: "行動／網路銀行使用者代碼", type: "text" },
+      { key: "password", label: "網路密碼", type: "password" },
+      {
+        key: "lookbackMonths",
+        label: "帳單往回月份",
+        type: "number",
+        placeholder: "3",
+      },
+    ],
   };
   const jobs = createQuery(syncJobsQuery(() => api));
   const rules = createQuery(classificationRulesQuery(() => api));
   const bank = createQuery(bankQuery(() => api));
   let selectedConnector = $state<ConnectorId | null>(null);
-  const enabledJobs = $derived(($jobs.data ?? []).filter((j) => j.enabled).length);
-  const needsAction = $derived(($jobs.data ?? []).filter((j) => j.lastStatus === "failed" || j.lastStatus === "needs_user_action").length);
-  function selectConnector(id: ConnectorId) { selectedConnector = selectedConnector === id ? null : id; }
+  const enabledJobs = $derived(
+    ($jobs.data ?? []).filter((j) => j.enabled).length,
+  );
+  const needsAction = $derived(
+    ($jobs.data ?? []).filter(
+      (j) => j.lastStatus === "failed" || j.lastStatus === "needs_user_action",
+    ).length,
+  );
+  function selectConnector(id: ConnectorId) {
+    selectedConnector = selectedConnector === id ? null : id;
+  }
 </script>
 
 {#if mobileView === "more"}
-  <MobileMore demoMode={demoMode} jobs={$jobs.data ?? []} rules={$rules.data ?? []} bank={$bank.data ?? { accounts: [], transactions: [] }} {navigate} api={api} />
+  <MobileMore
+    {demoMode}
+    jobs={$jobs.data ?? []}
+    rules={$rules.data ?? []}
+    bank={$bank.data ?? { accounts: [], transactions: [] }}
+    {navigate}
+    {api}
+  />
 {:else if mobileView === "data-sources"}
-  <div class="grid gap-3">{#each sources as source (source.id)}<SourceCard {api} {...source} id={source.id} jobs={$jobs.data ?? []} selected={selectedConnector === source.id} onConfigure={() => selectConnector(source.id)} />{/each}{#if selectedConnector}{#key selectedConnector}<ConnectorPanel {api} connectorId={selectedConnector} demoMode={demoMode} title={sources.find((s) => s.id === selectedConnector)?.title ?? selectedConnector} fields={connectorFields[selectedConnector]} />{/key}{/if}</div>
+  <div class="grid gap-3">
+    {#each sources as source (source.id)}<SourceCard
+        {api}
+        {...source}
+        id={source.id}
+        jobs={$jobs.data ?? []}
+        selected={selectedConnector === source.id}
+        onConfigure={() => selectConnector(source.id)}
+      />{/each}{#if selectedConnector}{#key selectedConnector}<ConnectorPanel
+          {api}
+          connectorId={selectedConnector}
+          {demoMode}
+          title={sources.find((s) => s.id === selectedConnector)?.title ??
+            selectedConnector}
+          fields={connectorFields[selectedConnector]}
+        />{/key}{/if}
+  </div>
 {:else if mobileView === "exchange-rates"}<ExchangeRatesPanel {api} />
-{:else if mobileView === "classification-rules"}<ClassificationRulesPanel {api} />
+{:else if mobileView === "classification-rules"}<ClassificationRulesPanel
+    {api}
+  />
 {:else}
-  <div class="grid gap-5"><div class="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4"><Metric label="已設定來源" value={String(sources.length)} detail="資料連接器" /><Metric label="同步排程" value={String(enabledJobs)} detail="已啟用" /><Metric label="分類規則" value={String($rules.data?.length ?? 0)} detail="銀行交易" /><Metric label="需要處理" value={String(needsAction)} detail="同步狀態" tone={needsAction ? "negative" : "positive"} /></div><section class="grid gap-3 md:grid-cols-2">{#each sources as source (source.id)}<SourceCard {api} {...source} id={source.id} jobs={$jobs.data ?? []} selected={selectedConnector === source.id} onConfigure={() => selectConnector(source.id)} />{/each}</section>{#if selectedConnector}{#key selectedConnector}<ConnectorPanel {api} connectorId={selectedConnector} demoMode={demoMode} title={sources.find((s) => s.id === selectedConnector)?.title ?? selectedConnector} fields={connectorFields[selectedConnector]} />{/key}{/if}<section class="grid gap-5"><ExchangeRatesPanel {api} /><ClassificationRulesPanel {api} /></section></div>
+  <div class="grid gap-5">
+    <div class="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
+      <Metric
+        label="已設定來源"
+        value={String(sources.length)}
+        detail="資料連接器"
+      /><Metric
+        label="同步排程"
+        value={String(enabledJobs)}
+        detail="已啟用"
+      /><Metric
+        label="分類規則"
+        value={String($rules.data?.length ?? 0)}
+        detail="銀行交易"
+      /><Metric
+        label="需要處理"
+        value={String(needsAction)}
+        detail="同步狀態"
+        tone={needsAction ? "negative" : "positive"}
+      />
+    </div>
+    <section class="grid gap-3 md:grid-cols-2">
+      {#each sources as source (source.id)}<SourceCard
+          {api}
+          {...source}
+          id={source.id}
+          jobs={$jobs.data ?? []}
+          selected={selectedConnector === source.id}
+          onConfigure={() => selectConnector(source.id)}
+        />{/each}
+    </section>
+    {#if selectedConnector}{#key selectedConnector}<ConnectorPanel
+          {api}
+          connectorId={selectedConnector}
+          {demoMode}
+          title={sources.find((s) => s.id === selectedConnector)?.title ??
+            selectedConnector}
+          fields={connectorFields[selectedConnector]}
+        />{/key}{/if}
+    <section class="grid gap-5">
+      <ExchangeRatesPanel {api} /><ClassificationRulesPanel {api} />
+    </section>
+  </div>
 {/if}

--- a/apps/web/src/features/settings/SourceCard.svelte
+++ b/apps/web/src/features/settings/SourceCard.svelte
@@ -9,9 +9,74 @@
   import { connectorSettingsQuery } from "../../lib/queries";
   import type { ConnectorId, SyncJobRow } from "../../lib/types";
   import { formatDateTime } from "../../lib/format.svelte";
-  let { api, id, title, description, selected, onConfigure, jobs }: { api: ApiClient; id: ConnectorId; title: string; description: string; selected: boolean; onConfigure: () => void; jobs?: SyncJobRow[] } = $props();
-  const settings = createQuery(toStore(() => connectorSettingsQuery(() => api, id)));
-  const job = $derived((jobs ?? []).find((item) => item.connectorId === id && item.scope === "all"));
-  const needsAction = $derived(job?.lastStatus === "failed" || job?.lastStatus === "needs_user_action");
+  let {
+    api,
+    id,
+    title,
+    description,
+    selected,
+    onConfigure,
+    jobs,
+  }: {
+    api: ApiClient;
+    id: ConnectorId;
+    title: string;
+    description: string;
+    selected: boolean;
+    onConfigure: () => void;
+    jobs?: SyncJobRow[];
+  } = $props();
+  const settings = createQuery(
+    toStore(() => connectorSettingsQuery(() => api, id)),
+  );
+  const job = $derived(
+    (jobs ?? []).find(
+      (item) => item.connectorId === id && item.scope === "all",
+    ),
+  );
+  const needsAction = $derived(
+    job?.lastStatus === "failed" || job?.lastStatus === "needs_user_action",
+  );
 </script>
-<Card class={selected ? "ring-2 ring-ring/30" : ""}><CardContent class="pt-5"><div class="flex items-start justify-between gap-4"><div class="min-w-0"><h2 class="text-lg font-semibold">{title}</h2><p class="mt-1 text-sm text-muted-foreground">{description}</p></div><Badge variant={needsAction ? "destructive" : $settings.data?.configured ? "success" : "secondary"}>{needsAction ? "需要處理" : $settings.data?.configured ? "已設定" : "未設定"}</Badge></div><div class="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4"><div class="text-xs text-muted-foreground"><p>上次成功：{job?.lastSuccessAt ? formatDateTime(job.lastSuccessAt) : "尚無紀錄"}</p><p class="mt-1">排程：{job?.enabled ? `${job.intervalMinutes / 60} 小時` : "關閉"}</p></div><Button size="sm" variant={selected ? "default" : "outline"} onclick={onConfigure}>{selected ? "收合設定" : "設定"}</Button></div></CardContent></Card>
+
+<Card class={selected ? "ring-2 ring-ring/30" : ""}
+  ><CardContent class="pt-5"
+    ><div class="flex items-start justify-between gap-4">
+      <div class="min-w-0">
+        <h2 class="text-lg font-semibold">{title}</h2>
+        <p class="mt-1 text-sm text-muted-foreground">{description}</p>
+      </div>
+      <Badge
+        variant={needsAction
+          ? "destructive"
+          : $settings.data?.configured
+            ? "success"
+            : "secondary"}
+        >{needsAction
+          ? "需要處理"
+          : $settings.data?.configured
+            ? "已設定"
+            : "未設定"}</Badge
+      >
+    </div>
+    <div
+      class="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4"
+    >
+      <div class="text-xs text-muted-foreground">
+        <p>
+          上次成功：{job?.lastSuccessAt
+            ? formatDateTime(job.lastSuccessAt)
+            : "尚無紀錄"}
+        </p>
+        <p class="mt-1">
+          排程：{job?.enabled ? `${job.intervalMinutes / 60} 小時` : "關閉"}
+        </p>
+      </div>
+      <Button
+        size="sm"
+        variant={selected ? "default" : "outline"}
+        onclick={onConfigure}>{selected ? "收合設定" : "設定"}</Button
+      >
+    </div></CardContent
+  ></Card
+>

--- a/apps/web/src/lib/activity-chart.test.ts
+++ b/apps/web/src/lib/activity-chart.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { activityCashAmountTwd, buildActivityCategorySlices } from "./activity-chart";
+import {
+  activityCashAmountTwd,
+  buildActivityCategorySlices,
+} from "./activity-chart";
 import type { ActivityItem } from "./types";
 
 function item(overrides: Partial<ActivityItem>): ActivityItem {
@@ -13,28 +16,40 @@ function item(overrides: Partial<ActivityItem>): ActivityItem {
     currency: "TWD",
     category: "其他",
     status: "posted",
-    ...overrides
+    ...overrides,
   };
 }
 
 describe("activity category chart", () => {
   it("converts bank cash flow to TWD and treats card activity as expense", () => {
-    expect(activityCashAmountTwd(item({ amount: 10, currency: "USD" }), { USD: 32 })).toBe(320);
-    expect(activityCashAmountTwd(item({ source: "card", amount: 500 }), {})).toBe(-500);
-    expect(activityCashAmountTwd(item({ source: "invoice", amount: 500 }), {})).toBe(0);
+    expect(
+      activityCashAmountTwd(item({ amount: 10, currency: "USD" }), { USD: 32 }),
+    ).toBe(320);
+    expect(
+      activityCashAmountTwd(item({ source: "card", amount: 500 }), {}),
+    ).toBe(-500);
+    expect(
+      activityCashAmountTwd(item({ source: "invoice", amount: 500 }), {}),
+    ).toBe(0);
   });
 
   it("groups categories and sorts them by amount descending", () => {
-    const slices = buildActivityCategorySlices([
-      item({ amount: -100, category: "餐飲" }),
-      item({ id: "2", amount: -300, category: "交通" }),
-      item({ id: "3", amount: -50, category: "餐飲" }),
-      item({ id: "4", amount: 900, category: "薪資" })
-    ], "expense", {});
+    const slices = buildActivityCategorySlices(
+      [
+        item({ amount: -100, category: "餐飲" }),
+        item({ id: "2", amount: -300, category: "交通" }),
+        item({ id: "3", amount: -50, category: "餐飲" }),
+        item({ id: "4", amount: 900, category: "薪資" }),
+      ],
+      "expense",
+      {},
+    );
 
-    expect(slices.map(({ category, amount }) => ({ category, amount }))).toEqual([
+    expect(
+      slices.map(({ category, amount }) => ({ category, amount })),
+    ).toEqual([
       { category: "交通", amount: 300 },
-      { category: "餐飲", amount: 150 }
+      { category: "餐飲", amount: 150 },
     ]);
     expect(slices[0]?.percentage).toBeCloseTo(66.67, 1);
   });

--- a/apps/web/src/lib/activity-chart.ts
+++ b/apps/web/src/lib/activity-chart.ts
@@ -17,12 +17,16 @@ export const ACTIVITY_CATEGORY_COLORS = [
   "#7665a8",
   "#388d82",
   "#a45c78",
-  "#68747b"
+  "#68747b",
 ];
 
-export function activityCashAmountTwd(item: ActivityItem, rates: Record<string, number>) {
-  if (item.amount == null || (item.source !== "bank" && item.source !== "card")) return 0;
-  const rate = item.currency === "TWD" ? 1 : rates[item.currency] ?? 0;
+export function activityCashAmountTwd(
+  item: ActivityItem,
+  rates: Record<string, number>,
+) {
+  if (item.amount == null || (item.source !== "bank" && item.source !== "card"))
+    return 0;
+  const rate = item.currency === "TWD" ? 1 : (rates[item.currency] ?? 0);
   const converted = item.amount * rate;
   return item.source === "card" ? -Math.abs(converted) : converted;
 }
@@ -30,14 +34,17 @@ export function activityCashAmountTwd(item: ActivityItem, rates: Record<string, 
 export function buildActivityCategorySlices(
   items: ActivityItem[],
   flow: ActivityFlow,
-  rates: Record<string, number>
+  rates: Record<string, number>,
 ): ActivityCategorySlice[] {
   const grouped = new Map<string, number>();
 
   for (const item of items) {
     const amount = activityCashAmountTwd(item, rates);
     if (flow === "income" ? amount <= 0 : amount >= 0) continue;
-    grouped.set(item.category, (grouped.get(item.category) ?? 0) + Math.abs(amount));
+    grouped.set(
+      item.category,
+      (grouped.get(item.category) ?? 0) + Math.abs(amount),
+    );
   }
 
   const sorted = [...grouped.entries()].sort((a, b) => b[1] - a[1]);
@@ -46,7 +53,7 @@ export function buildActivityCategorySlices(
   return sorted.map(([category, amount], index) => ({
     category,
     amount,
-    percentage: total === 0 ? 0 : amount / total * 100,
-    color: ACTIVITY_CATEGORY_COLORS[index % ACTIVITY_CATEGORY_COLORS.length]!
+    percentage: total === 0 ? 0 : (amount / total) * 100,
+    color: ACTIVITY_CATEGORY_COLORS[index % ACTIVITY_CATEGORY_COLORS.length]!,
   }));
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -14,23 +14,37 @@ function isApiError(value: unknown): value is ApiError {
 
 export function createApiClient(): ApiClient {
   async function request<T>(path: string, init: RequestInit = {}) {
-    const response = await fetch(path, { ...init, headers: { "Content-Type": "application/json", ...init.headers } });
+    const response = await fetch(path, {
+      ...init,
+      headers: { "Content-Type": "application/json", ...init.headers },
+    });
     const text = await response.text();
     let data: T | ApiError;
     try {
       data = JSON.parse(text) as T | ApiError;
     } catch {
-      throw new Error(response.ok ? "伺服器回應格式錯誤。" : `伺服器暫時無法完成請求（HTTP ${response.status}）。`);
+      throw new Error(
+        response.ok
+          ? "伺服器回應格式錯誤。"
+          : `伺服器暫時無法完成請求（HTTP ${response.status}）。`,
+      );
     }
-    if (!response.ok) throw new Error(isApiError(data) ? data.error.message : "請求失敗。");
+    if (!response.ok)
+      throw new Error(isApiError(data) ? data.error.message : "請求失敗。");
     return data as T;
   }
   return {
     get: (path) => request(path),
-    post: (path, body) => request(path, { method: "POST", body: body === undefined ? undefined : JSON.stringify(body) }),
-    put: (path, body) => request(path, { method: "PUT", body: JSON.stringify(body) }),
-    patch: (path, body) => request(path, { method: "PATCH", body: JSON.stringify(body) }),
-    delete: (path) => request(path, { method: "DELETE" })
+    post: (path, body) =>
+      request(path, {
+        method: "POST",
+        body: body === undefined ? undefined : JSON.stringify(body),
+      }),
+    put: (path, body) =>
+      request(path, { method: "PUT", body: JSON.stringify(body) }),
+    patch: (path, body) =>
+      request(path, { method: "PATCH", body: JSON.stringify(body) }),
+    delete: (path) => request(path, { method: "DELETE" }),
   };
 }
 
@@ -48,7 +62,9 @@ export const queryKeys = {
   syncJobs: ["sync-jobs"] as const,
   classificationRules: ["classification-rules"] as const,
   connectorSettings: (id: string) => ["connector-settings", id] as const,
-  manualAssetHistory: (id: string) => ["manualAssetHistory", id] as const
+  manualAssetHistory: (id: string) => ["manualAssetHistory", id] as const,
 };
 
-export function messageFromError(error: unknown) { return error instanceof Error ? error.message : "請求失敗。"; }
+export function messageFromError(error: unknown) {
+  return error instanceof Error ? error.message : "請求失敗。";
+}

--- a/apps/web/src/lib/format.svelte.ts
+++ b/apps/web/src/lib/format.svelte.ts
@@ -1,15 +1,30 @@
-import type { BankAccountRow, BankTransactionRow, ExchangeRateRow } from "./types";
+import type {
+  BankAccountRow,
+  BankTransactionRow,
+  ExchangeRateRow,
+} from "./types";
 
 export const moneyState = $state({ hidden: false });
 
 export function formatCurrency(value: number, currency = "TWD") {
   if (moneyState.hidden) return "••••••";
   const sign = value < 0 ? "−" : "";
-  const number = new Intl.NumberFormat("zh-TW", { maximumFractionDigits: 0 }).format(Math.abs(value));
-  const symbols: Record<string, string> = { TWD: "NT$", USD: "US$", JPY: "JP¥", EUR: "€" };
+  const number = new Intl.NumberFormat("zh-TW", {
+    maximumFractionDigits: 0,
+  }).format(Math.abs(value));
+  const symbols: Record<string, string> = {
+    TWD: "NT$",
+    USD: "US$",
+    JPY: "JP¥",
+    EUR: "€",
+  };
   return `${sign}${symbols[currency] ?? `${currency} `}${number}`;
 }
-export function formatNumber(value: number) { return new Intl.NumberFormat("zh-TW", { maximumFractionDigits: 0 }).format(value); }
+export function formatNumber(value: number) {
+  return new Intl.NumberFormat("zh-TW", { maximumFractionDigits: 0 }).format(
+    value,
+  );
+}
 export function formatCompactTwd(value: number) {
   if (moneyState.hidden) return "••••";
   const abs = Math.abs(value);
@@ -18,11 +33,16 @@ export function formatCompactTwd(value: number) {
   return formatNumber(Math.round(value));
 }
 export function formatDateTime(value?: string) {
-  const date = parseValidDate(value); if (!date) return "";
-  return new Intl.DateTimeFormat("zh-TW", { dateStyle: "medium", timeStyle: "short" }).format(date);
+  const date = parseValidDate(value);
+  if (!date) return "";
+  return new Intl.DateTimeFormat("zh-TW", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
 }
 export function formatDate(value?: string) {
-  const date = parseValidDate(value); if (!date) return "";
+  const date = parseValidDate(value);
+  if (!date) return "";
   return new Intl.DateTimeFormat("zh-TW", { dateStyle: "short" }).format(date);
 }
 export function normalizeFinancialDate(value?: string) {
@@ -34,17 +54,36 @@ export function normalizeFinancialDate(value?: string) {
 export function parseValidDate(value?: string) {
   if (!value) return undefined;
   const normalized = normalizeFinancialDate(value);
-  const date = new Date(normalized); if (!Number.isNaN(date.getTime())) return date;
-  const prefix = normalized.match(/^(\d{4})-(\d{2})-(\d{2})/); if (!prefix) return undefined;
-  const fallback = new Date(Number(prefix[1]), Number(prefix[2]) - 1, Number(prefix[3]));
+  const date = new Date(normalized);
+  if (!Number.isNaN(date.getTime())) return date;
+  const prefix = normalized.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!prefix) return undefined;
+  const fallback = new Date(
+    Number(prefix[1]),
+    Number(prefix[2]) - 1,
+    Number(prefix[3]),
+  );
   return Number.isNaN(fallback.getTime()) ? undefined : fallback;
 }
-export function todayStr() { return new Date().toISOString().slice(0, 10); }
-export function formatBankAccountName(account: { accountName?: string; sourceId?: string; accountSourceId?: string; accountType?: string }) {
-  if (account.accountType === "credit") return account.accountName ?? account.sourceId ?? account.accountSourceId ?? "-";
+export function todayStr() {
+  return new Date().toISOString().slice(0, 10);
+}
+export function formatBankAccountName(account: {
+  accountName?: string;
+  sourceId?: string;
+  accountSourceId?: string;
+  accountType?: string;
+}) {
+  if (account.accountType === "credit")
+    return (
+      account.accountName ?? account.sourceId ?? account.accountSourceId ?? "-"
+    );
   const sourceId = account.accountSourceId ?? account.sourceId ?? "";
-  const last5 = bankAccountLast5(sourceId); if (last5) return last5;
-  const name = account.accountName?.startsWith("末五碼 ") ? account.accountName.slice(4) : account.accountName;
+  const last5 = bankAccountLast5(sourceId);
+  if (last5) return last5;
+  const name = account.accountName?.startsWith("末五碼 ")
+    ? account.accountName.slice(4)
+    : account.accountName;
   return name ?? sourceId ?? "-";
 }
 export function bankAccountLast5(sourceId: string) {
@@ -55,17 +94,31 @@ export function bankAccountLast5(sourceId: string) {
 }
 export function formatCurrencyTotals(totals: Record<string, number>) {
   if (moneyState.hidden && Object.keys(totals).length > 0) return "••••••";
-  const entries = Object.entries(totals); if (entries.length === 0) return formatCurrency(0);
-  if (entries.length === 1) return formatCurrency(entries[0]![1], entries[0]![0]);
-  return entries.map(([currency, amount]) => formatCurrency(amount, currency)).join(" · ");
+  const entries = Object.entries(totals);
+  if (entries.length === 0) return formatCurrency(0);
+  if (entries.length === 1)
+    return formatCurrency(entries[0]![1], entries[0]![0]);
+  return entries
+    .map(([currency, amount]) => formatCurrency(amount, currency))
+    .join(" · ");
 }
-export function sumAccountsByCurrency(accounts: BankAccountRow[], field: "balance" | "availableBalance") {
+export function sumAccountsByCurrency(
+  accounts: BankAccountRow[],
+  field: "balance" | "availableBalance",
+) {
   return accounts.reduce<Record<string, number>>((totals, account) => {
-    const currency = account.currency || "TWD"; totals[currency] = (totals[currency] ?? 0) + (account[field] ?? 0); return totals;
+    const currency = account.currency || "TWD";
+    totals[currency] = (totals[currency] ?? 0) + (account[field] ?? 0);
+    return totals;
   }, {});
 }
-export function rateMap(rates: ExchangeRateRow[] | undefined) { return Object.fromEntries((rates ?? []).map((r) => [r.currency, r.rateTwd])); }
-export function transactionValueTwd(transaction: BankTransactionRow, rates: Record<string, number>) {
+export function rateMap(rates: ExchangeRateRow[] | undefined) {
+  return Object.fromEntries((rates ?? []).map((r) => [r.currency, r.rateTwd]));
+}
+export function transactionValueTwd(
+  transaction: BankTransactionRow,
+  rates: Record<string, number>,
+) {
   if (transaction.currency === "TWD") return transaction.amount;
   return transaction.amount * (rates[transaction.currency] ?? 1);
 }

--- a/apps/web/src/lib/format.test.ts
+++ b/apps/web/src/lib/format.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { bankAccountLast5, formatBankAccountName, formatNumber, normalizeFinancialDate, parseValidDate, rateMap, transactionValueTwd } from "./format.svelte";
+import {
+  bankAccountLast5,
+  formatBankAccountName,
+  formatNumber,
+  normalizeFinancialDate,
+  parseValidDate,
+  rateMap,
+  transactionValueTwd,
+} from "./format.svelte";
 
 describe("financial formatting helpers", () => {
   it("formats numbers using the Taiwan locale", () => {
@@ -13,20 +21,35 @@ describe("financial formatting helpers", () => {
   });
 
   it("uses account labels when a source id has no account number", () => {
-    expect(formatBankAccountName({ accountName: "末五碼 12345", sourceId: "unknown" })).toBe("12345");
-    expect(formatBankAccountName({ accountName: "現金", accountType: "credit" })).toBe("現金");
+    expect(
+      formatBankAccountName({
+        accountName: "末五碼 12345",
+        sourceId: "unknown",
+      }),
+    ).toBe("12345");
+    expect(
+      formatBankAccountName({ accountName: "現金", accountType: "credit" }),
+    ).toBe("現金");
   });
 
   it("accepts ISO dates and date-only fallbacks while rejecting invalid values", () => {
     expect(parseValidDate("2026-07-13")?.getFullYear()).toBe(2026);
-    expect(normalizeFinancialDate("0115-07-13T00:00:00.000Z")).toBe("2026-07-13T00:00:00.000Z");
-    expect(parseValidDate("0115-07-13T00:00:00.000Z")?.getFullYear()).toBe(2026);
+    expect(normalizeFinancialDate("0115-07-13T00:00:00.000Z")).toBe(
+      "2026-07-13T00:00:00.000Z",
+    );
+    expect(parseValidDate("0115-07-13T00:00:00.000Z")?.getFullYear()).toBe(
+      2026,
+    );
     expect(parseValidDate("not-a-date")).toBeUndefined();
   });
 
   it("maps exchange rates and converts non-TWD transactions", () => {
-    const rates = rateMap([{ currency: "USD", rateTwd: 32, updatedAt: "2026-07-13T00:00:00Z" }]);
+    const rates = rateMap([
+      { currency: "USD", rateTwd: 32, updatedAt: "2026-07-13T00:00:00Z" },
+    ]);
     expect(rates).toEqual({ USD: 32 });
-    expect(transactionValueTwd({ currency: "USD", amount: 10 } as never, rates)).toBe(320);
+    expect(
+      transactionValueTwd({ currency: "USD", amount: 10 } as never, rates),
+    ).toBe(320);
   });
 });

--- a/apps/web/src/lib/net-worth-chart.test.ts
+++ b/apps/web/src/lib/net-worth-chart.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildNetWorthChartData, getAvailableNetWorthAssets } from "./net-worth-chart";
+import {
+  buildNetWorthChartData,
+  getAvailableNetWorthAssets,
+} from "./net-worth-chart";
 import type { NetWorthHistoryRow } from "./types";
 
 const rows: NetWorthHistoryRow[] = [
@@ -7,18 +10,53 @@ const rows: NetWorthHistoryRow[] = [
   { date: "2026-01-02", netWorth: 40, assetType: "fund", source: "tdcc" },
   { date: "2026-01-02", netWorth: 500, assetType: "deposit", source: "bank" },
   { date: "2026-01-03", netWorth: 110, assetType: "stock", source: "tdcc" },
-  { date: "2026-01-03", netWorth: 200, assetType: "manual:home", source: "manual" },
-  { date: "2026-01-03", netWorth: 50, assetType: "manual:policy", source: "manual" }
+  {
+    date: "2026-01-03",
+    netWorth: 200,
+    assetType: "manual:home",
+    source: "manual",
+  },
+  {
+    date: "2026-01-03",
+    netWorth: 50,
+    assetType: "manual:policy",
+    source: "manual",
+  },
 ];
 
 describe("net worth chart data", () => {
   it("aggregates selected asset types into one point per date", () => {
-    const points = buildNetWorthChartData(rows, ["stock", "fund", "deposit"], "ALL");
+    const points = buildNetWorthChartData(
+      rows,
+      ["stock", "fund", "deposit"],
+      "ALL",
+    );
 
     expect(points).toEqual([
-      { date: "2026-01-01", stock: 100, fund: 0, deposit: 0, manual: 0, selectedTotal: 100 },
-      { date: "2026-01-02", stock: 100, fund: 40, deposit: 500, manual: 0, selectedTotal: 640 },
-      { date: "2026-01-03", stock: 110, fund: 40, deposit: 500, manual: 250, selectedTotal: 650 }
+      {
+        date: "2026-01-01",
+        stock: 100,
+        fund: 0,
+        deposit: 0,
+        manual: 0,
+        selectedTotal: 100,
+      },
+      {
+        date: "2026-01-02",
+        stock: 100,
+        fund: 40,
+        deposit: 500,
+        manual: 0,
+        selectedTotal: 640,
+      },
+      {
+        date: "2026-01-03",
+        stock: 110,
+        fund: 40,
+        deposit: 500,
+        manual: 250,
+        selectedTotal: 650,
+      },
     ]);
   });
 
@@ -26,16 +64,33 @@ describe("net worth chart data", () => {
     const points = buildNetWorthChartData(rows, ["manual"], "ALL");
 
     expect(points).toEqual([
-      { date: "2026-01-03", stock: 110, fund: 40, deposit: 500, manual: 250, selectedTotal: 250 }
+      {
+        date: "2026-01-03",
+        stock: 110,
+        fund: 40,
+        deposit: 500,
+        manual: 250,
+        selectedTotal: 250,
+      },
     ]);
   });
 
   it("reports the asset types that have history", () => {
-    expect([...getAvailableNetWorthAssets(rows)]).toEqual(["stock", "fund", "deposit", "manual"]);
+    expect([...getAvailableNetWorthAssets(rows)]).toEqual([
+      "stock",
+      "fund",
+      "deposit",
+      "manual",
+    ]);
   });
 
   it("filters points outside the selected timeframe", () => {
-    const points = buildNetWorthChartData(rows, ["stock"], "1M", new Date("2026-02-02T00:00:00Z"));
+    const points = buildNetWorthChartData(
+      rows,
+      ["stock"],
+      "1M",
+      new Date("2026-02-02T00:00:00Z"),
+    );
 
     expect(points.map((point) => point.date)).toEqual(["2026-01-03"]);
     expect(points[0]?.stock).toBe(110);

--- a/apps/web/src/lib/net-worth-chart.ts
+++ b/apps/web/src/lib/net-worth-chart.ts
@@ -21,22 +21,27 @@ export const NET_WORTH_ASSET_SERIES: Array<{
   { key: "stock", label: "股票/ETF", color: "#6574cd" },
   { key: "fund", label: "基金", color: "#9b6bb0" },
   { key: "deposit", label: "存款", color: "#3e6f7c" },
-  { key: "manual", label: "其他資產", color: "#b5853f" }
+  { key: "manual", label: "其他資產", color: "#b5853f" },
 ];
 
-export const NET_WORTH_DEFAULT_ASSETS: NetWorthAssetType[] = ["stock", "fund", "deposit"];
+export const NET_WORTH_DEFAULT_ASSETS: NetWorthAssetType[] = [
+  "stock",
+  "fund",
+  "deposit",
+];
 
 const TIMEFRAME_MONTHS: Record<NetWorthTimeframe, number | null> = {
   "1M": 1,
   "3M": 3,
   "6M": 6,
   "1Y": 12,
-  ALL: null
+  ALL: null,
 };
 
 function matchesAssetType(row: NetWorthHistoryRow, type: NetWorthAssetType) {
   if (type === "manual") return row.source === "manual";
-  if (type === "deposit") return row.source === "bank" && row.assetType === "deposit";
+  if (type === "deposit")
+    return row.source === "bank" && row.assetType === "deposit";
   return row.assetType === type;
 }
 
@@ -44,8 +49,16 @@ function cutoffDate(timeframe: NetWorthTimeframe, now: Date) {
   const months = TIMEFRAME_MONTHS[timeframe];
   if (months === null) return null;
   const targetMonth = new Date(now.getFullYear(), now.getMonth() - months, 1);
-  const lastDay = new Date(targetMonth.getFullYear(), targetMonth.getMonth() + 1, 0).getDate();
-  const cutoff = new Date(targetMonth.getFullYear(), targetMonth.getMonth(), Math.min(now.getDate(), lastDay));
+  const lastDay = new Date(
+    targetMonth.getFullYear(),
+    targetMonth.getMonth() + 1,
+    0,
+  ).getDate();
+  const cutoff = new Date(
+    targetMonth.getFullYear(),
+    targetMonth.getMonth(),
+    Math.min(now.getDate(), lastDay),
+  );
   const year = cutoff.getFullYear();
   const month = String(cutoff.getMonth() + 1).padStart(2, "0");
   const day = String(cutoff.getDate()).padStart(2, "0");
@@ -61,7 +74,11 @@ function latestValue(rows: NetWorthHistoryRow[], date: string) {
   return value;
 }
 
-function buildAssetSeries(rows: NetWorthHistoryRow[], type: NetWorthAssetType, dates: string[]) {
+function buildAssetSeries(
+  rows: NetWorthHistoryRow[],
+  type: NetWorthAssetType,
+  dates: string[],
+) {
   const matchingRows = rows.filter((row) => matchesAssetType(row, type));
   const identities = new Map<string, NetWorthHistoryRow[]>();
 
@@ -79,16 +96,19 @@ function buildAssetSeries(rows: NetWorthHistoryRow[], type: NetWorthAssetType, d
   return new Map(
     dates.map((date) => [
       date,
-      [...identities.values()].reduce((sum, values) => sum + latestValue(values, date), 0)
-    ])
+      [...identities.values()].reduce(
+        (sum, values) => sum + latestValue(values, date),
+        0,
+      ),
+    ]),
   );
 }
 
 export function getAvailableNetWorthAssets(rows: NetWorthHistoryRow[]) {
   return new Set(
-    NET_WORTH_ASSET_SERIES
-      .filter(({ key }) => rows.some((row) => matchesAssetType(row, key)))
-      .map(({ key }) => key)
+    NET_WORTH_ASSET_SERIES.filter(({ key }) =>
+      rows.some((row) => matchesAssetType(row, key)),
+    ).map(({ key }) => key),
   );
 }
 
@@ -96,20 +116,29 @@ export function buildNetWorthChartData(
   rows: NetWorthHistoryRow[],
   includedAssets: NetWorthAssetType[],
   timeframe: NetWorthTimeframe,
-  now = new Date()
+  now = new Date(),
 ): NetWorthChartPoint[] {
   const sortedRows = rows.slice().sort((a, b) => a.date.localeCompare(b.date));
   const cutoff = cutoffDate(timeframe, now);
   const included = new Set(includedAssets);
-  const dates = [...new Set(
-    sortedRows
-      .filter((row) => NET_WORTH_ASSET_SERIES.some(({ key }) => included.has(key) && matchesAssetType(row, key)))
-      .map((row) => row.date)
-      .filter((date) => cutoff === null || date >= cutoff)
-  )].sort();
+  const dates = [
+    ...new Set(
+      sortedRows
+        .filter((row) =>
+          NET_WORTH_ASSET_SERIES.some(
+            ({ key }) => included.has(key) && matchesAssetType(row, key),
+          ),
+        )
+        .map((row) => row.date)
+        .filter((date) => cutoff === null || date >= cutoff),
+    ),
+  ].sort();
 
   const valuesByType = Object.fromEntries(
-    NET_WORTH_ASSET_SERIES.map(({ key }) => [key, buildAssetSeries(sortedRows, key, dates)])
+    NET_WORTH_ASSET_SERIES.map(({ key }) => [
+      key,
+      buildAssetSeries(sortedRows, key, dates),
+    ]),
   ) as Record<NetWorthAssetType, Map<string, number>>;
 
   return dates.map((date) => {
@@ -119,9 +148,12 @@ export function buildNetWorthChartData(
       fund: valuesByType.fund.get(date) ?? 0,
       deposit: valuesByType.deposit.get(date) ?? 0,
       manual: valuesByType.manual.get(date) ?? 0,
-      selectedTotal: 0
+      selectedTotal: 0,
     };
-    point.selectedTotal = includedAssets.reduce((sum, key) => sum + point[key], 0);
+    point.selectedTotal = includedAssets.reduce(
+      (sum, key) => sum + point[key],
+      0,
+    );
     return point;
   });
 }

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -13,68 +13,94 @@ import type {
   ManualAssetHistoryEntry,
   ManualAssetRow,
   NetWorthHistoryRow,
-  SyncJobRow
+  SyncJobRow,
 } from "./types";
 
 type ApiProvider = () => ApiClient;
 
-export const bankQuery = (getApi: ApiProvider) => queryOptions({
-  queryKey: queryKeys.bank,
-  queryFn: () => getApi().get<BankData>("/api/bank")
-});
+export const bankQuery = (getApi: ApiProvider) =>
+  queryOptions({
+    queryKey: queryKeys.bank,
+    queryFn: () => getApi().get<BankData>("/api/bank"),
+  });
 
-export const creditCardBillsQuery = (getApi: ApiProvider) => queryOptions({
-  queryKey: queryKeys.bills,
-  queryFn: () => getApi().get<CreditCardBillRow[]>("/api/bank/bills")
-});
+export const creditCardBillsQuery = (getApi: ApiProvider) =>
+  queryOptions({
+    queryKey: queryKeys.bills,
+    queryFn: () => getApi().get<CreditCardBillRow[]>("/api/bank/bills"),
+  });
 
-export const investmentsQuery = (getApi: ApiProvider) => queryOptions({
-  queryKey: queryKeys.investments,
-  queryFn: () => getApi().get<InvestmentRow[]>("/api/investments")
-});
+export const investmentsQuery = (getApi: ApiProvider) =>
+  queryOptions({
+    queryKey: queryKeys.investments,
+    queryFn: () => getApi().get<InvestmentRow[]>("/api/investments"),
+  });
 
-export const investmentTransactionsQuery = (getApi: ApiProvider) => queryOptions({
-  queryKey: queryKeys.investmentTransactions,
-  queryFn: () => getApi().get<InvestmentTransactionRow[]>("/api/investment-transactions")
-});
+export const investmentTransactionsQuery = (getApi: ApiProvider) =>
+  queryOptions({
+    queryKey: queryKeys.investmentTransactions,
+    queryFn: () =>
+      getApi().get<InvestmentTransactionRow[]>("/api/investment-transactions"),
+  });
 
-export const invoicesQuery = (getApi: ApiProvider) => queryOptions({
-  queryKey: queryKeys.invoices,
-  queryFn: () => getApi().get<InvoiceRow[]>("/api/invoices")
-});
+export const invoicesQuery = (getApi: ApiProvider) =>
+  queryOptions({
+    queryKey: queryKeys.invoices,
+    queryFn: () => getApi().get<InvoiceRow[]>("/api/invoices"),
+  });
 
-export const manualAssetsQuery = (getApi: ApiProvider) => queryOptions({
-  queryKey: queryKeys.manualAssets,
-  queryFn: () => getApi().get<ManualAssetRow[]>("/api/manual-assets")
-});
+export const manualAssetsQuery = (getApi: ApiProvider) =>
+  queryOptions({
+    queryKey: queryKeys.manualAssets,
+    queryFn: () => getApi().get<ManualAssetRow[]>("/api/manual-assets"),
+  });
 
-export const manualAssetHistoryQuery = (getApi: ApiProvider, assetId: string | null) => queryOptions({
-  queryKey: queryKeys.manualAssetHistory(assetId ?? ""),
-  queryFn: () => getApi().get<ManualAssetHistoryEntry[]>(`/api/manual-assets/${assetId}/history`),
-  enabled: Boolean(assetId)
-});
+export const manualAssetHistoryQuery = (
+  getApi: ApiProvider,
+  assetId: string | null,
+) =>
+  queryOptions({
+    queryKey: queryKeys.manualAssetHistory(assetId ?? ""),
+    queryFn: () =>
+      getApi().get<ManualAssetHistoryEntry[]>(
+        `/api/manual-assets/${assetId}/history`,
+      ),
+    enabled: Boolean(assetId),
+  });
 
-export const exchangeRatesQuery = (getApi: ApiProvider) => queryOptions({
-  queryKey: queryKeys.exchangeRates,
-  queryFn: () => getApi().get<ExchangeRateRow[]>("/api/exchange-rates")
-});
+export const exchangeRatesQuery = (getApi: ApiProvider) =>
+  queryOptions({
+    queryKey: queryKeys.exchangeRates,
+    queryFn: () => getApi().get<ExchangeRateRow[]>("/api/exchange-rates"),
+  });
 
-export const netWorthHistoryQuery = (getApi: ApiProvider) => queryOptions({
-  queryKey: queryKeys.netWorthHistory,
-  queryFn: () => getApi().get<NetWorthHistoryRow[]>("/api/history/net-worth")
-});
+export const netWorthHistoryQuery = (getApi: ApiProvider) =>
+  queryOptions({
+    queryKey: queryKeys.netWorthHistory,
+    queryFn: () => getApi().get<NetWorthHistoryRow[]>("/api/history/net-worth"),
+  });
 
-export const syncJobsQuery = (getApi: ApiProvider) => queryOptions({
-  queryKey: queryKeys.syncJobs,
-  queryFn: () => getApi().get<SyncJobRow[]>("/api/sync-jobs")
-});
+export const syncJobsQuery = (getApi: ApiProvider) =>
+  queryOptions({
+    queryKey: queryKeys.syncJobs,
+    queryFn: () => getApi().get<SyncJobRow[]>("/api/sync-jobs"),
+  });
 
-export const classificationRulesQuery = (getApi: ApiProvider) => queryOptions({
-  queryKey: queryKeys.classificationRules,
-  queryFn: () => getApi().get<ClassificationRuleRow[]>("/api/classification/rules")
-});
+export const classificationRulesQuery = (getApi: ApiProvider) =>
+  queryOptions({
+    queryKey: queryKeys.classificationRules,
+    queryFn: () =>
+      getApi().get<ClassificationRuleRow[]>("/api/classification/rules"),
+  });
 
-export const connectorSettingsQuery = (getApi: ApiProvider, connectorId: string) => queryOptions({
-  queryKey: queryKeys.connectorSettings(connectorId),
-  queryFn: () => getApi().get<ConnectorSettings>(`/api/connectors/${connectorId}/settings`)
-});
+export const connectorSettingsQuery = (
+  getApi: ApiProvider,
+  connectorId: string,
+) =>
+  queryOptions({
+    queryKey: queryKeys.connectorSettings(connectorId),
+    queryFn: () =>
+      getApi().get<ConnectorSettings>(
+        `/api/connectors/${connectorId}/settings`,
+      ),
+  });

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,60 +1,217 @@
 import type {
   ApiErrorResponse,
   ConnectorId as CoreConnectorId,
-  Summary as CoreSummary
+  Summary as CoreSummary,
 } from "@taiwan-fin-hub/core";
 
-export interface NetWorthHistoryRow { date: string; netWorth: number; assetType: string; source: string; }
-export interface ExchangeRateRow { currency: string; rateTwd: number; updatedAt: string; }
-export interface ManualAssetRow { id: string; name: string; category: string; note: string | null; createdAt: string; value?: number; date?: string; }
-export interface ManualAssetHistoryEntry { date: string; value: number; }
+export interface NetWorthHistoryRow {
+  date: string;
+  netWorth: number;
+  assetType: string;
+  source: string;
+}
+export interface ExchangeRateRow {
+  currency: string;
+  rateTwd: number;
+  updatedAt: string;
+}
+export interface ManualAssetRow {
+  id: string;
+  name: string;
+  category: string;
+  note: string | null;
+  createdAt: string;
+  value?: number;
+  date?: string;
+}
+export interface ManualAssetHistoryEntry {
+  date: string;
+  value: number;
+}
 
-export type PrimaryView = "overview" | "assets" | "activity" | "invoices" | "settings";
+export type PrimaryView =
+  "overview" | "assets" | "activity" | "invoices" | "settings";
 export type DetailView = "bank" | "cards" | "investments" | "manual-assets";
-export type MobileSettingsView = "data-sources" | "exchange-rates" | "classification-rules";
+export type MobileSettingsView =
+  "data-sources" | "exchange-rates" | "classification-rules";
 export type View = PrimaryView | DetailView | MobileSettingsView | "more";
-export type AssetSection = "all" | "bank" | "cards" | "investments" | "manual-assets";
-export interface MoneyVisibilityState { hidden: boolean; }
+export type AssetSection =
+  "all" | "bank" | "cards" | "investments" | "manual-assets";
+export interface MoneyVisibilityState {
+  hidden: boolean;
+}
 export interface ActivityItem {
-  id: string; source: "bank" | "card" | "investment" | "invoice"; date: string;
-  title: string; subtitle: string; amount?: number; currency: string; category: string;
-  categoryId?: string; transactionId?: string; status: string;
+  id: string;
+  source: "bank" | "card" | "investment" | "invoice";
+  date: string;
+  title: string;
+  subtitle: string;
+  amount?: number;
+  currency: string;
+  category: string;
+  categoryId?: string;
+  transactionId?: string;
+  status: string;
 }
 export type ConnectorId = CoreConnectorId;
 export type SyncTarget = "default" | "investments" | "bank" | "trades";
 
 export type Summary = CoreSummary;
-export interface InvoiceLineItemRow { id: string; invoiceId?: string; sourceId: string; lineNumber: number; description: string; quantity?: number; unitPrice?: number; amount: number; }
-export interface InvoiceRow { id: string; connectorId: ConnectorId; sourceId: string; invoiceDate: string; invoiceNumber?: string; sellerName?: string; amount: number; items: InvoiceLineItemRow[]; }
-export interface InvestmentRow { id: string; assetType: "stock" | "etf" | "fund"; symbol?: string; name: string; quantity?: number; marketValue?: number; cashBalance?: number; currency: string; asOfDate: string; }
+export interface InvoiceLineItemRow {
+  id: string;
+  invoiceId?: string;
+  sourceId: string;
+  lineNumber: number;
+  description: string;
+  quantity?: number;
+  unitPrice?: number;
+  amount: number;
+}
+export interface InvoiceRow {
+  id: string;
+  connectorId: ConnectorId;
+  sourceId: string;
+  invoiceDate: string;
+  invoiceNumber?: string;
+  sellerName?: string;
+  amount: number;
+  items: InvoiceLineItemRow[];
+}
+export interface InvestmentRow {
+  id: string;
+  assetType: "stock" | "etf" | "fund";
+  symbol?: string;
+  name: string;
+  quantity?: number;
+  marketValue?: number;
+  cashBalance?: number;
+  currency: string;
+  asOfDate: string;
+}
 export interface InvestmentTransactionRow {
-  id: string; connectorId: ConnectorId; accountId: string; sourceId: string; brokerNo?: string; brokerAccount?: string;
-  brokerName?: string; symbol?: string; name?: string; assetType?: "stock" | "etf" | "fund" | "bond" | "unknown";
-  tradeDate?: string; postedDate?: string; transactionCode?: string; transactionName?: string; quantity?: number;
-  price?: number; amount?: number; currency: string;
+  id: string;
+  connectorId: ConnectorId;
+  accountId: string;
+  sourceId: string;
+  brokerNo?: string;
+  brokerAccount?: string;
+  brokerName?: string;
+  symbol?: string;
+  name?: string;
+  assetType?: "stock" | "etf" | "fund" | "bond" | "unknown";
+  tradeDate?: string;
+  postedDate?: string;
+  transactionCode?: string;
+  transactionName?: string;
+  quantity?: number;
+  price?: number;
+  amount?: number;
+  currency: string;
 }
 export interface BankAccountRow {
-  id: string; connectorId: ConnectorId; sourceId: string; institutionName?: string; accountName?: string;
-  accountType?: string; currency: string; bankCode?: string; accountLast4?: string; balance?: number;
-  availableBalance?: number; paymentDueDate?: string; statementClosingDate?: string; asOfAt?: string;
+  id: string;
+  connectorId: ConnectorId;
+  sourceId: string;
+  institutionName?: string;
+  accountName?: string;
+  accountType?: string;
+  currency: string;
+  bankCode?: string;
+  accountLast4?: string;
+  balance?: number;
+  availableBalance?: number;
+  paymentDueDate?: string;
+  statementClosingDate?: string;
+  asOfAt?: string;
 }
 export interface BankTransactionRow {
-  id: string; connectorId: ConnectorId; accountId: string; accountSourceId?: string; accountName?: string;
-  institutionName?: string; accountType?: string; bankCode?: string; accountLast4?: string; sourceId: string;
-  postedDate?: string; authorizedAt?: string; amount: number; currency: string; description?: string;
-  counterparty?: string; status: "pending" | "posted";
-  classification?: { categoryId: string; label: string; source: "override" | "user_rule" | "system_rule" | "fallback"; ruleId?: string; };
+  id: string;
+  connectorId: ConnectorId;
+  accountId: string;
+  accountSourceId?: string;
+  accountName?: string;
+  institutionName?: string;
+  accountType?: string;
+  bankCode?: string;
+  accountLast4?: string;
+  sourceId: string;
+  postedDate?: string;
+  authorizedAt?: string;
+  amount: number;
+  currency: string;
+  description?: string;
+  counterparty?: string;
+  status: "pending" | "posted";
+  classification?: {
+    categoryId: string;
+    label: string;
+    source: "override" | "user_rule" | "system_rule" | "fallback";
+    ruleId?: string;
+  };
 }
-export interface CreditCardBillRow { id: string; connectorId: ConnectorId; accountId: string; accountSourceId?: string; sourceId: string; billingPeriod: string; statementAmount?: number; minimumPayment?: number; paidAmount?: number; isPaid?: number; paymentDueDate?: string; statementClosingDate?: string; currency: string; }
-export interface BankData { accounts: BankAccountRow[]; transactions: BankTransactionRow[]; }
-export interface ConnectorSettings { connectorId: ConnectorId; configured: boolean; updatedAt?: string; publicConfig?: Record<string, unknown> | null; sessionAvailable?: boolean; }
+export interface CreditCardBillRow {
+  id: string;
+  connectorId: ConnectorId;
+  accountId: string;
+  accountSourceId?: string;
+  sourceId: string;
+  billingPeriod: string;
+  statementAmount?: number;
+  minimumPayment?: number;
+  paidAmount?: number;
+  isPaid?: number;
+  paymentDueDate?: string;
+  statementClosingDate?: string;
+  currency: string;
+}
+export interface BankData {
+  accounts: BankAccountRow[];
+  transactions: BankTransactionRow[];
+}
+export interface ConnectorSettings {
+  connectorId: ConnectorId;
+  configured: boolean;
+  updatedAt?: string;
+  publicConfig?: Record<string, unknown> | null;
+  sessionAvailable?: boolean;
+}
 export interface SyncJobRow {
-  id: string; connectorId: ConnectorId; scope: string; enabled: boolean; intervalMinutes: number; nextRunAt: string;
-  lockedUntil: string | null; lockedBy: string | null; lockTrigger: "manual" | "scheduled" | null; lockScope: string | null;
-  lastRunAt: string | null; lastSuccessAt: string | null; lastStatus: "success" | "failed" | "needs_user_action" | null;
-  lastError: string | null; updatedAt: string; running: boolean;
+  id: string;
+  connectorId: ConnectorId;
+  scope: string;
+  enabled: boolean;
+  intervalMinutes: number;
+  nextRunAt: string;
+  lockedUntil: string | null;
+  lockedBy: string | null;
+  lockTrigger: "manual" | "scheduled" | null;
+  lockScope: string | null;
+  lastRunAt: string | null;
+  lastSuccessAt: string | null;
+  lastStatus: "success" | "failed" | "needs_user_action" | null;
+  lastError: string | null;
+  updatedAt: string;
+  running: boolean;
 }
 export type ApiError = ApiErrorResponse;
-export interface RuntimeInfo { demoMode: boolean; }
-export interface ConnectorField { key: string; label: string; type: "text" | "password" | "number" | "checkbox"; placeholder?: string; }
-export interface ClassificationRuleRow { id: string; categoryId: string; targetType: string; field: string; operator: string; pattern: string; priority: number; enabled: boolean; description?: string; createdAt?: string; }
+export interface RuntimeInfo {
+  demoMode: boolean;
+}
+export interface ConnectorField {
+  key: string;
+  label: string;
+  type: "text" | "password" | "number" | "checkbox";
+  placeholder?: string;
+}
+export interface ClassificationRuleRow {
+  id: string;
+  categoryId: string;
+  targetType: string;
+  field: string;
+  operator: string;
+  pattern: string;
+  priority: number;
+  enabled: boolean;
+  description?: string;
+  createdAt?: string;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,4 +1,4 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 
 @theme {
   --breakpoint-*: initial;
@@ -95,7 +95,7 @@
       system-ui,
       -apple-system,
       BlinkMacSystemFont,
-      'Segoe UI',
+      "Segoe UI",
       sans-serif;
     text-rendering: geometricPrecision;
     color: hsl(var(--foreground));

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -1,5 +1,5 @@
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 export default {
-  preprocess: vitePreprocess()
+  preprocess: vitePreprocess(),
 };

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -5,5 +5,13 @@
     "esModuleInterop": true,
     "lib": ["DOM", "DOM.Iterable", "ES2022"]
   },
-  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.svelte", "vite.config.ts", "vitest.config.ts", "playwright.config.ts", "svelte.config.js"]
+  "include": [
+    "src/**/*.d.ts",
+    "src/**/*.ts",
+    "src/**/*.svelte",
+    "vite.config.ts",
+    "vitest.config.ts",
+    "playwright.config.ts",
+    "svelte.config.js"
+  ]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,10 +6,10 @@ export default defineConfig({
   plugins: [tailwindcss(), svelte()],
   server: {
     proxy: {
-      "/api": "http://localhost:8787"
-    }
+      "/api": "http://localhost:8787",
+    },
   },
   build: {
-    target: ["es2022", "chrome111", "firefox128", "safari16.4"]
-  }
+    target: ["es2022", "chrome111", "firefox128", "safari16.4"],
+  },
 });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./src/test-setup.ts"],
-    include: ["src/**/*.test.ts"]
-  }
+    include: ["src/**/*.test.ts"],
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,8 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.4.2",
         "jsdom": "^29.1.1",
+        "prettier": "^3.9.5",
+        "prettier-plugin-svelte": "^4.1.1",
         "svelte-check": "^4.7.2",
         "tailwindcss": "^4.3.2",
         "vite": "^8.1.4",
@@ -4743,6 +4745,36 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-svelte": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-4.1.1.tgz",
+      "integrity": "sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "svelte": "^5.0.0"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   ],
   "scripts": {
     "build": "npm run build --workspaces",
+    "format": "npm run format -w @taiwan-fin-hub/web",
+    "format:check": "npm run format:check -w @taiwan-fin-hub/web",
     "typecheck": "npm run typecheck --workspaces",
     "test:unit": "npm run test:unit -w @taiwan-fin-hub/web",
     "test:backend": "npm test -w @taiwan-fin-hub/worker && npm run test:selfcheck -w @taiwan-fin-hub/connectors",


### PR DESCRIPTION
## 變更內容

- 在前端加入 Prettier 3 與 `prettier-plugin-svelte`
- 新增前端 `format`、`format:check` 指令，並讓根目錄的同名指令預設套用到前端 workspace
- 排除 `dist`、`node_modules`、Playwright 報告與測試輸出
- 使用新的 Svelte 格式化設定統一格式化整個 `apps/web`

## 影響

- 後續可直接在專案根目錄執行 `npm run format` 格式化前端
- CI 或本機可使用 `npm run format:check` 檢查格式
- 本次僅調整程式碼排版與格式化工具設定，不變更前端行為

## 驗證

- `npm run format:check`
- `npm run typecheck -w @taiwan-fin-hub/web`
- `npm run test:unit -w @taiwan-fin-hub/web`
- `npm run build -w @taiwan-fin-hub/web`
- `npm run test:e2e -w @taiwan-fin-hub/web`
- Svelte autofixer 檢查所有 `.svelte` 與 `.svelte.ts` 檔案
