### PR TITLE
修正同步空請求並強化永豐 Cookie 輪替

### DIFF
--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApiClient } from "./api";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("API client", () => {
+  it("does not declare JSON when a POST request has no body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createApiClient().post("/api/connectors/sinopac/sync");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/connectors/sinopac/sync",
+      expect.objectContaining({
+        method: "POST",
+        body: undefined,
+        headers: undefined,
+      }),
+    );
+  });
+
+  it("declares and serializes JSON when a request has a body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createApiClient().post("/api/connectors/sinopac/sync", {
+      captcha: "123456",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/connectors/sinopac/sync",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ captcha: "123456" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -14,9 +14,13 @@ function isApiError(value: unknown): value is ApiError {
 
 export function createApiClient(): ApiClient {
   async function request<T>(path: string, init: RequestInit = {}) {
+    const headers =
+      init.body === undefined
+        ? init.headers
+        : { "Content-Type": "application/json", ...init.headers };
     const response = await fetch(path, {
       ...init,
-      headers: { "Content-Type": "application/json", ...init.headers },
+      headers,
     });
     const text = await response.text();
     let data: T | ApiError;

--- a/apps/worker/src/connectors/sinopac.ts
+++ b/apps/worker/src/connectors/sinopac.ts
@@ -92,17 +92,56 @@ export function createSinopacConnector(browser?: Fetcher, fetchImpl: FetchImpl =
       }
 
       const lookbackMonths = config.lookbackMonths ?? 3;
-      const client = new SinopacAppClient(sessionCookies, fetchImpl);
-      const payloads = await client.fetchCreditCards(lookbackMonths);
-      const cards = parseSinopacCardData(payloads, lookbackMonths);
-      sessionCookies = client.serializedCookies();
+      const sessionAttempts = !verifiedThisRun
+        && config.candidateSessionCookies
+        && config.candidateSessionCookies !== sessionCookies
+        ? [
+            { source: "candidate" as const, cookies: config.candidateSessionCookies },
+            { source: "stable" as const, cookies: sessionCookies }
+          ]
+        : [{ source: "stable" as const, cookies: sessionCookies }];
+      let cards: Scraped | undefined;
+      let stableSessionCookies = sessionCookies;
+      let candidateSessionCookies: string | undefined;
+
+      for (const [index, attempt] of sessionAttempts.entries()) {
+        try {
+          const client = new SinopacAppClient(attempt.cookies, fetchImpl);
+          const canarySummary = attempt.source === "candidate"
+            ? await client.fetchSummary()
+            : undefined;
+          const payloads = await client.fetchCreditCards(lookbackMonths, canarySummary);
+          cards = parseSinopacCardData(payloads, lookbackMonths);
+          stableSessionCookies = attempt.cookies;
+          const rotatedCookies = client.serializedCookies();
+          candidateSessionCookies = rotatedCookies === attempt.cookies ? undefined : rotatedCookies;
+          if (attempt.source === "candidate") {
+            console.log("[sinopac] promoted candidate session after a successful cross-run canary");
+          } else if (index > 0) {
+            console.log("[sinopac] retained the known-good session after candidate rejection");
+          }
+          break;
+        } catch (error) {
+          const canFallback =
+            error instanceof SinopacVerificationRequiredError
+            && attempt.source === "candidate"
+            && index + 1 < sessionAttempts.length;
+          if (!canFallback) throw error;
+          console.warn("[sinopac] candidate session rejected; retrying the known-good session");
+        }
+      }
+      if (!cards) {
+        throw new SinopacVerificationRequiredError("永豐銀行 session 已失效，請重新完成圖形驗證。");
+      }
       const now = new Date();
 
       return {
         records: [],
         ...cards,
         cursor: JSON.stringify({
-          sessionCookies,
+          sessionCookies: stableSessionCookies,
+          candidateSessionCookies,
+          candidateSessionCreatedAt: candidateSessionCookies ? now.toISOString() : undefined,
           sessionExpiresAt: new Date(now.getTime() + SESSION_VALIDITY_MS).toISOString(),
           protocol: SESSION_PROTOCOL,
           syncedAt: now.toISOString()
@@ -126,8 +165,15 @@ class SinopacAppClient {
     return this.cookies.serialize();
   }
 
-  async fetchCreditCards(lookbackMonths: number): Promise<SinopacApiPayloads> {
-    const summary = await this.post(CARD_SUMMARY_PATH, "信用卡總覽");
+  fetchSummary() {
+    return this.post(CARD_SUMMARY_PATH, "信用卡總覽");
+  }
+
+  async fetchCreditCards(
+    lookbackMonths: number,
+    canarySummary?: unknown
+  ): Promise<SinopacApiPayloads> {
+    const summary = canarySummary ?? await this.fetchSummary();
     const initialBills = await this.post(`${CARD_BILLS_PATH}?TxDate=default&TxType=01`, "近期帳單");
     const billMonths = extractAdvertisedBillMonths(initialBills)
       .slice(1, Math.max(1, Math.min(3, lookbackMonths)));

--- a/apps/worker/src/features/connectors/service.ts
+++ b/apps/worker/src/features/connectors/service.ts
@@ -105,6 +105,8 @@ export async function updateConnectorSettings(
     ) {
       for (const key of [
         "sessionCookies",
+        "candidateSessionCookies",
+        "candidateSessionCreatedAt",
         "sessionExpiresAt",
         "browserSessionId",
         "browserSessionExpiresAt",

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -457,6 +457,8 @@ export async function syncSinopac(
     }
     if (error instanceof SinopacVerificationRequiredError) {
       delete cleaned.sessionCookies;
+      delete cleaned.candidateSessionCookies;
+      delete cleaned.candidateSessionCreatedAt;
       delete cleaned.sessionExpiresAt;
       delete cleaned.protocol;
     }
@@ -504,6 +506,8 @@ export async function syncSinopac(
     const cursorState = JSON.parse(result.cursor) as Record<string, unknown>;
     const {
       sessionCookies: _sessionCookies,
+      candidateSessionCookies: _candidateSessionCookies,
+      candidateSessionCreatedAt: _candidateSessionCreatedAt,
       sessionExpiresAt: _sessionExpiresAt,
       ...safeCursorState
     } = cursorState;
@@ -512,6 +516,8 @@ export async function syncSinopac(
       browserSessionId: _browserSessionId,
       browserSessionExpiresAt: _browserSessionExpiresAt,
       captcha: _captcha,
+      candidateSessionCookies: _previousCandidateSessionCookies,
+      candidateSessionCreatedAt: _previousCandidateSessionCreatedAt,
       ...reusableConfig
     } = config;
     finalizeStatements.push(

--- a/apps/worker/tests/connectors/sinopac.test.ts
+++ b/apps/worker/tests/connectors/sinopac.test.ts
@@ -131,6 +131,11 @@ const sessionCookies = JSON.stringify([{
   domain: "m.sinopac.com"
 }]);
 
+function cookieValue(serialized: string, name: string) {
+  const cookies = JSON.parse(serialized) as Array<{ name?: string; value?: string }>;
+  return cookies.find((cookie) => cookie.name === name)?.value;
+}
+
 describe("sinopac App JSON parser", () => {
   it("parses Taiwan amounts and ROC dates", () => {
     expect(parseAmount("NT$ 1,234.50")).toBe(1234.5);
@@ -249,7 +254,7 @@ describe("sinopac App JSON parser", () => {
     });
   });
 
-  it("applies rotated mobile cookies to later requests and persists the refreshed session", async () => {
+  it("applies rotated mobile cookies within a run and stores them as a candidate", async () => {
     const rotatingCookies = JSON.stringify([
       ...JSON.parse(sessionCookies),
       { name: "sinopac_cookie", value: "stale-cookie", domain: "m.sinopac.com", path: "/" }
@@ -274,11 +279,97 @@ describe("sinopac App JSON parser", () => {
     expect(requestCookies[0]).toContain("sinopac_cookie=stale-cookie");
     expect(requestCookies[1]).toContain("sinopac_cookie=summary-cookie");
     expect(requestCookies[2]).toContain("sinopac_cookie=billing-cookie");
-    const refreshedCookies = JSON.parse(JSON.parse(result.cursor ?? "{}").sessionCookies) as Array<{
-      name: string;
-      value: string;
-    }>;
-    expect(refreshedCookies.find((cookie) => cookie.name === "sinopac_cookie")?.value).toBe("unbilled-cookie");
+    const cursor = JSON.parse(result.cursor ?? "{}") as {
+      sessionCookies: string;
+      candidateSessionCookies: string;
+      candidateSessionCreatedAt: string;
+    };
+    expect(cookieValue(cursor.sessionCookies, "sinopac_cookie")).toBe("stale-cookie");
+    expect(cookieValue(cursor.candidateSessionCookies, "sinopac_cookie")).toBe("unbilled-cookie");
+    expect(cursor.candidateSessionCreatedAt).toBeTruthy();
+  });
+
+  it("promotes a candidate only after it succeeds in a later sync", async () => {
+    const stableCookies = JSON.stringify([
+      ...JSON.parse(sessionCookies),
+      { name: "sinopac_cookie", value: "stable-cookie", domain: "m.sinopac.com", path: "/" }
+    ]);
+    const candidateCookies = JSON.stringify([
+      ...JSON.parse(sessionCookies),
+      { name: "sinopac_cookie", value: "candidate-cookie", domain: "m.sinopac.com", path: "/" }
+    ]);
+    const requestCookies: string[] = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestCookies.push(new Headers(init?.headers).get("cookie") ?? "");
+      const call = requestCookies.length;
+      const payload = call === 1 ? summaryPayload : call === 2 ? billPayload : unbilledPayload;
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Set-Cookie": `sinopac_cookie=next-${call}; Path=/; HttpOnly; Secure` }
+      });
+    });
+
+    const result = await createSinopacConnector(undefined, fetchMock as typeof fetch).sync({
+      sessionCookies: stableCookies,
+      candidateSessionCookies: candidateCookies,
+      protocol: "sinopac-mobile-app-json-v1"
+    });
+
+    const cursor = JSON.parse(result.cursor ?? "{}") as {
+      sessionCookies: string;
+      candidateSessionCookies: string;
+    };
+    expect(requestCookies).toHaveLength(3);
+    expect(requestCookies[0]).toContain("sinopac_cookie=candidate-cookie");
+    expect(cookieValue(cursor.sessionCookies, "sinopac_cookie")).toBe("candidate-cookie");
+    expect(cookieValue(cursor.candidateSessionCookies, "sinopac_cookie")).toBe("next-3");
+  });
+
+  it("falls back to the known-good session when a candidate is rejected", async () => {
+    const stableCookies = JSON.stringify([
+      ...JSON.parse(sessionCookies),
+      { name: "sinopac_cookie", value: "stable-cookie", domain: "m.sinopac.com", path: "/" }
+    ]);
+    const candidateCookies = JSON.stringify([
+      ...JSON.parse(sessionCookies),
+      { name: "sinopac_cookie", value: "candidate-cookie", domain: "m.sinopac.com", path: "/" }
+    ]);
+    const requestCookies: string[] = [];
+    const requestUrls: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const cookie = new Headers(init?.headers).get("cookie") ?? "";
+      requestCookies.push(cookie);
+      requestUrls.push(String(input));
+      if (cookie.includes("sinopac_cookie=candidate-cookie")) {
+        return new Response(JSON.stringify([{ Header: "TIMEOUT", Message: "您尚未登入網銀" }]));
+      }
+      const stableCall = requestCookies.length - 1;
+      const payload = stableCall === 1 ? summaryPayload : stableCall === 2 ? billPayload : unbilledPayload;
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Set-Cookie": `sinopac_cookie=fallback-${stableCall}; Path=/; HttpOnly; Secure` }
+      });
+    });
+
+    const result = await createSinopacConnector(undefined, fetchMock as typeof fetch).sync({
+      sessionCookies: stableCookies,
+      candidateSessionCookies: candidateCookies,
+      protocol: "sinopac-mobile-app-json-v1"
+    });
+
+    const cursor = JSON.parse(result.cursor ?? "{}") as {
+      sessionCookies: string;
+      candidateSessionCookies: string;
+    };
+    expect(requestCookies).toHaveLength(4);
+    expect(requestUrls.slice(0, 2)).toEqual([
+      "https://m.sinopac.com/ws/card/cardqry/ws_cardsum.ashx",
+      "https://m.sinopac.com/ws/card/cardqry/ws_cardsum.ashx"
+    ]);
+    expect(requestCookies[0]).toContain("sinopac_cookie=candidate-cookie");
+    expect(requestCookies[1]).toContain("sinopac_cookie=stable-cookie");
+    expect(cookieValue(cursor.sessionCookies, "sinopac_cookie")).toBe("stable-cookie");
+    expect(cookieValue(cursor.candidateSessionCookies, "sinopac_cookie")).toBe("fallback-3");
   });
 
   it("fetches the remaining statement months advertised by the default response", async () => {
@@ -318,6 +409,32 @@ describe("sinopac App JSON parser", () => {
       protocol: "sinopac-mobile-app-json-v1"
     })).rejects.toBeInstanceOf(SinopacVerificationRequiredError);
     expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("requests verification only after both candidate and stable sessions are rejected", async () => {
+    const requestUrls: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      requestUrls.push(String(input));
+      return new Response(JSON.stringify([{
+        Header: "TIMEOUT",
+        Message: "您尚未登入網銀"
+      }]));
+    });
+
+    await expect(createSinopacConnector(undefined, fetchMock as typeof fetch).sync({
+      sessionCookies,
+      candidateSessionCookies: JSON.stringify([{
+        name: "ASP.NET_SessionId",
+        value: "candidate-session",
+        domain: "m.sinopac.com"
+      }]),
+      protocol: "sinopac-mobile-app-json-v1"
+    })).rejects.toBeInstanceOf(SinopacVerificationRequiredError);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(requestUrls).toEqual([
+      "https://m.sinopac.com/ws/card/cardqry/ws_cardsum.ashx",
+      "https://m.sinopac.com/ws/card/cardqry/ws_cardsum.ashx"
+    ]);
   });
 
   it("does not reuse a legacy MMA session after switching protocols", async () => {

--- a/packages/connectors/src/sinopac.ts
+++ b/packages/connectors/src/sinopac.ts
@@ -6,6 +6,8 @@ export const sinopacConfigSchema = z.object({
   account: z.string().min(1).optional(),
   password: z.string().min(1).optional(),
   sessionCookies: z.string().optional(),
+  candidateSessionCookies: z.string().optional(),
+  candidateSessionCreatedAt: z.string().optional(),
   sessionExpiresAt: z.string().optional(),
   browserSessionId: z.string().optional(),
   browserSessionExpiresAt: z.string().optional(),


### PR DESCRIPTION
## 變更內容

- 無 request body 時不再宣告 `Content-Type: application/json`，避免 Hono 將空 body 視為 malformed JSON
- 永豐輪替 Cookie 改為兩階段 promotion：先保存候選 Cookie，下次同步通過輕量 canary 後才取代穩定 Cookie
- 候選 Cookie timeout 時回退穩定 Cookie；候選與穩定 Cookie 都失效時才要求重新完成圖形驗證
- 候選 Cookie 僅保存於加密 connector 設定，並從公開 `sync_cursor` 排除
- 更新連線憑證時清除舊候選 Cookie，避免跨身份沿用
- 補上空 body API 與永豐跨次同步、promotion、fallback、雙重失效的回歸測試

## 問題原因

前端同步請求即使沒有 body，仍固定送出 JSON content type，Worker 的 JSON middleware 因此嘗試解析空內容並回傳 `Request data does not match the expected format.`。

永豐回應的輪替 Cookie 若在同一次同步後直接覆蓋已驗證 Cookie，無法確認新 Cookie 是否能在下一次獨立 session 使用；一旦新值不可重用，原本可維持數天的穩定 Cookie 也會被提前淘汰。

## 影響

- 集保、玉山、發票等無 body 的同步 request 不再觸發空 JSON 解析錯誤
- 永豐保留最後已驗證可跨次使用的 Cookie，只有候選 Cookie 通過下一次同步 canary 才會 promotion
- 既有已失效的永豐 session 在部署後仍需重新完成一次圖形驗證；後續同步才會開始套用新的 promotion 流程

## 驗證

- `npm exec -w @taiwan-fin-hub/worker -- vitest run tests/connectors/sinopac.test.ts tests/features/sync/sinopac.test.ts`（2 files、16 tests）
- `npm run test:backend`（Worker 70 tests、DB 4 tests、selfchecks 通過）
- `npm run typecheck`
- `npm run test:unit`（Web 37 tests）
- `npm run build -w @taiwan-fin-hub/web`
- `git diff --check`
