### PR TITLE
feat: 完善排除計算的分類瀏覽與規則編輯

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -211,8 +211,17 @@ test("excludes a bank transaction from activity calculations and restores it", a
     page.getByRole("button", { name: "恢復 台新卡費 的統計計算" }),
   ).toBeVisible();
   await expect(expenseSlice).toBeHidden();
+  const excludedExpenseSlice = page.getByRole("button", {
+    name: "其他 0.0% NT$0",
+  });
+  await expect(excludedExpenseSlice).toBeVisible();
+  await excludedExpenseSlice.click();
+  await expect(
+    page.getByRole("button", { name: "恢復 台新卡費 的統計計算" }),
+  ).toBeVisible();
 
   await page.reload();
+  await expect(excludedExpenseSlice).toBeVisible();
   await expect(
     page.getByRole("button", { name: "恢復 台新卡費 的統計計算" }),
   ).toBeVisible();

--- a/apps/web/src/features/activity/Activity.svelte
+++ b/apps/web/src/features/activity/Activity.svelte
@@ -37,6 +37,7 @@
   import {
     buildActivityCategorySlices,
     activityCashAmountTwd,
+    activityCashFlow,
   } from "../../lib/activity-chart";
   import {
     formatCompactTwd,
@@ -227,10 +228,8 @@
   );
   const filtered = $derived(
     rawItems.filter((item) => {
-      const amount = activityCashAmountTwd(item, rateValues);
       const matchesFlow =
-        !selectedCategory ||
-        (selectedCategory.flow === "income" ? amount > 0 : amount < 0);
+        !selectedCategory || activityCashFlow(item) === selectedCategory.flow;
       return (
         (source === "all" || item.source === source) &&
         item.date.startsWith(selectedMonth) &&

--- a/apps/web/src/features/settings/ClassificationRulesPanel.svelte
+++ b/apps/web/src/features/settings/ClassificationRulesPanel.svelte
@@ -4,7 +4,7 @@
     createQuery,
     useQueryClient,
   } from "@tanstack/svelte-query";
-  import { Plus } from "@lucide/svelte";
+  import { Pencil, Plus } from "@lucide/svelte";
   import Card from "../../components/ui/Card.svelte";
   import CardHeader from "../../components/ui/CardHeader.svelte";
   import CardContent from "../../components/ui/CardContent.svelte";
@@ -20,7 +20,19 @@
     classificationCategoriesQuery,
     classificationRulesQuery,
   } from "../../lib/queries";
-  import type { ClassificationCategoryRow } from "../../lib/types";
+  import type {
+    ClassificationCategoryRow,
+    ClassificationRuleRow,
+  } from "../../lib/types";
+
+  type RuleOperator = "contains" | "equals" | "starts_with" | "regex";
+  type EditableRule = {
+    id: string;
+    categoryId: string;
+    pattern: string;
+    operator: RuleOperator;
+    excludedFromCalculation: boolean;
+  };
 
   let { api }: { api: ApiClient } = $props();
 
@@ -46,6 +58,17 @@
   });
   let showCategoryForm = $state(false);
   let categoryName = $state("");
+  let editingRule = $state<EditableRule | undefined>();
+
+  function startEditing(rule: ClassificationRuleRow) {
+    editingRule = {
+      id: rule.id,
+      categoryId: rule.categoryId,
+      pattern: rule.pattern,
+      operator: rule.operator as RuleOperator,
+      excludedFromCalculation: rule.excludedFromCalculation,
+    };
+  }
 
   function invalidateRuleResults() {
     qc.invalidateQueries({ queryKey: queryKeys.classificationRules });
@@ -84,6 +107,19 @@
         enabled: payload.enabled,
       }),
     onSuccess: invalidateRuleResults,
+  });
+  const update = createMutation({
+    mutationFn: (rule: EditableRule) =>
+      api.put(`/api/classification/rules/${rule.id}`, {
+        categoryId: rule.categoryId,
+        pattern: rule.pattern,
+        operator: rule.operator,
+        excludedFromCalculation: rule.excludedFromCalculation,
+      }),
+    onSuccess: () => {
+      invalidateRuleResults();
+      editingRule = undefined;
+    },
   });
   const remove = createMutation({
     mutationFn: (id: string) => api.delete(`/api/classification/rules/${id}`),
@@ -214,54 +250,137 @@
     {:else}
       <div class="divide-y divide-border">
         {#each $rules.data ?? [] as rule (rule.id)}
-          <div class="flex items-start gap-3 py-3.5 text-sm">
-            <Checkbox
-              aria-label={`${rule.enabled ? "停用" : "啟用"}${categoryLabels[rule.categoryId] ?? rule.categoryId}規則`}
-              class="mt-1"
-              checked={rule.enabled}
-              disabled={rule.isSystem}
-              onchange={(event: Event) =>
-                $toggle.mutate({
-                  id: rule.id,
-                  enabled: (event.currentTarget as HTMLInputElement).checked,
-                })}
-            />
-            <div class="min-w-0 flex-1">
-              <div class="flex flex-wrap items-center gap-1.5">
-                <Badge variant="outline">
-                  {categoryLabels[rule.categoryId] ?? rule.categoryId}
-                </Badge>
-                {#if rule.excludedFromCalculation}
-                  <Badge class="border-transparent bg-coral/10 text-coral">
-                    不計入收支
-                  </Badge>
-                {/if}
-                {#if rule.isSystem}
-                  <Badge variant="secondary">內建</Badge>
+          <div class="py-3.5 text-sm">
+            {#if editingRule && editingRule.id === rule.id}
+              <form
+                class="rounded-lg border border-border bg-muted/30 p-4"
+                onsubmit={(event) => {
+                  event.preventDefault();
+                  if (editingRule?.pattern.trim()) $update.mutate(editingRule);
+                }}
+              >
+                <div
+                  class="grid gap-3 md:grid-cols-[minmax(0,140px)_minmax(0,140px)_minmax(0,1fr)]"
+                >
+                  <label class="grid gap-1.5 font-medium">
+                    分類
+                    <Select bind:value={editingRule.categoryId}>
+                      {#each $categories.data ?? [] as category (category.id)}
+                        <option value={category.id}>{category.label}</option>
+                      {/each}
+                    </Select>
+                  </label>
+                  <label class="grid gap-1.5 font-medium">
+                    條件
+                    <Select bind:value={editingRule.operator}>
+                      <option value="contains">包含</option>
+                      <option value="equals">完全等於</option>
+                      <option value="starts_with">開頭為</option>
+                      <option value="regex">符合正規表示式</option>
+                    </Select>
+                  </label>
+                  <label class="grid gap-1.5 font-medium">
+                    關鍵字
+                    <Input bind:value={editingRule.pattern} />
+                  </label>
+                </div>
+                <div
+                  class="mt-4 flex flex-col gap-3 border-t border-border pt-3 sm:flex-row sm:items-center"
+                >
+                  <div class="flex min-w-0 flex-1 items-center gap-3">
+                    <Switch
+                      aria-label="編輯規則是否不計入收支"
+                      bind:checked={editingRule.excludedFromCalculation}
+                    />
+                    <div class="min-w-0">
+                      <p class="font-semibold">符合時不計入收支</p>
+                      <p class="text-xs text-muted-foreground">
+                        仍保留所選分類，只排除圖表與收支加總。
+                      </p>
+                    </div>
+                  </div>
+                  <div class="flex justify-end gap-2">
+                    <Button
+                      variant="ghost"
+                      disabled={$update.isPending}
+                      onclick={() => (editingRule = undefined)}>取消</Button
+                    >
+                    <Button
+                      type="submit"
+                      variant="primary"
+                      disabled={!editingRule.pattern.trim() ||
+                        $update.isPending}
+                    >
+                      {$update.isPending ? "儲存中…" : "儲存變更"}
+                    </Button>
+                  </div>
+                </div>
+              </form>
+            {:else}
+              <div class="flex items-start gap-3">
+                <Checkbox
+                  aria-label={`${rule.enabled ? "停用" : "啟用"}${categoryLabels[rule.categoryId] ?? rule.categoryId}規則`}
+                  class="mt-1"
+                  checked={rule.enabled}
+                  disabled={rule.isSystem}
+                  onchange={(event: Event) =>
+                    $toggle.mutate({
+                      id: rule.id,
+                      enabled: (event.currentTarget as HTMLInputElement)
+                        .checked,
+                    })}
+                />
+                <div class="min-w-0 flex-1">
+                  <div class="flex flex-wrap items-center gap-1.5">
+                    <Badge variant="outline">
+                      {categoryLabels[rule.categoryId] ?? rule.categoryId}
+                    </Badge>
+                    {#if rule.excludedFromCalculation}
+                      <Badge class="border-transparent bg-coral/10 text-coral">
+                        不計入收支
+                      </Badge>
+                    {/if}
+                    {#if rule.isSystem}
+                      <Badge variant="secondary">內建</Badge>
+                    {/if}
+                  </div>
+                  <p class="mt-1.5 break-words text-foreground/80">
+                    {operatorLabels[rule.operator] ??
+                      rule.operator}「{rule.pattern}」
+                  </p>
+                </div>
+                {#if !rule.isSystem}
+                  <div class="flex items-center gap-1">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      disabled={$update.isPending || $remove.isPending}
+                      onclick={() => startEditing(rule)}
+                    >
+                      <Pencil class="size-4" />編輯
+                    </Button>
+                    <Button
+                      class="text-destructive hover:text-destructive"
+                      size="sm"
+                      variant="ghost"
+                      disabled={$remove.isPending &&
+                        $remove.variables === rule.id}
+                      onclick={() => $remove.mutate(rule.id)}>刪除</Button
+                    >
+                  </div>
                 {/if}
               </div>
-              <p class="mt-1.5 break-words text-foreground/80">
-                {operatorLabels[rule.operator] ??
-                  rule.operator}「{rule.pattern}」
-              </p>
-            </div>
-            {#if !rule.isSystem}
-              <Button
-                class="text-destructive hover:text-destructive"
-                size="sm"
-                variant="ghost"
-                disabled={$remove.isPending && $remove.variables === rule.id}
-                onclick={() => $remove.mutate(rule.id)}>刪除</Button
-              >
             {/if}
           </div>
         {/each}
       </div>
     {/if}
 
-    {#if $add.isError || $toggle.isError || $remove.isError}
+    {#if $add.isError || $toggle.isError || $update.isError || $remove.isError}
       <p class="mt-3 text-sm text-destructive" role="alert">
-        {messageFromError($add.error ?? $toggle.error ?? $remove.error)}
+        {messageFromError(
+          $add.error ?? $toggle.error ?? $update.error ?? $remove.error,
+        )}
       </p>
     {/if}
   </CardContent>

--- a/apps/web/src/lib/activity-chart.test.ts
+++ b/apps/web/src/lib/activity-chart.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   activityCashAmountTwd,
+  activityCashFlow,
   buildActivityCategorySlices,
 } from "./activity-chart";
 import type { ActivityItem } from "./types";
@@ -54,10 +55,45 @@ describe("activity category chart", () => {
     expect(slices[0]?.percentage).toBeCloseTo(66.67, 1);
   });
 
-  it("does not count transactions excluded by the user", () => {
+  it("keeps excluded categories selectable without counting their amount", () => {
     const excluded = item({ amount: -500, excludedFromCalculation: true });
 
     expect(activityCashAmountTwd(excluded, {})).toBe(0);
-    expect(buildActivityCategorySlices([excluded], "expense", {})).toEqual([]);
+    expect(activityCashFlow(excluded)).toBe("expense");
+    expect(buildActivityCategorySlices([excluded], "expense", {})).toEqual([
+      {
+        category: "其他",
+        amount: 0,
+        percentage: 0,
+        color: "#3e6f7c",
+      },
+    ]);
+  });
+
+  it("sorts zero-value excluded categories after counted categories", () => {
+    const slices = buildActivityCategorySlices(
+      [
+        item({ amount: -500, category: "餐飲" }),
+        item({
+          id: "2",
+          amount: -300,
+          category: "其他",
+          excludedFromCalculation: true,
+        }),
+      ],
+      "expense",
+      {},
+    );
+
+    expect(
+      slices.map(({ category, amount, percentage }) => ({
+        category,
+        amount,
+        percentage,
+      })),
+    ).toEqual([
+      { category: "餐飲", amount: 500, percentage: 100 },
+      { category: "其他", amount: 0, percentage: 0 },
+    ]);
   });
 });

--- a/apps/web/src/lib/activity-chart.ts
+++ b/apps/web/src/lib/activity-chart.ts
@@ -20,6 +20,15 @@ export const ACTIVITY_CATEGORY_COLORS = [
   "#68747b",
 ];
 
+export function activityCashFlow(item: ActivityItem): ActivityFlow | null {
+  if (item.amount == null || (item.source !== "bank" && item.source !== "card"))
+    return null;
+  if (item.source === "card") return "expense";
+  if (item.amount > 0) return "income";
+  if (item.amount < 0) return "expense";
+  return null;
+}
+
 export function activityCashAmountTwd(
   item: ActivityItem,
   rates: Record<string, number>,
@@ -43,12 +52,9 @@ export function buildActivityCategorySlices(
   const grouped = new Map<string, number>();
 
   for (const item of items) {
-    const amount = activityCashAmountTwd(item, rates);
-    if (flow === "income" ? amount <= 0 : amount >= 0) continue;
-    grouped.set(
-      item.category,
-      (grouped.get(item.category) ?? 0) + Math.abs(amount),
-    );
+    if (activityCashFlow(item) !== flow) continue;
+    const amount = Math.abs(activityCashAmountTwd(item, rates));
+    grouped.set(item.category, (grouped.get(item.category) ?? 0) + amount);
   }
 
   const sorted = [...grouped.entries()].sort((a, b) => b[1] - a[1]);

--- a/apps/worker/src/routes/classification.test.ts
+++ b/apps/worker/src/routes/classification.test.ts
@@ -101,4 +101,32 @@ describe("classification rule actions", () => {
     expect(insert?.sql).toContain("excluded_from_calculation");
     expect(insert?.values[8]).toBe(1);
   });
+
+  it("updates an editable rule's category, condition, keyword, and calculation action", async () => {
+    const { calls, db } = createDb();
+    const response = await testApp().request(
+      "/classification/rules/user:rule-1",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          categoryId: "investment",
+          operator: "equals",
+          pattern: "定期買股",
+          excludedFromCalculation: false
+        })
+      },
+      { DB: db } as Env
+    );
+
+    expect(response.status).toBe(200);
+    const update = calls.find(({ sql }) => sql.includes("UPDATE classification_rules"));
+    expect(update?.sql).toContain("category_id = ?");
+    expect(update?.sql).toContain("operator = ?");
+    expect(update?.sql).toContain("pattern = ?");
+    expect(update?.sql).toContain("excluded_from_calculation = ?");
+    expect(update?.sql).toContain("is_system = 0");
+    expect(update?.values).toContain("equals");
+    expect(update?.values).toContain(0);
+  });
 });

--- a/apps/worker/src/routes/classification.ts
+++ b/apps/worker/src/routes/classification.ts
@@ -20,6 +20,7 @@ const createRuleSchema = z.object({
 });
 const updateRuleSchema = z.object({
   categoryId: z.string().min(1).max(64).optional(),
+  operator: z.enum(["contains", "equals", "starts_with", "regex"]).optional(),
   pattern: z.string().min(1).max(300).optional(),
   priority: z.number().int().min(0).max(10_000).optional(),
   enabled: z.boolean().optional(),
@@ -169,9 +170,18 @@ export function registerClassificationRoutes(api: Hono<AppBindings>) {
   api.put("/classification/rules/:ruleId", async (c) => {
     const parsed = updateRuleSchema.safeParse(await c.req.json().catch(() => null));
     if (!parsed.success) return jsonError("INVALID_REQUEST", "Classification rule update is invalid.");
+    if (parsed.data.categoryId) {
+      const category = await c.env.DB.prepare(
+        "SELECT id FROM classification_categories WHERE id = ?"
+      ).bind(parsed.data.categoryId).first<{ id: string }>();
+      if (!category) {
+        return jsonError("CATEGORY_NOT_FOUND", "Classification category was not found.", 404);
+      }
+    }
     const sets: string[] = [];
     const values: unknown[] = [];
     if (parsed.data.categoryId) { sets.push("category_id = ?"); values.push(parsed.data.categoryId); }
+    if (parsed.data.operator !== undefined) { sets.push("operator = ?"); values.push(parsed.data.operator); }
     if (parsed.data.pattern !== undefined) { sets.push("pattern = ?"); values.push(parsed.data.pattern); }
     if (parsed.data.priority !== undefined) { sets.push("priority = ?"); values.push(parsed.data.priority); }
     if (parsed.data.enabled !== undefined) { sets.push("enabled = ?"); values.push(parsed.data.enabled ? 1 : 0); }


### PR DESCRIPTION
## 變更內容

- 分類圖例保留有活動但計算金額為 0 的分類
- 已排除交易不計入金額與百分比，但分類仍顯示為 `0.0% / NT$0`
- 點選零元分類後，仍能列出已排除交易並調整分類或恢復計算
- 自訂分類規則新增行內編輯，可修改分類、比對條件、關鍵字及「不計入收支」
- 內建分類規則維持唯讀
- Worker 更新 API 支援修改比對條件，並驗證指定分類存在

## 問題原因

排除計算的交易原本會因統計金額歸零而失去分類入口，使用者難以再次找到交易。同時，既有自訂規則只能停用或刪除，若要修正關鍵字或排除設定必須重建規則。

這次將「交易屬於收入或支出」與「是否計入統計金額」拆開處理，並為自訂規則補上完整的行內編輯流程。

## 使用者影響

- 排除計算後仍能依分類找到交易
- 可直接修正既有自訂規則，不需刪除重建
- 系統預設規則不會被意外修改

## 驗證

- `npm run typecheck -w @taiwan-fin-hub/web`：0 errors、0 warnings
- `npm run typecheck -w @taiwan-fin-hub/worker`：通過
- `npm run test:unit -w @taiwan-fin-hub/web`：17 項通過
- `npm test -w @taiwan-fin-hub/worker`：54 項通過
- `npm run test:e2e -w @taiwan-fin-hub/web`：5 項通過
- `npm run build -w @taiwan-fin-hub/web`：通過
- Svelte autofixer：無問題
- 瀏覽器實測：零元排除分類可開啟；自訂規則編輯版面與欄位顯示正常