### PR TITLE
feat(設定): 優化連接器設定並新增預設同步排程

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -4,7 +4,7 @@ test.beforeEach(async ({ page }) => {
   await page.route("**/api/**", async (route) => {
     const path = new URL(route.request().url()).pathname;
     let body: unknown;
-    if (path === "/api/runtime") body = { demoMode: true };
+    if (path === "/api/runtime") body = { demoMode: false };
     else if (path === "/api/summary")
       body = {
         totalAssetsTwd: 0,
@@ -23,10 +23,45 @@ test.beforeEach(async ({ page }) => {
     else if (path === "/api/manual-assets") body = [];
     else if (path === "/api/exchange-rates") body = [];
     else if (path === "/api/history/net-worth") body = [];
-    else if (path === "/api/sync-jobs") body = [];
+    else if (path === "/api/sync-jobs")
+      body = [
+        {
+          id: "einvoice:all",
+          connectorId: "einvoice",
+          scope: "all",
+          enabled: true,
+          intervalMinutes: 1440,
+          nextRunAt: "2026-07-17T22:50:00.000Z",
+          scheduleMode: "inherit",
+          preferredTime: "06:50",
+          lockedUntil: null,
+          lockedBy: null,
+          lockTrigger: null,
+          lockScope: null,
+          lastRunAt: "2026-07-16T22:50:00.000Z",
+          lastSuccessAt: "2026-07-16T22:50:00.000Z",
+          lastStatus: "success",
+          lastError: null,
+          updatedAt: "2026-07-16T22:50:00.000Z",
+          running: false,
+        },
+      ];
+    else if (path === "/api/sync-schedule")
+      body = {
+        intervalMinutes: 1440,
+        preferredTime: "06:50",
+        timezone: "Asia/Taipei",
+        updatedAt: "2026-07-16T10:50:00.000Z",
+      };
     else if (path === "/api/classification/rules") body = [];
     else if (path.includes("/connectors/") && path.endsWith("/settings"))
-      body = { configured: false, publicConfig: {} };
+      body = path.includes("/connectors/einvoice/")
+        ? {
+            configured: true,
+            updatedAt: "2026-07-16T10:50:00.000Z",
+            publicConfig: { periodsBack: 1, fetchDetails: true },
+          }
+        : { configured: false, publicConfig: {} };
     else throw new Error(`Unexpected API request in E2E mock: ${path}`);
     await route.fulfill({
       status: 200,
@@ -117,4 +152,58 @@ test("opens a primary view from its hash route", async ({ page }) => {
   await expect(
     page.getByRole("heading", { name: "發票", exact: true }),
   ).toBeVisible();
+});
+
+test("shows the settings dashboard at a glance", async ({ page }) => {
+  await page.goto("/#/settings");
+
+  await expect(
+    page.getByText("資料來源", { exact: true }).first(),
+  ).toBeVisible();
+  await expect(page.getByText("同步排程", { exact: true })).toBeVisible();
+  await expect(page.getByText("需要處理", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "電子發票" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "預設同步排程" }),
+  ).toBeVisible();
+  const scheduleCard = page
+    .getByRole("heading", { name: "預設同步排程" })
+    .locator("xpath=ancestor::section[1]");
+  await expect(scheduleCard.locator('input[type="time"]')).toHaveCount(0);
+  const timePicker = scheduleCard.locator("[data-popover-trigger]");
+  await expect(timePicker).toHaveAccessibleName("選擇時間，目前 06:50");
+  await timePicker.click();
+  const timePopover = page.locator("[data-popover-content]");
+  await expect(timePopover.getByText("選擇同步時間")).toBeVisible();
+  await timePopover.getByLabel("分鐘").selectOption("40");
+  await expect(timePicker).toHaveAccessibleName("選擇時間，目前 06:40");
+  await timePopover.getByRole("button", { name: "完成" }).click();
+  await expect(timePopover).not.toBeVisible();
+  await expect(page.getByRole("heading", { name: "匯率" })).toBeVisible();
+  await expect(page.getByText("目前沒有外幣帳戶")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "資料安全" })).toBeVisible();
+  await expect(page.getByPlaceholder("比對文字")).toBeVisible();
+
+  const invoiceCard = page
+    .getByRole("heading", { name: "電子發票" })
+    .locator("xpath=ancestor::div[contains(@class, 'bg-card')][1]");
+  await invoiceCard.getByRole("button", { name: "管理設定" }).click();
+  await expect(
+    invoiceCard.getByRole("heading", { name: "連線與同步" }),
+  ).toBeVisible();
+  await expect(
+    invoiceCard.getByRole("heading", { name: "連線憑證" }),
+  ).toBeVisible();
+  await expect(invoiceCard.getByText("App ID", { exact: true })).toHaveCount(0);
+  await expect(invoiceCard.getByText("API Key", { exact: true })).toHaveCount(
+    0,
+  );
+  await expect(
+    invoiceCard.getByText("手機號碼（電子發票帳號）", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    invoiceCard.getByText("電子發票 App 登入密碼", { exact: true }),
+  ).toBeVisible();
+  await expect(invoiceCard.getByText("已儲存", { exact: true })).toHaveCount(2);
+  await expect(invoiceCard.getByText(/跟隨預設：.*每天.*06:50/)).toBeVisible();
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@lucide/svelte": "^1.24.0",
     "@taiwan-fin-hub/core": "0.1.0",
     "@tanstack/svelte-query": "^5.90.2",
+    "bits-ui": "^2.18.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "layerchart": "^2.0.1",

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -81,7 +81,7 @@
       view: "settings",
       label: "設定",
       shortLabel: "設定",
-      description: "設定連接器、同步資料與匯率。",
+      description: "管理資料來源、同步排程、匯率與交易分類。",
       icon: Settings,
     },
   ];
@@ -302,8 +302,8 @@
               {#if primaryView === "settings"}<Button
                   class="hidden md:inline-flex"
                   onclick={() => queryClient.invalidateQueries()}
-                  variant="primary"
-                  ><Icon icon={RefreshCw} size="sm" />同步資料</Button
+                  variant="secondary"
+                  ><Icon icon={RefreshCw} size="sm" />重新整理</Button
                 >{/if}
             </div>
           </div>

--- a/apps/web/src/components/ui/TimePicker.svelte
+++ b/apps/web/src/components/ui/TimePicker.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import { Popover } from "bits-ui";
+  import { Check, ChevronDown, Clock3 } from "@lucide/svelte";
+  import Button from "./Button.svelte";
+  import Select from "./Select.svelte";
+
+  let {
+    value = $bindable("06:00"),
+    disabled = false,
+    minuteStep = 10,
+    onchange,
+  }: {
+    value?: string;
+    disabled?: boolean;
+    minuteStep?: number;
+    onchange?: (value: string) => void;
+  } = $props();
+
+  let open = $state(false);
+  const hours = Array.from({ length: 24 }, (_, hour) =>
+    String(hour).padStart(2, "0"),
+  );
+  const selectedHour = $derived(normalizeTime(value).split(":")[0]);
+  const selectedMinute = $derived(normalizeTime(value).split(":")[1]);
+  const minutes = $derived.by(() => {
+    const safeStep = Math.min(30, Math.max(1, Math.floor(minuteStep)));
+    const options = Array.from(
+      { length: Math.ceil(60 / safeStep) },
+      (_, index) => String(index * safeStep).padStart(2, "0"),
+    ).filter((minute) => Number(minute) < 60);
+    return [...new Set([...options, selectedMinute])].sort();
+  });
+
+  function normalizeTime(input: string) {
+    const match = /^(\d{1,2}):(\d{2})$/.exec(input);
+    if (!match) return "06:00";
+    const hour = Math.min(23, Math.max(0, Number(match[1])));
+    const minute = Math.min(59, Math.max(0, Number(match[2])));
+    return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+  }
+
+  function update(nextHour: string, nextMinute: string) {
+    const nextValue = normalizeTime(`${nextHour}:${nextMinute}`);
+    value = nextValue;
+    onchange?.(nextValue);
+  }
+</script>
+
+<Popover.Root bind:open>
+  <Popover.Trigger {disabled}>
+    {#snippet child({ props })}
+      <Button
+        {...props}
+        variant="outline"
+        class="w-full justify-between px-3 font-normal"
+        {disabled}
+        aria-label={`選擇時間，目前 ${normalizeTime(value)}`}
+      >
+        <span class="flex items-center gap-2">
+          <Clock3 />
+          <span class="tabular-nums">{normalizeTime(value)}</span>
+        </span>
+        <ChevronDown class="text-muted-foreground" />
+      </Button>
+    {/snippet}
+  </Popover.Trigger>
+  <Popover.Content
+    align="start"
+    sideOffset={6}
+    class="w-64 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md outline-none"
+  >
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col gap-1">
+        <p class="text-sm font-semibold">選擇同步時間</p>
+        <p class="text-xs text-muted-foreground">時區：Asia/Taipei</p>
+      </div>
+      <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-2">
+        <label class="flex flex-col gap-1.5 text-xs font-medium">
+          小時
+          <Select
+            value={selectedHour}
+            onchange={(event: Event) =>
+              update(
+                (event.currentTarget as HTMLSelectElement).value,
+                selectedMinute,
+              )}
+          >
+            {#each hours as hour (hour)}
+              <option value={hour}>{hour}</option>
+            {/each}
+          </Select>
+        </label>
+        <span class="pb-2 text-sm font-semibold text-muted-foreground">:</span>
+        <label class="flex flex-col gap-1.5 text-xs font-medium">
+          分鐘
+          <Select
+            value={selectedMinute}
+            onchange={(event: Event) =>
+              update(
+                selectedHour,
+                (event.currentTarget as HTMLSelectElement).value,
+              )}
+          >
+            {#each minutes as minute (minute)}
+              <option value={minute}>{minute}</option>
+            {/each}
+          </Select>
+        </label>
+      </div>
+      <Button size="sm" onclick={() => (open = false)}>
+        <Check />完成
+      </Button>
+    </div>
+  </Popover.Content>
+</Popover.Root>

--- a/apps/web/src/features/settings/ConnectorPanel.svelte
+++ b/apps/web/src/features/settings/ConnectorPanel.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { SvelteDate } from "svelte/reactivity";
   import { toStore } from "svelte/store";
   import {
     createMutation,
@@ -19,9 +18,14 @@
   import Checkbox from "../../components/ui/Checkbox.svelte";
   import Input from "../../components/ui/Input.svelte";
   import Select from "../../components/ui/Select.svelte";
+  import TimePicker from "../../components/ui/TimePicker.svelte";
   import type { ApiClient } from "../../lib/api";
   import { queryKeys } from "../../lib/api";
-  import { connectorSettingsQuery, syncJobsQuery } from "../../lib/queries";
+  import {
+    connectorSettingsQuery,
+    syncJobsQuery,
+    syncScheduleQuery,
+  } from "../../lib/queries";
   import type {
     ConnectorField,
     ConnectorId,
@@ -35,18 +39,21 @@
     demoMode,
     title,
     fields,
+    embedded = false,
   }: {
     api: ApiClient;
     connectorId: ConnectorId;
     demoMode: boolean;
     title: string;
     fields: ConnectorField[];
+    embedded?: boolean;
   } = $props();
   const qc = useQueryClient();
   const settings = createQuery(
     toStore(() => connectorSettingsQuery(() => api, connectorId)),
   );
   const jobs = createQuery(syncJobsQuery(() => api));
+  const defaultSchedule = createQuery(syncScheduleQuery(() => api));
   let values = $state<Record<string, string | boolean>>({});
   let error = $state("");
   let otp = $state("");
@@ -88,10 +95,16 @@
       if (!Object.keys(config).length) throw new Error("請先填寫欄位再儲存。");
       return api.put(`/api/connectors/${connectorId}/settings`, { config });
     },
-    onSuccess: () =>
+    onSuccess: () => {
+      error = "";
+      for (const field of fields) {
+        if (field.type === "text" || field.type === "password")
+          values[field.key] = "";
+      }
       qc.invalidateQueries({
         queryKey: queryKeys.connectorSettings(connectorId),
-      }),
+      });
+    },
     onError: (e) => (error = e instanceof Error ? e.message : "儲存失敗"),
   });
   const updateJob = createMutation({
@@ -230,20 +243,25 @@
     }
     return Object.fromEntries(entries);
   }
-  function scheduleTime(event: Event) {
-    const value = (event.currentTarget as HTMLInputElement).value;
-    const [hours, minutes] = value.split(":").map(Number);
-    const next = new SvelteDate();
-    next.setHours(hours, minutes, 0, 0);
-    if (next.getTime() <= Date.now()) next.setDate(next.getDate() + 1);
-    $updateJob.mutate({ nextRunAt: next.toISOString() });
+  function intervalLabel(minutes: number) {
+    return (
+      intervalOptions.find((option) => option.minutes === minutes)?.label ??
+      `${minutes} 分鐘`
+    );
   }
 </script>
 
-<Card as="article" class="p-4">
+<Card
+  as="article"
+  class={embedded
+    ? "rounded-none border-0 bg-transparent p-0 shadow-none"
+    : "p-4"}
+>
   <div class="flex flex-wrap items-start justify-between gap-3">
     <div>
-      <h2 class="text-lg font-semibold">{title}</h2>
+      <h2 class="text-lg font-semibold">
+        {embedded ? "連線與同步" : title}
+      </h2>
       <p class="text-sm text-ink/65">
         {$settings.data?.configured
           ? `已設定於 ${formatDateTime($settings.data.updatedAt)}。機密資料不會在此顯示；重新填寫欄位即可覆寫。`
@@ -251,13 +269,6 @@
       </p>
     </div>
     <div class="flex flex-wrap gap-2">
-      <Button
-        size="sm"
-        onclick={() => {
-          error = "";
-          $save.mutate(buildConfig());
-        }}><Save class="size-4" />儲存</Button
-      >
       {#if connectorId === "tdcc"}
         <Button
           size="sm"
@@ -343,7 +354,6 @@
     </p>{/if}
   {#if connectorId === "tdcc"}<details
       class="mt-3 rounded-md border border-ink/10 bg-paper text-sm text-ink/70"
-      open
     >
       <summary
         class="cursor-pointer select-none px-3 py-2 font-medium text-ink/80"
@@ -358,7 +368,6 @@
     </details>{/if}
   {#if connectorId === "sinopac"}<details
       class="mt-3 rounded-md border border-ink/10 bg-paper text-sm text-ink/70"
-      open
     >
       <summary
         class="cursor-pointer select-none px-3 py-2 font-medium text-ink/80"
@@ -416,89 +425,207 @@
       </div>
     </div>
   {/if}
-  <div
-    class="mt-3 rounded-md border border-ink/10 bg-paper px-3 py-2 text-sm text-ink/70"
-  >
-    <div class="flex flex-wrap items-center justify-between gap-2">
-      <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
-        <span class="font-medium">自動同步：{job?.enabled ? "開" : "關"}</span
-        >{#if connectorId === "sinopac"}<span
-            >登入：{sinopacSessionAvailable
-              ? "session 可自動續用"
-              : "需要人工驗證"}</span
-          >{/if}{#if job}<span
-            >狀態：{job.running
-              ? "同步中"
-              : job.lastStatus === "success"
-                ? "正常"
-                : job.lastStatus === "failed"
-                  ? "失敗"
-                  : job.lastStatus === "needs_user_action"
-                    ? "需要處理"
-                    : "尚未同步"}</span
-          >{#if job.lastRunAt}<span>上次：{formatDateTime(job.lastRunAt)}</span
-            >{/if}{#if job.enabled}<span class="flex items-center gap-1.5"
-              ><Select
-                class="h-8 w-auto px-2 text-xs"
-                value={intervalOptions.find(
-                  (option) => option.minutes === job.intervalMinutes,
-                )?.minutes ?? 1440}
-                onchange={(e: Event) =>
-                  $updateJob.mutate({
-                    intervalMinutes: Number(
-                      (e.currentTarget as HTMLSelectElement).value,
-                    ),
-                  })}
-                >{#each intervalOptions as option (option.minutes)}<option
-                    value={option.minutes}>{option.label}</option
-                  >{/each}</Select
-              >{#if job.intervalMinutes >= 1440 && job.nextRunAt}<Input
-                  type="time"
-                  class="h-8 w-auto text-xs"
-                  value={new Date(job.nextRunAt).toTimeString().slice(0, 5)}
-                  onchange={scheduleTime}
-                /><span class="text-muted-foreground">同步</span>{/if}</span
-            >{/if}{/if}
+  <div class="mt-3 rounded-xl border border-ink/10 bg-paper p-3 text-sm">
+    <div class="flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-ink/70">
+          <span class="font-semibold text-ink">
+            自動同步：{job?.enabled ? "開" : "關"}
+          </span>
+          {#if connectorId === "sinopac"}<span
+              >登入：{sinopacSessionAvailable
+                ? "session 可自動續用"
+                : "需要人工驗證"}</span
+            >{/if}
+          {#if job}<span
+              >狀態：{job.running
+                ? "同步中"
+                : job.lastStatus === "success"
+                  ? "正常"
+                  : job.lastStatus === "failed"
+                    ? "失敗"
+                    : job.lastStatus === "needs_user_action"
+                      ? "需要處理"
+                      : "尚未同步"}</span
+            >{/if}
+        </div>
+        {#if job?.lastRunAt}
+          <p class="mt-1 text-xs text-muted-foreground">
+            上次同步：{formatDateTime(job.lastRunAt)}
+          </p>
+        {/if}
       </div>
       {#if job}<Button
           size="sm"
           variant="outline"
-          disabled={$updateJob.isPending}
+          disabled={demoMode || $updateJob.isPending}
           onclick={() => $updateJob.mutate({ enabled: !job.enabled })}
           >{job.enabled ? "關閉" : "開啟"}</Button
         >{/if}
     </div>
+
+    {#if job?.enabled}
+      <div class="mt-3 grid gap-3 border-t border-ink/10 pt-3 md:grid-cols-3">
+        <label class="grid gap-1 text-xs font-semibold text-ink/70">
+          排程方式
+          <Select
+            value={job.scheduleMode ?? "custom"}
+            disabled={demoMode || $updateJob.isPending}
+            onchange={(event: Event) =>
+              $updateJob.mutate({
+                scheduleMode: (event.currentTarget as HTMLSelectElement).value,
+              })}
+          >
+            <option value="inherit">跟隨預設</option>
+            <option value="custom">自訂排程</option>
+          </Select>
+        </label>
+
+        {#if job.scheduleMode === "inherit"}
+          <div
+            class="flex items-center rounded-lg border border-moss/15 bg-moss/5 px-3 py-2 text-sm text-moss md:col-span-2"
+          >
+            <span class="font-semibold">跟隨預設：</span>
+            {#if $defaultSchedule.data}
+              {intervalLabel(
+                $defaultSchedule.data.intervalMinutes,
+              )}{#if $defaultSchedule.data.intervalMinutes >= 1440}
+                {$defaultSchedule.data.preferredTime} 起{/if}
+            {:else}
+              讀取中…
+            {/if}
+          </div>
+        {:else}
+          <label class="grid gap-1 text-xs font-semibold text-ink/70">
+            同步頻率
+            <Select
+              value={job.intervalMinutes}
+              disabled={demoMode || $updateJob.isPending}
+              onchange={(event: Event) =>
+                $updateJob.mutate({
+                  intervalMinutes: Number(
+                    (event.currentTarget as HTMLSelectElement).value,
+                  ),
+                })}
+            >
+              {#each intervalOptions as option (option.minutes)}
+                <option value={option.minutes}>{option.label}</option>
+              {/each}
+            </Select>
+          </label>
+          {#if job.intervalMinutes >= 1440}
+            <label class="grid gap-1 text-xs font-semibold text-ink/70">
+              開始時間
+              <TimePicker
+                value={job.preferredTime}
+                disabled={demoMode || $updateJob.isPending}
+                onchange={(preferredTime) =>
+                  $updateJob.mutate({
+                    preferredTime,
+                  })}
+              />
+            </label>
+          {:else}
+            <div
+              class="flex items-end pb-2 text-xs leading-relaxed text-muted-foreground"
+            >
+              從上次同步完成後重新計時。
+            </div>
+          {/if}
+        {/if}
+      </div>
+    {/if}
     {#if error || (job?.lastError && !sinopacCaptchaImage)}<p
-        class="mt-1 text-xs text-coral"
+        class="mt-2 text-xs text-coral"
       >
         {error ? `本次同步：${error}` : `上次同步：${job?.lastError}`}
       </p>{/if}
   </div>
-  <div class="mt-4 grid gap-3">
-    {#each fields as field (field.key)}
-      {#if field.type === "checkbox"}
-        <label class="flex items-center gap-2 text-sm"
-          ><Checkbox
-            checked={Boolean(values[field.key])}
-            onchange={(e: Event) =>
-              (values[field.key] = (
-                e.currentTarget as HTMLInputElement
-              ).checked)}
-          />{field.label}</label
-        >
-      {:else}
-        <label class="grid gap-1 text-sm"
-          >{field.label}<Input
-            type={field.type}
-            placeholder={field.placeholder}
-            value={String(values[field.key] ?? "")}
-            oninput={(e: Event) =>
-              (values[field.key] = (e.currentTarget as HTMLInputElement).value)}
-          /></label
-        >
-      {/if}
-    {/each}
-  </div>
+  <section class="mt-4 overflow-hidden rounded-xl border border-border">
+    <div
+      class="flex flex-wrap items-start justify-between gap-2 border-b border-border bg-muted/45 px-4 py-3"
+    >
+      <div>
+        <h3 class="text-sm font-semibold">連線憑證</h3>
+        <p class="mt-0.5 text-xs text-muted-foreground">
+          已儲存的機密欄位不會顯示內容；留白會維持原值。
+        </p>
+      </div>
+      {#if $save.isSuccess}<span
+          class="rounded-full bg-moss/10 px-2.5 py-1 text-xs font-semibold text-moss"
+          >已安全儲存</span
+        >{/if}
+    </div>
+    <div class="grid gap-3 p-4">
+      {#each fields as field (field.key)}
+        {#if field.type === "checkbox"}
+          <label class="flex items-center gap-2 text-sm"
+            ><Checkbox
+              checked={Boolean(values[field.key])}
+              onchange={(e: Event) =>
+                (values[field.key] = (
+                  e.currentTarget as HTMLInputElement
+                ).checked)}
+            />{field.label}</label
+          >
+        {:else}
+          {@const storedCredential = Boolean(
+            $settings.data?.configured &&
+            (field.type === "text" || field.type === "password"),
+          )}
+          {@const hasReplacement = Boolean(String(values[field.key] ?? ""))}
+          <label class="grid gap-1.5 text-sm font-medium">
+            <span class="flex flex-wrap items-center gap-2">
+              <span>{field.label}</span>
+              {#if storedCredential}
+                <span
+                  class={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${hasReplacement ? "bg-steel/10 text-steel" : "bg-moss/10 text-moss"}`}
+                >
+                  {hasReplacement ? "將更新" : "已儲存"}
+                </span>
+              {/if}
+            </span>
+            <Input
+              class={storedCredential && !hasReplacement
+                ? "bg-moss/[0.035] placeholder:text-ink/55"
+                : ""}
+              type={field.type}
+              placeholder={storedCredential && !hasReplacement
+                ? "••••••••　已安全儲存"
+                : field.placeholder}
+              value={String(values[field.key] ?? "")}
+              oninput={(e: Event) =>
+                (values[field.key] = (
+                  e.currentTarget as HTMLInputElement
+                ).value)}
+            />
+          </label>
+        {/if}
+      {/each}
+    </div>
+    <div
+      class="flex flex-wrap items-center justify-between gap-3 border-t border-border bg-paper/70 px-4 py-3"
+    >
+      <p class="text-xs text-muted-foreground">
+        儲存完成後，再使用上方的同步按鈕測試連線。
+      </p>
+      <Button
+        size="sm"
+        disabled={$save.isPending}
+        onclick={() => {
+          error = "";
+          $save.reset();
+          $save.mutate(buildConfig());
+        }}
+        ><Save class="size-4" />{$save.isPending
+          ? "儲存中…"
+          : "儲存憑證"}</Button
+      >
+    </div>
+  </section>
+  {#if $save.isError}<p class="mt-2 text-xs font-medium text-coral">
+      儲存失敗：{error}
+    </p>{/if}
   {#if otpRequired}<div
       class="mt-3 rounded-md border border-destructive/40 bg-destructive/10 p-3"
     >

--- a/apps/web/src/features/settings/DefaultSchedulePanel.svelte
+++ b/apps/web/src/features/settings/DefaultSchedulePanel.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import {
+    createMutation,
+    createQuery,
+    useQueryClient,
+  } from "@tanstack/svelte-query";
+  import { Clock3, Save } from "@lucide/svelte";
+  import Card from "../../components/ui/Card.svelte";
+  import Button from "../../components/ui/Button.svelte";
+  import Select from "../../components/ui/Select.svelte";
+  import TimePicker from "../../components/ui/TimePicker.svelte";
+  import type { ApiClient } from "../../lib/api";
+  import { queryKeys } from "../../lib/api";
+  import { syncScheduleQuery } from "../../lib/queries";
+  import type { SyncJobRow, SyncScheduleSettings } from "../../lib/types";
+
+  let {
+    api,
+    demoMode,
+    jobs,
+  }: {
+    api: ApiClient;
+    demoMode: boolean;
+    jobs: SyncJobRow[];
+  } = $props();
+
+  const queryClient = useQueryClient();
+  const schedule = createQuery(syncScheduleQuery(() => api));
+  const intervalOptions = [
+    { label: "每小時", minutes: 60 },
+    { label: "每 6 小時", minutes: 360 },
+    { label: "每 12 小時", minutes: 720 },
+    { label: "每天", minutes: 1440 },
+    { label: "每週", minutes: 10080 },
+  ];
+  let intervalMinutes = $state(1440);
+  let preferredTime = $state("06:00");
+  const inheritedJobs = $derived(
+    jobs.filter((job) => job.scheduleMode === "inherit").length,
+  );
+
+  onMount(() =>
+    schedule.subscribe((result) => {
+      if (!result.data) return;
+      intervalMinutes = result.data.intervalMinutes;
+      preferredTime = result.data.preferredTime;
+    }),
+  );
+
+  const save = createMutation({
+    mutationFn: () =>
+      api.put<SyncScheduleSettings>("/api/sync-schedule", {
+        intervalMinutes,
+        preferredTime,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.syncSchedule });
+      queryClient.invalidateQueries({ queryKey: queryKeys.syncJobs });
+    },
+  });
+</script>
+
+<Card as="section" class="overflow-hidden">
+  <div
+    class="flex flex-wrap items-start justify-between gap-4 border-b border-border bg-ink px-5 py-4 text-white"
+  >
+    <div class="flex items-start gap-3">
+      <span
+        class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-white/10 text-white"
+      >
+        <Clock3 class="size-5" />
+      </span>
+      <div>
+        <h2 class="font-semibold">預設同步排程</h2>
+        <p class="mt-1 text-xs text-white/55">
+          選擇跟隨預設的連接器，會從設定時間起依序同步。
+        </p>
+      </div>
+    </div>
+    <div class="flex flex-wrap items-center gap-2 text-xs">
+      <span class="rounded-full bg-white/10 px-3 py-1.5 text-white/70">
+        Asia/Taipei
+      </span>
+      <span class="rounded-full bg-white/10 px-3 py-1.5 font-semibold">
+        {inheritedJobs} 個連接器跟隨
+      </span>
+    </div>
+  </div>
+  <div
+    class="grid gap-4 p-5 md:grid-cols-[minmax(180px,0.8fr)_minmax(180px,0.8fr)_1fr_auto] md:items-end"
+  >
+    <label class="grid gap-1.5 text-sm font-medium">
+      同步頻率
+      <Select bind:value={intervalMinutes} disabled={demoMode}>
+        {#each intervalOptions as option (option.minutes)}
+          <option value={option.minutes}>{option.label}</option>
+        {/each}
+      </Select>
+    </label>
+    {#if intervalMinutes >= 1440}
+      <label class="grid gap-1.5 text-sm font-medium">
+        開始時間
+        <TimePicker bind:value={preferredTime} disabled={demoMode} />
+      </label>
+    {:else}
+      <div class="grid gap-1.5 text-sm font-medium">
+        計時方式
+        <div
+          class="flex h-10 items-center rounded-md border border-border bg-muted/50 px-3 text-sm text-muted-foreground"
+        >
+          從上次同步完成後計算
+        </div>
+      </div>
+    {/if}
+    <p class="text-xs leading-relaxed text-muted-foreground md:pb-2">
+      修改後只會影響「跟隨預設」的來源；自訂排程不會改變。
+    </p>
+    <Button
+      disabled={demoMode || $save.isPending}
+      onclick={() => $save.mutate()}
+    >
+      <Save class="size-4" />{$save.isPending ? "儲存中…" : "儲存預設"}
+    </Button>
+  </div>
+  {#if $save.isSuccess}
+    <p
+      class="border-t border-border bg-moss/5 px-5 py-2 text-xs font-medium text-moss"
+    >
+      預設同步排程已更新，跟隨此設定的連接器也已重新排程。
+    </p>
+  {:else if $save.isError}
+    <p
+      class="border-t border-border bg-coral/5 px-5 py-2 text-xs font-medium text-coral"
+    >
+      預設排程儲存失敗，請稍後再試。
+    </p>
+  {/if}
+</Card>

--- a/apps/web/src/features/settings/Settings.svelte
+++ b/apps/web/src/features/settings/Settings.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createQuery } from "@tanstack/svelte-query";
+  import { ShieldCheck } from "@lucide/svelte";
   import type { ApiClient } from "../../lib/api";
   import {
     bankQuery,
@@ -18,6 +19,7 @@
   import ClassificationRulesPanel from "./ClassificationRulesPanel.svelte";
   import ConnectorPanel from "./ConnectorPanel.svelte";
   import MobileMore from "./MobileMore.svelte";
+  import DefaultSchedulePanel from "./DefaultSchedulePanel.svelte";
   let {
     api,
     demoMode,
@@ -41,13 +43,21 @@
     {
       id: "sinopac",
       title: "永豐行動銀行",
-      description: "App JSON API：信用卡帳務、近期帳單與未出帳消費",
+      description: "信用卡帳務、近期帳單與消費",
     },
   ];
   const connectorFields: Record<ConnectorId, ConnectorField[]> = {
     einvoice: [
-      { key: "appId", label: "App ID", type: "text" },
-      { key: "apiKey", label: "API Key", type: "password" },
+      {
+        key: "mobile",
+        label: "手機號碼（電子發票帳號）",
+        type: "text",
+      },
+      {
+        key: "password",
+        label: "電子發票 App 登入密碼",
+        type: "password",
+      },
       {
         key: "periodsBack",
         label: "往回期數",
@@ -119,22 +129,31 @@
     {api}
   />
 {:else if mobileView === "data-sources"}
-  <div class="grid gap-3">
-    {#each sources as source (source.id)}<SourceCard
-        {api}
-        {...source}
-        id={source.id}
-        jobs={$jobs.data ?? []}
-        selected={selectedConnector === source.id}
-        onConfigure={() => selectConnector(source.id)}
-      />{/each}{#if selectedConnector}{#key selectedConnector}<ConnectorPanel
+  <div class="grid gap-4">
+    <DefaultSchedulePanel {api} {demoMode} jobs={$jobs.data ?? []} />
+    <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5">
+      {#each sources as source (source.id)}
+        <SourceCard
           {api}
-          connectorId={selectedConnector}
-          {demoMode}
-          title={sources.find((s) => s.id === selectedConnector)?.title ??
-            selectedConnector}
-          fields={connectorFields[selectedConnector]}
-        />{/key}{/if}
+          {...source}
+          id={source.id}
+          jobs={$jobs.data ?? []}
+          selected={selectedConnector === source.id}
+          onConfigure={() => selectConnector(source.id)}
+        >
+          {#if selectedConnector === source.id}
+            {#key source.id}<ConnectorPanel
+                {api}
+                connectorId={source.id}
+                {demoMode}
+                title={source.title}
+                fields={connectorFields[source.id]}
+                embedded
+              />{/key}
+          {/if}
+        </SourceCard>
+      {/each}
+    </div>
   </div>
 {:else if mobileView === "exchange-rates"}<ExchangeRatesPanel {api} />
 {:else if mobileView === "classification-rules"}<ClassificationRulesPanel
@@ -142,15 +161,16 @@
   />
 {:else}
   <div class="grid gap-5">
-    <div class="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
+    <section class="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
       <Metric
-        label="已設定來源"
+        label="資料來源"
         value={String(sources.length)}
-        detail="資料連接器"
+        detail="支援的連接器"
       /><Metric
         label="同步排程"
         value={String(enabledJobs)}
         detail="已啟用"
+        tone={enabledJobs ? "positive" : "neutral"}
       /><Metric
         label="分類規則"
         value={String($rules.data?.length ?? 0)}
@@ -158,30 +178,64 @@
       /><Metric
         label="需要處理"
         value={String(needsAction)}
-        detail="同步狀態"
+        detail="同步或驗證狀態"
         tone={needsAction ? "negative" : "positive"}
       />
-    </div>
-    <section class="grid gap-3 md:grid-cols-2">
-      {#each sources as source (source.id)}<SourceCard
+    </section>
+
+    <DefaultSchedulePanel {api} {demoMode} jobs={$jobs.data ?? []} />
+
+    <section
+      aria-label="資料來源"
+      class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5"
+    >
+      {#each sources as source (source.id)}
+        <SourceCard
           {api}
           {...source}
           id={source.id}
           jobs={$jobs.data ?? []}
           selected={selectedConnector === source.id}
           onConfigure={() => selectConnector(source.id)}
-        />{/each}
+        >
+          {#if selectedConnector === source.id}
+            {#key source.id}<ConnectorPanel
+                {api}
+                connectorId={source.id}
+                {demoMode}
+                title={source.title}
+                fields={connectorFields[source.id]}
+                embedded
+              />{/key}
+          {/if}
+        </SourceCard>
+      {/each}
     </section>
-    {#if selectedConnector}{#key selectedConnector}<ConnectorPanel
-          {api}
-          connectorId={selectedConnector}
-          {demoMode}
-          title={sources.find((s) => s.id === selectedConnector)?.title ??
-            selectedConnector}
-          fields={connectorFields[selectedConnector]}
-        />{/key}{/if}
-    <section class="grid gap-5">
-      <ExchangeRatesPanel {api} /><ClassificationRulesPanel {api} />
+
+    <section
+      class="grid items-start gap-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]"
+    >
+      <div class="grid gap-5">
+        <ExchangeRatesPanel {api} />
+        <aside
+          class="rounded-xl border border-border bg-card p-5 text-card-foreground shadow-xs"
+        >
+          <div class="flex items-start gap-3">
+            <span
+              class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-moss/10 text-moss"
+            >
+              <ShieldCheck class="size-5" />
+            </span>
+            <div>
+              <h2 class="font-semibold">資料安全</h2>
+              <p class="mt-1 text-sm leading-relaxed text-muted-foreground">
+                連接器憑證僅用於個人資料同步，機密欄位會加密保存，且不會重新顯示在設定頁。
+              </p>
+            </div>
+          </div>
+        </aside>
+      </div>
+      <ClassificationRulesPanel {api} />
     </section>
   </div>
 {/if}

--- a/apps/web/src/features/settings/SourceCard.svelte
+++ b/apps/web/src/features/settings/SourceCard.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { Snippet } from "svelte";
+  import { ChartCandlestick, Landmark, ReceiptText } from "@lucide/svelte";
   import { toStore } from "svelte/store";
   import { createQuery } from "@tanstack/svelte-query";
   import Button from "../../components/ui/Button.svelte";
@@ -17,6 +19,7 @@
     selected,
     onConfigure,
     jobs,
+    children,
   }: {
     api: ApiClient;
     id: ConnectorId;
@@ -25,6 +28,7 @@
     selected: boolean;
     onConfigure: () => void;
     jobs?: SyncJobRow[];
+    children?: Snippet;
   } = $props();
   const settings = createQuery(
     toStore(() => connectorSettingsQuery(() => api, id)),
@@ -37,16 +41,43 @@
   const needsAction = $derived(
     job?.lastStatus === "failed" || job?.lastStatus === "needs_user_action",
   );
+  const scheduleLabel = $derived(
+    !job?.enabled
+      ? "關閉"
+      : job.scheduleMode === "inherit"
+        ? "跟隨預設"
+        : job.intervalMinutes === 1440
+          ? `每天 ${job.preferredTime}`
+          : job.intervalMinutes === 10080
+            ? `每週 ${job.preferredTime}`
+            : `每 ${job.intervalMinutes / 60} 小時`,
+  );
+  const SourceIcon = $derived(
+    id === "einvoice"
+      ? ReceiptText
+      : id === "tdcc"
+        ? ChartCandlestick
+        : Landmark,
+  );
 </script>
 
-<Card class={selected ? "ring-2 ring-ring/30" : ""}
+<Card
+  class={`transition duration-200 ${selected ? "sm:col-span-2 lg:col-span-3 2xl:col-span-5 border-steel/50 shadow-md ring-2 ring-steel/15" : "hover:-translate-y-0.5 hover:border-ink/20 hover:shadow-sm"}`}
   ><CardContent class="pt-5"
     ><div class="flex items-start justify-between gap-4">
-      <div class="min-w-0">
-        <h2 class="text-lg font-semibold">{title}</h2>
-        <p class="mt-1 text-sm text-muted-foreground">{description}</p>
+      <div class="flex min-w-0 items-start gap-3">
+        <span
+          class={`flex size-10 shrink-0 items-center justify-center rounded-xl ${selected ? "bg-steel text-white" : "bg-steel/10 text-steel"}`}
+        >
+          <SourceIcon class="size-5" />
+        </span>
+        <div class="min-w-0">
+          <h2 class="font-semibold">{title}</h2>
+          <p class="mt-0.5 text-sm text-muted-foreground">{description}</p>
+        </div>
       </div>
       <Badge
+        class="shrink-0 whitespace-nowrap"
         variant={needsAction
           ? "destructive"
           : $settings.data?.configured
@@ -69,14 +100,20 @@
             : "尚無紀錄"}
         </p>
         <p class="mt-1">
-          排程：{job?.enabled ? `${job.intervalMinutes / 60} 小時` : "關閉"}
+          排程：{scheduleLabel}
         </p>
       </div>
       <Button
         size="sm"
         variant={selected ? "default" : "outline"}
-        onclick={onConfigure}>{selected ? "收合設定" : "設定"}</Button
+        aria-expanded={selected}
+        onclick={onConfigure}>{selected ? "收合" : "管理設定"}</Button
       >
-    </div></CardContent
+    </div>
+    {#if selected && children}
+      <div class="mt-5 border-t border-border pt-5">
+        {@render children()}
+      </div>
+    {/if}</CardContent
   ></Card
 >

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -60,6 +60,7 @@ export const queryKeys = {
   exchangeRates: ["exchange-rates"] as const,
   netWorthHistory: ["netWorthHistory"] as const,
   syncJobs: ["sync-jobs"] as const,
+  syncSchedule: ["sync-schedule"] as const,
   classificationRules: ["classification-rules"] as const,
   connectorSettings: (id: string) => ["connector-settings", id] as const,
   manualAssetHistory: (id: string) => ["manualAssetHistory", id] as const,

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -14,6 +14,7 @@ import type {
   ManualAssetRow,
   NetWorthHistoryRow,
   SyncJobRow,
+  SyncScheduleSettings,
 } from "./types";
 
 type ApiProvider = () => ApiClient;
@@ -84,6 +85,12 @@ export const syncJobsQuery = (getApi: ApiProvider) =>
   queryOptions({
     queryKey: queryKeys.syncJobs,
     queryFn: () => getApi().get<SyncJobRow[]>("/api/sync-jobs"),
+  });
+
+export const syncScheduleQuery = (getApi: ApiProvider) =>
+  queryOptions({
+    queryKey: queryKeys.syncSchedule,
+    queryFn: () => getApi().get<SyncScheduleSettings>("/api/sync-schedule"),
   });
 
 export const classificationRulesQuery = (getApi: ApiProvider) =>

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -182,6 +182,8 @@ export interface SyncJobRow {
   enabled: boolean;
   intervalMinutes: number;
   nextRunAt: string;
+  scheduleMode: "inherit" | "custom";
+  preferredTime: string;
   lockedUntil: string | null;
   lockedBy: string | null;
   lockTrigger: "manual" | "scheduled" | null;
@@ -192,6 +194,12 @@ export interface SyncJobRow {
   lastError: string | null;
   updatedAt: string;
   running: boolean;
+}
+export interface SyncScheduleSettings {
+  intervalMinutes: number;
+  preferredTime: string;
+  timezone: "Asia/Taipei";
+  updatedAt: string;
 }
 export type ApiError = ApiErrorResponse;
 export interface RuntimeInfo {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -39,9 +39,11 @@ import {
   getConnectorSettings,
   markManualSyncFailure,
   markManualSyncSuccess,
+  nextSyncRunAt,
   releaseSyncJobLock,
   renewSyncJobLock,
   type SyncJobRow,
+  type SyncScheduleMode,
   type SyncStatus,
   type SyncTrigger,
   upsertConnectorSettings
@@ -111,6 +113,16 @@ const settingsBodySchema = z.object({
   config: z.record(z.string(), z.unknown())
 });
 
+const syncIntervalSchema = z.number().int().refine(
+  (value) => [60, 360, 720, 1440, 10080].includes(value),
+  "Unsupported sync interval."
+);
+const preferredTimeSchema = z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/);
+const syncScheduleUpdateSchema = z.object({
+  intervalMinutes: syncIntervalSchema,
+  preferredTime: preferredTimeSchema
+});
+
 const PUBLIC_FIELDS: Record<string, string[]> = {
   esun: ["lookbackMonths"],
   cathaybk: ["lookbackMonths"],
@@ -139,8 +151,13 @@ const bankHistoryRebuildBodySchema = z.object({
 const syncJobUpdateSchema = z.object({
   enabled: z.boolean().optional(),
   nextRunAt: z.string().datetime().optional(),
-  intervalMinutes: z.number().int().min(10).optional()
-}).refine(d => d.enabled !== undefined || d.nextRunAt !== undefined || d.intervalMinutes !== undefined);
+  intervalMinutes: syncIntervalSchema.optional(),
+  preferredTime: preferredTimeSchema.optional(),
+  scheduleMode: z.enum(["inherit", "custom"]).optional()
+}).refine(
+  data => Object.values(data).some(value => value !== undefined),
+  "At least one sync job setting is required."
+);
 const scheduledSyncScopeSchema = z.literal("all");
 
 function requireAccessSecrets(env: Env): asserts env is Env & { TEAM_DOMAIN: string } {
@@ -155,6 +172,27 @@ function configEncryptionKey(env: Env) {
   }
 
   return env.CONFIG_ENCRYPTION_KEY;
+}
+
+type DefaultSyncSchedule = {
+  intervalMinutes: number;
+  preferredTime: string;
+  timezone: "Asia/Taipei";
+  updatedAt: string;
+};
+
+async function getDefaultSyncSchedule(db: D1Database) {
+  const schedule = await db.prepare(
+    `SELECT
+       interval_minutes AS intervalMinutes,
+       preferred_time AS preferredTime,
+       timezone,
+       updated_at AS updatedAt
+     FROM sync_schedule_settings
+     WHERE id = 'default'`
+  ).first<DefaultSyncSchedule>();
+  if (!schedule) throw new Error("Default sync schedule is not configured.");
+  return schedule;
 }
 
 api.use("*", async (c, next) => {
@@ -595,6 +633,63 @@ api.put("/connectors/:connectorId/settings", async (c) => {
   });
 });
 
+api.get("/sync-schedule", async (c) => {
+  return c.json(await getDefaultSyncSchedule(c.env.DB));
+});
+
+api.put("/sync-schedule", async (c) => {
+  const body = syncScheduleUpdateSchema.safeParse(await c.req.json().catch(() => null));
+  if (!body.success) {
+    return jsonError(
+      "INVALID_REQUEST_BODY",
+      "Sync schedule requires a supported interval and HH:mm time."
+    );
+  }
+
+  const now = new Date();
+  const inheritedJobs = await c.env.DB.prepare(
+    `SELECT id, next_run_at AS nextRunAt
+     FROM sync_jobs
+     WHERE schedule_mode = 'inherit'`
+  ).all<{ id: string; nextRunAt: string }>();
+  const statements: D1PreparedStatement[] = [
+    c.env.DB.prepare(
+      `INSERT INTO sync_schedule_settings (
+         id, interval_minutes, preferred_time, timezone, updated_at
+       ) VALUES ('default', ?, ?, 'Asia/Taipei', ?)
+       ON CONFLICT(id) DO UPDATE SET
+         interval_minutes = excluded.interval_minutes,
+         preferred_time = excluded.preferred_time,
+         timezone = excluded.timezone,
+         updated_at = excluded.updated_at`
+    ).bind(body.data.intervalMinutes, body.data.preferredTime, now.toISOString())
+  ];
+
+  for (const job of inheritedJobs.results) {
+    statements.push(
+      c.env.DB.prepare(
+        `UPDATE sync_jobs
+         SET interval_minutes = ?, preferred_time = ?, next_run_at = ?, updated_at = ?
+         WHERE id = ?`
+      ).bind(
+        body.data.intervalMinutes,
+        body.data.preferredTime,
+        nextSyncRunAt(body.data.intervalMinutes, body.data.preferredTime, now, job.nextRunAt),
+        now.toISOString(),
+        job.id
+      )
+    );
+  }
+
+  await c.env.DB.batch(statements);
+  return c.json({
+    intervalMinutes: body.data.intervalMinutes,
+    preferredTime: body.data.preferredTime,
+    timezone: "Asia/Taipei",
+    updatedAt: now.toISOString()
+  } satisfies DefaultSyncSchedule);
+});
+
 api.get("/sync-jobs", async (c) => {
   const rows = await c.env.DB.prepare(
     `SELECT
@@ -604,6 +699,8 @@ api.get("/sync-jobs", async (c) => {
        enabled,
        interval_minutes AS intervalMinutes,
        next_run_at AS nextRunAt,
+       schedule_mode AS scheduleMode,
+       preferred_time AS preferredTime,
        locked_until AS lockedUntil,
        locked_by AS lockedBy,
        lock_trigger AS lockTrigger,
@@ -622,6 +719,8 @@ api.get("/sync-jobs", async (c) => {
     enabled: number;
     intervalMinutes: number;
     nextRunAt: string;
+    scheduleMode: SyncScheduleMode;
+    preferredTime: string;
     lockedUntil: string | null;
     lockedBy: string | null;
     lockTrigger: SyncTrigger | null;
@@ -653,23 +752,51 @@ api.patch("/sync-jobs/:connectorId/:scope", async (c) => {
   const scope = scopeResult.data;
   const body = syncJobUpdateSchema.safeParse(await c.req.json().catch(() => null));
   if (!body.success) {
-    return jsonError("INVALID_REQUEST_BODY", "Request body must include an enabled boolean.");
+    return jsonError("INVALID_REQUEST_BODY", "Request body must include a valid sync job setting.");
   }
 
-  const now = new Date().toISOString();
+  const job = await c.env.DB.prepare(
+    "SELECT * FROM sync_jobs WHERE connector_id = ? AND scope = ?"
+  ).bind(connectorId, scope).first<SyncJobRow<ConnectorId>>();
+  if (!job) {
+    return jsonError("SYNC_JOB_NOT_FOUND", "Sync job is not configured.", 404);
+  }
+
+  const now = new Date();
+  const scheduleMode = body.data.scheduleMode ?? job.schedule_mode;
+  const defaultSchedule = scheduleMode === "inherit"
+    ? await getDefaultSyncSchedule(c.env.DB)
+    : null;
+  const intervalMinutes = defaultSchedule?.intervalMinutes
+    ?? body.data.intervalMinutes
+    ?? job.interval_minutes;
+  const preferredTime = defaultSchedule?.preferredTime
+    ?? body.data.preferredTime
+    ?? job.preferred_time;
+  const scheduleChanged = body.data.scheduleMode !== undefined
+    || body.data.intervalMinutes !== undefined
+    || body.data.preferredTime !== undefined;
+  const nextRunAt = body.data.nextRunAt
+    ?? (scheduleChanged || body.data.enabled === true
+      ? nextSyncRunAt(intervalMinutes, preferredTime, now, job.next_run_at)
+      : job.next_run_at);
   const result = await c.env.DB.prepare(
     `UPDATE sync_jobs
      SET enabled = COALESCE(?, enabled),
-         next_run_at = COALESCE(?, next_run_at),
-         interval_minutes = COALESCE(?, interval_minutes),
+         next_run_at = ?,
+         interval_minutes = ?,
+         schedule_mode = ?,
+         preferred_time = ?,
          updated_at = ?
      WHERE connector_id = ?
        AND scope = ?`
   ).bind(
     body.data.enabled !== undefined ? (body.data.enabled ? 1 : 0) : null,
-    body.data.nextRunAt ?? null,
-    body.data.intervalMinutes ?? null,
-    now,
+    nextRunAt,
+    intervalMinutes,
+    scheduleMode,
+    preferredTime,
+    now.toISOString(),
     connectorId,
     scope
   ).run();
@@ -682,7 +809,11 @@ api.patch("/sync-jobs/:connectorId/:scope", async (c) => {
     success: true,
     connectorId,
     scope,
-    enabled: body.data.enabled
+    enabled: body.data.enabled ?? Boolean(job.enabled),
+    intervalMinutes,
+    preferredTime,
+    scheduleMode,
+    nextRunAt
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@lucide/svelte": "^1.24.0",
         "@taiwan-fin-hub/core": "0.1.0",
         "@tanstack/svelte-query": "^5.90.2",
+        "bits-ui": "^2.18.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "layerchart": "^2.0.1",
@@ -1521,6 +1522,16 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2027,6 +2038,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -2930,6 +2951,30 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bits-ui": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-2.18.1.tgz",
+      "integrity": "sha512-KkemzKFH4T3gt3H+P86JcnAWExjByv/6vlwjm/BoCwTPHu03yiCdxbghdJLvFReQTe0acCAiRcKfmixxD6XvlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.1",
+        "@floating-ui/dom": "^1.7.1",
+        "esm-env": "^1.1.2",
+        "runed": "^0.35.1",
+        "svelte-toolbelt": "^0.10.6",
+        "tabbable": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/huntabyte"
+      },
+      "peerDependencies": {
+        "@internationalized/date": "^3.8.1",
+        "svelte": "^5.33.0"
       }
     },
     "node_modules/blake3-wasm": {
@@ -3965,6 +4010,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -4969,6 +5020,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/runed": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/runed/-/runed-0.35.1.tgz",
+      "integrity": "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==",
+      "funding": [
+        "https://github.com/sponsors/huntabyte",
+        "https://github.com/sponsors/tglide"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "esm-env": "^1.0.0",
+        "lz-string": "^1.5.0"
+      },
+      "peerDependencies": {
+        "@sveltejs/kit": "^2.21.0",
+        "svelte": "^5.7.0"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
@@ -5194,6 +5269,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -5259,11 +5343,37 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/svelte-toolbelt": {
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/svelte-toolbelt/-/svelte-toolbelt-0.10.6.tgz",
+      "integrity": "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==",
+      "funding": [
+        "https://github.com/sponsors/huntabyte"
+      ],
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "runed": "^0.35.1",
+        "style-to-object": "^1.0.8"
+      },
+      "engines": {
+        "node": ">=18",
+        "pnpm": ">=8.7.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.30.2"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
@@ -6046,7 +6156,8 @@
       "name": "@taiwan-fin-hub/db",
       "version": "0.1.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20240620.0"
+        "@cloudflare/workers-types": "^4.20240620.0",
+        "vitest": "^4.1.10"
       }
     }
   }

--- a/packages/db/migrations/0008_default_sync_schedule.sql
+++ b/packages/db/migrations/0008_default_sync_schedule.sql
@@ -1,0 +1,33 @@
+ALTER TABLE sync_jobs
+  ADD COLUMN schedule_mode TEXT NOT NULL DEFAULT 'inherit'
+  CHECK (schedule_mode IN ('inherit', 'custom'));
+
+ALTER TABLE sync_jobs
+  ADD COLUMN preferred_time TEXT NOT NULL DEFAULT '06:00';
+
+-- Preserve every existing user's current schedule during the upgrade.
+UPDATE sync_jobs
+SET schedule_mode = 'custom',
+    preferred_time = strftime('%H:%M', datetime(next_run_at, '+8 hours'));
+
+CREATE TABLE IF NOT EXISTS sync_schedule_settings (
+  id TEXT PRIMARY KEY CHECK (id = 'default'),
+  interval_minutes INTEGER NOT NULL,
+  preferred_time TEXT NOT NULL,
+  timezone TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO sync_schedule_settings (
+  id,
+  interval_minutes,
+  preferred_time,
+  timezone,
+  updated_at
+) VALUES (
+  'default',
+  1440,
+  '06:00',
+  'Asia/Taipei',
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+);

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,9 +8,11 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "tsc -p tsconfig.json",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20240620.0"
+    "@cloudflare/workers-types": "^4.20240620.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -83,7 +83,8 @@ export {
   findNextDueSyncJob,
   markManualSyncFailure,
   markManualSyncSuccess,
+  nextSyncRunAt,
   releaseSyncJobLock,
   renewSyncJobLock
 } from "./sync-jobs";
-export type { SyncJobRow, SyncStatus, SyncTrigger } from "./sync-jobs";
+export type { SyncJobRow, SyncScheduleMode, SyncStatus, SyncTrigger } from "./sync-jobs";

--- a/packages/db/src/sync-jobs.test.ts
+++ b/packages/db/src/sync-jobs.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { nextSyncRunAt } from "./sync-jobs";
+
+describe("nextSyncRunAt", () => {
+  it("keeps a daily schedule anchored to Asia/Taipei time", () => {
+    expect(
+      nextSyncRunAt(
+        1440,
+        "06:50",
+        new Date("2026-07-17T00:05:00.000Z"),
+        "2026-07-16T22:50:00.000Z",
+      ),
+    ).toBe("2026-07-17T22:50:00.000Z");
+  });
+
+  it("does not postpone an already-future anchored run after manual sync", () => {
+    expect(
+      nextSyncRunAt(
+        1440,
+        "06:50",
+        new Date("2026-07-17T07:00:00.000Z"),
+        "2026-07-17T22:50:00.000Z",
+      ),
+    ).toBe("2026-07-17T22:50:00.000Z");
+  });
+
+  it("uses rolling intervals for sub-daily schedules", () => {
+    expect(
+      nextSyncRunAt(360, "06:50", new Date("2026-07-17T00:00:00.000Z")),
+    ).toBe("2026-07-17T06:00:00.000Z");
+  });
+});

--- a/packages/db/src/sync-jobs.ts
+++ b/packages/db/src/sync-jobs.ts
@@ -1,5 +1,6 @@
 export type SyncTrigger = "manual" | "scheduled";
 export type SyncStatus = "success" | "failed" | "needs_user_action";
+export type SyncScheduleMode = "inherit" | "custom";
 
 export interface SyncJobRow<TConnectorId extends string = string> {
   id: string;
@@ -8,6 +9,8 @@ export interface SyncJobRow<TConnectorId extends string = string> {
   enabled: number;
   interval_minutes: number;
   next_run_at: string;
+  schedule_mode: SyncScheduleMode;
+  preferred_time: string;
   locked_until: string | null;
   locked_by: string | null;
   lock_trigger: SyncTrigger | null;
@@ -18,6 +21,41 @@ export interface SyncJobRow<TConnectorId extends string = string> {
   last_error: string | null;
   created_at: string;
   updated_at: string;
+}
+
+const TAIPEI_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+export function nextSyncRunAt(
+  intervalMinutes: number,
+  preferredTime: string,
+  now = new Date(),
+  anchor?: string
+) {
+  if (intervalMinutes < 1440) {
+    return new Date(now.getTime() + intervalMinutes * 60_000).toISOString();
+  }
+
+  const match = /^(\d{2}):(\d{2})$/.exec(preferredTime);
+  if (!match) return new Date(now.getTime() + intervalMinutes * 60_000).toISOString();
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (hours > 23 || minutes > 59) {
+    return new Date(now.getTime() + intervalMinutes * 60_000).toISOString();
+  }
+
+  const anchorDate = anchor ? new Date(anchor) : now;
+  const safeAnchor = Number.isNaN(anchorDate.getTime()) ? now : anchorDate;
+  const taipeiAnchor = new Date(safeAnchor.getTime() + TAIPEI_OFFSET_MS);
+  let candidate = Date.UTC(
+    taipeiAnchor.getUTCFullYear(),
+    taipeiAnchor.getUTCMonth(),
+    taipeiAnchor.getUTCDate(),
+    hours,
+    minutes
+  ) - TAIPEI_OFFSET_MS;
+  const intervalMs = intervalMinutes * 60_000;
+  while (candidate <= now.getTime()) candidate += intervalMs;
+  return new Date(candidate).toISOString();
 }
 
 export async function findNextDueSyncJob<TConnectorId extends string>(db: D1Database, now = new Date()) {
@@ -98,7 +136,7 @@ export async function releaseSyncJobLock(db: D1Database, lockRowId: string, runI
 
 export async function completeSyncJob(db: D1Database, job: SyncJobRow) {
   const now = new Date();
-  const nextRunAt = new Date(now.getTime() + job.interval_minutes * 60_000).toISOString();
+  const nextRunAt = nextSyncRunAt(job.interval_minutes, job.preferred_time, now, job.next_run_at);
   await db.prepare(
     `UPDATE sync_jobs
      SET last_status = 'success',
@@ -118,7 +156,7 @@ export async function failSyncJob(
 ) {
   const now = new Date();
   const nextRunAt = input.status === "failed"
-    ? new Date(now.getTime() + job.interval_minutes * 60_000).toISOString()
+    ? nextSyncRunAt(job.interval_minutes, job.preferred_time, now, job.next_run_at)
     : job.next_run_at;
   await db.prepare(
     `UPDATE sync_jobs
@@ -150,7 +188,7 @@ export async function markManualSyncSuccess(
   if (!job) return;
 
   const now = new Date();
-  const nextRunAt = new Date(now.getTime() + job.interval_minutes * 60_000).toISOString();
+  const nextRunAt = nextSyncRunAt(job.interval_minutes, job.preferred_time, now, job.next_run_at);
   await db.prepare(
     `UPDATE sync_jobs
      SET last_status = 'success',


### PR DESCRIPTION
## 變更摘要

- 重整設定頁資訊架構，讓連接器可直接在卡片內展開與管理
- 修正電子發票欄位名稱為「手機號碼（電子發票帳號）」與「電子發票 App 登入密碼」
- 已儲存的敏感欄位改顯示「已儲存」，避免有資料卻看似空白
- 新增全域預設同步排程；每個連接器可選擇跟隨預設或使用自己的排程
- 將原生時間輸入改為 shadcn 組合式 Time Picker（Popover + Button + 小時／分鐘 Select）
- 新增 `/api/sync-schedule` 與 sync job 排程覆寫欄位
- 新增 D1 migration `0008_default_sync_schedule.sql`，既有 job 會保留為自訂排程，新 job 預設跟隨共通排程

## 資料流

設定頁透過 `/api/sync-schedule` 讀寫共通排程，並透過 `/api/sync-jobs/:id` 設定連接器為 `inherit` 或 `custom`。排程時間以 `Asia/Taipei` 為基準；每日／每週排程固定錨定選定時間，短週期排程則從上次完成後重新計時。

## Migration／部署注意事項

> 本 PR 建立與審查期間不得手動套用遠端 D1 migration。

- 必須先將本 PR 合併進 `main`
- 合併後切到最新 `main`，再執行 `npm run deploy`
- 現有 deploy script 會先執行 `npm run db:migrate:remote`，成功後才部署 Worker
- 目前 GitHub Actions 僅執行 CI，沒有 merge 後自動部署；因此上述部署步驟仍需由合併後的 main 明確執行
- 遠端目前尚未套用本 PR 的 `0008`

## 驗證

- [x] 全 workspace typecheck：0 errors / 0 warnings
- [x] DB tests：3 passed
- [x] Worker tests：24 passed
- [x] Web unit tests：15 passed
- [x] Web E2E：其餘 4 項通過；Time Picker 設定頁案例修正後單獨重跑 1 passed
- [x] Web、Worker、Connectors、Core、DB build 通過
- [x] `git diff --check` 通過

## 合併後檢查

- [ ] 從最新 `main` 執行 `npm run deploy`
- [ ] 確認遠端 D1 migration 清單包含 `0008_default_sync_schedule.sql`
- [ ] 確認 `/api/sync-schedule` 與設定頁正常回應
