### PR TITLE
新增活動發票配對與交易詳情

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -20,6 +20,7 @@ test.beforeEach(async ({ page }) => {
     else if (path === "/api/investments") body = [];
     else if (path === "/api/investment-transactions") body = [];
     else if (path === "/api/invoices") body = [];
+    else if (path === "/api/activity/invoice-mappings") body = [];
     else if (path === "/api/manual-assets") body = [];
     else if (path === "/api/exchange-rates") body = [];
     else if (path === "/api/history/net-worth") body = [];
@@ -244,44 +245,324 @@ test("excludes a bank transaction from activity calculations and restores it", a
   });
   await expect(expenseSlice).toBeVisible();
 
-  await page.getByRole("button", { name: "排除 台新卡費 的統計計算" }).click();
+  await page.getByRole("button", { name: "查看 台新卡費 活動詳情" }).click();
+  await expect(page.getByRole("heading", { name: "活動明細" })).toBeVisible();
+  await page
+    .getByRole("checkbox", { name: "排除 台新卡費 的統計計算" })
+    .click();
   await expect(
-    page.getByRole("button", { name: "恢復 台新卡費 的統計計算" }),
-  ).toBeVisible();
+    page.getByRole("checkbox", { name: "恢復 台新卡費 的統計計算" }),
+  ).toBeChecked();
   await expect(expenseSlice).toBeHidden();
+  await page.getByRole("button", { name: "返回活動列表" }).click();
   const excludedExpenseSlice = page.getByRole("button", {
     name: "其他 0.0% NT$0",
   });
   await expect(excludedExpenseSlice).toBeVisible();
   await excludedExpenseSlice.click();
+  await page.getByRole("button", { name: "查看 台新卡費 活動詳情" }).click();
   await expect(
-    page.getByRole("button", { name: "恢復 台新卡費 的統計計算" }),
-  ).toBeVisible();
+    page.getByRole("checkbox", { name: "恢復 台新卡費 的統計計算" }),
+  ).toBeChecked();
 
   await page.reload();
   await expect(excludedExpenseSlice).toBeVisible();
+  await page.getByRole("button", { name: "查看 台新卡費 活動詳情" }).click();
   await expect(
-    page.getByRole("button", { name: "恢復 台新卡費 的統計計算" }),
-  ).toBeVisible();
+    page.getByRole("checkbox", { name: "恢復 台新卡費 的統計計算" }),
+  ).toBeChecked();
 
-  await page.getByRole("button", { name: "恢復 台新卡費 的統計計算" }).click();
+  await page
+    .getByRole("checkbox", { name: "恢復 台新卡費 的統計計算" })
+    .click();
   await expect(
-    page.getByRole("button", { name: "排除 台新卡費 的統計計算" }),
-  ).toBeVisible();
+    page.getByRole("checkbox", { name: "排除 台新卡費 的統計計算" }),
+  ).not.toBeChecked();
   await expect(expenseSlice).toBeVisible();
 
+  await page.getByRole("button", { name: "返回活動列表" }).click();
   await page.setViewportSize({ width: 390, height: 844 });
-  const categorySelect = page.getByRole("combobox", {
-    name: "更新 台新卡費 分類",
+  await expect(
+    page.getByRole("combobox", { name: "更新 台新卡費 分類" }),
+  ).toHaveCount(0);
+  await page.getByRole("button", { name: "查看 台新卡費 活動詳情" }).click();
+  const detailDialog = page.getByRole("dialog", { name: "活動明細" });
+  const detailBox = await detailDialog.boundingBox();
+  if (!detailBox) throw new Error("Mobile activity detail is not visible.");
+  expect(detailBox.width).toBe(390);
+  expect(detailBox.height).toBe(844);
+  await expect(
+    page.getByRole("combobox", { name: "更新 台新卡費 分類" }),
+  ).toBeVisible();
+});
+
+test("merges a matching invoice and counts an unmatched invoice as expense", async ({
+  page,
+}) => {
+  const month = new Date().toISOString().slice(0, 7);
+  await page.route("**/api/bank", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        accounts: [
+          {
+            id: "card-1",
+            connectorId: "sinopac",
+            sourceId: "card-source-1",
+            institutionName: "測試銀行",
+            accountName: "測試信用卡",
+            accountType: "credit",
+            currency: "TWD",
+          },
+        ],
+        transactions: [
+          {
+            id: "transaction-1",
+            connectorId: "sinopac",
+            accountId: "card-1",
+            sourceId: "transaction-source-1",
+            postedDate: `${month}-10`,
+            authorizedAt: `${month}-10T12:00:00.000Z`,
+            amount: 860,
+            currency: "TWD",
+            description: "信用卡消費",
+            counterparty: "好食餐飲",
+            status: "posted",
+            excludedFromCalculation: false,
+            classification: {
+              categoryId: "food",
+              label: "餐飲",
+              source: "fallback",
+            },
+          },
+        ],
+      }),
+    });
   });
-  const calculationButton = page.getByRole("button", {
-    name: "排除 台新卡費 的統計計算",
+  await page.route("**/api/invoices", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          id: "invoice-matched",
+          connectorId: "einvoice",
+          sourceId: "invoice-source-1",
+          invoiceDate: `${month}-10`,
+          invoiceNumber: "AB12345678",
+          sellerName: "好食餐飲有限公司",
+          amount: 860,
+          items: [],
+        },
+        {
+          id: "invoice-unmatched",
+          connectorId: "einvoice",
+          sourceId: "invoice-source-2",
+          invoiceDate: `${month}-08`,
+          invoiceNumber: "CD12345678",
+          sellerName: "未支援銀行商店",
+          amount: 1490,
+          items: [],
+        },
+      ]),
+    });
   });
-  const [selectBox, buttonBox] = await Promise.all([
-    categorySelect.boundingBox(),
-    calculationButton.boundingBox(),
-  ]);
-  if (!selectBox || !buttonBox)
-    throw new Error("Mobile activity controls are not visible.");
-  expect(Math.abs(selectBox.y - buttonBox.y)).toBeLessThan(2);
+
+  await page.goto("/#/activity");
+
+  await expect(
+    page.getByRole("button", { name: "發票 63.4% NT$1,490" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "餐飲 36.6% NT$860" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("−NT$2,350", { exact: true }).first(),
+  ).toBeVisible();
+
+  const activityRows = page.locator("tbody tr");
+  await expect(activityRows).toHaveCount(2);
+  await expect(
+    activityRows.filter({ hasText: "好食餐飲有限公司" }),
+  ).toContainText("信用卡＋發票");
+  await expect(
+    activityRows.filter({ hasText: "未支援銀行商店" }),
+  ).toContainText("−NT$1,490");
+
+  await page.getByRole("tab", { name: "發票", exact: true }).click();
+  await expect(activityRows).toHaveCount(2);
+  await page.getByRole("tab", { name: "信用卡", exact: true }).click();
+  await expect(activityRows).toHaveCount(1);
+});
+
+test("manually maps, manages, and separates a same-day invoice transaction on mobile", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  const month = new Date().toISOString().slice(0, 7);
+  let mappings: Array<{
+    invoiceId: string;
+    transactionId: string | null;
+    decision: "linked" | "separate";
+    updatedAt: string;
+  }> = [];
+
+  await page.route("**/api/activity/invoice-mappings**", async (route) => {
+    const request = route.request();
+    const invoiceId = new URL(request.url()).pathname.split("/").at(-1)!;
+    if (request.method() === "PUT") {
+      const body = request.postDataJSON() as { transactionId: string };
+      const preference = {
+        invoiceId,
+        transactionId: body.transactionId,
+        decision: "linked" as const,
+        updatedAt: new Date().toISOString(),
+      };
+      mappings = [preference];
+      await route.fulfill({ json: preference });
+      return;
+    }
+    if (request.method() === "DELETE") {
+      const preference = {
+        invoiceId,
+        transactionId: null,
+        decision: "separate" as const,
+        updatedAt: new Date().toISOString(),
+      };
+      mappings = [preference];
+      await route.fulfill({ json: preference });
+      return;
+    }
+    await route.fulfill({ json: mappings });
+  });
+  await page.route("**/api/bank", async (route) => {
+    await route.fulfill({
+      json: {
+        accounts: [
+          {
+            id: "card-1",
+            connectorId: "sinopac",
+            sourceId: "card-source-1",
+            institutionName: "玉山銀行",
+            accountName: "信用卡",
+            accountType: "credit",
+            currency: "TWD",
+          },
+        ],
+        transactions: [
+          {
+            id: "pxpay-tea",
+            connectorId: "sinopac",
+            accountId: "card-1",
+            sourceId: "transaction-source-1",
+            postedDate: `${month}-06`,
+            amount: 37,
+            currency: "TWD",
+            description: "全支付﹘樂法 台中漢口店",
+            counterparty: "全支付﹘樂法 台中漢口店",
+            status: "posted",
+            excludedFromCalculation: false,
+            classification: {
+              categoryId: "food",
+              label: "餐飲",
+              source: "fallback",
+            },
+          },
+          {
+            id: "dinner",
+            connectorId: "sinopac",
+            accountId: "card-1",
+            sourceId: "transaction-source-2",
+            postedDate: `${month}-06`,
+            amount: -265,
+            currency: "TWD",
+            description: "連支＊萬川雞飯．肉骨茶",
+            counterparty: "連支＊萬川雞飯．肉骨茶",
+            status: "posted",
+            excludedFromCalculation: false,
+            classification: {
+              categoryId: "food",
+              label: "餐飲",
+              source: "fallback",
+            },
+          },
+        ],
+      },
+    });
+  });
+  await page.route("**/api/invoices", async (route) => {
+    await route.fulfill({
+      json: [
+        {
+          id: "invoice-1",
+          connectorId: "einvoice",
+          sourceId: "invoice-source-1",
+          invoiceDate: `${month}-06T04:39:18.000Z`,
+          invoiceNumber: "DR95850239",
+          sellerName: "菲尖極道商行",
+          amount: 50,
+          items: [
+            {
+              id: "invoice-line-1",
+              sourceId: "invoice-line-source-1",
+              lineNumber: 1,
+              description: "瓶裝飲料",
+              quantity: 1,
+              unitPrice: 50,
+              amount: 50,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  await page.goto("/#/activity");
+  await page
+    .getByRole("button", { name: "查看 菲尖極道商行 活動詳情" })
+    .click();
+  await expect(page.getByText("瓶裝飲料", { exact: true })).toBeVisible();
+  await expect(page.getByText("尚未找到銀行／信用卡交易")).toBeVisible();
+  await page.getByRole("button", { name: "配對交易" }).click();
+  await expect(
+    page.getByRole("heading", { name: "選擇同日候選交易" }),
+  ).toBeVisible();
+  await page
+    .getByRole("button", {
+      name: /^全支付﹘樂法 台中漢口店 玉山銀行/,
+    })
+    .click();
+  await page.getByRole("button", { name: "下一步" }).click();
+  await expect(
+    page.getByRole("heading", { name: "確認合併這兩筆？" }),
+  ).toBeVisible();
+  await expect(page.getByText("差額 NT$13", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "確認配對" }).click();
+
+  await expect(page.getByText("已完成配對，活動只顯示一筆")).toBeVisible();
+  await expect(
+    page.getByText("信用卡＋發票 · 2026/7/6", { exact: true }),
+  ).toBeVisible();
+  await page
+    .getByRole("button", { name: "查看 菲尖極道商行 活動詳情" })
+    .click();
+  const detail = page.getByRole("dialog", { name: "活動明細" });
+  await expect(
+    detail
+      .getByText("銀行／信用卡原始名稱")
+      .locator("..")
+      .getByText("全支付﹘樂法 台中漢口店", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    detail
+      .getByText("發票商家名稱")
+      .locator("..")
+      .getByText("菲尖極道商行", { exact: true }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "管理配對" }).click();
+  await page.getByRole("button", { name: "解除並保持分開" }).click();
+  await expect(page.getByText("已解除配對，兩筆活動將保持分開")).toBeVisible();
+  await expect(page.getByText("菲尖極道商行").first()).toBeVisible();
+  await expect(page.getByText("全支付﹘樂法 台中漢口店").first()).toBeVisible();
 });

--- a/apps/web/src/features/activity/Activity.svelte
+++ b/apps/web/src/features/activity/Activity.svelte
@@ -11,6 +11,13 @@
     CreditCard,
     FileText,
     TrendingUp,
+    ArrowDown,
+    Check,
+    Link2,
+    Unlink2,
+    ArrowLeft,
+    ChevronRight,
+    X,
   } from "@lucide/svelte";
   import Card from "../../components/ui/Card.svelte";
   import CardHeader from "../../components/ui/CardHeader.svelte";
@@ -30,15 +37,28 @@
     bankQuery,
     classificationCategoriesQuery,
     exchangeRatesQuery,
+    invoiceTransactionMappingsQuery,
     investmentTransactionsQuery,
     invoicesQuery,
   } from "../../lib/queries";
-  import type { ActivityItem, BankData, View } from "../../lib/types";
+  import type {
+    ActivityItem,
+    BankData,
+    BankTransactionRow,
+    InvoiceRow,
+    InvoiceTransactionPreference,
+    View,
+  } from "../../lib/types";
   import {
     buildActivityCategorySlices,
     activityCashAmountTwd,
     activityCashFlow,
   } from "../../lib/activity-chart";
+  import {
+    deduplicateBankTransactions,
+    invoiceTransactionCandidates,
+    matchInvoicesToTransactions,
+  } from "../../lib/activity-matching";
   import {
     formatCompactTwd,
     formatCurrency,
@@ -51,6 +71,9 @@
     $props();
   const bank = createQuery(bankQuery(() => api));
   const invoices = createQuery(invoicesQuery(() => api));
+  const invoiceMappings = createQuery(
+    invoiceTransactionMappingsQuery(() => api),
+  );
   const trades = createQuery(investmentTransactionsQuery(() => api));
   const rates = createQuery(exchangeRatesQuery(() => api));
   const categoryRows = createQuery(classificationCategoriesQuery(() => api));
@@ -69,6 +92,13 @@
     pattern: string;
     operator: "contains" | "equals";
   } | null>(null);
+  let mappingDialog = $state<{
+    invoice: InvoiceRow;
+    step: "candidates" | "confirm" | "actions";
+    transactionId?: string;
+  } | null>(null);
+  let mappingNotice = $state("");
+  let detailKey = $state<string | null>(null);
   const fallbackCategories = [
     { id: "salary", label: "薪資" },
     { id: "transfer", label: "轉帳" },
@@ -99,43 +129,79 @@
       ($bank.data?.accounts ?? []).map((account) => [account.id, account]),
     ),
   );
+  const activityBankTransactions = $derived(
+    deduplicateBankTransactions(
+      ($bank.data?.transactions ?? []).map((transaction) => ({
+        ...transaction,
+        accountType:
+          transaction.accountType ??
+          bankAccounts.get(transaction.accountId)?.accountType,
+      })),
+    ),
+  );
+  const invoiceMatches = $derived(
+    matchInvoicesToTransactions(
+      activityBankTransactions,
+      $invoices.data ?? [],
+      $invoiceMappings.data ?? [],
+    ),
+  );
   const rawItems = $derived<ActivityItem[]>(
     [
-      ...($bank.data?.transactions ?? []).map((t) => {
+      ...activityBankTransactions.map((t) => {
         const account = bankAccounts.get(t.accountId);
+        const matchedInvoice = invoiceMatches.transactionToInvoice.get(t.id);
         const isCard =
           account?.accountType === "credit" || t.accountType === "credit";
+        const accountLabel =
+          t.institutionName ??
+          account?.institutionName ??
+          t.accountName ??
+          account?.accountName ??
+          "";
         return {
           id: t.id,
           source: isCard ? ("card" as const) : ("bank" as const),
           date: t.postedDate ?? t.authorizedAt ?? "",
-          title: t.description ?? t.counterparty ?? "銀行交易",
-          subtitle:
-            t.institutionName ??
-            account?.institutionName ??
-            t.accountName ??
-            account?.accountName ??
-            "",
+          title:
+            matchedInvoice?.sellerName ??
+            t.description ??
+            t.counterparty ??
+            "銀行交易",
+          subtitle: [accountLabel, matchedInvoice?.invoiceNumber]
+            .filter(Boolean)
+            .join(" · "),
           amount: t.amount,
           currency: t.currency,
           category: t.classification?.label ?? "其他",
           categoryId: t.classification?.categoryId ?? "other",
+          classificationPattern: t.counterparty ?? t.description,
           transactionId: t.id,
+          invoiceId: matchedInvoice?.id,
+          invoiceAmount: matchedInvoice?.amount,
+          invoiceSearchText: matchedInvoice
+            ? `${matchedInvoice.sellerName ?? ""} ${matchedInvoice.invoiceNumber ?? ""} ${matchedInvoice.items.map((item) => item.description).join(" ")}`
+            : undefined,
           excludedFromCalculation: t.excludedFromCalculation,
           status: t.status,
         };
       }),
-      ...($invoices.data ?? []).map((i) => ({
-        id: i.id,
-        source: "invoice" as const,
-        date: i.invoiceDate,
-        title: i.sellerName ?? "電子發票",
-        subtitle: i.invoiceNumber ?? "",
-        amount: i.amount,
-        currency: "TWD",
-        category: "發票",
-        status: "已開立",
-      })),
+      ...($invoices.data ?? [])
+        .filter((i) => !invoiceMatches.invoiceToTransactionId.has(i.id))
+        .map((i) => ({
+          id: i.id,
+          source: "invoice" as const,
+          date: i.invoiceDate,
+          title: i.sellerName ?? "電子發票",
+          subtitle: i.invoiceNumber ?? "",
+          amount: i.amount,
+          currency: "TWD",
+          category: "發票",
+          invoiceId: i.id,
+          invoiceAmount: i.amount,
+          invoiceSearchText: i.items.map((item) => item.description).join(" "),
+          status: "已開立",
+        })),
       ...($trades.data ?? []).map((t) => ({
         id: t.id,
         source: "investment" as const,
@@ -154,6 +220,9 @@
       })),
     ].sort((a, b) => b.date.localeCompare(a.date)),
   );
+  const detailItem = $derived(
+    rawItems.find((item) => activityKey(item) === detailKey),
+  );
   const months = $derived(
     [
       ...new Set(
@@ -166,18 +235,20 @@
       .sort((a, b) => b.localeCompare(a))
       .slice(0, 12),
   );
-  const monthlyCashItems = $derived(
+  const monthlyCalculatedItems = $derived(
     rawItems.filter(
       (item) =>
         item.date.startsWith(selectedMonth) &&
-        (item.source === "bank" || item.source === "card"),
+        (item.source === "bank" ||
+          item.source === "card" ||
+          item.source === "invoice"),
     ),
   );
   const incomeSlices = $derived(
-    buildActivityCategorySlices(monthlyCashItems, "income", rateValues),
+    buildActivityCategorySlices(monthlyCalculatedItems, "income", rateValues),
   );
   const expenseSlices = $derived(
-    buildActivityCategorySlices(monthlyCashItems, "expense", rateValues),
+    buildActivityCategorySlices(monthlyCalculatedItems, "expense", rateValues),
   );
   const incomeTotal = $derived(
     incomeSlices.reduce((sum, slice) => sum + slice.amount, 0),
@@ -204,7 +275,9 @@
       const items = rawItems.filter(
         (item) =>
           item.date.startsWith(month) &&
-          (item.source === "bank" || item.source === "card"),
+          (item.source === "bank" ||
+            item.source === "card" ||
+            item.source === "invoice"),
       );
       return {
         month,
@@ -230,11 +303,15 @@
     rawItems.filter((item) => {
       const matchesFlow =
         !selectedCategory || activityCashFlow(item) === selectedCategory.flow;
+      const matchesSource =
+        source === "all" ||
+        item.source === source ||
+        (source === "invoice" && Boolean(item.invoiceId));
       return (
-        (source === "all" || item.source === source) &&
+        matchesSource &&
         item.date.startsWith(selectedMonth) &&
         (!search.trim() ||
-          `${item.title} ${item.subtitle} ${item.category}`
+          `${item.title} ${item.subtitle} ${item.category} ${item.invoiceSearchText ?? ""}`
             .toLowerCase()
             .includes(search.toLowerCase())) &&
         (!selectedCategory ||
@@ -242,6 +319,19 @@
       );
     }),
   );
+  const mappingCandidates = $derived.by(() => {
+    if (!mappingDialog) return [];
+    const unavailableTransactionIds = new Set(
+      Array.from(invoiceMatches.transactionToInvoice.entries())
+        .filter(([, invoice]) => invoice.id !== mappingDialog!.invoice.id)
+        .map(([transactionId]) => transactionId),
+    );
+    return invoiceTransactionCandidates(
+      activityBankTransactions,
+      mappingDialog.invoice,
+      unavailableTransactionIds,
+    );
+  });
   const categoryMutation = createMutation({
     mutationFn: async (payload: {
       transactionId: string;
@@ -299,13 +389,38 @@
       qc.invalidateQueries({ queryKey: queryKeys.bank });
     },
   });
+  const mappingMutation = createMutation({
+    mutationFn: (payload: { invoiceId: string; transactionId: string }) =>
+      api.put<InvoiceTransactionPreference>(
+        `/api/activity/invoice-mappings/${encodeURIComponent(payload.invoiceId)}`,
+        { transactionId: payload.transactionId },
+      ),
+    onSuccess: (preference) => {
+      updateMappingPreference(preference);
+      mappingDialog = null;
+      detailKey = null;
+      showMappingNotice("已完成配對，活動只顯示一筆");
+    },
+  });
+  const separationMutation = createMutation({
+    mutationFn: (invoiceId: string) =>
+      api.delete<InvoiceTransactionPreference>(
+        `/api/activity/invoice-mappings/${encodeURIComponent(invoiceId)}`,
+      ),
+    onSuccess: (preference) => {
+      updateMappingPreference(preference);
+      mappingDialog = null;
+      detailKey = null;
+      showMappingNotice("已解除配對，兩筆活動將保持分開");
+    },
+  });
   function openCategory(item: ActivityItem, categoryId: string) {
     if (item.transactionId && categoryId !== item.categoryId)
       pending = {
         item,
         categoryId,
         addRule: false,
-        pattern: item.title,
+        pattern: item.classificationPattern ?? item.title,
         operator: "contains",
       };
   }
@@ -319,13 +434,27 @@
     selectedMonth = month;
     selectedCategory = null;
   }
-  function sourceLabel(source: ActivityItem["source"]) {
-    return {
+  function sourceLabel(item: ActivityItem) {
+    const label = {
       bank: "銀行",
       card: "信用卡",
       investment: "投資",
       invoice: "發票",
-    }[source];
+    }[item.source];
+    return item.source !== "invoice" && item.invoiceId
+      ? `${label}＋發票`
+      : label;
+  }
+  function activityKey(item: ActivityItem) {
+    return `${item.source}-${item.id}`;
+  }
+  function openDetail(item: ActivityItem) {
+    detailKey = activityKey(item);
+  }
+  function transactionForItem(item: ActivityItem) {
+    return activityBankTransactions.find(
+      (transaction) => transaction.id === item.transactionId,
+    );
   }
   function toggleCalculation(item: ActivityItem) {
     if (!item.transactionId) return;
@@ -334,12 +463,75 @@
       excludedFromCalculation: !item.excludedFromCalculation,
     });
   }
+  function updateMappingPreference(preference: InvoiceTransactionPreference) {
+    qc.setQueryData<InvoiceTransactionPreference[]>(
+      queryKeys.invoiceTransactionMappings,
+      (current = []) => [
+        preference,
+        ...current.filter((row) => row.invoiceId !== preference.invoiceId),
+      ],
+    );
+    qc.invalidateQueries({ queryKey: queryKeys.invoiceTransactionMappings });
+  }
+  function showMappingNotice(message: string) {
+    mappingNotice = message;
+    window.setTimeout(() => {
+      if (mappingNotice === message) mappingNotice = "";
+    }, 3500);
+  }
+  function invoiceForItem(item: ActivityItem) {
+    return ($invoices.data ?? []).find(
+      (invoice) => invoice.id === item.invoiceId,
+    );
+  }
+  function openMapping(item: ActivityItem) {
+    const invoice = invoiceForItem(item);
+    if (!invoice) return;
+    mappingDialog = {
+      invoice,
+      step: item.transactionId ? "actions" : "candidates",
+      transactionId: item.transactionId,
+    };
+  }
+  function chooseMappingTransaction(transactionId: string) {
+    if (!mappingDialog) return;
+    mappingDialog.transactionId = transactionId;
+  }
+  function selectedMappingTransaction(): BankTransactionRow | undefined {
+    if (!mappingDialog?.transactionId) return undefined;
+    return activityBankTransactions.find(
+      (transaction) => transaction.id === mappingDialog?.transactionId,
+    );
+  }
+  function mappingMerchant(transaction: BankTransactionRow) {
+    return transaction.counterparty ?? transaction.description ?? "銀行交易";
+  }
+  function mappingAccount(transaction: BankTransactionRow) {
+    return (
+      transaction.institutionName ??
+      transaction.accountName ??
+      bankAccounts.get(transaction.accountId)?.institutionName ??
+      "銀行／信用卡"
+    );
+  }
+  function mappingDifference(
+    invoice: InvoiceRow,
+    transaction: BankTransactionRow,
+  ) {
+    return Math.abs(invoice.amount - Math.abs(transaction.amount));
+  }
+  function itemMappingDifference(item: ActivityItem) {
+    if (item.invoiceAmount == null || item.amount == null) return 0;
+    return Math.abs(item.invoiceAmount - Math.abs(item.amount));
+  }
   function renderedAmount(item: ActivityItem) {
-    return item.source === "card" ? -Math.abs(item.amount ?? 0) : item.amount;
+    return item.source === "card" || item.source === "invoice"
+      ? -Math.abs(item.amount ?? 0)
+      : item.amount;
   }
   function countMatches() {
     if (!pending) return 0;
-    return ($bank.data?.transactions ?? []).filter((t) =>
+    return activityBankTransactions.filter((t) =>
       `${t.description ?? ""} ${t.counterparty ?? ""}`
         .toLowerCase()
         .includes(pending!.pattern.toLowerCase()),
@@ -347,7 +539,7 @@
   }
 </script>
 
-{#if $bank.isPending || $invoices.isPending || $trades.isPending}<EmptyState
+{#if $bank.isPending || $invoices.isPending || $invoiceMappings.isPending || $trades.isPending}<EmptyState
     title="載入活動中"
     body="正在整理銀行、投資與發票資料。"
   />{:else}
@@ -375,7 +567,7 @@
             −{formatCurrency(expenseTotal)}
           </p>
           <p class="mt-1 text-xs text-ink/45">
-            不計入發票與已排除活動
+            含未配對發票，不計入已排除活動
           </p></CardContent
         ></Card
       >
@@ -408,7 +600,7 @@
         <div class="min-w-0">
           <h2 class="text-lg font-semibold">每月分類比例</h2>
           <p class="mt-1 text-xs text-ink/45">
-            收入與支出分開計算，發票與已排除活動不列入
+            未配對發票列為支出，已配對發票不重複計算
           </p>
         </div>
         <Select
@@ -547,8 +739,10 @@
               沒有符合條件的活動。
             </p>{:else}{#each filtered.slice(0, 100) as item (item.source + "-" + item.id)}{@const amount =
                 renderedAmount(item)}
-              <div
-                class={`flex min-w-0 items-center gap-3 px-4 py-3 ${item.excludedFromCalculation ? "bg-ink/[0.025]" : ""}`}
+              <button
+                aria-label={`查看 ${item.title} 活動詳情`}
+                class={`flex w-full min-w-0 items-center gap-3 px-4 py-3 text-left transition hover:bg-paper ${item.excludedFromCalculation ? "bg-ink/[0.025]" : ""}`}
+                onclick={() => openDetail(item)}
               >
                 <span
                   class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-steel/10 text-steel"
@@ -563,119 +757,77 @@
                 <div class="min-w-0 flex-1">
                   <p class="truncate text-sm font-semibold">{item.title}</p>
                   <p class="mt-0.5 truncate text-xs text-ink/45">
-                    {sourceLabel(item.source)} · {formatDate(item.date)}
+                    {sourceLabel(item)} · {formatDate(item.date)}
                   </p>
-                  {#if item.transactionId}<div
-                      class="mt-1 flex min-w-0 items-center gap-1.5"
-                    >
-                      <Select
-                        aria-label={`更新 ${item.title} 分類`}
-                        class="h-8 w-24 shrink-0 px-2 py-1 text-xs font-medium text-steel"
-                        value={item.categoryId}
-                        onchange={(e: Event) =>
-                          openCategory(
-                            item,
-                            (e.currentTarget as HTMLSelectElement).value,
-                          )}
-                        >{#each categoryOptions as category (category.id)}<option
-                            value={category.id}>{category.label}</option
-                          >{/each}</Select
-                      >
-                      <Button
-                        aria-label={`${item.excludedFromCalculation ? "恢復" : "排除"} ${item.title} 的統計計算`}
-                        aria-pressed={item.excludedFromCalculation}
-                        class="h-8 shrink-0 px-2 text-[11px]"
-                        disabled={$calculationMutation.isPending &&
-                          $calculationMutation.variables?.transactionId ===
-                            item.transactionId}
-                        size="sm"
-                        variant={item.excludedFromCalculation
-                          ? "secondary"
-                          : "outline"}
-                        onclick={() => toggleCalculation(item)}
-                        >{item.excludedFromCalculation
-                          ? "恢復計算"
-                          : "排除計算"}</Button
-                      >
-                    </div>{/if}
+                  <Badge variant="secondary" class="mt-1.5"
+                    >{item.category}</Badge
+                  >
                 </div>
-                <p
-                  class={`max-w-[42%] shrink-0 truncate text-sm font-semibold tabular-nums ${item.excludedFromCalculation ? "text-ink/35 line-through" : (amount ?? 0) < 0 ? "text-coral" : item.source !== "invoice" ? "text-moss" : ""}`}
-                >
-                  {amount == null
-                    ? "—"
-                    : `${amount >= 0 && item.source !== "invoice" ? "+" : ""}${formatCurrency(amount, item.currency)}`}
-                </p>
-              </div>{/each}{/if}
+                <span class="flex shrink-0 items-center gap-1">
+                  <span
+                    class={`max-w-[38vw] truncate text-sm font-semibold tabular-nums ${item.excludedFromCalculation ? "text-ink/35 line-through" : (amount ?? 0) < 0 ? "text-coral" : item.source !== "invoice" ? "text-moss" : ""}`}
+                  >
+                    {amount == null
+                      ? "—"
+                      : `${amount >= 0 && item.source !== "invoice" ? "+" : ""}${formatCurrency(amount, item.currency)}`}
+                  </span>
+                  <ChevronRight class="size-4 text-ink/30" />
+                </span>
+              </button>{/each}{/if}
         </div>
         <div class="hidden overflow-x-auto md:block">
-          <table class="w-full min-w-[920px] text-left text-sm">
+          <table class="w-full min-w-[760px] text-left text-sm">
             <thead class="bg-paper text-xs font-semibold text-ink/45"
               ><tr
                 ><th class="px-5 py-3">日期</th><th class="px-4 py-3">來源</th
                 ><th class="px-4 py-3">說明／商家</th><th class="px-4 py-3"
                   >分類</th
-                ><th class="px-4 py-3 text-right">金額</th><th class="px-4 py-3"
-                  >計算</th
-                ><th class="px-5 py-3">狀態</th></tr
+                ><th class="px-5 py-3 text-right">金額</th></tr
               ></thead
             ><tbody class="divide-y divide-ink/8"
               >{#if filtered.length === 0}<tr
-                  ><td class="px-5 py-8 text-center text-ink/50" colspan="7"
+                  ><td class="px-5 py-8 text-center text-ink/50" colspan="5"
                     >沒有符合條件的活動。</td
                   ></tr
                 >{:else}{#each filtered.slice(0, 100) as item (item.source + "-" + item.id)}{@const amount =
                     renderedAmount(item)}<tr
-                    class={item.excludedFromCalculation ? "bg-ink/[0.025]" : ""}
+                    aria-label={`查看 ${item.title} 活動詳情`}
+                    class={`cursor-pointer transition hover:bg-paper focus-visible:outline-2 focus-visible:outline-steel ${item.excludedFromCalculation ? "bg-ink/[0.025]" : ""}`}
+                    onclick={() => openDetail(item)}
+                    onkeydown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        openDetail(item);
+                      }
+                    }}
+                    role="button"
+                    tabindex="0"
                     ><td class="whitespace-nowrap px-5 py-3 text-ink/55"
                       >{formatDate(item.date)}</td
-                    ><td class="px-4 py-3">{sourceLabel(item.source)}</td><td
+                    ><td class="px-4 py-3">{sourceLabel(item)}</td><td
                       class="max-w-xs px-4 py-3"
                       ><p class="truncate font-semibold">{item.title}</p>
                       <p class="truncate text-xs text-ink/40">
                         {item.subtitle}
-                      </p></td
+                      </p>
+                      {#if item.transactionId && item.invoiceId && itemMappingDifference(item) > 0}<Badge
+                          variant="secondary"
+                          class="mt-1 bg-amber-50 text-amber-800"
+                          >點數折抵 {formatCurrency(
+                            itemMappingDifference(item),
+                          )}</Badge
+                        >{/if}</td
                     ><td class="px-4 py-3"
-                      >{#if item.transactionId}<Select
-                          aria-label={`更新 ${item.title} 分類`}
-                          class="h-9 w-auto px-2 text-sm font-medium text-steel"
-                          value={item.categoryId}
-                          onchange={(e: Event) =>
-                            openCategory(
-                              item,
-                              (e.currentTarget as HTMLSelectElement).value,
-                            )}
-                          >{#each categoryOptions as category (category.id)}<option
-                              value={category.id}>{category.label}</option
-                            >{/each}</Select
-                        >{:else}{item.category}{/if}</td
+                      ><Badge variant="secondary">{item.category}</Badge></td
                     ><td
-                      class={`whitespace-nowrap px-4 py-3 text-right font-semibold tabular-nums ${item.excludedFromCalculation ? "text-ink/35 line-through" : (amount ?? 0) < 0 ? "text-coral" : item.source !== "invoice" ? "text-moss" : ""}`}
-                      >{amount == null
-                        ? "—"
-                        : formatCurrency(amount, item.currency)}</td
-                    ><td class="whitespace-nowrap px-4 py-3"
-                      >{#if item.transactionId}<Button
-                          aria-label={`${item.excludedFromCalculation ? "恢復" : "排除"} ${item.title} 的統計計算`}
-                          aria-pressed={item.excludedFromCalculation}
-                          disabled={$calculationMutation.isPending &&
-                            $calculationMutation.variables?.transactionId ===
-                              item.transactionId}
-                          size="sm"
-                          variant={item.excludedFromCalculation
-                            ? "secondary"
-                            : "outline"}
-                          onclick={() => toggleCalculation(item)}
-                          >{item.excludedFromCalculation
-                            ? "恢復計算"
-                            : "排除計算"}</Button
-                        >{:else}<span class="text-ink/35">—</span>{/if}</td
-                    ><td class="whitespace-nowrap px-5 py-3 text-ink/55"
-                      >{item.status === "pending"
-                        ? "待入帳"
-                        : item.status === "posted"
-                          ? "已入帳"
-                          : item.status}</td
+                      class={`whitespace-nowrap px-5 py-3 text-right font-semibold tabular-nums ${item.excludedFromCalculation ? "text-ink/35 line-through" : (amount ?? 0) < 0 ? "text-coral" : item.source !== "invoice" ? "text-moss" : ""}`}
+                      ><span class="inline-flex items-center gap-2"
+                        >{amount == null
+                          ? "—"
+                          : formatCurrency(amount, item.currency)}<ChevronRight
+                          class="size-4 text-ink/30"
+                        /></span
+                      ></td
                     ></tr
                   >{/each}{/if}</tbody
             >
@@ -688,6 +840,234 @@
         >查看完整發票明細 →</Button
       >
     </div>
+    {#if detailItem}
+      {@const amount = renderedAmount(detailItem)}
+      {@const transaction = transactionForItem(detailItem)}
+      {@const invoice = invoiceForItem(detailItem)}
+      <div
+        aria-labelledby="activity-detail-title"
+        aria-modal="true"
+        class="fixed inset-0 z-[60] bg-ink/40 md:flex md:justify-end"
+        role="dialog"
+      >
+        <div
+          class="flex h-full w-full flex-col overflow-hidden bg-white shadow-2xl md:max-w-[32rem]"
+        >
+          <header
+            class="flex shrink-0 items-center justify-between border-b border-ink/10 px-4 py-3 md:px-6"
+          >
+            <div class="flex min-w-0 items-center gap-2">
+              <button
+                aria-label="返回活動列表"
+                class="flex size-11 shrink-0 items-center justify-center rounded-full text-ink/60 hover:bg-paper"
+                onclick={() => (detailKey = null)}
+                ><ArrowLeft class="size-5 md:hidden" /><X
+                  class="hidden size-5 md:block"
+                /></button
+              >
+              <h2
+                class="truncate text-lg font-semibold"
+                id="activity-detail-title"
+              >
+                活動明細
+              </h2>
+            </div>
+            <span class="text-xs font-medium text-ink/45"
+              >{sourceLabel(detailItem)}</span
+            >
+          </header>
+
+          <div class="min-h-0 flex-1 overflow-y-auto px-5 py-5 md:px-7 md:py-6">
+            <section class="border-b border-ink/10 pb-5">
+              <div class="flex items-start justify-between gap-4">
+                <div class="min-w-0">
+                  <h3 class="break-words text-xl font-semibold leading-snug">
+                    {detailItem.title}
+                  </h3>
+                  <p class="mt-1 text-sm text-ink/50">
+                    {formatDate(detailItem.date)}{#if transaction}
+                      · {mappingAccount(transaction)}
+                    {/if}
+                  </p>
+                </div>
+                <p
+                  class={`shrink-0 pt-1 text-lg font-bold tabular-nums ${detailItem.excludedFromCalculation ? "text-ink/35 line-through" : (amount ?? 0) < 0 ? "text-coral" : detailItem.source !== "invoice" ? "text-moss" : ""}`}
+                >
+                  {amount == null
+                    ? "—"
+                    : `${amount >= 0 && detailItem.source !== "invoice" ? "+" : ""}${formatCurrency(amount, detailItem.currency)}`}
+                </p>
+              </div>
+              <Badge variant="secondary" class="mt-3"
+                >{detailItem.category}</Badge
+              >
+              {#if detailItem.excludedFromCalculation}<Badge
+                  variant="secondary"
+                  class="ml-2 mt-3">已排除計算</Badge
+                >{/if}
+              {#if transaction && invoice && itemMappingDifference(detailItem) > 0}<Badge
+                  variant="secondary"
+                  class="ml-2 mt-3 bg-amber-50 text-amber-800"
+                  >點數折抵 {formatCurrency(
+                    itemMappingDifference(detailItem),
+                  )}</Badge
+                >{/if}
+            </section>
+
+            <section class="border-b border-ink/10 py-5">
+              <h3 class="text-base font-semibold">來源名稱</h3>
+              <div class="mt-3 grid gap-3">
+                {#if transaction}<div class="rounded-xl bg-steel/10 p-4">
+                    <p class="text-xs font-semibold text-steel">
+                      銀行／信用卡原始名稱
+                    </p>
+                    <p class="mt-1 break-words font-semibold">
+                      {mappingMerchant(transaction)}
+                    </p>
+                    {#if transaction.description && transaction.description !== mappingMerchant(transaction)}<p
+                        class="mt-1 break-words text-xs text-ink/50"
+                      >
+                        {transaction.description}
+                      </p>{/if}
+                    <p class="mt-1 text-xs text-ink/50">
+                      {mappingAccount(transaction)} · 實付 {formatCurrency(
+                        Math.abs(transaction.amount),
+                        transaction.currency,
+                      )}
+                    </p>
+                  </div>{/if}
+                {#if invoice}<div class="rounded-xl bg-coral/10 p-4">
+                    <p class="text-xs font-semibold text-coral">發票商家名稱</p>
+                    <p class="mt-1 break-words font-semibold">
+                      {invoice.sellerName ?? "電子發票"}
+                    </p>
+                    <p class="mt-1 text-xs text-ink/50">
+                      發票 {invoice.invoiceNumber ?? "無發票號碼"} · 總額
+                      {formatCurrency(invoice.amount)}
+                    </p>
+                  </div>{/if}
+                {#if !transaction && invoice}<div
+                    class="rounded-xl bg-amber-50 p-4 text-amber-900"
+                  >
+                    <p class="font-semibold">尚未找到銀行／信用卡交易</p>
+                    <p class="mt-1 text-xs text-ink/55">
+                      仍會列入當月支出；你可以在下方手動配對。
+                    </p>
+                  </div>{/if}
+                {#if !transaction && !invoice}<div
+                    class="rounded-xl bg-paper p-4"
+                  >
+                    <p class="text-xs font-semibold text-ink/50">來源說明</p>
+                    <p class="mt-1 break-words font-semibold">
+                      {detailItem.subtitle || detailItem.title}
+                    </p>
+                  </div>{/if}
+              </div>
+            </section>
+
+            {#if invoice}<section class="border-b border-ink/10 py-5">
+                <h3 class="text-base font-semibold">發票細項</h3>
+                {#if invoice.items.length === 0}<p
+                    class="mt-3 rounded-xl bg-paper p-4 text-sm text-ink/50"
+                  >
+                    此發票沒有品項明細。
+                  </p>{:else}<div class="mt-2 divide-y divide-ink/10">
+                    {#each invoice.items as line (line.id)}<div
+                        class="flex items-start justify-between gap-4 py-3"
+                      >
+                        <div class="min-w-0">
+                          <p class="break-words font-medium">
+                            {line.description}
+                          </p>
+                          <p class="mt-1 text-xs text-ink/50">
+                            {line.quantity != null
+                              ? `${formatNumber(line.quantity)} 件`
+                              : "數量未提供"}{line.unitPrice != null
+                              ? ` × ${formatCurrency(line.unitPrice)}`
+                              : ""}
+                          </p>
+                        </div>
+                        <p class="shrink-0 font-semibold tabular-nums">
+                          {formatCurrency(line.amount)}
+                        </p>
+                      </div>{/each}
+                  </div>{/if}
+              </section>{/if}
+
+            <section class="py-5">
+              <h3 class="text-base font-semibold">活動設定</h3>
+              <div class="mt-2 divide-y divide-ink/10">
+                <div class="flex items-center justify-between gap-4 py-4">
+                  <div>
+                    <p class="font-semibold">分類</p>
+                    {#if !detailItem.transactionId}<p
+                        class="mt-1 text-xs text-ink/50"
+                      >
+                        {invoice
+                          ? "配對銀行／信用卡交易後即可調整"
+                          : "此來源目前不支援調整"}
+                      </p>{/if}
+                  </div>
+                  {#if detailItem.transactionId}<Select
+                      aria-label={`更新 ${detailItem.title} 分類`}
+                      class="h-11 w-40 shrink-0 font-medium text-steel"
+                      value={detailItem.categoryId}
+                      onchange={(event: Event) =>
+                        openCategory(
+                          detailItem,
+                          (event.currentTarget as HTMLSelectElement).value,
+                        )}
+                      >{#each categoryOptions as category (category.id)}<option
+                          value={category.id}>{category.label}</option
+                        >{/each}</Select
+                    >{:else}<Badge variant="secondary"
+                      >{detailItem.category}</Badge
+                    >{/if}
+                </div>
+
+                {#if detailItem.transactionId}<label
+                    class="flex cursor-pointer items-center justify-between gap-4 py-4"
+                  >
+                    <span>
+                      <span class="block font-semibold">排除統計計算</span>
+                      <span class="mt-1 block text-xs text-ink/50"
+                        >保留活動，但不計入收支</span
+                      >
+                    </span>
+                    <Checkbox
+                      aria-label={`${detailItem.excludedFromCalculation ? "恢復" : "排除"} ${detailItem.title} 的統計計算`}
+                      checked={detailItem.excludedFromCalculation}
+                      disabled={$calculationMutation.isPending &&
+                        $calculationMutation.variables?.transactionId ===
+                          detailItem.transactionId}
+                      onchange={() => toggleCalculation(detailItem)}
+                    />
+                  </label>{/if}
+
+                {#if invoice}<div
+                    class="flex items-center justify-between gap-4 py-4"
+                  >
+                    <div class="min-w-0">
+                      <p class="font-semibold">發票配對</p>
+                      <p
+                        class={`mt-1 text-xs ${transaction ? "text-moss" : "text-coral"}`}
+                      >
+                        {transaction ? "已配對，可變更或解除" : "尚未配對"}
+                      </p>
+                    </div>
+                    <Button
+                      class="h-11 shrink-0 whitespace-nowrap"
+                      variant={transaction ? "outline" : "default"}
+                      onclick={() => openMapping(detailItem)}
+                      >{transaction ? "管理配對" : "配對交易"}</Button
+                    >
+                  </div>{/if}
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    {/if}
     {#if pending}<div
         aria-modal="true"
         class="fixed inset-0 z-[70] flex items-end bg-ink/45 md:items-center md:justify-center md:p-6"
@@ -749,6 +1129,233 @@
               更新失敗。
             </p>{/if}
         </div>
+      </div>{/if}
+    {#if mappingDialog}<div
+        aria-modal="true"
+        class="fixed inset-0 z-[75] flex items-end bg-ink/45 md:items-center md:justify-center md:p-6"
+        role="dialog"
+      >
+        <div
+          class="max-h-[92vh] w-full overflow-y-auto rounded-t-2xl bg-white p-5 shadow-2xl md:max-w-xl md:rounded-2xl md:p-6"
+        >
+          <div
+            class="mx-auto mb-4 h-1.5 w-14 rounded-full bg-ink/20 md:hidden"
+          ></div>
+          <div class="flex items-start justify-between gap-4">
+            <div class="min-w-0">
+              <h2 class="text-xl font-semibold">
+                {mappingDialog.step === "actions"
+                  ? "管理配對"
+                  : mappingDialog.step === "confirm"
+                    ? "確認合併這兩筆？"
+                    : "選擇同日候選交易"}
+              </h2>
+              {#if mappingDialog.step === "candidates"}<p
+                  class="mt-1 truncate text-sm text-ink/50"
+                >
+                  發票：{mappingDialog.invoice.sellerName ?? "電子發票"} ·
+                  {formatCurrency(mappingDialog.invoice.amount)}
+                </p>{:else if mappingDialog.step === "confirm"}<p
+                  class="mt-1 text-sm text-ink/50"
+                >
+                  合併後活動只顯示一筆，支出採銀行／信用卡實付金額。
+                </p>{/if}
+            </div>
+            <button
+              aria-label="關閉配對視窗"
+              class="flex size-11 shrink-0 items-center justify-center rounded-full text-ink/50 hover:bg-paper"
+              onclick={() => (mappingDialog = null)}
+              ><X class="size-5" /></button
+            >
+          </div>
+
+          {#if mappingDialog.step === "actions"}
+            {@const transaction = selectedMappingTransaction()}
+            {#if transaction}<div
+                class="mt-5 rounded-xl border border-steel/30 bg-steel/5 p-4"
+              >
+                <div class="flex items-start justify-between gap-4">
+                  <div class="min-w-0">
+                    <p class="truncate font-semibold">
+                      {mappingDialog.invoice.sellerName ?? "電子發票"}
+                    </p>
+                    <p class="mt-1 truncate text-xs text-ink/50">
+                      信用卡＋發票 · {mappingDialog.invoice.invoiceNumber ??
+                        "無發票號碼"}
+                    </p>
+                  </div>
+                  <p class="shrink-0 font-semibold text-coral">
+                    {formatCurrency(-Math.abs(transaction.amount))}
+                  </p>
+                </div>
+                {#if mappingDifference(mappingDialog.invoice, transaction) > 0}<Badge
+                    variant="secondary"
+                    class="mt-3 bg-amber-50 text-amber-800"
+                    >點數折抵 {formatCurrency(
+                      mappingDifference(mappingDialog.invoice, transaction),
+                    )}</Badge
+                  >{/if}
+              </div>{/if}
+            <div class="mt-5 grid gap-3">
+              <Button
+                class="h-12 justify-start gap-3"
+                variant="outline"
+                onclick={() => (mappingDialog!.step = "candidates")}
+                ><Link2 class="size-4 text-steel" />變更配對</Button
+              >
+              <Button
+                class="h-12 justify-start gap-3 text-coral"
+                disabled={$separationMutation.isPending}
+                variant="outline"
+                onclick={() =>
+                  $separationMutation.mutate(mappingDialog!.invoice.id)}
+                ><Unlink2 class="size-4" />{$separationMutation.isPending
+                  ? "解除中…"
+                  : "解除並保持分開"}</Button
+              >
+            </div>
+          {:else if mappingDialog.step === "candidates"}
+            <div class="mt-5 grid max-h-[52vh] gap-3 overflow-y-auto pr-1">
+              {#if mappingCandidates.length === 0}<div
+                  class="rounded-xl border border-dashed border-ink/15 bg-paper p-6 text-center"
+                >
+                  <p class="font-semibold">同一天沒有可配對的支出</p>
+                  <p class="mt-1 text-xs text-ink/50">
+                    只有同一天的 TWD 銀行或信用卡支出會列在這裡。
+                  </p>
+                </div>{:else}{#each mappingCandidates as transaction (transaction.id)}{@const difference =
+                    mappingDifference(
+                      mappingDialog.invoice,
+                      transaction,
+                    )}<button
+                    aria-pressed={mappingDialog.transactionId ===
+                      transaction.id}
+                    class={`min-h-24 rounded-xl border p-4 text-left transition ${mappingDialog.transactionId === transaction.id ? "border-steel bg-steel/10 ring-2 ring-steel/15" : "border-ink/10 hover:border-steel/40 hover:bg-paper"}`}
+                    onclick={() => chooseMappingTransaction(transaction.id)}
+                  >
+                    <span class="flex items-start justify-between gap-3">
+                      <span class="min-w-0">
+                        <span class="block truncate font-semibold"
+                          >{mappingMerchant(transaction)}</span
+                        >
+                        <span class="mt-1 block truncate text-xs text-ink/50"
+                          >{mappingAccount(transaction)} · {formatDate(
+                            transaction.postedDate ??
+                              transaction.authorizedAt ??
+                              "",
+                          )}</span
+                        >
+                      </span>
+                      <span class="shrink-0 font-semibold text-coral"
+                        >{formatCurrency(-Math.abs(transaction.amount))}</span
+                      >
+                    </span>
+                    <span class="mt-3 flex flex-wrap items-center gap-2">
+                      <Badge variant="secondary" class="bg-moss/10 text-moss"
+                        >同一天</Badge
+                      >
+                      {#if difference > 0}<Badge
+                          variant="secondary"
+                          class="bg-amber-50 text-amber-800"
+                          >差額 {formatCurrency(difference)}</Badge
+                        >{/if}
+                    </span>
+                  </button>{/each}{/if}
+            </div>
+            <p class="mt-4 text-xs text-ink/50">
+              依同一天與金額接近排序；商家名稱可能因支付工具而不同，最後由你決定。
+            </p>
+            <div class="mt-5 grid grid-cols-[7rem_1fr] gap-3">
+              <Button
+                class="h-12"
+                variant="secondary"
+                onclick={() => (mappingDialog = null)}>取消</Button
+              ><Button
+                class="h-12"
+                disabled={!mappingDialog.transactionId}
+                onclick={() => (mappingDialog!.step = "confirm")}>下一步</Button
+              >
+            </div>
+          {:else}
+            {@const transaction = selectedMappingTransaction()}
+            {#if transaction}{@const difference = mappingDifference(
+                mappingDialog.invoice,
+                transaction,
+              )}
+              <div class="mt-5 grid gap-3">
+                <div class="rounded-xl bg-coral/10 p-4">
+                  <p class="text-xs font-semibold text-coral">發票</p>
+                  <div class="mt-2 flex items-center justify-between gap-4">
+                    <p class="truncate font-semibold">
+                      {mappingDialog.invoice.sellerName ?? "電子發票"}
+                    </p>
+                    <p class="shrink-0 font-semibold">
+                      {formatCurrency(mappingDialog.invoice.amount)}
+                    </p>
+                  </div>
+                </div>
+                <ArrowDown class="mx-auto size-5 text-steel" />
+                <div class="rounded-xl bg-steel/10 p-4">
+                  <p class="text-xs font-semibold text-steel">銀行／信用卡</p>
+                  <div class="mt-2 flex items-center justify-between gap-4">
+                    <p class="truncate font-semibold">
+                      {mappingMerchant(transaction)}
+                    </p>
+                    <p class="shrink-0 font-semibold">
+                      {formatCurrency(Math.abs(transaction.amount))}
+                    </p>
+                  </div>
+                </div>
+                {#if difference > 0}<div
+                    class="rounded-xl bg-amber-50 p-4 text-amber-900"
+                  >
+                    <p class="font-semibold">
+                      差額 {formatCurrency(difference)}
+                    </p>
+                    <p class="mt-1 text-xs text-ink/55">
+                      可能來自 LINE Pay 點數或其他折抵
+                    </p>
+                  </div>{/if}
+                <p class="text-xs text-ink/50">
+                  當月支出將計入 {formatCurrency(
+                    Math.abs(transaction.amount),
+                  )}，發票資料保留在合併紀錄中。
+                </p>
+              </div>
+              <div class="mt-5 grid grid-cols-[7rem_1fr] gap-3">
+                <Button
+                  class="h-12"
+                  variant="secondary"
+                  onclick={() => (mappingDialog!.step = "candidates")}
+                  >返回</Button
+                ><Button
+                  class="h-12"
+                  disabled={$mappingMutation.isPending}
+                  onclick={() =>
+                    $mappingMutation.mutate({
+                      invoiceId: mappingDialog!.invoice.id,
+                      transactionId: transaction.id,
+                    })}
+                  >{$mappingMutation.isPending ? "配對中…" : "確認配對"}</Button
+                >
+              </div>
+            {:else}<p class="mt-5 text-sm text-coral">
+                找不到選取的交易，請返回重新選擇。
+              </p>{/if}
+          {/if}
+
+          {#if $mappingMutation.isError || $separationMutation.isError}<p
+              class="mt-4 text-sm font-medium text-coral"
+            >
+              無法更新配對，資料可能已變更，請重新整理後再試。
+            </p>{/if}
+        </div>
+      </div>{/if}
+    {#if mappingNotice}<div
+        aria-live="polite"
+        class="fixed left-1/2 top-20 z-[85] flex w-[min(22rem,calc(100vw-2rem))] -translate-x-1/2 items-center gap-3 rounded-xl bg-ink px-4 py-3 text-sm font-semibold text-white shadow-xl"
+      >
+        <Check class="size-5 shrink-0 text-lime-300" />{mappingNotice}
       </div>{/if}
   </div>
 {/if}

--- a/apps/web/src/lib/activity-chart.test.ts
+++ b/apps/web/src/lib/activity-chart.test.ts
@@ -22,7 +22,7 @@ function item(overrides: Partial<ActivityItem>): ActivityItem {
 }
 
 describe("activity category chart", () => {
-  it("converts bank cash flow to TWD and treats card activity as expense", () => {
+  it("converts cash flow to TWD and treats cards and invoices as expenses", () => {
     expect(
       activityCashAmountTwd(item({ amount: 10, currency: "USD" }), { USD: 32 }),
     ).toBe(320);
@@ -31,7 +31,10 @@ describe("activity category chart", () => {
     ).toBe(-500);
     expect(
       activityCashAmountTwd(item({ source: "invoice", amount: 500 }), {}),
-    ).toBe(0);
+    ).toBe(-500);
+    expect(activityCashFlow(item({ source: "invoice", amount: 500 }))).toBe(
+      "expense",
+    );
   });
 
   it("groups categories and sorts them by amount descending", () => {

--- a/apps/web/src/lib/activity-chart.ts
+++ b/apps/web/src/lib/activity-chart.ts
@@ -21,9 +21,14 @@ export const ACTIVITY_CATEGORY_COLORS = [
 ];
 
 export function activityCashFlow(item: ActivityItem): ActivityFlow | null {
-  if (item.amount == null || (item.source !== "bank" && item.source !== "card"))
+  if (
+    item.amount == null ||
+    (item.source !== "bank" &&
+      item.source !== "card" &&
+      item.source !== "invoice")
+  )
     return null;
-  if (item.source === "card") return "expense";
+  if (item.source === "card" || item.source === "invoice") return "expense";
   if (item.amount > 0) return "income";
   if (item.amount < 0) return "expense";
   return null;
@@ -36,12 +41,16 @@ export function activityCashAmountTwd(
   if (
     item.amount == null ||
     item.excludedFromCalculation ||
-    (item.source !== "bank" && item.source !== "card")
+    (item.source !== "bank" &&
+      item.source !== "card" &&
+      item.source !== "invoice")
   )
     return 0;
   const rate = item.currency === "TWD" ? 1 : (rates[item.currency] ?? 0);
   const converted = item.amount * rate;
-  return item.source === "card" ? -Math.abs(converted) : converted;
+  return item.source === "card" || item.source === "invoice"
+    ? -Math.abs(converted)
+    : converted;
 }
 
 export function buildActivityCategorySlices(

--- a/apps/web/src/lib/activity-matching.test.ts
+++ b/apps/web/src/lib/activity-matching.test.ts
@@ -1,0 +1,435 @@
+import { describe, expect, it } from "vitest";
+import {
+  deduplicateBankTransactions,
+  invoiceTransactionCandidates,
+  matchInvoicesToTransactions,
+} from "./activity-matching";
+import type { BankTransactionRow, InvoiceRow } from "./types";
+
+function transaction(
+  overrides: Partial<BankTransactionRow> = {},
+): BankTransactionRow {
+  return {
+    id: "transaction-1",
+    connectorId: "sinopac",
+    accountId: "card-1",
+    sourceId: "source-1",
+    postedDate: "2026-07-10",
+    authorizedAt: "2026-07-10T12:00:00.000Z",
+    amount: -860,
+    currency: "TWD",
+    description: "信用卡消費",
+    counterparty: "好食餐飲",
+    status: "posted",
+    excludedFromCalculation: false,
+    ...overrides,
+  };
+}
+
+function invoice(overrides: Partial<InvoiceRow> = {}): InvoiceRow {
+  return {
+    id: "invoice-1",
+    connectorId: "einvoice",
+    sourceId: "invoice-source-1",
+    invoiceDate: "2026-07-10",
+    invoiceNumber: "AB12345678",
+    sellerName: "好食餐飲有限公司",
+    amount: 860,
+    items: [],
+    ...overrides,
+  };
+}
+
+describe("invoice transaction matching", () => {
+  it("matches an exact amount, same date, and normalized merchant name", () => {
+    const result = matchInvoicesToTransactions([transaction()], [invoice()]);
+
+    expect(result.invoiceToTransactionId.get("invoice-1")).toBe(
+      "transaction-1",
+    );
+    expect(result.transactionToInvoice.get("transaction-1")?.id).toBe(
+      "invoice-1",
+    );
+  });
+
+  it("matches a positive pending card amount through a payment processor", () => {
+    const result = matchInvoicesToTransactions(
+      [
+        transaction({
+          accountType: "credit",
+          postedDate: "2026-07-06T00:00:00.000Z",
+          authorizedAt: undefined,
+          amount: 134,
+          description: "全支付﹘全聯",
+          counterparty: "全支付﹘全聯",
+        }),
+      ],
+      [
+        invoice({
+          invoiceDate: "2026-07-06T14:06:40.000Z",
+          sellerName: "全聯實業股份有限公司台中旅順分公司",
+          amount: 134,
+        }),
+      ],
+    );
+
+    expect(result.invoiceToTransactionId.get("invoice-1")).toBe(
+      "transaction-1",
+    );
+  });
+
+  it("matches a LINE Pay card charge reduced by redeemed points", () => {
+    const result = matchInvoicesToTransactions(
+      [
+        transaction({
+          accountType: "credit",
+          postedDate: "2026-07-09T00:00:00.000Z",
+          authorizedAt: undefined,
+          amount: -125,
+          description: "連支×楓康超市",
+          counterparty: "連支×楓康超市",
+        }),
+      ],
+      [
+        invoice({
+          invoiceDate: "2026-07-09T13:20:00.000Z",
+          sellerName: "台灣楓康超市股份有限公司大連分公司",
+          amount: 168,
+        }),
+      ],
+    );
+
+    expect(result.invoiceToTransactionId.get("invoice-1")).toBe(
+      "transaction-1",
+    );
+  });
+
+  it("prefers an exact amount over a possible LINE Pay points match", () => {
+    const result = matchInvoicesToTransactions(
+      [
+        transaction({
+          accountType: "credit",
+          amount: -125,
+          description: "連支×楓康超市",
+          counterparty: "連支×楓康超市",
+        }),
+      ],
+      [
+        invoice({
+          id: "exact-invoice",
+          sellerName: "台灣楓康超市股份有限公司大連分公司",
+          amount: 125,
+        }),
+        invoice({
+          id: "points-invoice",
+          sellerName: "台灣楓康超市股份有限公司大連分公司",
+          amount: 168,
+        }),
+      ],
+    );
+
+    expect(result.invoiceToTransactionId.get("exact-invoice")).toBe(
+      "transaction-1",
+    );
+    expect(result.invoiceToTransactionId.has("points-invoice")).toBe(false);
+  });
+
+  it("does not allow amount differences outside LINE Pay point redemption", () => {
+    const ordinaryCard = transaction({
+      accountType: "credit",
+      amount: -125,
+      description: "楓康超市",
+      counterparty: "楓康超市",
+    });
+    const linePayOvercharge = transaction({
+      accountType: "credit",
+      amount: -180,
+      description: "連支×楓康超市",
+      counterparty: "連支×楓康超市",
+    });
+    const targetInvoice = invoice({
+      sellerName: "台灣楓康超市股份有限公司大連分公司",
+      amount: 168,
+    });
+
+    expect(
+      matchInvoicesToTransactions([ordinaryCard], [targetInvoice])
+        .invoiceToTransactionId.size,
+    ).toBe(0);
+    expect(
+      matchInvoicesToTransactions([linePayOvercharge], [targetInvoice])
+        .invoiceToTransactionId.size,
+    ).toBe(0);
+  });
+
+  it("offers same-day expenses for manual mapping without auto-linking unrelated merchants", () => {
+    const transactions = [
+      transaction({
+        id: "pxpay-tea",
+        accountType: "credit",
+        postedDate: "2026-07-06T00:00:00.000Z",
+        authorizedAt: undefined,
+        amount: 37,
+        description: "全支付﹘樂法 台中漢口店",
+        counterparty: "全支付﹘樂法 台中漢口店",
+      }),
+      transaction({
+        id: "linepay-dinner",
+        accountType: "credit",
+        postedDate: "2026-07-06",
+        authorizedAt: undefined,
+        amount: -265,
+        description: "連支＊萬川雞飯．肉骨茶",
+        counterparty: "連支＊萬川雞飯．肉骨茶",
+      }),
+    ];
+    const targetInvoice = invoice({
+      invoiceDate: "2026-07-06T04:39:18.000Z",
+      sellerName: "菲尖極道商行",
+      amount: 50,
+    });
+    const result = matchInvoicesToTransactions(transactions, [targetInvoice]);
+
+    expect(result.invoiceToTransactionId.size).toBe(0);
+    expect(
+      invoiceTransactionCandidates(transactions, targetInvoice).map(
+        ({ id }) => id,
+      ),
+    ).toEqual(["pxpay-tea", "linepay-dinner"]);
+  });
+
+  it("applies manual links before automatic matching", () => {
+    const result = matchInvoicesToTransactions(
+      [transaction()],
+      [invoice({ sellerName: "不同商家", amount: 999 })],
+      [
+        {
+          invoiceId: "invoice-1",
+          transactionId: "transaction-1",
+          decision: "linked",
+          updatedAt: "2026-07-19T00:00:00.000Z",
+        },
+      ],
+    );
+
+    expect(result.invoiceToTransactionId.get("invoice-1")).toBe(
+      "transaction-1",
+    );
+  });
+
+  it("keeps an automatic match separate after the user unlinks it", () => {
+    const result = matchInvoicesToTransactions(
+      [transaction()],
+      [invoice()],
+      [
+        {
+          invoiceId: "invoice-1",
+          transactionId: null,
+          decision: "separate",
+          updatedAt: "2026-07-19T00:00:00.000Z",
+        },
+      ],
+    );
+
+    expect(result.invoiceToTransactionId.size).toBe(0);
+    expect(result.transactionToInvoice.size).toBe(0);
+  });
+
+  it("leaves unrelated payment-processor candidates unpaired when the remainder is ambiguous", () => {
+    const result = matchInvoicesToTransactions(
+      [
+        transaction({
+          id: "payment-1",
+          accountType: "credit",
+          amount: -37,
+          description: "全支付﹘品牌甲",
+          counterparty: "全支付﹘品牌甲",
+        }),
+        transaction({
+          id: "payment-2",
+          accountType: "credit",
+          amount: -40,
+          description: "連支＊品牌乙",
+          counterparty: "連支＊品牌乙",
+        }),
+      ],
+      [invoice({ sellerName: "無關登記商號", amount: 50 })],
+    );
+
+    expect(result.invoiceToTransactionId.size).toBe(0);
+    expect(result.transactionToInvoice.size).toBe(0);
+  });
+
+  it("does not treat a positive bank deposit as an expense match", () => {
+    const result = matchInvoicesToTransactions(
+      [transaction({ accountType: "checking", amount: 860 })],
+      [invoice()],
+    );
+
+    expect(result.invoiceToTransactionId.size).toBe(0);
+  });
+
+  it("does not match an otherwise identical transaction from another day", () => {
+    const result = matchInvoicesToTransactions(
+      [
+        transaction({
+          postedDate: "2026-07-11",
+          authorizedAt: "2026-07-10T12:00:00.000Z",
+        }),
+      ],
+      [invoice()],
+    );
+
+    expect(result.invoiceToTransactionId.size).toBe(0);
+  });
+
+  it("uses the Taipei calendar day for ISO timestamps near midnight", () => {
+    const nextTaipeiDay = transaction({
+      accountType: "credit",
+      postedDate: "2026-07-06T16:00:00.000Z",
+      authorizedAt: undefined,
+      amount: 50,
+    });
+    const targetInvoice = invoice({
+      invoiceDate: "2026-07-06T04:39:18.000Z",
+      amount: 50,
+    });
+
+    expect(
+      matchInvoicesToTransactions([nextTaipeiDay], [targetInvoice])
+        .invoiceToTransactionId.size,
+    ).toBe(0);
+    expect(
+      invoiceTransactionCandidates([nextTaipeiDay], targetInvoice),
+    ).toEqual([]);
+  });
+
+  it("matches highly overlapping CJK merchant names with repeated branding", () => {
+    const result = matchInvoicesToTransactions(
+      [
+        transaction({
+          accountType: "credit",
+          postedDate: "2026-07-16T00:00:00.000Z",
+          authorizedAt: undefined,
+          amount: 129,
+          description: "全國加油站昌平站",
+          counterparty: "全國加油站昌平站",
+        }),
+      ],
+      [
+        invoice({
+          invoiceDate: "2026-07-16T10:26:00.000Z",
+          sellerName: "全國加油站股份有限公司全國昌平站",
+          amount: 129,
+        }),
+      ],
+    );
+
+    expect(result.invoiceToTransactionId.get("invoice-1")).toBe(
+      "transaction-1",
+    );
+  });
+
+  it("does not fuzzy-match a different branch", () => {
+    const result = matchInvoicesToTransactions(
+      [
+        transaction({
+          accountType: "credit",
+          amount: 129,
+          description: "全國加油站文心站",
+          counterparty: "全國加油站文心站",
+        }),
+      ],
+      [
+        invoice({
+          sellerName: "全國加油站股份有限公司全國昌平站",
+          amount: 129,
+        }),
+      ],
+    );
+
+    expect(result.invoiceToTransactionId.size).toBe(0);
+  });
+
+  it("does not match when amount, date, or merchant differs", () => {
+    expect(
+      matchInvoicesToTransactions([transaction({ amount: -861 })], [invoice()])
+        .invoiceToTransactionId.size,
+    ).toBe(0);
+    expect(
+      matchInvoicesToTransactions(
+        [transaction({ postedDate: "2026-07-20", authorizedAt: undefined })],
+        [invoice()],
+      ).invoiceToTransactionId.size,
+    ).toBe(0);
+    expect(
+      matchInvoicesToTransactions(
+        [transaction({ counterparty: "另一間商店" })],
+        [invoice()],
+      ).invoiceToTransactionId.size,
+    ).toBe(0);
+  });
+
+  it("leaves ambiguous matches unpaired", () => {
+    const result = matchInvoicesToTransactions(
+      [transaction(), transaction({ id: "transaction-2" })],
+      [invoice()],
+    );
+
+    expect(result.invoiceToTransactionId.size).toBe(0);
+    expect(result.transactionToInvoice.size).toBe(0);
+  });
+});
+
+describe("bank transaction deduplication", () => {
+  it("prefers the posted E.SUN lifecycle copy and lets its invoice match", () => {
+    const pending = transaction({
+      id: "pending",
+      connectorId: "esun",
+      sourceId:
+        "2026-07-05T00:00:00.000Z:credit:esun:1204:全支付﹘全聯:252:TWD:未入帳:1",
+      accountType: "credit",
+      postedDate: "2026-07-05T00:00:00.000Z",
+      amount: 252,
+      description: "全支付﹘全聯",
+      counterparty: "全支付﹘全聯",
+    });
+    const posted = transaction({
+      ...pending,
+      id: "posted",
+      sourceId: pending.sourceId.replace("未入帳", "已入帳"),
+    });
+    const transactions = deduplicateBankTransactions([pending, posted]);
+
+    expect(transactions.map(({ id }) => id)).toEqual(["posted"]);
+    expect(
+      matchInvoicesToTransactions(transactions, [
+        invoice({
+          invoiceDate: "2026-07-05T14:41:11.000Z",
+          sellerName: "全聯實業股份有限公司台中旅順分公司",
+          amount: 252,
+        }),
+      ]).invoiceToTransactionId.get("invoice-1"),
+    ).toBe("posted");
+  });
+
+  it("keeps distinct occurrences and unrelated connectors", () => {
+    const first = transaction({
+      id: "first",
+      connectorId: "esun",
+      sourceId: "same:已入帳:1",
+    });
+    const second = transaction({
+      id: "second",
+      connectorId: "esun",
+      sourceId: "same:已入帳:2",
+    });
+    const unrelated = transaction({ id: "unrelated", connectorId: "tdcc" });
+
+    expect(
+      deduplicateBankTransactions([first, second, unrelated]).map(
+        ({ id }) => id,
+      ),
+    ).toEqual(["first", "second", "unrelated"]);
+  });
+});

--- a/apps/web/src/lib/activity-matching.ts
+++ b/apps/web/src/lib/activity-matching.ts
@@ -1,0 +1,333 @@
+import type {
+  BankTransactionRow,
+  InvoiceRow,
+  InvoiceTransactionPreference,
+} from "./types";
+
+const MERCHANT_ENTITY_MARKERS = [
+  "股份有限公司",
+  "有限責任公司",
+  "有限公司",
+  "股份",
+  "公司",
+];
+const MERCHANT_BRANCH_SUFFIXES = ["分公司", "門市"];
+const LINE_PAY_PREFIXES = ["連加", "連支", "linepay"];
+const PAYMENT_PROCESSOR_PREFIXES = ["全支付", ...LINE_PAY_PREFIXES];
+const TAIPEI_DAY_FORMATTER = new Intl.DateTimeFormat("en", {
+  timeZone: "Asia/Taipei",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+export interface InvoiceTransactionMatches {
+  invoiceToTransactionId: Map<string, string>;
+  transactionToInvoice: Map<string, InvoiceRow>;
+}
+
+type MatchCandidate = {
+  invoice: InvoiceRow;
+  transaction: BankTransactionRow;
+  kind: "exact" | "payment-points";
+};
+
+const ESUN_LIFECYCLE_MARKER = /:(已入帳|未入帳):(?=\d+$)/u;
+
+export function deduplicateBankTransactions(
+  transactions: BankTransactionRow[],
+): BankTransactionRow[] {
+  const preferredByKey = new Map<
+    string,
+    { transaction: BankTransactionRow; priority: number }
+  >();
+
+  for (const transaction of transactions) {
+    if (transaction.connectorId !== "esun") continue;
+    const lifecycle = transaction.sourceId.match(ESUN_LIFECYCLE_MARKER)?.[1];
+    const key = transaction.sourceId.replace(ESUN_LIFECYCLE_MARKER, ":");
+    const priority = lifecycle == null ? 2 : lifecycle === "已入帳" ? 1 : 0;
+    const current = preferredByKey.get(key);
+    if (!current || priority > current.priority)
+      preferredByKey.set(key, { transaction, priority });
+  }
+
+  const preferredIds = new Set(
+    Array.from(preferredByKey.values(), ({ transaction }) => transaction.id),
+  );
+  return transactions.filter(
+    (transaction) =>
+      transaction.connectorId !== "esun" || preferredIds.has(transaction.id),
+  );
+}
+
+export function matchInvoicesToTransactions(
+  transactions: BankTransactionRow[],
+  invoices: InvoiceRow[],
+  preferences: InvoiceTransactionPreference[] = [],
+): InvoiceTransactionMatches {
+  const invoiceById = new Map(invoices.map((invoice) => [invoice.id, invoice]));
+  const transactionById = new Map(
+    transactions.map((transaction) => [transaction.id, transaction]),
+  );
+  const invoiceToTransactionId = new Map<string, string>();
+  const transactionToInvoice = new Map<string, InvoiceRow>();
+  const separateInvoiceIds = new Set(
+    preferences
+      .filter(({ decision }) => decision === "separate")
+      .map(({ invoiceId }) => invoiceId),
+  );
+
+  for (const preference of preferences) {
+    if (preference.decision !== "linked" || !preference.transactionId) continue;
+    const invoice = invoiceById.get(preference.invoiceId);
+    const transaction = transactionById.get(preference.transactionId);
+    if (!invoice || !transaction || transactionToInvoice.has(transaction.id))
+      continue;
+    invoiceToTransactionId.set(invoice.id, transaction.id);
+    transactionToInvoice.set(transaction.id, invoice);
+  }
+
+  const autoInvoices = invoices.filter(
+    (invoice) =>
+      !separateInvoiceIds.has(invoice.id) &&
+      !invoiceToTransactionId.has(invoice.id),
+  );
+  const autoTransactions = transactions.filter(
+    (transaction) => !transactionToInvoice.has(transaction.id),
+  );
+  const allStrongCandidates = autoInvoices.flatMap((invoice) =>
+    autoTransactions
+      .map((transaction) => ({
+        invoice,
+        transaction,
+        kind: matchCandidateKind(transaction, invoice),
+      }))
+      .filter(
+        (candidate): candidate is MatchCandidate => candidate.kind != null,
+      ),
+  );
+  const exactInvoiceIds = new Set(
+    allStrongCandidates
+      .filter(({ kind }) => kind === "exact")
+      .map(({ invoice }) => invoice.id),
+  );
+  const exactTransactionIds = new Set(
+    allStrongCandidates
+      .filter(({ kind }) => kind === "exact")
+      .map(({ transaction }) => transaction.id),
+  );
+  const strongCandidates = allStrongCandidates.filter(
+    ({ invoice, transaction, kind }) =>
+      kind === "exact" ||
+      (!exactInvoiceIds.has(invoice.id) &&
+        !exactTransactionIds.has(transaction.id)),
+  );
+  addUniqueMatches(
+    strongCandidates,
+    invoiceToTransactionId,
+    transactionToInvoice,
+  );
+
+  return { invoiceToTransactionId, transactionToInvoice };
+}
+
+export function invoiceTransactionCandidates(
+  transactions: BankTransactionRow[],
+  invoice: InvoiceRow,
+  unavailableTransactionIds: ReadonlySet<string> = new Set(),
+) {
+  return transactions
+    .filter(
+      (transaction) =>
+        !unavailableTransactionIds.has(transaction.id) &&
+        isSameDayTwdExpense(transaction, invoice),
+    )
+    .sort((left, right) => {
+      const leftDifference = Math.abs(invoice.amount - Math.abs(left.amount));
+      const rightDifference = Math.abs(invoice.amount - Math.abs(right.amount));
+      return (
+        leftDifference - rightDifference ||
+        (left.counterparty ?? left.description ?? left.id).localeCompare(
+          right.counterparty ?? right.description ?? right.id,
+          "zh-TW",
+        )
+      );
+    });
+}
+
+function addUniqueMatches(
+  candidates: MatchCandidate[],
+  invoiceToTransactionId: Map<string, string>,
+  transactionToInvoice: Map<string, InvoiceRow>,
+) {
+  const invoiceCandidateCount = countBy(
+    candidates,
+    ({ invoice }) => invoice.id,
+  );
+  const transactionCandidateCount = countBy(
+    candidates,
+    ({ transaction }) => transaction.id,
+  );
+
+  for (const { invoice, transaction } of candidates) {
+    if (
+      invoiceCandidateCount.get(invoice.id) !== 1 ||
+      transactionCandidateCount.get(transaction.id) !== 1
+    )
+      continue;
+    invoiceToTransactionId.set(invoice.id, transaction.id);
+    transactionToInvoice.set(transaction.id, invoice);
+  }
+}
+
+function matchCandidateKind(
+  transaction: BankTransactionRow,
+  invoice: InvoiceRow,
+): MatchCandidate["kind"] | undefined {
+  if (!isSameDayTwdExpense(transaction, invoice)) return undefined;
+
+  const merchants = [transaction.counterparty, transaction.description];
+  if (
+    !merchants.some((merchant) =>
+      merchantNamesMatch(invoice.sellerName, merchant),
+    )
+  )
+    return undefined;
+
+  const chargedAmount = Math.abs(transaction.amount);
+  if (chargedAmount === invoice.amount) return "exact";
+  if (
+    transaction.accountType === "credit" &&
+    chargedAmount < invoice.amount &&
+    merchants.some(isPaymentProcessorMerchant)
+  )
+    return "payment-points";
+  return undefined;
+}
+
+function isSameDayTwdExpense(
+  transaction: BankTransactionRow,
+  invoice: InvoiceRow,
+) {
+  if (
+    transaction.amount === 0 ||
+    (transaction.accountType !== "credit" && transaction.amount > 0) ||
+    transaction.currency !== "TWD"
+  )
+    return false;
+
+  const transactionDate = dayNumber(
+    transaction.postedDate ?? transaction.authorizedAt,
+  );
+  const invoiceDate = dayNumber(invoice.invoiceDate);
+  return invoiceDate != null && transactionDate === invoiceDate;
+}
+
+function isPaymentProcessorMerchant(value?: string) {
+  const normalized = normalizeMerchantName(value);
+  return PAYMENT_PROCESSOR_PREFIXES.some((prefix) =>
+    normalized.startsWith(prefix),
+  );
+}
+
+function merchantNamesMatch(left?: string, right?: string) {
+  const normalizedLeft = normalizeMerchantName(left);
+  const normalizedRight = stripPaymentProcessorPrefix(
+    normalizeMerchantName(right),
+  );
+  if (!normalizedLeft || !normalizedRight) return false;
+  if (normalizedLeft === normalizedRight) return true;
+  const shorter =
+    normalizedLeft.length <= normalizedRight.length
+      ? normalizedLeft
+      : normalizedRight;
+  const longer =
+    normalizedLeft.length > normalizedRight.length
+      ? normalizedLeft
+      : normalizedRight;
+  const isContainedName =
+    (shorter.length >= 4 || isShortCjkBrand(shorter)) &&
+    longer.includes(shorter);
+  return isContainedName || hasHighCjkSubsequenceOverlap(shorter, longer);
+}
+
+function normalizeMerchantName(value?: string) {
+  let normalized = (value ?? "")
+    .normalize("NFKC")
+    .toLocaleLowerCase("zh-TW")
+    .replace(/[^\p{Letter}\p{Number}]+/gu, "");
+  for (const marker of MERCHANT_ENTITY_MARKERS)
+    normalized = normalized.replaceAll(marker, "");
+  let removedSuffix = true;
+  while (removedSuffix) {
+    removedSuffix = false;
+    for (const suffix of MERCHANT_BRANCH_SUFFIXES) {
+      if (!normalized.endsWith(suffix)) continue;
+      normalized = normalized.slice(0, -suffix.length);
+      removedSuffix = true;
+      break;
+    }
+  }
+  return normalized;
+}
+
+function stripPaymentProcessorPrefix(value: string) {
+  for (const prefix of PAYMENT_PROCESSOR_PREFIXES) {
+    if (value.startsWith(prefix) && value.length - prefix.length >= 2)
+      return value.slice(prefix.length);
+  }
+  return value;
+}
+
+function isShortCjkBrand(value: string) {
+  return value.length >= 2 && /^[\p{Script=Han}]+$/u.test(value);
+}
+
+function hasHighCjkSubsequenceOverlap(shorter: string, longer: string) {
+  if (
+    shorter.length < 4 ||
+    shorter.length / longer.length < 0.75 ||
+    !isShortCjkBrand(shorter) ||
+    !isShortCjkBrand(longer)
+  )
+    return false;
+
+  let shorterIndex = 0;
+  for (const character of longer) {
+    if (character === shorter[shorterIndex]) shorterIndex += 1;
+  }
+  return shorterIndex === shorter.length;
+}
+
+function dayNumber(value?: string) {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  if (!Number.isNaN(parsed.getTime())) {
+    const parts = Object.fromEntries(
+      TAIPEI_DAY_FORMATTER.formatToParts(parsed).map(({ type, value }) => [
+        type,
+        value,
+      ]),
+    );
+    return (
+      Date.UTC(Number(parts.year), Number(parts.month) - 1, Number(parts.day)) /
+      86_400_000
+    );
+  }
+  const match = value?.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return undefined;
+  return (
+    Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])) /
+    86_400_000
+  );
+}
+
+function countBy<T>(items: T[], key: (item: T) => string) {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const value = key(item);
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return counts;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -56,6 +56,7 @@ export const queryKeys = {
   investments: ["investments"] as const,
   investmentTransactions: ["investment-transactions"] as const,
   invoices: ["invoices"] as const,
+  invoiceTransactionMappings: ["invoice-transaction-mappings"] as const,
   manualAssets: ["manualAssets"] as const,
   exchangeRates: ["exchange-rates"] as const,
   netWorthHistory: ["netWorthHistory"] as const,

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -11,6 +11,7 @@ import type {
   InvestmentRow,
   InvestmentTransactionRow,
   InvoiceRow,
+  InvoiceTransactionPreference,
   ManualAssetHistoryEntry,
   ManualAssetRow,
   NetWorthHistoryRow,
@@ -49,6 +50,15 @@ export const invoicesQuery = (getApi: ApiProvider) =>
   queryOptions({
     queryKey: queryKeys.invoices,
     queryFn: () => getApi().get<InvoiceRow[]>("/api/invoices"),
+  });
+
+export const invoiceTransactionMappingsQuery = (getApi: ApiProvider) =>
+  queryOptions({
+    queryKey: queryKeys.invoiceTransactionMappings,
+    queryFn: () =>
+      getApi().get<InvoiceTransactionPreference[]>(
+        "/api/activity/invoice-mappings",
+      ),
   });
 
 export const manualAssetsQuery = (getApi: ApiProvider) =>

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -50,8 +50,12 @@ export interface ActivityItem {
   currency: string;
   category: string;
   categoryId?: string;
+  classificationPattern?: string;
   transactionId?: string;
   excludedFromCalculation?: boolean;
+  invoiceId?: string;
+  invoiceAmount?: number;
+  invoiceSearchText?: string;
   status: string;
 }
 export type ConnectorId = CoreConnectorId;
@@ -77,6 +81,12 @@ export interface InvoiceRow {
   sellerName?: string;
   amount: number;
   items: InvoiceLineItemRow[];
+}
+export interface InvoiceTransactionPreference {
+  invoiceId: string;
+  transactionId: string | null;
+  decision: "linked" | "separate";
+  updatedAt: string;
 }
 export interface InvestmentRow {
   id: string;

--- a/apps/worker/src/connectors/esun.ts
+++ b/apps/worker/src/connectors/esun.ts
@@ -263,7 +263,7 @@ interface EsunCardOverviewData {
   }> | null;
 }
 
-interface EsunTimelineTransaction {
+export interface EsunTimelineTransaction {
   payCur?: string | null;
   payAmt?: string | null;
   storeName?: string | null;
@@ -277,7 +277,7 @@ interface EsunTimelineTransaction {
   acfg?: string | null;
 }
 
-interface EsunTimelineMonth {
+export interface EsunTimelineMonth {
   year?: string | null;
   month?: string | null;
   txnList?: EsunTimelineTransaction[] | null;
@@ -290,7 +290,7 @@ interface EsunTimelineData {
   isNoData?: boolean | null;
 }
 
-interface EsunTimelinePage {
+export interface EsunTimelinePage {
   timelineList: EsunTimelineMonth[];
   startDate?: string;
   endDate?: string;
@@ -415,10 +415,31 @@ function getCreditCards(detail: EsunCardDetailData): EsunCardRow[] {
   });
 }
 
-async function scrapeTransactions(client: EsunHttpClient): Promise<Array<Omit<BankTransaction, "id" | "connectorId">>> {
+async function scrapeTransactions(
+  client: EsunHttpClient,
+): Promise<Array<Omit<BankTransaction, "id" | "connectorId">>> {
   const pages = await fetchTimelinePages(client);
-  const transactions: Array<Omit<BankTransaction, "id" | "connectorId">> = [];
-  const sourceIdOccurrences = new Map<string, number>();
+  return normalizeEsunTimelineTransactions(pages);
+}
+
+type EsunTimelineCandidate = {
+  transaction: EsunTimelineTransaction;
+  timelinePage: EsunTimelinePage;
+  timelineMonth: EsunTimelineMonth;
+  accountId: string;
+  postedDate: string;
+  amount: number;
+  currency: string;
+  description: string;
+  sourceKey: string;
+  lifecycle: string;
+  order: number;
+};
+
+export function normalizeEsunTimelineTransactions(
+  pages: EsunTimelinePage[],
+): Array<Omit<BankTransaction, "id" | "connectorId">> {
+  const candidates: EsunTimelineCandidate[] = [];
 
   for (const timelinePage of pages) {
     for (const month of timelinePage.timelineList) {
@@ -426,7 +447,10 @@ async function scrapeTransactions(client: EsunHttpClient): Promise<Array<Omit<Ba
       if (!year) continue;
 
       for (const txn of month.txnList ?? []) {
-        const postedDate = normalizeEsunMonthDay(year, txn.consumerDt ?? txn.postingDt ?? "");
+        const postedDate = normalizeEsunMonthDay(
+          year,
+          txn.consumerDt ?? txn.postingDt ?? "",
+        );
         const amount = parseTwd(txn.payAmt ?? txn.consumerAmt ?? "0");
         const currency = txn.payCur?.trim() || txn.consumerCur?.trim() || "TWD";
         const description = txn.storeName?.trim() || "玉山信用卡交易";
@@ -437,33 +461,66 @@ async function scrapeTransactions(client: EsunHttpClient): Promise<Array<Omit<Ba
           description,
           amount,
           currency,
-          txn.acfg?.trim() ?? ""
         ].join(":");
-        const occurrence = (sourceIdOccurrences.get(sourceKey) ?? 0) + 1;
-        sourceIdOccurrences.set(sourceKey, occurrence);
-
-        transactions.push({
+        candidates.push({
+          transaction: txn,
+          timelinePage,
+          timelineMonth: month,
           accountId,
-          sourceId: `${sourceKey}:${occurrence}`,
           postedDate,
           amount,
           currency,
           description,
-          counterparty: description,
-          raw: {
-            ...txn,
-            timelineYear: month.year,
-            timelineMonth: month.month,
-            timelineStartDate: timelinePage.startDate,
-            timelineEndDate: timelinePage.endDate,
-            duplicateOccurrence: occurrence
-          }
+          sourceKey,
+          lifecycle: txn.acfg?.trim() ?? "",
+          order: candidates.length,
         });
       }
     }
   }
 
-  return transactions;
+  const candidatesBySourceKey = new Map<string, EsunTimelineCandidate[]>();
+  for (const candidate of candidates) {
+    const group = candidatesBySourceKey.get(candidate.sourceKey) ?? [];
+    group.push(candidate);
+    candidatesBySourceKey.set(candidate.sourceKey, group);
+  }
+
+  const selected = Array.from(candidatesBySourceKey.values()).flatMap(
+    (group) => {
+      const posted = group.filter(({ lifecycle }) => lifecycle === "已入帳");
+      const pending = group.filter(({ lifecycle }) => lifecycle === "未入帳");
+      const other = group.filter(
+        ({ lifecycle }) => lifecycle !== "已入帳" && lifecycle !== "未入帳",
+      );
+      if (posted.length === 0 || pending.length === 0) return group;
+      return [...posted, ...pending.slice(posted.length), ...other];
+    },
+  );
+  selected.sort((left, right) => left.order - right.order);
+
+  const sourceIdOccurrences = new Map<string, number>();
+  return selected.map((candidate) => {
+    const occurrence = (sourceIdOccurrences.get(candidate.sourceKey) ?? 0) + 1;
+    sourceIdOccurrences.set(candidate.sourceKey, occurrence);
+    return {
+      accountId: candidate.accountId,
+      sourceId: `${candidate.sourceKey}:${occurrence}`,
+      postedDate: candidate.postedDate,
+      amount: candidate.amount,
+      currency: candidate.currency,
+      description: candidate.description,
+      counterparty: candidate.description,
+      raw: {
+        ...candidate.transaction,
+        timelineYear: candidate.timelineMonth.year,
+        timelineMonth: candidate.timelineMonth.month,
+        timelineStartDate: candidate.timelinePage.startDate,
+        timelineEndDate: candidate.timelinePage.endDate,
+        duplicateOccurrence: occurrence,
+      },
+    };
+  });
 }
 
 async function fetchTimelinePages(client: EsunHttpClient): Promise<EsunTimelinePage[]> {

--- a/apps/worker/src/features/activity/repository.ts
+++ b/apps/worker/src/features/activity/repository.ts
@@ -1,0 +1,113 @@
+export type InvoiceTransactionPreferenceRow = {
+  invoiceId: string;
+  transactionId: string | null;
+  decision: "linked" | "separate";
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type MappingInvoiceRow = {
+  id: string;
+  invoiceDate: string;
+};
+
+export type MappingTransactionRow = {
+  id: string;
+  postedDate: string | null;
+  authorizedAt: string | null;
+  amount: number;
+  currency: string;
+  accountType: string | null;
+};
+
+export async function listInvoiceTransactionPreferences(db: D1Database) {
+  const rows = await db
+    .prepare(
+      `SELECT
+        invoice_id AS invoiceId,
+        transaction_id AS transactionId,
+        decision,
+        created_at AS createdAt,
+        updated_at AS updatedAt
+      FROM invoice_transaction_preferences
+      ORDER BY updated_at DESC, invoice_id ASC`,
+    )
+    .all<InvoiceTransactionPreferenceRow>();
+  return rows.results;
+}
+
+export async function findMappingInvoice(db: D1Database, invoiceId: string) {
+  return db
+    .prepare(
+      `SELECT id, invoice_date AS invoiceDate
+       FROM invoices
+       WHERE id = ?`,
+    )
+    .bind(invoiceId)
+    .first<MappingInvoiceRow>();
+}
+
+export async function findMappingTransaction(
+  db: D1Database,
+  transactionId: string,
+) {
+  return db
+    .prepare(
+      `SELECT
+        bank_tx.id,
+        bank_tx.posted_date AS postedDate,
+        bank_tx.authorized_at AS authorizedAt,
+        bank_tx.amount,
+        bank_tx.currency,
+        account.account_type AS accountType
+      FROM bank_transactions bank_tx
+      JOIN bank_accounts account ON account.id = bank_tx.account_id
+      WHERE bank_tx.id = ?`,
+    )
+    .bind(transactionId)
+    .first<MappingTransactionRow>();
+}
+
+export async function findLinkedInvoiceId(
+  db: D1Database,
+  transactionId: string,
+) {
+  const row = await db
+    .prepare(
+      `SELECT invoice_id AS invoiceId
+       FROM invoice_transaction_preferences
+       WHERE transaction_id = ? AND decision = 'linked'`,
+    )
+    .bind(transactionId)
+    .first<{ invoiceId: string }>();
+  return row?.invoiceId;
+}
+
+export async function upsertInvoiceTransactionPreference(
+  db: D1Database,
+  input: {
+    invoiceId: string;
+    transactionId: string | null;
+    decision: "linked" | "separate";
+    now: string;
+  },
+) {
+  await db
+    .prepare(
+      `INSERT INTO invoice_transaction_preferences
+       (invoice_id, transaction_id, decision, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(invoice_id) DO UPDATE SET
+         transaction_id = excluded.transaction_id,
+         decision = excluded.decision,
+         updated_at = excluded.updated_at`,
+    )
+    .bind(
+      input.invoiceId,
+      input.transactionId,
+      input.decision,
+      input.now,
+      input.now,
+    )
+    .run();
+}

--- a/apps/worker/src/features/activity/route.ts
+++ b/apps/worker/src/features/activity/route.ts
@@ -1,0 +1,92 @@
+import type { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import type { AppBindings } from "../../platform/env";
+import { honoFactory } from "../../platform/hono";
+import { jsonError } from "../../platform/http";
+import { validationHook } from "../../platform/validation";
+import { listInvoiceTransactionPreferences } from "./repository";
+import {
+  keepInvoiceSeparate,
+  linkInvoiceToTransaction,
+  MappingDateMismatchError,
+  MappingInvoiceNotFoundError,
+  MappingTransactionNotExpenseError,
+  MappingTransactionNotFoundError,
+  MappingTransactionUnavailableError,
+} from "./service";
+
+const mappingSchema = z.object({
+  transactionId: z.string().trim().min(1),
+});
+
+export const activityRoutes = honoFactory.createApp();
+registerActivityRoutes(activityRoutes);
+
+function registerActivityRoutes(api: Hono<AppBindings>) {
+  api.get("/activity/invoice-mappings", async (c) =>
+    c.json(await listInvoiceTransactionPreferences(c.env.DB)),
+  );
+
+  api.put(
+    "/activity/invoice-mappings/:invoiceId",
+    zValidator(
+      "json",
+      mappingSchema,
+      validationHook("INVALID_REQUEST", "Invoice mapping is invalid."),
+    ),
+    async (c) => {
+      try {
+        return c.json(
+          await linkInvoiceToTransaction(
+            c.env.DB,
+            c.req.param("invoiceId"),
+            c.req.valid("json").transactionId,
+          ),
+        );
+      } catch (error) {
+        return mappingError(error);
+      }
+    },
+  );
+
+  api.delete("/activity/invoice-mappings/:invoiceId", async (c) => {
+    try {
+      return c.json(
+        await keepInvoiceSeparate(c.env.DB, c.req.param("invoiceId")),
+      );
+    } catch (error) {
+      return mappingError(error);
+    }
+  });
+}
+
+function mappingError(error: unknown) {
+  if (error instanceof MappingInvoiceNotFoundError)
+    return jsonError("INVOICE_NOT_FOUND", "Invoice was not found.", 404);
+  if (error instanceof MappingTransactionNotFoundError)
+    return jsonError(
+      "BANK_TRANSACTION_NOT_FOUND",
+      "Bank transaction was not found.",
+      404,
+    );
+  if (error instanceof MappingTransactionUnavailableError)
+    return jsonError(
+      "BANK_TRANSACTION_ALREADY_MAPPED",
+      "Bank transaction is already mapped to another invoice.",
+      409,
+    );
+  if (error instanceof MappingDateMismatchError)
+    return jsonError(
+      "MAPPING_DATE_MISMATCH",
+      "Invoice and bank transaction must be on the same day.",
+      400,
+    );
+  if (error instanceof MappingTransactionNotExpenseError)
+    return jsonError(
+      "MAPPING_TRANSACTION_NOT_EXPENSE",
+      "Only TWD expense transactions can be mapped to an invoice.",
+      400,
+    );
+  throw error;
+}

--- a/apps/worker/src/features/activity/route.ts
+++ b/apps/worker/src/features/activity/route.ts
@@ -22,6 +22,7 @@ const mappingSchema = z.object({
 
 export const activityRoutes = honoFactory.createApp();
 registerActivityRoutes(activityRoutes);
+activityRoutes.onError((error) => mappingError(error));
 
 function registerActivityRoutes(api: Hono<AppBindings>) {
   api.get("/activity/invoice-mappings", async (c) =>
@@ -35,30 +36,19 @@ function registerActivityRoutes(api: Hono<AppBindings>) {
       mappingSchema,
       validationHook("INVALID_REQUEST", "Invoice mapping is invalid."),
     ),
-    async (c) => {
-      try {
-        return c.json(
-          await linkInvoiceToTransaction(
-            c.env.DB,
-            c.req.param("invoiceId"),
-            c.req.valid("json").transactionId,
-          ),
-        );
-      } catch (error) {
-        return mappingError(error);
-      }
-    },
+    async (c) =>
+      c.json(
+        await linkInvoiceToTransaction(
+          c.env.DB,
+          c.req.param("invoiceId"),
+          c.req.valid("json").transactionId,
+        ),
+      ),
   );
 
-  api.delete("/activity/invoice-mappings/:invoiceId", async (c) => {
-    try {
-      return c.json(
-        await keepInvoiceSeparate(c.env.DB, c.req.param("invoiceId")),
-      );
-    } catch (error) {
-      return mappingError(error);
-    }
-  });
+  api.delete("/activity/invoice-mappings/:invoiceId", async (c) =>
+    c.json(await keepInvoiceSeparate(c.env.DB, c.req.param("invoiceId"))),
+  );
 }
 
 function mappingError(error: unknown) {

--- a/apps/worker/src/features/activity/service.ts
+++ b/apps/worker/src/features/activity/service.ts
@@ -1,0 +1,95 @@
+import {
+  findLinkedInvoiceId,
+  findMappingInvoice,
+  findMappingTransaction,
+  upsertInvoiceTransactionPreference,
+} from "./repository";
+
+export class MappingInvoiceNotFoundError extends Error {}
+export class MappingTransactionNotFoundError extends Error {}
+export class MappingTransactionUnavailableError extends Error {}
+export class MappingDateMismatchError extends Error {}
+export class MappingTransactionNotExpenseError extends Error {}
+
+const taipeiDayFormatter = new Intl.DateTimeFormat("en", {
+  timeZone: "Asia/Taipei",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+function financialDay(value?: string | null) {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime()))
+    return value.match(/^\d{4}-\d{2}-\d{2}/)?.[0];
+  const parts = Object.fromEntries(
+    taipeiDayFormatter
+      .formatToParts(parsed)
+      .map(({ type, value }) => [type, value]),
+  );
+  return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+export async function linkInvoiceToTransaction(
+  db: D1Database,
+  invoiceId: string,
+  transactionId: string,
+) {
+  const [invoice, transaction] = await Promise.all([
+    findMappingInvoice(db, invoiceId),
+    findMappingTransaction(db, transactionId),
+  ]);
+  if (!invoice) throw new MappingInvoiceNotFoundError();
+  if (!transaction) throw new MappingTransactionNotFoundError();
+
+  const invoiceDay = financialDay(invoice.invoiceDate);
+  const transactionDay = financialDay(
+    transaction.postedDate ?? transaction.authorizedAt,
+  );
+  if (!invoiceDay || invoiceDay !== transactionDay)
+    throw new MappingDateMismatchError();
+
+  const isExpense =
+    transaction.currency === "TWD" &&
+    transaction.amount !== 0 &&
+    (transaction.accountType === "credit" || transaction.amount < 0);
+  if (!isExpense) throw new MappingTransactionNotExpenseError();
+
+  const linkedInvoiceId = await findLinkedInvoiceId(db, transactionId);
+  if (linkedInvoiceId && linkedInvoiceId !== invoiceId)
+    throw new MappingTransactionUnavailableError();
+
+  const now = new Date().toISOString();
+  await upsertInvoiceTransactionPreference(db, {
+    invoiceId,
+    transactionId,
+    decision: "linked",
+    now,
+  });
+  return {
+    invoiceId,
+    transactionId,
+    decision: "linked" as const,
+    updatedAt: now,
+  };
+}
+
+export async function keepInvoiceSeparate(db: D1Database, invoiceId: string) {
+  if (!(await findMappingInvoice(db, invoiceId)))
+    throw new MappingInvoiceNotFoundError();
+
+  const now = new Date().toISOString();
+  await upsertInvoiceTransactionPreference(db, {
+    invoiceId,
+    transactionId: null,
+    decision: "separate",
+    now,
+  });
+  return {
+    invoiceId,
+    transactionId: null,
+    decision: "separate" as const,
+    updatedAt: now,
+  };
+}

--- a/apps/worker/src/features/sync/repository.ts
+++ b/apps/worker/src/features/sync/repository.ts
@@ -73,6 +73,77 @@ export function deleteSyncedBankDataStatements(
   ];
 }
 
+export function reconcileEsunLifecycleShadowStatements(db: D1Database) {
+  const shadowJoin = `canonical.connector_id = shadow.connector_id
+      AND canonical.account_id = shadow.account_id
+      AND canonical.source_id = replace(
+        replace(shadow.source_id, ':已入帳:', ':'),
+        ':未入帳:', ':'
+      )`;
+  const isLifecycleShadow = `shadow.connector_id = 'esun'
+      AND (
+        instr(shadow.source_id, ':已入帳:') > 0
+        OR instr(shadow.source_id, ':未入帳:') > 0
+      )`;
+
+  return [
+    db.prepare(
+      `INSERT INTO bank_transaction_preferences
+        (transaction_id, excluded_from_calculation, created_at, updated_at)
+       SELECT canonical.id, preference.excluded_from_calculation,
+              preference.created_at, preference.updated_at
+       FROM bank_transactions shadow
+       JOIN bank_transactions canonical ON ${shadowJoin}
+       JOIN bank_transaction_preferences preference
+         ON preference.transaction_id = shadow.id
+       WHERE ${isLifecycleShadow}
+       ON CONFLICT(transaction_id) DO NOTHING`,
+    ),
+    db.prepare(
+      `INSERT INTO classification_overrides
+        (id, target_type, target_id, category_id, created_at, updated_at)
+       SELECT 'override:bank_transaction:' || canonical.id,
+              'bank_transaction', canonical.id, override.category_id,
+              override.created_at, override.updated_at
+       FROM bank_transactions shadow
+       JOIN bank_transactions canonical ON ${shadowJoin}
+       JOIN classification_overrides override
+         ON override.target_type = 'bank_transaction'
+        AND override.target_id = shadow.id
+       WHERE ${isLifecycleShadow}
+       ON CONFLICT(target_type, target_id) DO NOTHING`,
+    ),
+    db.prepare(
+      `DELETE FROM bank_transaction_preferences
+       WHERE transaction_id IN (
+         SELECT shadow.id
+         FROM bank_transactions shadow
+         JOIN bank_transactions canonical ON ${shadowJoin}
+         WHERE ${isLifecycleShadow}
+       )`,
+    ),
+    db.prepare(
+      `DELETE FROM classification_overrides
+       WHERE target_type = 'bank_transaction'
+         AND target_id IN (
+           SELECT shadow.id
+           FROM bank_transactions shadow
+           JOIN bank_transactions canonical ON ${shadowJoin}
+           WHERE ${isLifecycleShadow}
+         )`,
+    ),
+    db.prepare(
+      `DELETE FROM bank_transactions
+       WHERE id IN (
+         SELECT shadow.id
+         FROM bank_transactions shadow
+         JOIN bank_transactions canonical ON ${shadowJoin}
+         WHERE ${isLifecycleShadow}
+       )`,
+    ),
+  ];
+}
+
 export function linkCanonicalBankAccountsStatement(db: D1Database) {
   return db.prepare(
     `UPDATE bank_accounts

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -41,6 +41,7 @@ import {
   connectorStateStatement,
   deleteSyncedBankDataStatements,
   linkCanonicalBankAccountsStatement,
+  reconcileEsunLifecycleShadowStatements,
   updateConnectorEncryptedConfig,
 } from "./repository";
 import {
@@ -293,8 +294,11 @@ export async function syncEsun(
     records,
     afterPromoteStatements:
       bankAccounts.length > 0
-        ? [linkCanonicalBankAccountsStatement(env.DB)]
-        : [],
+        ? [
+            linkCanonicalBankAccountsStatement(env.DB),
+            ...reconcileEsunLifecycleShadowStatements(env.DB),
+          ]
+        : reconcileEsunLifecycleShadowStatements(env.DB),
     finalizeStatements,
   });
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,3 +1,4 @@
+import { activityRoutes } from "./features/activity/route";
 import { bankCalculationRoutes } from "./features/bank/calculation-route";
 import { bankRoutes } from "./features/bank/route";
 import { classificationRoutes } from "./features/classification/route";
@@ -29,6 +30,7 @@ api.route("/", manualAssetRoutes);
 api.route("/", exchangeRateRoutes);
 api.route("/", invoiceRoutes);
 api.route("/", classificationRoutes);
+api.route("/", activityRoutes);
 api.route("/", bankCalculationRoutes);
 api.route("/", dashboardRoutes);
 api.route("/", ocrRoutes);

--- a/apps/worker/tests/connectors/esun.test.ts
+++ b/apps/worker/tests/connectors/esun.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeEsunTimelineTransactions,
+  type EsunTimelinePage,
+  type EsunTimelineTransaction,
+} from "../../src/connectors/esun";
+
+function page(transactions: EsunTimelineTransaction[]): EsunTimelinePage {
+  return {
+    timelineList: [
+      {
+        year: "2026",
+        month: "07",
+        txnList: transactions,
+      },
+    ],
+  };
+}
+
+function transaction(
+  acfg: string,
+  overrides: Partial<EsunTimelineTransaction> = {},
+): EsunTimelineTransaction {
+  return {
+    payCur: "TWD",
+    payAmt: "252",
+    storeName: "全支付﹘全聯",
+    consumerDt: "07/05",
+    cardNo: "****1204",
+    acfg,
+    ...overrides,
+  };
+}
+
+describe("E.SUN credit card timeline normalization", () => {
+  it("collapses pending and posted lifecycle copies into one stable transaction", () => {
+    const rows = normalizeEsunTimelineTransactions([
+      page([transaction("未入帳"), transaction("已入帳")]),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sourceId).toBe(
+      "2026-07-05T00:00:00.000Z:credit:esun:1204:全支付﹘全聯:252:TWD:1",
+    );
+    expect((rows[0].raw as EsunTimelineTransaction).acfg).toBe("已入帳");
+  });
+
+  it("preserves repeated real purchases using occurrence numbers", () => {
+    const rows = normalizeEsunTimelineTransactions([
+      page([
+        transaction("未入帳"),
+        transaction("未入帳"),
+        transaction("已入帳"),
+        transaction("已入帳"),
+      ]),
+    ]);
+
+    expect(rows.map(({ sourceId }) => sourceId)).toEqual([
+      "2026-07-05T00:00:00.000Z:credit:esun:1204:全支付﹘全聯:252:TWD:1",
+      "2026-07-05T00:00:00.000Z:credit:esun:1204:全支付﹘全聯:252:TWD:2",
+    ]);
+    expect(
+      rows.map(({ raw }) => (raw as EsunTimelineTransaction).acfg),
+    ).toEqual(["已入帳", "已入帳"]);
+  });
+
+  it("keeps all pending purchases while no posted copy exists", () => {
+    const rows = normalizeEsunTimelineTransactions([
+      page([transaction("未入帳"), transaction("未入帳")]),
+    ]);
+
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/apps/worker/tests/features/activity/repository.test.ts
+++ b/apps/worker/tests/features/activity/repository.test.ts
@@ -1,0 +1,73 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { findMappingTransaction } from "../../../src/features/activity/repository";
+
+class SqliteQueryStatement {
+  private values: unknown[] = [];
+
+  constructor(
+    private readonly database: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: unknown[]) {
+    this.values = values;
+    return this;
+  }
+
+  async first<T>() {
+    return (
+      (this.database.prepare(this.sql).get(...(this.values as never[])) as T) ??
+      null
+    );
+  }
+}
+
+const databases: DatabaseSync[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+describe("activity repository", () => {
+  it("loads a mapping transaction with SQLite-compatible aliases", async () => {
+    const database = new DatabaseSync(":memory:");
+    databases.push(database);
+    database.exec(`
+      CREATE TABLE bank_accounts (
+        id TEXT PRIMARY KEY,
+        account_type TEXT
+      );
+      CREATE TABLE bank_transactions (
+        id TEXT PRIMARY KEY,
+        account_id TEXT NOT NULL,
+        posted_date TEXT,
+        authorized_at TEXT,
+        amount REAL NOT NULL,
+        currency TEXT NOT NULL
+      );
+      INSERT INTO bank_accounts (id, account_type)
+      VALUES ('card-1', 'credit');
+      INSERT INTO bank_transactions
+        (id, account_id, posted_date, amount, currency)
+      VALUES
+        ('transaction-1', 'card-1', '2026-07-13', -35, 'TWD');
+    `);
+    const db = {
+      prepare(sql: string) {
+        return new SqliteQueryStatement(database, sql);
+      },
+    } as unknown as D1Database;
+
+    await expect(findMappingTransaction(db, "transaction-1")).resolves.toEqual(
+      {
+        id: "transaction-1",
+        postedDate: "2026-07-13",
+        authorizedAt: null,
+        amount: -35,
+        currency: "TWD",
+        accountType: "credit",
+      },
+    );
+  });
+});

--- a/apps/worker/tests/features/activity/route.test.ts
+++ b/apps/worker/tests/features/activity/route.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import type { Env } from "../../../src/platform/env";
+import { activityRoutes } from "../../../src/features/activity/route";
+
+type Preference = {
+  invoiceId: string;
+  transactionId: string | null;
+  decision: "linked" | "separate";
+  createdAt: string;
+  updatedAt: string;
+};
+
+function createDb() {
+  const invoices = new Map([
+    ["invoice-1", { id: "invoice-1", invoiceDate: "2026-07-06T04:39:18.000Z" }],
+    ["invoice-2", { id: "invoice-2", invoiceDate: "2026-07-06" }],
+  ]);
+  const transactions = new Map([
+    [
+      "transaction-1",
+      {
+        id: "transaction-1",
+        postedDate: "2026-07-06",
+        authorizedAt: null,
+        amount: 37,
+        currency: "TWD",
+        accountType: "credit",
+      },
+    ],
+    [
+      "transaction-other-day",
+      {
+        id: "transaction-other-day",
+        postedDate: "2026-07-07",
+        authorizedAt: null,
+        amount: -50,
+        currency: "TWD",
+        accountType: "checking",
+      },
+    ],
+    [
+      "transaction-next-taipei-day",
+      {
+        id: "transaction-next-taipei-day",
+        postedDate: "2026-07-06T16:00:00.000Z",
+        authorizedAt: null,
+        amount: 50,
+        currency: "TWD",
+        accountType: "credit",
+      },
+    ],
+  ]);
+  const preferences = new Map<string, Preference>();
+
+  const db = {
+    prepare(sql: string) {
+      let values: unknown[] = [];
+      return {
+        bind(...nextValues: unknown[]) {
+          values = nextValues;
+          return this;
+        },
+        async first() {
+          if (sql.includes("FROM invoices"))
+            return invoices.get(String(values[0])) ?? null;
+          if (sql.includes("FROM bank_transactions"))
+            return transactions.get(String(values[0])) ?? null;
+          if (sql.includes("WHERE transaction_id")) {
+            const linked = Array.from(preferences.values()).find(
+              (preference) =>
+                preference.decision === "linked" &&
+                preference.transactionId === values[0],
+            );
+            return linked ? { invoiceId: linked.invoiceId } : null;
+          }
+          return null;
+        },
+        async all() {
+          return { results: Array.from(preferences.values()) };
+        },
+        async run() {
+          const [invoiceId, transactionId, decision, createdAt, updatedAt] =
+            values as [
+              string,
+              string | null,
+              "linked" | "separate",
+              string,
+              string,
+            ];
+          const previous = preferences.get(invoiceId);
+          preferences.set(invoiceId, {
+            invoiceId,
+            transactionId,
+            decision,
+            createdAt: previous?.createdAt ?? createdAt,
+            updatedAt,
+          });
+          return { meta: { changes: 1 } };
+        },
+      };
+    },
+  } as unknown as D1Database;
+  return { db, preferences };
+}
+
+describe("activity invoice transaction mappings", () => {
+  it("links an invoice to a same-day expense and lists the preference", async () => {
+    const { db } = createDb();
+    const response = await activityRoutes.request(
+      "/activity/invoice-mappings/invoice-1",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transactionId: "transaction-1" }),
+      },
+      { DB: db } as Env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      invoiceId: "invoice-1",
+      transactionId: "transaction-1",
+      decision: "linked",
+    });
+
+    const list = await activityRoutes.request(
+      "/activity/invoice-mappings",
+      {},
+      { DB: db } as Env,
+    );
+    await expect(list.json()).resolves.toEqual([
+      expect.objectContaining({
+        invoiceId: "invoice-1",
+        transactionId: "transaction-1",
+        decision: "linked",
+      }),
+    ]);
+  });
+
+  it("keeps a previously linked invoice separate", async () => {
+    const { db, preferences } = createDb();
+    preferences.set("invoice-1", {
+      invoiceId: "invoice-1",
+      transactionId: "transaction-1",
+      decision: "linked",
+      createdAt: "2026-07-19T00:00:00.000Z",
+      updatedAt: "2026-07-19T00:00:00.000Z",
+    });
+
+    const response = await activityRoutes.request(
+      "/activity/invoice-mappings/invoice-1",
+      { method: "DELETE" },
+      { DB: db } as Env,
+    );
+    expect(response.status).toBe(200);
+    expect(preferences.get("invoice-1")).toMatchObject({
+      transactionId: null,
+      decision: "separate",
+    });
+  });
+
+  it("rejects invalid, cross-day, and already-used mappings", async () => {
+    const { db, preferences } = createDb();
+    const invalid = await activityRoutes.request(
+      "/activity/invoice-mappings/invoice-1",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transactionId: "" }),
+      },
+      { DB: db } as Env,
+    );
+    expect(invalid.status).toBe(400);
+
+    const crossDay = await activityRoutes.request(
+      "/activity/invoice-mappings/invoice-1",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transactionId: "transaction-other-day" }),
+      },
+      { DB: db } as Env,
+    );
+    expect(crossDay.status).toBe(400);
+
+    const crossTaipeiDay = await activityRoutes.request(
+      "/activity/invoice-mappings/invoice-1",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          transactionId: "transaction-next-taipei-day",
+        }),
+      },
+      { DB: db } as Env,
+    );
+    expect(crossTaipeiDay.status).toBe(400);
+
+    preferences.set("invoice-2", {
+      invoiceId: "invoice-2",
+      transactionId: "transaction-1",
+      decision: "linked",
+      createdAt: "2026-07-19T00:00:00.000Z",
+      updatedAt: "2026-07-19T00:00:00.000Z",
+    });
+    const unavailable = await activityRoutes.request(
+      "/activity/invoice-mappings/invoice-1",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transactionId: "transaction-1" }),
+      },
+      { DB: db } as Env,
+    );
+    expect(unavailable.status).toBe(409);
+  });
+});

--- a/apps/worker/tests/features/activity/route.test.ts
+++ b/apps/worker/tests/features/activity/route.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Env } from "../../../src/platform/env";
 import { activityRoutes } from "../../../src/features/activity/route";
+import { honoFactory } from "../../../src/platform/hono";
+import { apiErrorResponse } from "../../../src/platform/http";
 
 type Preference = {
   invoiceId: string;
@@ -212,5 +214,35 @@ describe("activity invoice transaction mappings", () => {
       { DB: db } as Env,
     );
     expect(unavailable.status).toBe(409);
+  });
+
+  it("passes unexpected errors to the parent API error handler", async () => {
+    const api = honoFactory.createApp();
+    api.route("/", activityRoutes);
+    api.onError(apiErrorResponse);
+    const unexpected = new Error("D1 query failed");
+    const db = {
+      prepare() {
+        throw unexpected;
+      },
+    } as unknown as D1Database;
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await api.request(
+      "/activity/invoice-mappings",
+      {},
+      { DB: db } as Env,
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "An unexpected error occurred.",
+      },
+    });
+    expect(errorLog).toHaveBeenCalledWith("[api] unhandled error:", unexpected);
+    errorLog.mockRestore();
   });
 });

--- a/apps/worker/tests/features/sync/persistence.test.ts
+++ b/apps/worker/tests/features/sync/persistence.test.ts
@@ -6,6 +6,7 @@ import {
   persistStagedSyncWrite,
   type SyncWriteRecord,
 } from "../../../src/features/sync/persistence";
+import { reconcileEsunLifecycleShadowStatements } from "../../../src/features/sync/repository";
 
 class SqliteStatement {
   private values: unknown[] = [];
@@ -121,6 +122,54 @@ function bankAccountRecord(index: number): SyncWriteRecord {
 }
 
 describe("staged sync persistence", () => {
+  it("migrates preferences and removes E.SUN lifecycle shadow transactions", async () => {
+    const db = createDb();
+    db.database.exec(`
+      INSERT INTO bank_accounts
+        (id, connector_id, source_id, account_type, currency, raw_payload, created_at, updated_at)
+      VALUES
+        ('esun:credit:esun:1204', 'esun', 'credit:esun:1204', 'credit', 'TWD', '{}', '2026-07-01', '2026-07-01');
+
+      INSERT INTO bank_transactions
+        (id, connector_id, account_id, source_id, posted_date, amount, currency, description, raw_payload, created_at, updated_at)
+      VALUES
+        ('shadow-posted', 'esun', 'esun:credit:esun:1204', '2026-07-05:credit:esun:1204:全聯:252:TWD:已入帳:1', '2026-07-05', 252, 'TWD', '全聯', '{}', '2026-07-05', '2026-07-05'),
+        ('shadow-pending', 'esun', 'esun:credit:esun:1204', '2026-07-05:credit:esun:1204:全聯:252:TWD:未入帳:1', '2026-07-05', 252, 'TWD', '全聯', '{}', '2026-07-05', '2026-07-05'),
+        ('canonical', 'esun', 'esun:credit:esun:1204', '2026-07-05:credit:esun:1204:全聯:252:TWD:1', '2026-07-05', 252, 'TWD', '全聯', '{}', '2026-07-05', '2026-07-05');
+
+      INSERT INTO bank_transaction_preferences
+        (transaction_id, excluded_from_calculation, created_at, updated_at)
+      VALUES ('shadow-posted', 1, '2026-07-05', '2026-07-05');
+
+      INSERT INTO classification_overrides
+        (id, target_type, target_id, category_id, created_at, updated_at)
+      VALUES ('old-override', 'bank_transaction', 'shadow-posted', 'shopping', '2026-07-05', '2026-07-05');
+    `);
+
+    await db.batch(
+      reconcileEsunLifecycleShadowStatements(db as unknown as D1Database),
+    );
+
+    expect(
+      db.database
+        .prepare("SELECT id FROM bank_transactions ORDER BY id")
+        .all()
+        .map((row) => row.id),
+    ).toEqual(["canonical"]);
+    expect(
+      db.database
+        .prepare(
+          "SELECT transaction_id, excluded_from_calculation FROM bank_transaction_preferences",
+        )
+        .get(),
+    ).toEqual({ transaction_id: "canonical", excluded_from_calculation: 1 });
+    expect(
+      db.database
+        .prepare("SELECT target_id, category_id FROM classification_overrides")
+        .get(),
+    ).toEqual({ target_id: "canonical", category_id: "shopping" });
+  });
+
   it("stages records in bounded JSON chunks and advances the cursor only after promotion", async () => {
     const db = createDb();
     const records = Array.from({ length: 205 }, (_, index) =>

--- a/packages/db/migrations/0013_invoice_transaction_preferences.sql
+++ b/packages/db/migrations/0013_invoice_transaction_preferences.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS invoice_transaction_preferences (
+  invoice_id TEXT PRIMARY KEY,
+  transaction_id TEXT,
+  decision TEXT NOT NULL CHECK (decision IN ('linked', 'separate')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  CHECK (
+    (decision = 'linked' AND transaction_id IS NOT NULL)
+    OR decision = 'separate'
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_invoice_transaction_preferences_linked_transaction
+  ON invoice_transaction_preferences (transaction_id)
+  WHERE decision = 'linked';


### PR DESCRIPTION
## 摘要

- 將銀行、信用卡與電子發票整合到同一條活動時間軸，已配對資料只顯示並計算一次。
- 依同一天、商家名稱與金額自動辨識明確配對，並支援 LINE Pay／支付工具點數折抵造成的金額差異。
- 提供同日候選交易的人工配對、變更與解除功能，使用 D1 preference 保存使用者決定。
- 未找到銀行或信用卡交易的發票仍列入當月支出，避免未支援銀行的消費被漏算。
- 活動列表改為只讀分類；點入 Desktop 右側抽屜或 Mobile 滿版詳情後，才調整分類、排除計算與發票配對。
- 詳情頁同時呈現銀行／信用卡原始名稱、發票商家名稱與發票品項。
- 清理 E.SUN 信用卡「未入帳／已入帳」生命週期重複交易，並保留既有分類與排除偏好。

## 背景與原因

同一筆消費可能分別由信用卡與電子發票匯入。商家名稱可能因支付工具而不同，使用點數後實付金額也可能小於發票金額，因此只靠完全相同的名稱與金額會造成重複活動與重複支出。

## 資料與 API

- 新增 migration `0013_invoice_transaction_preferences.sql`。
- 新增 `/api/activity/invoice-mappings` 查詢、建立與解除配對 API。
- Activity feature 使用 feature-level `activityRoutes.onError` 統一轉換 domain errors；未知錯誤仍交由全域 handler 記錄並回傳安全的 500。

## 使用者影響

- 已配對的發票與銀行／信用卡交易只顯示一筆，支出採實付金額。
- 未配對發票仍納入當月支出。
- 使用者可在交易詳情中查看不同來源名稱與發票細項，並自行決定配對。
- 活動列表減少操作控制項，Desktop 與 Mobile 都能維持較清楚的單列資訊。

## 驗證

- `npm run format:check`
- `npm run typecheck`（所有 workspaces）
- `npm run test:unit`：35 tests
- `npm run test:backend`：Worker 67 tests、DB 4 tests、connector self-check
- `npm run test:e2e`：8 tests
- `npm run build`（所有 workspaces）
