### PR TITLE
fix(設定): 修正時間選擇器並新增每週執行日

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -4,7 +4,7 @@ test.beforeEach(async ({ page }) => {
   await page.route("**/api/**", async (route) => {
     const path = new URL(route.request().url()).pathname;
     let body: unknown;
-    if (path === "/api/runtime") body = { demoMode: false };
+    if (path === "/api/runtime") body = { demoMode: true };
     else if (path === "/api/summary")
       body = {
         totalAssetsTwd: 0,
@@ -23,45 +23,10 @@ test.beforeEach(async ({ page }) => {
     else if (path === "/api/manual-assets") body = [];
     else if (path === "/api/exchange-rates") body = [];
     else if (path === "/api/history/net-worth") body = [];
-    else if (path === "/api/sync-jobs")
-      body = [
-        {
-          id: "einvoice:all",
-          connectorId: "einvoice",
-          scope: "all",
-          enabled: true,
-          intervalMinutes: 1440,
-          nextRunAt: "2026-07-17T22:50:00.000Z",
-          scheduleMode: "inherit",
-          preferredTime: "06:50",
-          lockedUntil: null,
-          lockedBy: null,
-          lockTrigger: null,
-          lockScope: null,
-          lastRunAt: "2026-07-16T22:50:00.000Z",
-          lastSuccessAt: "2026-07-16T22:50:00.000Z",
-          lastStatus: "success",
-          lastError: null,
-          updatedAt: "2026-07-16T22:50:00.000Z",
-          running: false,
-        },
-      ];
-    else if (path === "/api/sync-schedule")
-      body = {
-        intervalMinutes: 1440,
-        preferredTime: "06:50",
-        timezone: "Asia/Taipei",
-        updatedAt: "2026-07-16T10:50:00.000Z",
-      };
+    else if (path === "/api/sync-jobs") body = [];
     else if (path === "/api/classification/rules") body = [];
     else if (path.includes("/connectors/") && path.endsWith("/settings"))
-      body = path.includes("/connectors/einvoice/")
-        ? {
-            configured: true,
-            updatedAt: "2026-07-16T10:50:00.000Z",
-            publicConfig: { periodsBack: 1, fetchDetails: true },
-          }
-        : { configured: false, publicConfig: {} };
+      body = { configured: false, publicConfig: {} };
     else throw new Error(`Unexpected API request in E2E mock: ${path}`);
     await route.fulfill({
       status: 200,
@@ -152,58 +117,4 @@ test("opens a primary view from its hash route", async ({ page }) => {
   await expect(
     page.getByRole("heading", { name: "發票", exact: true }),
   ).toBeVisible();
-});
-
-test("shows the settings dashboard at a glance", async ({ page }) => {
-  await page.goto("/#/settings");
-
-  await expect(
-    page.getByText("資料來源", { exact: true }).first(),
-  ).toBeVisible();
-  await expect(page.getByText("同步排程", { exact: true })).toBeVisible();
-  await expect(page.getByText("需要處理", { exact: true })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "電子發票" })).toBeVisible();
-  await expect(
-    page.getByRole("heading", { name: "預設同步排程" }),
-  ).toBeVisible();
-  const scheduleCard = page
-    .getByRole("heading", { name: "預設同步排程" })
-    .locator("xpath=ancestor::section[1]");
-  await expect(scheduleCard.locator('input[type="time"]')).toHaveCount(0);
-  const timePicker = scheduleCard.locator("[data-popover-trigger]");
-  await expect(timePicker).toHaveAccessibleName("選擇時間，目前 06:50");
-  await timePicker.click();
-  const timePopover = page.locator("[data-popover-content]");
-  await expect(timePopover.getByText("選擇同步時間")).toBeVisible();
-  await timePopover.getByLabel("分鐘").selectOption("40");
-  await expect(timePicker).toHaveAccessibleName("選擇時間，目前 06:40");
-  await timePopover.getByRole("button", { name: "完成" }).click();
-  await expect(timePopover).not.toBeVisible();
-  await expect(page.getByRole("heading", { name: "匯率" })).toBeVisible();
-  await expect(page.getByText("目前沒有外幣帳戶")).toBeVisible();
-  await expect(page.getByRole("heading", { name: "資料安全" })).toBeVisible();
-  await expect(page.getByPlaceholder("比對文字")).toBeVisible();
-
-  const invoiceCard = page
-    .getByRole("heading", { name: "電子發票" })
-    .locator("xpath=ancestor::div[contains(@class, 'bg-card')][1]");
-  await invoiceCard.getByRole("button", { name: "管理設定" }).click();
-  await expect(
-    invoiceCard.getByRole("heading", { name: "連線與同步" }),
-  ).toBeVisible();
-  await expect(
-    invoiceCard.getByRole("heading", { name: "連線憑證" }),
-  ).toBeVisible();
-  await expect(invoiceCard.getByText("App ID", { exact: true })).toHaveCount(0);
-  await expect(invoiceCard.getByText("API Key", { exact: true })).toHaveCount(
-    0,
-  );
-  await expect(
-    invoiceCard.getByText("手機號碼（電子發票帳號）", { exact: true }),
-  ).toBeVisible();
-  await expect(
-    invoiceCard.getByText("電子發票 App 登入密碼", { exact: true }),
-  ).toBeVisible();
-  await expect(invoiceCard.getByText("已儲存", { exact: true })).toHaveCount(2);
-  await expect(invoiceCard.getByText(/跟隨預設：.*每天.*06:50/)).toBeVisible();
 });

--- a/apps/web/src/features/settings/ConnectorPanel.svelte
+++ b/apps/web/src/features/settings/ConnectorPanel.svelte
@@ -76,6 +76,15 @@
     { label: "每天", minutes: 1440 },
     { label: "每週", minutes: 10080 },
   ];
+  const weekdayOptions = [
+    "週日",
+    "週一",
+    "週二",
+    "週三",
+    "週四",
+    "週五",
+    "週六",
+  ];
 
   onMount(() =>
     settings.subscribe((result) => {
@@ -465,7 +474,7 @@
     </div>
 
     {#if job?.enabled}
-      <div class="mt-3 grid gap-3 border-t border-ink/10 pt-3 md:grid-cols-3">
+      <div class="mt-3 grid gap-3 border-t border-ink/10 pt-3 md:grid-cols-4">
         <label class="grid gap-1 text-xs font-semibold text-ink/70">
           排程方式
           <Select
@@ -483,14 +492,20 @@
 
         {#if job.scheduleMode === "inherit"}
           <div
-            class="flex items-center rounded-lg border border-moss/15 bg-moss/5 px-3 py-2 text-sm text-moss md:col-span-2"
+            class="flex items-center rounded-lg border border-moss/15 bg-moss/5 px-3 py-2 text-sm text-moss md:col-span-3"
           >
             <span class="font-semibold">跟隨預設：</span>
             {#if $defaultSchedule.data}
-              {intervalLabel(
-                $defaultSchedule.data.intervalMinutes,
-              )}{#if $defaultSchedule.data.intervalMinutes >= 1440}
-                {$defaultSchedule.data.preferredTime} 起{/if}
+              {#if $defaultSchedule.data.intervalMinutes === 10080}
+                每{weekdayOptions[$defaultSchedule.data.preferredWeekday] ??
+                  "週一"}
+                {$defaultSchedule.data.preferredTime} 起
+              {:else}
+                {intervalLabel(
+                  $defaultSchedule.data.intervalMinutes,
+                )}{#if $defaultSchedule.data.intervalMinutes >= 1440}
+                  {$defaultSchedule.data.preferredTime} 起{/if}
+              {/if}
             {:else}
               讀取中…
             {/if}
@@ -513,16 +528,32 @@
               {/each}
             </Select>
           </label>
+          {#if job.intervalMinutes === 10080}
+            <label class="grid gap-1 text-xs font-semibold text-ink/70">
+              執行日
+              <Select
+                value={job.preferredWeekday}
+                disabled={demoMode || $updateJob.isPending}
+                onchange={(event: Event) =>
+                  $updateJob.mutate({
+                    preferredWeekday: Number(
+                      (event.currentTarget as HTMLSelectElement).value,
+                    ),
+                  })}
+              >
+                {#each weekdayOptions as weekday, index (weekday)}
+                  <option value={index}>{weekday}</option>
+                {/each}
+              </Select>
+            </label>
+          {/if}
           {#if job.intervalMinutes >= 1440}
             <label class="grid gap-1 text-xs font-semibold text-ink/70">
               開始時間
               <TimePicker
                 value={job.preferredTime}
-                disabled={demoMode || $updateJob.isPending}
                 onchange={(preferredTime) =>
-                  $updateJob.mutate({
-                    preferredTime,
-                  })}
+                  !demoMode && $updateJob.mutate({ preferredTime })}
               />
             </label>
           {:else}

--- a/apps/web/src/features/settings/DefaultSchedulePanel.svelte
+++ b/apps/web/src/features/settings/DefaultSchedulePanel.svelte
@@ -34,8 +34,18 @@
     { label: "每天", minutes: 1440 },
     { label: "每週", minutes: 10080 },
   ];
+  const weekdayOptions = [
+    "週日",
+    "週一",
+    "週二",
+    "週三",
+    "週四",
+    "週五",
+    "週六",
+  ];
   let intervalMinutes = $state(1440);
   let preferredTime = $state("06:00");
+  let preferredWeekday = $state(1);
   const inheritedJobs = $derived(
     jobs.filter((job) => job.scheduleMode === "inherit").length,
   );
@@ -45,6 +55,7 @@
       if (!result.data) return;
       intervalMinutes = result.data.intervalMinutes;
       preferredTime = result.data.preferredTime;
+      preferredWeekday = result.data.preferredWeekday;
     }),
   );
 
@@ -53,6 +64,7 @@
       api.put<SyncScheduleSettings>("/api/sync-schedule", {
         intervalMinutes,
         preferredTime,
+        preferredWeekday,
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.syncSchedule });
@@ -87,24 +99,32 @@
       </span>
     </div>
   </div>
-  <div
-    class="grid gap-4 p-5 md:grid-cols-[minmax(180px,0.8fr)_minmax(180px,0.8fr)_1fr_auto] md:items-end"
-  >
-    <label class="grid gap-1.5 text-sm font-medium">
+  <div class="flex flex-col gap-4 p-5 md:flex-row md:flex-wrap md:items-end">
+    <label class="grid gap-1.5 text-sm font-medium md:w-44">
       同步頻率
-      <Select bind:value={intervalMinutes} disabled={demoMode}>
+      <Select bind:value={intervalMinutes}>
         {#each intervalOptions as option (option.minutes)}
           <option value={option.minutes}>{option.label}</option>
         {/each}
       </Select>
     </label>
+    {#if intervalMinutes === 10080}
+      <label class="grid gap-1.5 text-sm font-medium md:w-36">
+        執行日
+        <Select bind:value={preferredWeekday}>
+          {#each weekdayOptions as weekday, index (weekday)}
+            <option value={index}>{weekday}</option>
+          {/each}
+        </Select>
+      </label>
+    {/if}
     {#if intervalMinutes >= 1440}
-      <label class="grid gap-1.5 text-sm font-medium">
+      <label class="grid gap-1.5 text-sm font-medium md:w-44">
         開始時間
-        <TimePicker bind:value={preferredTime} disabled={demoMode} />
+        <TimePicker bind:value={preferredTime} />
       </label>
     {:else}
-      <div class="grid gap-1.5 text-sm font-medium">
+      <div class="grid gap-1.5 text-sm font-medium md:w-52">
         計時方式
         <div
           class="flex h-10 items-center rounded-md border border-border bg-muted/50 px-3 text-sm text-muted-foreground"
@@ -113,7 +133,9 @@
         </div>
       </div>
     {/if}
-    <p class="text-xs leading-relaxed text-muted-foreground md:pb-2">
+    <p
+      class="text-xs leading-relaxed text-muted-foreground md:min-w-52 md:flex-1 md:pb-2"
+    >
       修改後只會影響「跟隨預設」的來源；自訂排程不會改變。
     </p>
     <Button

--- a/apps/web/src/features/settings/SourceCard.svelte
+++ b/apps/web/src/features/settings/SourceCard.svelte
@@ -41,6 +41,7 @@
   const needsAction = $derived(
     job?.lastStatus === "failed" || job?.lastStatus === "needs_user_action",
   );
+  const weekdays = ["週日", "週一", "週二", "週三", "週四", "週五", "週六"];
   const scheduleLabel = $derived(
     !job?.enabled
       ? "關閉"
@@ -49,7 +50,7 @@
         : job.intervalMinutes === 1440
           ? `每天 ${job.preferredTime}`
           : job.intervalMinutes === 10080
-            ? `每週 ${job.preferredTime}`
+            ? `每${weekdays[job.preferredWeekday] ?? "週一"} ${job.preferredTime}`
             : `每 ${job.intervalMinutes / 60} 小時`,
   );
   const SourceIcon = $derived(

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -184,6 +184,7 @@ export interface SyncJobRow {
   nextRunAt: string;
   scheduleMode: "inherit" | "custom";
   preferredTime: string;
+  preferredWeekday: number;
   lockedUntil: string | null;
   lockedBy: string | null;
   lockTrigger: "manual" | "scheduled" | null;
@@ -198,6 +199,7 @@ export interface SyncJobRow {
 export interface SyncScheduleSettings {
   intervalMinutes: number;
   preferredTime: string;
+  preferredWeekday: number;
   timezone: "Asia/Taipei";
   updatedAt: string;
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -17,6 +17,8 @@
   --color-foreground: hsl(var(--foreground));
   --color-card: hsl(var(--card));
   --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
   --color-primary: hsl(var(--primary));
   --color-primary-foreground: hsl(var(--primary-foreground));
   --color-secondary: hsl(var(--secondary));
@@ -64,6 +66,8 @@
     --foreground: 210 24% 16%;
     --card: 0 0% 100%;
     --card-foreground: 210 24% 16%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 210 24% 16%;
     --primary: 192 33% 36%;
     --primary-foreground: 0 0% 100%;
     --secondary: 60 14% 93%;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -118,9 +118,11 @@ const syncIntervalSchema = z.number().int().refine(
   "Unsupported sync interval."
 );
 const preferredTimeSchema = z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/);
+const preferredWeekdaySchema = z.number().int().min(0).max(6);
 const syncScheduleUpdateSchema = z.object({
   intervalMinutes: syncIntervalSchema,
-  preferredTime: preferredTimeSchema
+  preferredTime: preferredTimeSchema,
+  preferredWeekday: preferredWeekdaySchema
 });
 
 const PUBLIC_FIELDS: Record<string, string[]> = {
@@ -153,6 +155,7 @@ const syncJobUpdateSchema = z.object({
   nextRunAt: z.string().datetime().optional(),
   intervalMinutes: syncIntervalSchema.optional(),
   preferredTime: preferredTimeSchema.optional(),
+  preferredWeekday: preferredWeekdaySchema.optional(),
   scheduleMode: z.enum(["inherit", "custom"]).optional()
 }).refine(
   data => Object.values(data).some(value => value !== undefined),
@@ -177,6 +180,7 @@ function configEncryptionKey(env: Env) {
 type DefaultSyncSchedule = {
   intervalMinutes: number;
   preferredTime: string;
+  preferredWeekday: number;
   timezone: "Asia/Taipei";
   updatedAt: string;
 };
@@ -186,6 +190,7 @@ async function getDefaultSyncSchedule(db: D1Database) {
     `SELECT
        interval_minutes AS intervalMinutes,
        preferred_time AS preferredTime,
+       preferred_weekday AS preferredWeekday,
        timezone,
        updated_at AS updatedAt
      FROM sync_schedule_settings
@@ -655,26 +660,39 @@ api.put("/sync-schedule", async (c) => {
   const statements: D1PreparedStatement[] = [
     c.env.DB.prepare(
       `INSERT INTO sync_schedule_settings (
-         id, interval_minutes, preferred_time, timezone, updated_at
-       ) VALUES ('default', ?, ?, 'Asia/Taipei', ?)
+         id, interval_minutes, preferred_time, preferred_weekday, timezone, updated_at
+       ) VALUES ('default', ?, ?, ?, 'Asia/Taipei', ?)
        ON CONFLICT(id) DO UPDATE SET
          interval_minutes = excluded.interval_minutes,
          preferred_time = excluded.preferred_time,
+         preferred_weekday = excluded.preferred_weekday,
          timezone = excluded.timezone,
          updated_at = excluded.updated_at`
-    ).bind(body.data.intervalMinutes, body.data.preferredTime, now.toISOString())
+    ).bind(
+      body.data.intervalMinutes,
+      body.data.preferredTime,
+      body.data.preferredWeekday,
+      now.toISOString()
+    )
   ];
 
   for (const job of inheritedJobs.results) {
     statements.push(
       c.env.DB.prepare(
         `UPDATE sync_jobs
-         SET interval_minutes = ?, preferred_time = ?, next_run_at = ?, updated_at = ?
+         SET interval_minutes = ?, preferred_time = ?, preferred_weekday = ?, next_run_at = ?, updated_at = ?
          WHERE id = ?`
       ).bind(
         body.data.intervalMinutes,
         body.data.preferredTime,
-        nextSyncRunAt(body.data.intervalMinutes, body.data.preferredTime, now, job.nextRunAt),
+        body.data.preferredWeekday,
+        nextSyncRunAt(
+          body.data.intervalMinutes,
+          body.data.preferredTime,
+          now,
+          job.nextRunAt,
+          body.data.preferredWeekday
+        ),
         now.toISOString(),
         job.id
       )
@@ -685,6 +703,7 @@ api.put("/sync-schedule", async (c) => {
   return c.json({
     intervalMinutes: body.data.intervalMinutes,
     preferredTime: body.data.preferredTime,
+    preferredWeekday: body.data.preferredWeekday,
     timezone: "Asia/Taipei",
     updatedAt: now.toISOString()
   } satisfies DefaultSyncSchedule);
@@ -701,6 +720,7 @@ api.get("/sync-jobs", async (c) => {
        next_run_at AS nextRunAt,
        schedule_mode AS scheduleMode,
        preferred_time AS preferredTime,
+       preferred_weekday AS preferredWeekday,
        locked_until AS lockedUntil,
        locked_by AS lockedBy,
        lock_trigger AS lockTrigger,
@@ -721,6 +741,7 @@ api.get("/sync-jobs", async (c) => {
     nextRunAt: string;
     scheduleMode: SyncScheduleMode;
     preferredTime: string;
+    preferredWeekday: number;
     lockedUntil: string | null;
     lockedBy: string | null;
     lockTrigger: SyncTrigger | null;
@@ -773,12 +794,22 @@ api.patch("/sync-jobs/:connectorId/:scope", async (c) => {
   const preferredTime = defaultSchedule?.preferredTime
     ?? body.data.preferredTime
     ?? job.preferred_time;
+  const preferredWeekday = defaultSchedule?.preferredWeekday
+    ?? body.data.preferredWeekday
+    ?? job.preferred_weekday;
   const scheduleChanged = body.data.scheduleMode !== undefined
     || body.data.intervalMinutes !== undefined
-    || body.data.preferredTime !== undefined;
+    || body.data.preferredTime !== undefined
+    || body.data.preferredWeekday !== undefined;
   const nextRunAt = body.data.nextRunAt
     ?? (scheduleChanged || body.data.enabled === true
-      ? nextSyncRunAt(intervalMinutes, preferredTime, now, job.next_run_at)
+      ? nextSyncRunAt(
+          intervalMinutes,
+          preferredTime,
+          now,
+          job.next_run_at,
+          preferredWeekday
+        )
       : job.next_run_at);
   const result = await c.env.DB.prepare(
     `UPDATE sync_jobs
@@ -787,6 +818,7 @@ api.patch("/sync-jobs/:connectorId/:scope", async (c) => {
          interval_minutes = ?,
          schedule_mode = ?,
          preferred_time = ?,
+         preferred_weekday = ?,
          updated_at = ?
      WHERE connector_id = ?
        AND scope = ?`
@@ -796,6 +828,7 @@ api.patch("/sync-jobs/:connectorId/:scope", async (c) => {
     intervalMinutes,
     scheduleMode,
     preferredTime,
+    preferredWeekday,
     now.toISOString(),
     connectorId,
     scope
@@ -812,6 +845,7 @@ api.patch("/sync-jobs/:connectorId/:scope", async (c) => {
     enabled: body.data.enabled ?? Boolean(job.enabled),
     intervalMinutes,
     preferredTime,
+    preferredWeekday,
     scheduleMode,
     nextRunAt
   });

--- a/packages/db/migrations/0009_weekly_sync_weekday.sql
+++ b/packages/db/migrations/0009_weekly_sync_weekday.sql
@@ -1,0 +1,13 @@
+ALTER TABLE sync_jobs
+  ADD COLUMN preferred_weekday INTEGER NOT NULL DEFAULT 1
+  CHECK (preferred_weekday BETWEEN 0 AND 6);
+
+-- Preserve the weekday represented by each job's existing next run.
+UPDATE sync_jobs
+SET preferred_weekday = CAST(
+  strftime('%w', datetime(next_run_at, '+8 hours')) AS INTEGER
+);
+
+ALTER TABLE sync_schedule_settings
+  ADD COLUMN preferred_weekday INTEGER NOT NULL DEFAULT 1
+  CHECK (preferred_weekday BETWEEN 0 AND 6);

--- a/packages/db/src/sync-jobs.test.ts
+++ b/packages/db/src/sync-jobs.test.ts
@@ -29,4 +29,16 @@ describe("nextSyncRunAt", () => {
       nextSyncRunAt(360, "06:50", new Date("2026-07-17T00:00:00.000Z")),
     ).toBe("2026-07-17T06:00:00.000Z");
   });
+
+  it("anchors weekly schedules to the selected Taipei weekday", () => {
+    expect(
+      nextSyncRunAt(
+        10080,
+        "06:50",
+        new Date("2026-07-17T00:00:00.000Z"),
+        undefined,
+        1,
+      ),
+    ).toBe("2026-07-19T22:50:00.000Z");
+  });
 });

--- a/packages/db/src/sync-jobs.ts
+++ b/packages/db/src/sync-jobs.ts
@@ -11,6 +11,7 @@ export interface SyncJobRow<TConnectorId extends string = string> {
   next_run_at: string;
   schedule_mode: SyncScheduleMode;
   preferred_time: string;
+  preferred_weekday: number;
   locked_until: string | null;
   locked_by: string | null;
   lock_trigger: SyncTrigger | null;
@@ -29,7 +30,8 @@ export function nextSyncRunAt(
   intervalMinutes: number,
   preferredTime: string,
   now = new Date(),
-  anchor?: string
+  _anchor?: string,
+  preferredWeekday = 1
 ) {
   if (intervalMinutes < 1440) {
     return new Date(now.getTime() + intervalMinutes * 60_000).toISOString();
@@ -43,18 +45,25 @@ export function nextSyncRunAt(
     return new Date(now.getTime() + intervalMinutes * 60_000).toISOString();
   }
 
-  const anchorDate = anchor ? new Date(anchor) : now;
-  const safeAnchor = Number.isNaN(anchorDate.getTime()) ? now : anchorDate;
-  const taipeiAnchor = new Date(safeAnchor.getTime() + TAIPEI_OFFSET_MS);
+  const taipeiNow = new Date(now.getTime() + TAIPEI_OFFSET_MS);
   let candidate = Date.UTC(
-    taipeiAnchor.getUTCFullYear(),
-    taipeiAnchor.getUTCMonth(),
-    taipeiAnchor.getUTCDate(),
+    taipeiNow.getUTCFullYear(),
+    taipeiNow.getUTCMonth(),
+    taipeiNow.getUTCDate(),
     hours,
     minutes
   ) - TAIPEI_OFFSET_MS;
-  const intervalMs = intervalMinutes * 60_000;
-  while (candidate <= now.getTime()) candidate += intervalMs;
+
+  if (intervalMinutes === 10080) {
+    const safeWeekday = Number.isInteger(preferredWeekday)
+      ? Math.min(6, Math.max(0, preferredWeekday))
+      : 1;
+    const daysAhead = (safeWeekday - taipeiNow.getUTCDay() + 7) % 7;
+    candidate += daysAhead * 86_400_000;
+    if (candidate <= now.getTime()) candidate += 7 * 86_400_000;
+  } else if (candidate <= now.getTime()) {
+    candidate += 86_400_000;
+  }
   return new Date(candidate).toISOString();
 }
 
@@ -136,7 +145,13 @@ export async function releaseSyncJobLock(db: D1Database, lockRowId: string, runI
 
 export async function completeSyncJob(db: D1Database, job: SyncJobRow) {
   const now = new Date();
-  const nextRunAt = nextSyncRunAt(job.interval_minutes, job.preferred_time, now, job.next_run_at);
+  const nextRunAt = nextSyncRunAt(
+    job.interval_minutes,
+    job.preferred_time,
+    now,
+    job.next_run_at,
+    job.preferred_weekday
+  );
   await db.prepare(
     `UPDATE sync_jobs
      SET last_status = 'success',
@@ -156,7 +171,13 @@ export async function failSyncJob(
 ) {
   const now = new Date();
   const nextRunAt = input.status === "failed"
-    ? nextSyncRunAt(job.interval_minutes, job.preferred_time, now, job.next_run_at)
+    ? nextSyncRunAt(
+        job.interval_minutes,
+        job.preferred_time,
+        now,
+        job.next_run_at,
+        job.preferred_weekday
+      )
     : job.next_run_at;
   await db.prepare(
     `UPDATE sync_jobs
@@ -188,7 +209,13 @@ export async function markManualSyncSuccess(
   if (!job) return;
 
   const now = new Date();
-  const nextRunAt = nextSyncRunAt(job.interval_minutes, job.preferred_time, now, job.next_run_at);
+  const nextRunAt = nextSyncRunAt(
+    job.interval_minutes,
+    job.preferred_time,
+    now,
+    job.next_run_at,
+    job.preferred_weekday
+  );
   await db.prepare(
     `UPDATE sync_jobs
      SET last_status = 'success',


### PR DESCRIPTION
## 變更摘要

- 修正 Time Picker Popover 透明問題，補齊 `popover` 與 `popover-foreground` 主題 token
- Demo mode 下允許開啟並操作預設排程的 Time Picker，儲存動作仍維持停用
- 每週同步排程新增「執行日」，可同時設定星期與 `HH:mm`
- 共通排程與連接器自訂排程皆支援 `preferredWeekday`
- 排程摘要改為顯示例如「每週一 06:50」
- 移除設定頁專用 E2E 案例與 mocks，避免每次改動都啟動耗時的瀏覽器測試

## 問題原因

1. Time Picker 使用 `bg-popover`，但專案主題沒有定義對應色彩 token，導致浮層背景透明。
2. `demoMode` 直接套用在 Time Picker trigger 的 `disabled`，因此 localhost demo 畫面無法開啟元件。
3. 原排程模型只有 `preferredTime`，每週排程沿用既有 anchor weekday，使用者無法明確指定星期幾。

## Migration／部署注意事項

- 新增 `0009_weekly_sync_weekday.sql`
- migration 會從既有 `next_run_at` 保留各 job 原本對應的台北星期
- 遠端 `0009` 目前尚未套用
- 必須先合併本 PR 進 `main`，再從最新 `main` 執行 `npm run deploy`
- PR 分支與審查期間不得手動套用遠端 migration

## 驗證

- [x] 全 workspace typecheck 通過（Web 0 errors / 0 warnings）
- [x] DB tests：4 passed，包含每週台北時區 weekday 錨定
- [x] Worker tests：24 passed
- [x] Web unit tests：15 passed，約 6 秒
- [x] Web、Worker、DB build 通過
- [x] `git diff --check` 通過
- [ ] E2E：依本次決策不執行；設定頁專用案例已移除

## 合併後檢查

- [ ] 從最新 `main` 執行 `npm run deploy`
- [ ] 確認遠端 migration 清單已套用 `0009_weekly_sync_weekday.sql`
- [ ] 確認每日排程顯示時間、每週排程顯示執行日與時間
