### PR TITLE
fix: 修正總覽與手機活動排版

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -91,6 +91,44 @@ test("renders the mobile bottom navigation", async ({ page }) => {
   ).toBeVisible();
 });
 
+test("keeps long recent activity inside the overview card", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.route("**/api/bank", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        accounts: [],
+        transactions: [
+          {
+            id: "long-transaction",
+            connectorId: "cathaybk",
+            accountId: "account-1",
+            sourceId: "long-source-id",
+            postedDate: new Date().toISOString().slice(0, 10),
+            amount: -88,
+            currency: "TWD",
+            description:
+              "YSSL80300000051500038491812BDF7C03202607172521LONGACTIVITY",
+            institutionName: "測試銀行",
+            status: "posted",
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto("/#/overview");
+  await expect(page.getByRole("heading", { name: "近期活動" })).toBeVisible();
+  const pageWidth = await page.evaluate(() => ({
+    client: document.documentElement.clientWidth,
+    scroll: document.documentElement.scrollWidth,
+  }));
+  expect(pageWidth.scroll).toBe(pageWidth.client);
+});
+
 test("uses app-like scrolling and history only in standalone display mode", async ({
   page,
 }) => {
@@ -231,4 +269,19 @@ test("excludes a bank transaction from activity calculations and restores it", a
     page.getByRole("button", { name: "排除 台新卡費 的統計計算" }),
   ).toBeVisible();
   await expect(expenseSlice).toBeVisible();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const categorySelect = page.getByRole("combobox", {
+    name: "更新 台新卡費 分類",
+  });
+  const calculationButton = page.getByRole("button", {
+    name: "排除 台新卡費 的統計計算",
+  });
+  const [selectBox, buttonBox] = await Promise.all([
+    categorySelect.boundingBox(),
+    calculationButton.boundingBox(),
+  ]);
+  if (!selectBox || !buttonBox)
+    throw new Error("Mobile activity controls are not visible.");
+  expect(Math.abs(selectBox.y - buttonBox.y)).toBeLessThan(2);
 });

--- a/apps/web/src/features/activity/Activity.svelte
+++ b/apps/web/src/features/activity/Activity.svelte
@@ -566,11 +566,11 @@
                     {sourceLabel(item.source)} · {formatDate(item.date)}
                   </p>
                   {#if item.transactionId}<div
-                      class="mt-1 flex flex-wrap items-center gap-1.5"
+                      class="mt-1 flex min-w-0 items-center gap-1.5"
                     >
                       <Select
                         aria-label={`更新 ${item.title} 分類`}
-                        class="h-8 max-w-36 px-2 py-1 text-xs font-medium text-steel"
+                        class="h-8 w-24 shrink-0 px-2 py-1 text-xs font-medium text-steel"
                         value={item.categoryId}
                         onchange={(e: Event) =>
                           openCategory(
@@ -584,7 +584,7 @@
                       <Button
                         aria-label={`${item.excludedFromCalculation ? "恢復" : "排除"} ${item.title} 的統計計算`}
                         aria-pressed={item.excludedFromCalculation}
-                        class="h-8 px-2 text-[11px]"
+                        class="h-8 shrink-0 px-2 text-[11px]"
                         disabled={$calculationMutation.isPending &&
                           $calculationMutation.variables?.transactionId ===
                             item.transactionId}

--- a/apps/web/src/features/overview/Overview.svelte
+++ b/apps/web/src/features/overview/Overview.svelte
@@ -388,17 +388,19 @@
           {/each}
         </CardContent>
       </Card>
-      <Card>
+      <Card class="min-w-0 overflow-hidden">
         <CardHeader><h2 class="text-lg font-semibold">近期活動</h2></CardHeader>
-        <CardContent class="grid gap-4">
+        <CardContent class="grid min-w-0 gap-4">
           {#each recent as item (item.id)}
-            <div class="flex items-center justify-between gap-3 text-sm">
-              <div class="min-w-0">
+            <div
+              class="flex min-w-0 items-center justify-between gap-3 text-sm"
+            >
+              <div class="min-w-0 flex-1 overflow-hidden">
                 <p class="truncate font-semibold">{item.title}</p>
                 <p class="truncate text-xs text-ink/40">{item.detail}</p>
               </div>
               <span
-                class={`shrink-0 font-semibold tabular-nums ${item.amount != null && item.amount < 0 ? "text-coral" : item.amount != null ? "text-moss" : "text-ink/40"}`}
+                class={`max-w-[42%] shrink-0 truncate font-semibold tabular-nums ${item.amount != null && item.amount < 0 ? "text-coral" : item.amount != null ? "text-moss" : "text-ink/40"}`}
                 >{item.amount == null
                   ? "—"
                   : `${item.amount >= 0 ? "+" : ""}${formatCurrency(item.amount, item.currency)}`}</span


### PR DESCRIPTION
## 變更內容

- 限制桌面總覽「近期活動」卡片與文字容器寬度
- 超長活動名稱與金額會在卡片內截斷，不再撐開整個頁面
- 將手機活動分類選單縮窄為固定寬度
- 讓分類選單與「排除／恢復計算」按鈕保持同列
- 補上桌面水平溢位與手機控制列位置的 responsive E2E 測試

## 問題原因

「近期活動」內層 flex item 缺少完整的可縮排寬度約束，超長交易名稱會擴張 grid 欄位並造成頁面水平捲軸。手機活動列的分類選單與計算按鈕總寬度超過內容區可用空間，因此按鈕換到下一行。

## 使用者影響

- 桌面總覽不再因長交易名稱破版
- 手機活動的分類與排除計算操作保持緊湊且同列

## 驗證

- `npm run format:check`：通過
- `npm run typecheck -w @taiwan-fin-hub/web`：0 errors、0 warnings
- `npm run test:unit -w @taiwan-fin-hub/web`：17 項通過
- `npm run test:e2e -w @taiwan-fin-hub/web`：6 項通過
- `npm run build -w @taiwan-fin-hub/web`：通過
- Svelte autofixer：無問題
- 瀏覽器實測：407px 手機活動頁顯示正常