### PR TITLE
fix(永豐連接器): 新增排程 session 保活機制

### DIFF
--- a/apps/web/src/features/overview/Overview.svelte
+++ b/apps/web/src/features/overview/Overview.svelte
@@ -351,7 +351,7 @@
         <p class="font-semibold">{unhealthy.length} 個來源需要更新</p>
         <button
           class="mt-3 text-sm font-semibold"
-          onclick={() => navigate("settings")}>立即處理 →</button
+          onclick={() => navigate("data-sources")}>立即處理 →</button
         >
       </section>
     {/if}

--- a/apps/worker/src/connectors/sinopac.ts
+++ b/apps/worker/src/connectors/sinopac.ts
@@ -143,10 +143,51 @@ export function createSinopacConnector(browser?: Fetcher, fetchImpl: FetchImpl =
           candidateSessionCookies,
           candidateSessionCreatedAt: candidateSessionCookies ? now.toISOString() : undefined,
           sessionExpiresAt: new Date(now.getTime() + SESSION_VALIDITY_MS).toISOString(),
+          sessionKeepAliveFailures: 0,
           protocol: SESSION_PROTOCOL,
           syncedAt: now.toISOString()
         })
       };
+    },
+
+    async refreshSession(config: SinopacConfig) {
+      if (!config.sessionCookies || config.protocol !== SESSION_PROTOCOL) {
+        throw new SinopacVerificationRequiredError("永豐同步需要先完成一次圖形驗證。");
+      }
+
+      const attempts = config.candidateSessionCookies
+        && config.candidateSessionCookies !== config.sessionCookies
+        ? [
+            { source: "candidate" as const, cookies: config.candidateSessionCookies },
+            { source: "stable" as const, cookies: config.sessionCookies }
+          ]
+        : [{ source: "stable" as const, cookies: config.sessionCookies }];
+
+      for (const [index, attempt] of attempts.entries()) {
+        try {
+          const client = new SinopacAppClient(attempt.cookies, fetchImpl);
+          await client.fetchSummary();
+          const now = new Date();
+          const rotatedCookies = client.serializedCookies();
+          return {
+            sessionCookies: attempt.cookies,
+            candidateSessionCookies: rotatedCookies === attempt.cookies ? undefined : rotatedCookies,
+            candidateSessionCreatedAt: rotatedCookies === attempt.cookies ? undefined : now.toISOString(),
+            sessionExpiresAt: new Date(now.getTime() + SESSION_VALIDITY_MS).toISOString(),
+            sessionKeepAliveFailures: 0,
+            protocol: SESSION_PROTOCOL
+          };
+        } catch (error) {
+          const canFallback =
+            error instanceof SinopacVerificationRequiredError
+            && attempt.source === "candidate"
+            && index + 1 < attempts.length;
+          if (!canFallback) throw error;
+          console.warn("[sinopac] keep-alive candidate rejected; retrying the known-good session");
+        }
+      }
+
+      throw new SinopacVerificationRequiredError("永豐銀行 session 已失效，請重新完成圖形驗證。");
     }
   };
 }

--- a/apps/worker/src/features/connectors/service.ts
+++ b/apps/worker/src/features/connectors/service.ts
@@ -108,6 +108,7 @@ export async function updateConnectorSettings(
         "candidateSessionCookies",
         "candidateSessionCreatedAt",
         "sessionExpiresAt",
+        "sessionKeepAliveFailures",
         "browserSessionId",
         "browserSessionExpiresAt",
         "captcha",

--- a/apps/worker/src/features/sync/scheduler.ts
+++ b/apps/worker/src/features/sync/scheduler.ts
@@ -12,6 +12,7 @@ import type { Env } from "../../platform/env";
 import {
   canonicalSyncLockRowId,
   isUserActionError,
+  maintainSinopacSession,
   NeedsUserActionError,
   safeErrorMessage,
   startSyncLockHeartbeat,
@@ -29,6 +30,17 @@ export async function runSchedulerTick(
   env: Env,
   controller: ScheduledController,
 ) {
+  try {
+    await maintainSinopacSession(env);
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        event: "sinopac_session_keep_alive_failed",
+        cron: controller.cron,
+        message: safeErrorMessage(error),
+      }),
+    );
+  }
   for (let index = 0; index < MAX_SCHEDULED_JOBS_PER_TICK; index += 1) {
     const due = await findNextDueSyncJob<ConnectorId>(env.DB);
     if (!due) return;

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -73,6 +73,9 @@ export const TDCC_SCOPE_BANK = "bank";
 export const TDCC_SCOPE_TRADES = "trades";
 export const SYNC_LOCK_LEASE_MS = 30 * 60 * 1000;
 const SYNC_LOCK_HEARTBEAT_MS = 5 * 60 * 1000;
+const SINOPAC_SESSION_REFRESH_MARGIN_MS = 12 * 60 * 1000;
+const SINOPAC_KEEP_ALIVE_FAILURE_LIMIT = 2;
+const SINOPAC_KEEP_ALIVE_LOCK_LEASE_MS = 2 * 60 * 1000;
 
 export type SyncOutcome = {
   success: true;
@@ -102,6 +105,144 @@ export type EinvoiceSyncOverrides = {
 export type SinopacSyncOverrides = {
   captcha?: string;
 };
+
+export type SinopacSessionMaintenanceResult =
+  | "disabled"
+  | "not-configured"
+  | "not-needed"
+  | "busy"
+  | "refreshed"
+  | "retry-pending"
+  | "needs-user-action";
+
+export async function maintainSinopacSession(
+  env: Env,
+  now = new Date(),
+): Promise<SinopacSessionMaintenanceResult> {
+  const connectorId = "sinopac";
+  const scope = SYNC_SCOPE_ALL;
+  const job = await env.DB.prepare(
+    "SELECT enabled, next_run_at, last_status FROM sync_jobs WHERE connector_id = ? AND scope = ?",
+  )
+    .bind(connectorId, scope)
+    .first<{ enabled: number; next_run_at: string; last_status: SyncStatus | null }>();
+  if (!job?.enabled || job.last_status === "needs_user_action") return "disabled";
+
+  // A full sync that is already due will refresh the session itself.
+  if (new Date(job.next_run_at) <= now) return "not-needed";
+
+  const currentSettings = await getConnectorSettings(env.DB, connectorId);
+  if (!currentSettings) return "not-configured";
+  const currentConfig = await decryptJson<Record<string, unknown>>(
+    currentSettings.encrypted_config,
+    configEncryptionKey(env),
+  );
+  if (!sinopacSessionNeedsRefresh(currentConfig, now)) return "not-needed";
+
+  const runId = crypto.randomUUID();
+  const lockRowId = canonicalSyncLockRowId(connectorId);
+  const locked = await acquireSyncJobLock(env.DB, {
+    lockRowId,
+    scope,
+    trigger: "scheduled",
+    runId,
+    leaseMs: SINOPAC_KEEP_ALIVE_LOCK_LEASE_MS,
+  });
+  if (!locked) return "busy";
+
+  try {
+    // A manual sync may have refreshed the session before this lock was acquired.
+    const settings = await getConnectorSettings(env.DB, connectorId);
+    if (!settings) return "not-configured";
+    const stored = await decryptJson<Record<string, unknown>>(
+      settings.encrypted_config,
+      configEncryptionKey(env),
+    );
+    if (!sinopacSessionNeedsRefresh(stored, now)) return "not-needed";
+
+    const publicStored = settings.public_config
+      ? JSON.parse(settings.public_config)
+      : {};
+    const config = parseSinopacConfig({ ...stored, ...publicStored });
+    try {
+      const refreshed = await createSinopacConnector(env.BROWSER).refreshSession(config);
+      const {
+        candidateSessionCookies: _oldCandidateSessionCookies,
+        candidateSessionCreatedAt: _oldCandidateSessionCreatedAt,
+        sessionKeepAliveFailures: _oldSessionKeepAliveFailures,
+        ...reusableConfig
+      } = config;
+      await updateConnectorEncryptedConfig(
+        env.DB,
+        connectorId,
+        await encryptJson(
+          { ...reusableConfig, ...refreshed },
+          configEncryptionKey(env),
+        ),
+      );
+      console.log("[sinopac] refreshed the scheduled-sync session");
+      return "refreshed";
+    } catch (error) {
+      if (!(error instanceof SinopacVerificationRequiredError)) throw error;
+      const failures = Math.min(
+        Number(config.sessionKeepAliveFailures ?? 0) + 1,
+        SINOPAC_KEEP_ALIVE_FAILURE_LIMIT,
+      );
+      if (failures < SINOPAC_KEEP_ALIVE_FAILURE_LIMIT) {
+        await updateConnectorEncryptedConfig(
+          env.DB,
+          connectorId,
+          await encryptJson(
+            { ...stored, sessionKeepAliveFailures: failures },
+            configEncryptionKey(env),
+          ),
+        );
+        console.warn("[sinopac] keep-alive verification failed once; retrying on the next cron tick");
+        return "retry-pending";
+      }
+
+      const cleaned = { ...stored };
+      delete cleaned.sessionCookies;
+      delete cleaned.candidateSessionCookies;
+      delete cleaned.candidateSessionCreatedAt;
+      delete cleaned.sessionExpiresAt;
+      delete cleaned.sessionKeepAliveFailures;
+      delete cleaned.protocol;
+      await env.DB.batch([
+        connectorEncryptedConfigStatement(
+          env.DB,
+          connectorId,
+          await encryptJson(cleaned, configEncryptionKey(env)),
+          now.toISOString(),
+        ),
+        env.DB.prepare(
+          `UPDATE sync_jobs
+           SET last_status = 'needs_user_action', last_error = ?, updated_at = ?
+           WHERE connector_id = ? AND scope = ?`,
+        ).bind(error.message, now.toISOString(), connectorId, scope),
+      ]);
+      console.warn("[sinopac] scheduled-sync session expired during keep-alive");
+      return "needs-user-action";
+    }
+  } finally {
+    await releaseSyncJobLock(env.DB, lockRowId, runId);
+  }
+}
+
+export function sinopacSessionNeedsRefresh(
+  config: Record<string, unknown>,
+  now = new Date(),
+) {
+  if (
+    typeof config.sessionCookies !== "string"
+    || !config.sessionCookies
+    || config.protocol !== "sinopac-mobile-app-json-v1"
+  ) return false;
+  if (typeof config.sessionExpiresAt !== "string") return true;
+  const expiresAt = new Date(config.sessionExpiresAt).getTime();
+  return !Number.isFinite(expiresAt)
+    || expiresAt <= now.getTime() + SINOPAC_SESSION_REFRESH_MARGIN_MS;
+}
 
 export type TdccSyncOverrides = {
   otp?: string;
@@ -460,6 +601,7 @@ export async function syncSinopac(
       delete cleaned.candidateSessionCookies;
       delete cleaned.candidateSessionCreatedAt;
       delete cleaned.sessionExpiresAt;
+      delete cleaned.sessionKeepAliveFailures;
       delete cleaned.protocol;
     }
     if (
@@ -518,6 +660,7 @@ export async function syncSinopac(
       captcha: _captcha,
       candidateSessionCookies: _previousCandidateSessionCookies,
       candidateSessionCreatedAt: _previousCandidateSessionCreatedAt,
+      sessionKeepAliveFailures: _previousSessionKeepAliveFailures,
       ...reusableConfig
     } = config;
     finalizeStatements.push(

--- a/apps/worker/tests/connectors/sinopac.test.ts
+++ b/apps/worker/tests/connectors/sinopac.test.ts
@@ -325,6 +325,64 @@ describe("sinopac App JSON parser", () => {
     expect(cookieValue(cursor.candidateSessionCookies, "sinopac_cookie")).toBe("next-3");
   });
 
+  it("refreshes a scheduled session with one lightweight canary request", async () => {
+    const stableCookies = JSON.stringify([
+      ...JSON.parse(sessionCookies),
+      { name: "sinopac_cookie", value: "stable-cookie", domain: "m.sinopac.com", path: "/" }
+    ]);
+    const requestCookies: string[] = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestCookies.push(new Headers(init?.headers).get("cookie") ?? "");
+      return new Response(JSON.stringify(summaryPayload), {
+        headers: { "Set-Cookie": "sinopac_cookie=refreshed-cookie; Path=/; HttpOnly; Secure" }
+      });
+    });
+
+    const refreshed = await createSinopacConnector(undefined, fetchMock as typeof fetch).refreshSession({
+      sessionCookies: stableCookies,
+      sessionKeepAliveFailures: 1,
+      protocol: "sinopac-mobile-app-json-v1"
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(requestCookies[0]).toContain("sinopac_cookie=stable-cookie");
+    expect(cookieValue(refreshed.sessionCookies, "sinopac_cookie")).toBe("stable-cookie");
+    expect(cookieValue(refreshed.candidateSessionCookies!, "sinopac_cookie")).toBe("refreshed-cookie");
+    expect(refreshed.sessionKeepAliveFailures).toBe(0);
+    expect(new Date(refreshed.sessionExpiresAt).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("falls back to the stable session while refreshing a rejected candidate", async () => {
+    const stableCookies = JSON.stringify([
+      ...JSON.parse(sessionCookies),
+      { name: "sinopac_cookie", value: "stable-cookie", domain: "m.sinopac.com", path: "/" }
+    ]);
+    const candidateCookies = JSON.stringify([
+      ...JSON.parse(sessionCookies),
+      { name: "sinopac_cookie", value: "candidate-cookie", domain: "m.sinopac.com", path: "/" }
+    ]);
+    const requestCookies: string[] = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const cookie = new Headers(init?.headers).get("cookie") ?? "";
+      requestCookies.push(cookie);
+      if (cookie.includes("candidate-cookie")) {
+        return new Response(JSON.stringify([{ Header: "TIMEOUT", Message: "您尚未登入網銀" }]));
+      }
+      return new Response(JSON.stringify(summaryPayload));
+    });
+
+    const refreshed = await createSinopacConnector(undefined, fetchMock as typeof fetch).refreshSession({
+      sessionCookies: stableCookies,
+      candidateSessionCookies: candidateCookies,
+      protocol: "sinopac-mobile-app-json-v1"
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(requestCookies[0]).toContain("candidate-cookie");
+    expect(requestCookies[1]).toContain("stable-cookie");
+    expect(cookieValue(refreshed.sessionCookies, "sinopac_cookie")).toBe("stable-cookie");
+  });
+
   it("falls back to the known-good session when a candidate is rejected", async () => {
     const stableCookies = JSON.stringify([
       ...JSON.parse(sessionCookies),

--- a/apps/worker/tests/features/sync/sinopac-session-maintenance.test.ts
+++ b/apps/worker/tests/features/sync/sinopac-session-maintenance.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { sinopacSessionNeedsRefresh } from "../../../src/features/sync/service";
+
+const now = new Date("2026-07-20T02:00:00.000Z");
+const sessionCookies = JSON.stringify([
+  { name: "ASP.NET_SessionId", value: "active-session", domain: "m.sinopac.com" },
+]);
+
+describe("sinopac scheduled session maintenance", () => {
+  it("refreshes when the session has twelve minutes or less remaining", () => {
+    expect(sinopacSessionNeedsRefresh({
+      sessionCookies,
+      sessionExpiresAt: "2026-07-20T02:12:00.000Z",
+      protocol: "sinopac-mobile-app-json-v1",
+    }, now)).toBe(true);
+  });
+
+  it("does not refresh a recently renewed session", () => {
+    expect(sinopacSessionNeedsRefresh({
+      sessionCookies,
+      sessionExpiresAt: "2026-07-20T02:13:00.000Z",
+      protocol: "sinopac-mobile-app-json-v1",
+    }, now)).toBe(false);
+  });
+
+  it("refreshes a reusable legacy state that has no local expiry estimate", () => {
+    expect(sinopacSessionNeedsRefresh({
+      sessionCookies,
+      protocol: "sinopac-mobile-app-json-v1",
+    }, now)).toBe(true);
+  });
+
+  it("ignores missing and incompatible sessions", () => {
+    expect(sinopacSessionNeedsRefresh({}, now)).toBe(false);
+    expect(sinopacSessionNeedsRefresh({
+      sessionCookies,
+      protocol: "legacy-mobile-web",
+    }, now)).toBe(false);
+  });
+});

--- a/packages/connectors/src/sinopac.ts
+++ b/packages/connectors/src/sinopac.ts
@@ -9,6 +9,7 @@ export const sinopacConfigSchema = z.object({
   candidateSessionCookies: z.string().optional(),
   candidateSessionCreatedAt: z.string().optional(),
   sessionExpiresAt: z.string().optional(),
+  sessionKeepAliveFailures: z.number().int().min(0).max(2).optional(),
   browserSessionId: z.string().optional(),
   browserSessionExpiresAt: z.string().optional(),
   captcha: z.string().regex(/^\d{6}$/).optional(),


### PR DESCRIPTION
## 變更內容

- 在既有每 10 分鐘 Cron 中加入永豐 session 輕量保活檢查。
- session 接近本地預估期限時，只呼叫一次信用卡總覽 API，不執行完整帳單同步，也不改動上次完整同步時間。
- 延續候選／穩定 Cookie 的輪替與 fallback；連續兩次確認失效後才清除 session 並標記需要人工驗證。
- 與手動及完整排程同步共用 connector lock，避免同時覆寫 Cookie。

## 問題原因

原本雖然已保存 API 回傳的輪替 Cookie，但兩次每日排程之間沒有任何請求；短效 session 經過長時間閒置後仍會在下一次排程前失效。

## 驗證

- `node node_modules/typescript/bin/tsc -p apps/worker/tsconfig.json`
- `node node_modules/vitest/vitest.mjs run apps/worker/tests`：13 個測試檔、76 個測試全部通過（Node.js 24.14.0）
- `git diff --check`

## 風險與手動測試

- 銀行端仍可能有絕對 session 上限、風控或單一登入限制，因此保活為 best effort，不能保證永久有效。
- 部署後目前已失效的永豐 session 仍需重新完成一次圖形驗證。
- 建議觀察至少一個隔夜週期，確認 Cron 日誌出現 session refreshed，且隔日完整同步成功。
- 建議確認使用官方永豐 App 登入後是否會讓保活 session 失效。