### PR TITLE
修正 iPhone 雙擊意外放大頁面

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ research/
 docs/*
 !docs/
 !docs/*.md
+
+.vscode/

--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -74,7 +74,7 @@ test("uses app-like scrolling and history only in standalone display mode", asyn
 }) => {
   await page.goto("/");
   await expect(page.locator("html")).not.toHaveClass(/is-standalone/);
-  await expect(page.locator("html")).toHaveCSS("touch-action", "auto");
+  await expect(page.locator("html")).toHaveCSS("touch-action", "manipulation");
 
   await page.addInitScript(() => {
     const nativeMatchMedia = window.matchMedia.bind(window);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -85,6 +85,8 @@
 
   html {
     background: #f7f7f2;
+    /* Prevent iOS double-tap zoom while preserving scrolling and pinch zoom. */
+    touch-action: manipulation;
   }
 
   body {
@@ -151,5 +153,6 @@ html.is-standalone #root {
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: none;
+  /* Keep the installed PWA app-like: allow scrolling, but no gesture zoom. */
   touch-action: pan-x pan-y;
 }


### PR DESCRIPTION
## 變更內容

- 一般 iPhone Safari 停用雙擊放大，保留捲動與雙指縮放
- 安裝到主畫面的 PWA 維持只允許平移，禁止手勢縮放
- 更新行動版殼層 E2E 測試，鎖定兩種顯示模式的 `touch-action`
- 將 `.vscode/` 加入 `.gitignore`，避免提交本機工作區設定

## 原因

iPhone 使用者快速連點操作時，Safari 可能誤判為雙擊縮放；畫面放大後不易恢復，影響操作。

## 驗證

- `npm run format:check -w @taiwan-fin-hub/web`
- `npm run test:e2e -w @taiwan-fin-hub/web -- e2e/shell.spec.ts`（4 passed）