### PR TITLE
修正永豐行動 API Cookie 輪替保存

### DIFF
--- a/apps/worker/src/sinopac.test.ts
+++ b/apps/worker/src/sinopac.test.ts
@@ -249,6 +249,38 @@ describe("sinopac App JSON parser", () => {
     });
   });
 
+  it("applies rotated mobile cookies to later requests and persists the refreshed session", async () => {
+    const rotatingCookies = JSON.stringify([
+      ...JSON.parse(sessionCookies),
+      { name: "sinopac_cookie", value: "stale-cookie", domain: "m.sinopac.com", path: "/" }
+    ]);
+    const requestCookies: string[] = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestCookies.push(new Headers(init?.headers).get("cookie") ?? "");
+      const call = requestCookies.length;
+      const payload = call === 1 ? summaryPayload : call === 2 ? billPayload : unbilledPayload;
+      const nextCookie = call === 1 ? "summary-cookie" : call === 2 ? "billing-cookie" : "unbilled-cookie";
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Set-Cookie": `sinopac_cookie=${nextCookie}; Path=/; HttpOnly; Secure` }
+      });
+    });
+
+    const result = await createSinopacConnector(undefined, fetchMock as typeof fetch).sync({
+      sessionCookies: rotatingCookies,
+      protocol: "sinopac-mobile-app-json-v1"
+    });
+
+    expect(requestCookies[0]).toContain("sinopac_cookie=stale-cookie");
+    expect(requestCookies[1]).toContain("sinopac_cookie=summary-cookie");
+    expect(requestCookies[2]).toContain("sinopac_cookie=billing-cookie");
+    const refreshedCookies = JSON.parse(JSON.parse(result.cursor ?? "{}").sessionCookies) as Array<{
+      name: string;
+      value: string;
+    }>;
+    expect(refreshedCookies.find((cookie) => cookie.name === "sinopac_cookie")?.value).toBe("unbilled-cookie");
+  });
+
   it("fetches the remaining statement months advertised by the default response", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/apps/worker/src/sinopac.ts
+++ b/apps/worker/src/sinopac.ts
@@ -95,6 +95,7 @@ export function createSinopacConnector(browser?: Fetcher, fetchImpl: FetchImpl =
       const client = new SinopacAppClient(sessionCookies, fetchImpl);
       const payloads = await client.fetchCreditCards(lookbackMonths);
       const cards = parseSinopacCardData(payloads, lookbackMonths);
+      sessionCookies = client.serializedCookies();
       const now = new Date();
 
       return {
@@ -112,13 +113,17 @@ export function createSinopacConnector(browser?: Fetcher, fetchImpl: FetchImpl =
 }
 
 class SinopacAppClient {
-  private readonly cookieHeader: string;
+  private readonly cookies: SinopacCookieJar;
 
   constructor(
     serializedCookies: string,
     private readonly fetchImpl: FetchImpl
   ) {
-    this.cookieHeader = cookieHeaderFromSerialized(serializedCookies);
+    this.cookies = new SinopacCookieJar(serializedCookies);
+  }
+
+  serializedCookies() {
+    return this.cookies.serialize();
   }
 
   async fetchCreditCards(lookbackMonths: number): Promise<SinopacApiPayloads> {
@@ -140,13 +145,14 @@ class SinopacAppClient {
       headers: {
         Accept: "application/json, text/plain, */*",
         "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-        Cookie: this.cookieHeader,
+        Cookie: this.cookies.header(),
         Referer: `${MOBILE_HOST}/m/m_home.aspx`,
         "User-Agent": ANDROID_USER_AGENT,
         "X-Requested-With": "XMLHttpRequest"
       },
       body: ""
     });
+    this.cookies.updateFromResponse(response.headers);
     const text = await response.text();
     if (!response.ok) {
       throw new Error(`永豐${label} API 回應 HTTP ${response.status}。`);
@@ -342,33 +348,110 @@ function captchaHasVisibleDigits(bytes: Uint8Array | string) {
   }
 }
 
-function cookieHeaderFromSerialized(serialized: string) {
-  let cookies: unknown;
-  try {
-    cookies = JSON.parse(serialized);
-  } catch {
-    throw new SinopacVerificationRequiredError("永豐銀行 session 格式無效，請重新完成圖形驗證。");
-  }
-  if (!Array.isArray(cookies)) {
-    throw new SinopacVerificationRequiredError("永豐銀行 session 格式無效，請重新完成圖形驗證。");
-  }
-  const header = cookies
-    .filter((cookie): cookie is JsonRecord => isRecord(cookie))
-    .filter((cookie) => {
-      const domain = stringValue(cookie.domain).toLowerCase();
-      return !domain || domain === "m.sinopac.com" || domain.endsWith(".sinopac.com");
-    })
-    .map((cookie) => {
+class SinopacCookieJar {
+  private readonly cookies = new Map<string, JsonRecord>();
+
+  constructor(serialized: string) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(serialized);
+    } catch {
+      throw new SinopacVerificationRequiredError("永豐銀行 session 格式無效，請重新完成圖形驗證。");
+    }
+    if (!Array.isArray(parsed)) {
+      throw new SinopacVerificationRequiredError("永豐銀行 session 格式無效，請重新完成圖形驗證。");
+    }
+    for (const cookie of parsed) {
+      if (!isRecord(cookie) || !isSinopacCookie(cookie)) continue;
       const name = stringValue(cookie.name);
       const value = stringValue(cookie.value);
-      return name && value ? `${name}=${value}` : "";
-    })
-    .filter(Boolean)
-    .join("; ");
-  if (!header) {
-    throw new SinopacVerificationRequiredError("永豐銀行 session 沒有可用 Cookie，請重新完成圖形驗證。");
+      if (name && value) this.cookies.set(cookieKey(cookie), cookie);
+    }
+    if (this.cookies.size === 0) {
+      throw new SinopacVerificationRequiredError("永豐銀行 session 沒有可用 Cookie，請重新完成圖形驗證。");
+    }
   }
-  return header;
+
+  header() {
+    const nowSeconds = Date.now() / 1000;
+    return Array.from(this.cookies.values())
+      .filter((cookie) => {
+        const expires = numberValue(cookie.expires);
+        return expires == null || expires <= 0 || expires > nowSeconds;
+      })
+      .sort((left, right) => stringValue(right.path).length - stringValue(left.path).length)
+      .map((cookie) => `${stringValue(cookie.name)}=${stringValue(cookie.value)}`)
+      .join("; ");
+  }
+
+  updateFromResponse(headers: Headers) {
+    for (const value of readSetCookieHeaders(headers)) {
+      const cookie = parseSetCookie(value);
+      if (!cookie) continue;
+      const key = cookieKey(cookie);
+      const expires = numberValue(cookie.expires);
+      if (!stringValue(cookie.value) || (expires != null && expires > 0 && expires <= Date.now() / 1000)) {
+        this.cookies.delete(key);
+      } else {
+        this.cookies.set(key, cookie);
+      }
+    }
+  }
+
+  serialize() {
+    return JSON.stringify(Array.from(this.cookies.values()));
+  }
+}
+
+function isSinopacCookie(cookie: JsonRecord) {
+  const domain = stringValue(cookie.domain).replace(/^\./, "").toLowerCase();
+  return !domain || domain === "sinopac.com" || domain.endsWith(".sinopac.com");
+}
+
+function cookieKey(cookie: JsonRecord) {
+  const domain = stringValue(cookie.domain).replace(/^\./, "").toLowerCase() || "m.sinopac.com";
+  const path = stringValue(cookie.path) || "/";
+  return `${domain}\t${path}\t${stringValue(cookie.name)}`;
+}
+
+function readSetCookieHeaders(headers: Headers) {
+  const getSetCookie = (headers as Headers & { getSetCookie?: () => string[] }).getSetCookie;
+  const values = typeof getSetCookie === "function" ? getSetCookie.call(headers) : [];
+  if (values.length > 0) return values;
+  const combined = headers.get("set-cookie");
+  return combined ? combined.split(/,(?=\s*[^=;,\s]+=)/g) : [];
+}
+
+function parseSetCookie(value: string): JsonRecord | undefined {
+  const parts = value.split(";").map((part) => part.trim());
+  const first = parts.shift();
+  if (!first) return undefined;
+  const separator = first.indexOf("=");
+  if (separator <= 0) return undefined;
+  const cookie: JsonRecord = {
+    name: first.slice(0, separator).trim(),
+    value: first.slice(separator + 1),
+    domain: "m.sinopac.com",
+    path: "/"
+  };
+  let maxAge: number | undefined;
+  for (const attribute of parts) {
+    const attributeSeparator = attribute.indexOf("=");
+    const rawName = (attributeSeparator < 0 ? attribute : attribute.slice(0, attributeSeparator)).trim().toLowerCase();
+    const rawValue = attributeSeparator < 0 ? "" : attribute.slice(attributeSeparator + 1).trim();
+    if (rawName === "domain" && rawValue) cookie.domain = rawValue.replace(/^\./, "").toLowerCase();
+    else if (rawName === "path" && rawValue) cookie.path = rawValue;
+    else if (rawName === "secure") cookie.secure = true;
+    else if (rawName === "httponly") cookie.httpOnly = true;
+    else if (rawName === "samesite" && rawValue) cookie.sameSite = rawValue;
+    else if (rawName === "max-age") maxAge = Number.parseInt(rawValue, 10);
+    else if (rawName === "expires") {
+      const expiresAt = Date.parse(rawValue);
+      if (Number.isFinite(expiresAt)) cookie.expires = expiresAt / 1000;
+    }
+  }
+  if (maxAge != null && Number.isFinite(maxAge)) cookie.expires = Date.now() / 1000 + maxAge;
+  return cookie;
 }
 
 function assertSinopacApiSuccess(payload: unknown, label: string) {
@@ -906,4 +989,8 @@ function isRecord(value: unknown): value is JsonRecord {
 
 function stringValue(value: unknown) {
   return typeof value === "string" ? value : value == null ? "" : String(value);
+}
+
+function numberValue(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }


### PR DESCRIPTION
## 變更內容

- 為永豐行動 API 客戶端加入 Cookie jar。
- 接收每次 API 回應的 `Set-Cookie`，並立即套用到後續請求。
- 同步完成後加密保存最新 Cookie，同時忽略已過期 Cookie。
- 新增測試，驗證 Cookie 會依序輪替並寫回同步 session。

## 問題原因

永豐信用卡 API 會在回應中更新 `sinopac_cookie`，但原本的連接器只保存首次登入取得的 Cookie，後續同步沒有接收輪替值。持續使用舊 Cookie 可能讓 session 提早失效，導致使用者隔幾天就必須重新輸入圖形驗證碼。

## 影響

部署後仍需先完成一次人工驗證，但後續排程同步會像一般行動客戶端一樣維護 Cookie 狀態，預期可延長 session 的可用時間。這次不包含原生 App 的 FIDO 裝置登入模擬。

## 驗證

- `npm test -w @taiwan-fin-hub/worker -- --run src/sinopac.test.ts src/sinopac-session.test.ts`（13 項通過）
- `npm run typecheck -w @taiwan-fin-hub/worker`
- 完整後端測試先前驗證：55 項通過，Connectors self-check 通過
- 全專案 typecheck 通過