### PR TITLE
修正 PWA 滑動返回與活動抽屜關閉

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -183,6 +183,12 @@ test("opens a primary view from its hash route", async ({ page }) => {
 test("excludes a bank transaction from activity calculations and restores it", async ({
   page,
 }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "standalone", {
+      configurable: true,
+      value: true,
+    });
+  });
   let excludedFromCalculation = false;
   const month = new Date().toISOString().slice(0, 7);
 
@@ -240,6 +246,7 @@ test("excludes a bank transaction from activity calculations and restores it", a
   );
 
   await page.goto("/#/activity");
+  await expect(page.locator("html")).toHaveClass(/is-standalone/);
   const expenseSlice = page.getByRole("button", {
     name: "其他 100.0% NT$8,318",
   });
@@ -247,6 +254,13 @@ test("excludes a bank transaction from activity calculations and restores it", a
 
   await page.getByRole("button", { name: "查看 台新卡費 活動詳情" }).click();
   await expect(page.getByRole("heading", { name: "活動明細" })).toBeVisible();
+  const desktopDetailDialog = page.getByRole("dialog", { name: "活動明細" });
+  await page
+    .getByRole("button", { name: "關閉活動明細" })
+    .click({ position: { x: 20, y: 200 } });
+  await expect(desktopDetailDialog).toBeHidden();
+
+  await page.getByRole("button", { name: "查看 台新卡費 活動詳情" }).click();
   await page
     .getByRole("checkbox", { name: "排除 台新卡費 的統計計算" })
     .click();
@@ -294,6 +308,74 @@ test("excludes a bank transaction from activity calculations and restores it", a
   await expect(
     page.getByRole("combobox", { name: "更新 台新卡費 分類" }),
   ).toBeVisible();
+
+  await detailDialog.evaluate((element) => {
+    const start = new Touch({
+      identifier: 1,
+      target: element,
+      clientX: 8,
+      clientY: 300,
+    });
+    const end = new Touch({
+      identifier: 1,
+      target: element,
+      clientX: 38,
+      clientY: 420,
+    });
+    element.dispatchEvent(
+      new TouchEvent("touchstart", {
+        bubbles: true,
+        cancelable: true,
+        changedTouches: [start],
+        targetTouches: [start],
+        touches: [start],
+      }),
+    );
+    element.dispatchEvent(
+      new TouchEvent("touchend", {
+        bubbles: true,
+        cancelable: true,
+        changedTouches: [end],
+        targetTouches: [],
+        touches: [],
+      }),
+    );
+  });
+  await expect(detailDialog).toBeVisible();
+
+  await detailDialog.evaluate((element) => {
+    const start = new Touch({
+      identifier: 2,
+      target: element,
+      clientX: 8,
+      clientY: 300,
+    });
+    const end = new Touch({
+      identifier: 2,
+      target: element,
+      clientX: 108,
+      clientY: 312,
+    });
+    element.dispatchEvent(
+      new TouchEvent("touchstart", {
+        bubbles: true,
+        cancelable: true,
+        changedTouches: [start],
+        targetTouches: [start],
+        touches: [start],
+      }),
+    );
+    element.dispatchEvent(
+      new TouchEvent("touchend", {
+        bubbles: true,
+        cancelable: true,
+        changedTouches: [end],
+        targetTouches: [],
+        touches: [],
+      }),
+    );
+  });
+  await expect(detailDialog).toBeHidden();
 });
 
 test("merges a matching invoice and counts an unmatched invoice as expense", async ({

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -26,6 +26,7 @@
   import SettingsView from "./features/settings/Settings.svelte";
   import { createApiClient } from "./lib/api";
   import { moneyState } from "./lib/format.svelte";
+  import { swipeBack } from "./lib/swipe-back";
   import type {
     DetailView,
     MobileSettingsView,
@@ -184,6 +185,10 @@
     }
     scrollToTop();
   }
+  function navigateBack() {
+    if (isDetail(view)) navigate("assets");
+    else if (isMobileSetting(view)) navigate("more");
+  }
   function toggleMoneyVisibility() {
     moneyState.hidden = !moneyState.hidden;
     localStorage.setItem(
@@ -196,6 +201,10 @@
 <QueryClientProvider client={queryClient}>
   <div
     class="min-h-screen bg-paper text-ink xl:grid xl:grid-cols-[240px_minmax(0,1fr)]"
+    use:swipeBack={{
+      enabled: isStandalone() && (isDetail(view) || isMobileSetting(view)),
+      onBack: navigateBack,
+    }}
   >
     <aside
       class="hidden border-r border-white/10 bg-ink px-6 py-7 text-white xl:sticky xl:top-0 xl:flex xl:h-screen xl:flex-col"

--- a/apps/web/src/features/activity/Activity.svelte
+++ b/apps/web/src/features/activity/Activity.svelte
@@ -67,6 +67,7 @@
     normalizeFinancialDate,
     rateMap,
   } from "../../lib/format.svelte";
+  import { swipeBack } from "../../lib/swipe-back";
   let { api, navigate }: { api: ApiClient; navigate: (view: View) => void } =
     $props();
   const bank = createQuery(bankQuery(() => api));
@@ -844,14 +845,22 @@
       {@const amount = renderedAmount(detailItem)}
       {@const transaction = transactionForItem(detailItem)}
       {@const invoice = invoiceForItem(detailItem)}
-      <div
-        aria-labelledby="activity-detail-title"
-        aria-modal="true"
-        class="fixed inset-0 z-[60] bg-ink/40 md:flex md:justify-end"
-        role="dialog"
-      >
+      <div class="fixed inset-0 z-[60] bg-ink/40 md:flex md:justify-end">
+        <button
+          aria-label="關閉活動明細"
+          class="absolute inset-0 hidden md:block"
+          onclick={() => (detailKey = null)}
+        ></button>
         <div
-          class="flex h-full w-full flex-col overflow-hidden bg-white shadow-2xl md:max-w-[32rem]"
+          aria-labelledby="activity-detail-title"
+          aria-modal="true"
+          class="relative flex h-full w-full flex-col overflow-hidden bg-white shadow-2xl md:max-w-[32rem]"
+          role="dialog"
+          use:swipeBack={{
+            enabled:
+              document.documentElement.classList.contains("is-standalone"),
+            onBack: () => (detailKey = null),
+          }}
         >
           <header
             class="flex shrink-0 items-center justify-between border-b border-ink/10 px-4 py-3 md:px-6"

--- a/apps/web/src/lib/pwa.ts
+++ b/apps/web/src/lib/pwa.ts
@@ -1,0 +1,8 @@
+type IOSNavigator = Navigator & { standalone?: boolean };
+
+export function isStandalonePwa() {
+  return (
+    window.matchMedia("(display-mode: standalone)").matches ||
+    (navigator as IOSNavigator).standalone === true
+  );
+}

--- a/apps/web/src/lib/swipe-back.ts
+++ b/apps/web/src/lib/swipe-back.ts
@@ -1,0 +1,102 @@
+import type { Action } from "svelte/action";
+
+type SwipeBackOptions = {
+  enabled?: boolean;
+  onBack: () => void;
+};
+
+const EDGE_WIDTH = 40;
+const MIN_HORIZONTAL_DISTANCE = 72;
+const MAX_VERTICAL_DISTANCE = 80;
+
+export const swipeBack: Action<HTMLElement, SwipeBackOptions> = (
+  node,
+  initialOptions,
+) => {
+  let options = initialOptions;
+  let start:
+    { identifier: number; clientX: number; clientY: number } | undefined;
+  const originalTouchAction = node.style.touchAction;
+
+  function applyTouchAction() {
+    node.style.touchAction =
+      options.enabled === false ? originalTouchAction : "pan-y";
+  }
+
+  function reset() {
+    start = undefined;
+  }
+
+  function findTouch(touches: TouchList) {
+    if (!start) return;
+    return Array.from(touches).find(
+      (touch) => touch.identifier === start?.identifier,
+    );
+  }
+
+  function handleTouchStart(event: TouchEvent) {
+    if (options.enabled === false || event.touches.length !== 1) {
+      reset();
+      return;
+    }
+
+    const touch = event.touches[0];
+    if (!touch || touch.clientX > EDGE_WIDTH) {
+      reset();
+      return;
+    }
+
+    start = {
+      identifier: touch.identifier,
+      clientX: touch.clientX,
+      clientY: touch.clientY,
+    };
+  }
+
+  function handleTouchMove(event: TouchEvent) {
+    const touch = findTouch(event.touches);
+    if (!start || !touch) return;
+
+    const horizontalDistance = touch.clientX - start.clientX;
+    const verticalDistance = Math.abs(touch.clientY - start.clientY);
+    if (horizontalDistance > 10 && horizontalDistance > verticalDistance) {
+      event.preventDefault();
+    }
+  }
+
+  function handleTouchEnd(event: TouchEvent) {
+    const touch = findTouch(event.changedTouches);
+    if (!start || !touch) return;
+
+    const horizontalDistance = touch.clientX - start.clientX;
+    const verticalDistance = Math.abs(touch.clientY - start.clientY);
+    const isBackSwipe =
+      horizontalDistance >= MIN_HORIZONTAL_DISTANCE &&
+      verticalDistance <= MAX_VERTICAL_DISTANCE &&
+      horizontalDistance > verticalDistance * 1.25;
+
+    reset();
+    if (isBackSwipe) options.onBack();
+  }
+
+  applyTouchAction();
+  node.addEventListener("touchstart", handleTouchStart, { passive: true });
+  node.addEventListener("touchmove", handleTouchMove, { passive: false });
+  node.addEventListener("touchend", handleTouchEnd, { passive: true });
+  node.addEventListener("touchcancel", reset, { passive: true });
+
+  return {
+    update(nextOptions) {
+      options = nextOptions;
+      reset();
+      applyTouchAction();
+    },
+    destroy() {
+      node.style.touchAction = originalTouchAction;
+      node.removeEventListener("touchstart", handleTouchStart);
+      node.removeEventListener("touchmove", handleTouchMove);
+      node.removeEventListener("touchend", handleTouchEnd);
+      node.removeEventListener("touchcancel", reset);
+    },
+  };
+};

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,10 +1,8 @@
 import { mount } from "svelte";
 import App from "./App.svelte";
+import { isStandalonePwa } from "./lib/pwa";
 
-document.documentElement.classList.toggle(
-  "is-standalone",
-  window.matchMedia("(display-mode: standalone)").matches,
-);
+document.documentElement.classList.toggle("is-standalone", isStandalonePwa());
 
 const target = document.getElementById("root");
 if (!target) throw new Error("Missing #root element");


### PR DESCRIPTION
## 變更內容

- 新增可重用的左緣滑動返回 action，使用 iOS 可可靠接收的 Touch Event
- 同時支援 `display-mode: standalone` 與 iOS `navigator.standalone` 的 PWA 判斷
- 活動明細在 PWA 中可由螢幕左緣向右滑返回活動列表
- 資產與行動版設定子頁沿用同一套返回手勢
- 桌面版活動抽屜可點擊左側遮罩關閉，抽屜內操作不受影響

## 問題原因

iPhone 加到主畫面的 Web App 不一定會命中 `(display-mode: standalone)`，只依賴該媒體查詢時，手勢會被判斷為未啟用。活動明細原本也只有返回按鈕，沒有可處理實機觸控手勢的路徑。

## 使用者影響

安裝到 iPhone 主畫面後，可使用接近原生 App 的左緣返回手勢；一般垂直捲動不會誤觸返回。桌面使用者也能點擊抽屜左側背景關閉明細。

## 驗證

- `npm run typecheck -w @taiwan-fin-hub/web`
- `npm run test:unit -w @taiwan-fin-hub/web`（35 tests）
- `npm run test:e2e -w @taiwan-fin-hub/web`（8 tests）
- `npm run build -w @taiwan-fin-hub/web`
- Svelte autofixer：0 issues
- 實際瀏覽器驗證桌面左側遮罩可關閉活動明細