### PR TITLE
feat(集保連線): 重整首次驗證流程並簡化同步操作

### DIFF
--- a/apps/web/src/features/settings/ConnectorPanel.svelte
+++ b/apps/web/src/features/settings/ConnectorPanel.svelte
@@ -7,11 +7,13 @@
     useQueryClient,
   } from "@tanstack/svelte-query";
   import {
-    Database,
+    CircleCheckBig,
     KeyRound,
+    Mail,
     RefreshCw,
     Save,
-    WalletCards,
+    ShieldCheck,
+    Smartphone,
   } from "@lucide/svelte";
   import Card from "../../components/ui/Card.svelte";
   import Button from "../../components/ui/Button.svelte";
@@ -20,7 +22,7 @@
   import Select from "../../components/ui/Select.svelte";
   import TimePicker from "../../components/ui/TimePicker.svelte";
   import type { ApiClient } from "../../lib/api";
-  import { queryKeys } from "../../lib/api";
+  import { ApiRequestError, queryKeys } from "../../lib/api";
   import {
     connectorSettingsQuery,
     syncJobsQuery,
@@ -57,7 +59,9 @@
   let values = $state<Record<string, string | boolean>>({});
   let error = $state("");
   let otp = $state("");
-  let otpForced = $state(false);
+  let tdccSetupStep = $state<"credentials" | "email" | "sms" | "complete">(
+    "credentials",
+  );
   let sinopacCaptchaImage = $state("");
   let sinopacCaptcha = $state("");
   let pendingSyncTarget = $state<SyncTarget>("default");
@@ -68,6 +72,12 @@
   );
   const sinopacSessionAvailable = $derived(
     connectorId === "sinopac" && Boolean($settings.data?.sessionAvailable),
+  );
+  const tdccConnectionReady = $derived(
+    connectorId === "tdcc" && Boolean($settings.data?.sessionAvailable),
+  );
+  const tdccCredentialsComplete = $derived(
+    connectorId === "tdcc" && Boolean($settings.data?.credentialsComplete),
   );
   const intervalOptions = [
     { label: "每小時", minutes: 60 },
@@ -135,6 +145,8 @@
       );
     },
     onSuccess: () => {
+      error = "";
+      if (connectorId === "tdcc") tdccSetupStep = "complete";
       qc.invalidateQueries({ queryKey: queryKeys.syncJobs });
       qc.invalidateQueries({ queryKey: queryKeys.summary });
       if (connectorId === "einvoice")
@@ -160,11 +172,37 @@
       }
     },
     onError: (e) => {
+      if (handleTdccVerificationRequired(e)) return;
       error = e instanceof Error ? e.message : "同步失敗";
       if (connectorId === "sinopac")
         qc.invalidateQueries({
           queryKey: queryKeys.connectorSettings(connectorId),
         });
+    },
+  });
+  const connectTdcc = createMutation({
+    mutationFn: async () => {
+      if (demoMode) throw new Error("Demo site 已停用連接器同步。");
+      const config = buildConfig();
+      if (
+        !tdccCredentialsComplete &&
+        (!String(config.userId ?? "").trim() ||
+          !String(config.password ?? "").trim())
+      ) {
+        throw new Error("請輸入身分證字號與集保 App 密碼。");
+      }
+      if (Object.keys(config).length > 0) {
+        await api.put("/api/connectors/tdcc/settings", { config });
+      }
+      return api.post("/api/connectors/tdcc/sync");
+    },
+    onSuccess: () => finishTdccConnection(),
+    onError: (e) => {
+      qc.invalidateQueries({
+        queryKey: queryKeys.connectorSettings(connectorId),
+      });
+      if (handleTdccVerificationRequired(e)) return;
+      error = e instanceof Error ? e.message : "集保連線失敗";
     },
   });
   const prepareSinopac = createMutation({
@@ -205,13 +243,6 @@
     },
     onError: (e) => (error = e instanceof Error ? e.message : "驗證或同步失敗"),
   });
-  const syncErrorMessage = $derived(
-    $sync.error instanceof Error ? $sync.error.message : "",
-  );
-  const otpRequired = $derived(
-    connectorId === "tdcc" && (otpForced || /OTP/i.test(syncErrorMessage)),
-  );
-  const otpChannel = $derived(/SMS/i.test(syncErrorMessage) ? "sms" : "email");
   const verifyOtp = createMutation({
     mutationFn: () => {
       if (demoMode) throw new Error("Demo site 已停用連接器同步。");
@@ -220,23 +251,57 @@
         connectorId === "tdcc" && pendingSyncTarget !== "default"
           ? `/api/connectors/${connectorId}/sync/${pendingSyncTarget}`
           : `/api/connectors/${connectorId}/sync`;
-      return api.post(path, { otp: otp.trim(), otpChannel });
-    },
-    onSuccess: () => {
-      otp = "";
-      otpForced = false;
-      $sync.reset();
-      qc.invalidateQueries({
-        queryKey: queryKeys.connectorSettings(connectorId),
+      return api.post(path, {
+        otp: otp.trim(),
+        otpChannel: tdccSetupStep === "sms" ? "sms" : "email",
       });
-      qc.invalidateQueries({ queryKey: queryKeys.syncJobs });
-      qc.invalidateQueries({ queryKey: queryKeys.summary });
-      qc.invalidateQueries({ queryKey: queryKeys.investments });
-      qc.invalidateQueries({ queryKey: queryKeys.investmentTransactions });
-      qc.invalidateQueries({ queryKey: queryKeys.bank });
     },
-    onError: (e) => (error = e instanceof Error ? e.message : "驗證失敗"),
+    onSuccess: () => finishTdccConnection(),
+    onError: (e) => {
+      if (handleTdccVerificationRequired(e)) {
+        otp = "";
+        return;
+      }
+      error = e instanceof Error ? e.message : "驗證失敗";
+    },
   });
+
+  function handleTdccVerificationRequired(errorValue: unknown) {
+    if (!(errorValue instanceof ApiRequestError)) return false;
+    if (errorValue.code === "TDCC_EMAIL_OTP_REQUIRED") {
+      error = "";
+      otp = "";
+      tdccSetupStep = "email";
+      pendingSyncTarget = "default";
+      return true;
+    }
+    if (errorValue.code === "TDCC_SMS_OTP_REQUIRED") {
+      error = "";
+      otp = "";
+      tdccSetupStep = "sms";
+      return true;
+    }
+    return false;
+  }
+
+  function finishTdccConnection() {
+    error = "";
+    otp = "";
+    tdccSetupStep = "complete";
+    $sync.reset();
+    for (const field of fields) {
+      if (field.type === "text" || field.type === "password")
+        values[field.key] = "";
+    }
+    qc.invalidateQueries({
+      queryKey: queryKeys.connectorSettings(connectorId),
+    });
+    qc.invalidateQueries({ queryKey: queryKeys.syncJobs });
+    qc.invalidateQueries({ queryKey: queryKeys.summary });
+    qc.invalidateQueries({ queryKey: queryKeys.investments });
+    qc.invalidateQueries({ queryKey: queryKeys.investmentTransactions });
+    qc.invalidateQueries({ queryKey: queryKeys.bank });
+  }
 
   function buildConfig() {
     const entries: Array<[string, string | number | boolean]> = [];
@@ -272,31 +337,33 @@
         {embedded ? "連線與同步" : title}
       </h2>
       <p class="text-sm text-ink/65">
-        {$settings.data?.configured
-          ? `已設定於 ${formatDateTime($settings.data.updatedAt)}。機密資料不會在此顯示；重新填寫欄位即可覆寫。`
-          : "尚未設定"}
+        {connectorId === "tdcc" && tdccConnectionReady
+          ? "連線已完成；登入狀態會安全保存並供後續同步使用。"
+          : connectorId === "tdcc" &&
+              $settings.data?.configured &&
+              !tdccCredentialsComplete
+            ? "舊設定缺少完整的登入資料，請重新輸入身分證字號與 App 密碼。"
+            : $settings.data?.configured
+              ? `已設定於 ${formatDateTime($settings.data.updatedAt)}。機密資料不會在此顯示；重新填寫欄位即可覆寫。`
+              : "尚未設定"}
       </p>
     </div>
     <div class="flex flex-wrap gap-2">
-      {#if connectorId === "tdcc"}
+      {#if connectorId === "tdcc" && tdccConnectionReady}
         <Button
           size="sm"
-          disabled={demoMode}
-          onclick={() => $sync.mutate("investments")}
-          ><WalletCards class="size-4" />同步投資</Button
+          disabled={demoMode || $sync.isPending || $verifyOtp.isPending}
+          onclick={() => $sync.mutate("default")}
+          ><RefreshCw
+            class={$sync.isPending ? "size-4 animate-spin" : "size-4"}
+          />{$sync.isPending ? "同步中…" : "同步"}</Button
         >
-        <Button
-          size="sm"
-          disabled={demoMode}
-          onclick={() => $sync.mutate("bank")}
-          ><RefreshCw class="size-4" />同步銀行</Button
+      {:else if connectorId === "tdcc"}
+        <span
+          class="inline-flex items-center gap-1.5 rounded-full border border-steel/20 bg-steel/[0.06] px-3 py-1.5 text-xs font-semibold text-steel"
         >
-        <Button
-          size="sm"
-          disabled={demoMode}
-          onclick={() => $sync.mutate("trades")}
-          ><Database class="size-4" />同步交易</Button
-        >
+          <ShieldCheck class="size-3.5" />等待完成身分驗證
+        </span>
       {:else if connectorId === "sinopac"}
         {#if sinopacSessionAvailable}
           <Button
@@ -347,13 +414,6 @@
           ><RefreshCw class="size-4" />同步</Button
         >
       {/if}
-      {#if connectorId === "tdcc"}<Button
-          size="sm"
-          variant="secondary"
-          disabled={demoMode}
-          onclick={() => (otpForced = true)}
-          ><KeyRound class="size-4" />輸入 OTP</Button
-        >{/if}
     </div>
   </div>
   {#if demoMode}<p
@@ -361,7 +421,42 @@
     >
       Demo site 已停用同步；你仍可查看示範資料與介面互動。
     </p>{/if}
-  {#if connectorId === "tdcc"}<details
+  {#if connectorId === "tdcc"}
+    <div
+      class="mt-4 grid overflow-hidden rounded-xl border border-ink/10 bg-paper sm:grid-cols-3"
+      aria-label="集保連線進度"
+    >
+      <div
+        class={`flex items-center gap-3 px-3 py-3 ${tdccSetupStep === "credentials" && !tdccConnectionReady ? "bg-steel/[0.07] text-steel" : "text-ink/55"}`}
+      >
+        <span
+          class="grid size-7 shrink-0 place-items-center rounded-full border border-current/20 text-xs font-bold"
+          >1</span
+        >
+        <span class="text-xs font-semibold">確認集保帳密</span>
+      </div>
+      <div
+        class={`flex items-center gap-3 border-t border-ink/10 px-3 py-3 sm:border-l sm:border-t-0 ${tdccSetupStep === "email" || tdccSetupStep === "sms" ? "bg-steel/[0.07] text-steel" : "text-ink/55"}`}
+      >
+        <span
+          class="grid size-7 shrink-0 place-items-center rounded-full border border-current/20 text-xs font-bold"
+          >2</span
+        >
+        <span class="text-xs font-semibold">驗證這台裝置</span>
+      </div>
+      <div
+        class={`flex items-center gap-3 border-t border-ink/10 px-3 py-3 sm:border-l sm:border-t-0 ${tdccConnectionReady || tdccSetupStep === "complete" ? "bg-moss/[0.07] text-moss" : "text-ink/55"}`}
+      >
+        <span
+          class="grid size-7 shrink-0 place-items-center rounded-full border border-current/20 text-xs font-bold"
+          >{#if tdccConnectionReady || tdccSetupStep === "complete"}<CircleCheckBig
+              class="size-4"
+            />{:else}3{/if}</span
+        >
+        <span class="text-xs font-semibold">完成首次同步</span>
+      </div>
+    </div>
+    <details
       class="mt-3 rounded-md border border-ink/10 bg-paper text-sm text-ink/70"
     >
       <summary
@@ -370,11 +465,12 @@
       >
       <ol class="list-decimal space-y-1.5 px-3 pb-3 pt-1 pl-8">
         <li>先在手機下載並登入「集保e存摺」，確認可看到股票與基金資料。</li>
-        <li>填入身分證字號與集保 App 密碼，儲存後再按同步。</li>
-        <li>首次同步需要驗證碼，請查看手機簡訊或電子信箱。</li>
-        <li>完成後即可看到持倉；日後同步通常不需重新輸入驗證碼。</li>
+        <li>填入身分證字號與集保 App 密碼，再按「連線並取得驗證碼」。</li>
+        <li>系統只會在集保要求時寄出 Email；部分帳號還需要簡訊驗證。</li>
+        <li>驗證成功後會自動執行首次同步，日後通常不需重新輸入驗證碼。</li>
       </ol>
-    </details>{/if}
+    </details>
+  {/if}
   {#if connectorId === "sinopac"}<details
       class="mt-3 rounded-md border border-ink/10 bg-paper text-sm text-ink/70"
     >
@@ -434,7 +530,9 @@
       </div>
     </div>
   {/if}
-  <div class="mt-3 rounded-xl border border-ink/10 bg-paper p-3 text-sm">
+  <div
+    class={`mt-3 rounded-xl border border-ink/10 bg-paper p-3 text-sm ${connectorId === "tdcc" && !tdccConnectionReady ? "hidden" : ""}`}
+  >
     <div class="flex flex-wrap items-start justify-between gap-3">
       <div>
         <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-ink/70">
@@ -577,9 +675,13 @@
       class="flex flex-wrap items-start justify-between gap-2 border-b border-border bg-muted/45 px-4 py-3"
     >
       <div>
-        <h3 class="text-sm font-semibold">連線憑證</h3>
+        <h3 class="text-sm font-semibold">
+          {connectorId === "tdcc" ? "集保 App 身分驗證" : "連線憑證"}
+        </h3>
         <p class="mt-0.5 text-xs text-muted-foreground">
-          已儲存的機密欄位不會顯示內容；留白會維持原值。
+          {connectorId === "tdcc"
+            ? "請使用集保 e 存摺 App 的登入資料；不是券商網路下單密碼。"
+            : "已儲存的機密欄位不會顯示內容；留白會維持原值。"}
         </p>
       </div>
       {#if $save.isSuccess}<span
@@ -602,6 +704,7 @@
         {:else}
           {@const storedCredential = Boolean(
             $settings.data?.configured &&
+            (connectorId !== "tdcc" || tdccCredentialsComplete) &&
             (field.type === "text" || field.type === "password"),
           )}
           {@const hasReplacement = Boolean(String(values[field.key] ?? ""))}
@@ -638,49 +741,129 @@
       class="flex flex-wrap items-center justify-between gap-3 border-t border-border bg-paper/70 px-4 py-3"
     >
       <p class="text-xs text-muted-foreground">
-        儲存完成後，再使用上方的同步按鈕測試連線。
+        {connectorId === "tdcc"
+          ? tdccConnectionReady
+            ? "重新填寫任一欄位會清除舊的登入狀態並重新驗證。"
+            : "按下後會先登入集保；只有集保要求裝置驗證時才會寄信。"
+          : "儲存完成後，再使用上方的同步按鈕測試連線。"}
       </p>
-      <Button
-        size="sm"
-        disabled={$save.isPending}
-        onclick={() => {
-          error = "";
-          $save.reset();
-          $save.mutate(buildConfig());
-        }}
-        ><Save class="size-4" />{$save.isPending
-          ? "儲存中…"
-          : "儲存憑證"}</Button
-      >
+      {#if connectorId === "tdcc"}
+        <Button
+          size="sm"
+          disabled={$connectTdcc.isPending || $verifyOtp.isPending || demoMode}
+          onclick={() => {
+            error = "";
+            tdccSetupStep = "credentials";
+            $connectTdcc.mutate();
+          }}
+          ><ShieldCheck class="size-4" />{$connectTdcc.isPending
+            ? "正在連線…"
+            : tdccConnectionReady
+              ? "更新並重新連線"
+              : "連線並取得驗證碼"}</Button
+        >
+      {:else}
+        <Button
+          size="sm"
+          disabled={$save.isPending}
+          onclick={() => {
+            error = "";
+            $save.reset();
+            $save.mutate(buildConfig());
+          }}
+          ><Save class="size-4" />{$save.isPending
+            ? "儲存中…"
+            : "儲存憑證"}</Button
+        >
+      {/if}
     </div>
   </section>
   {#if $save.isError}<p class="mt-2 text-xs font-medium text-coral">
       儲存失敗：{error}
     </p>{/if}
-  {#if otpRequired}<div
-      class="mt-3 rounded-md border border-destructive/40 bg-destructive/10 p-3"
+  {#if connectorId === "tdcc" && (tdccSetupStep === "email" || tdccSetupStep === "sms")}<div
+      class="mt-3 overflow-hidden rounded-xl border border-steel/20 bg-steel/[0.055]"
     >
-      <p class="text-sm font-medium text-ink/80">
-        TDCC 需要驗證碼，請查看{otpChannel === "sms"
-          ? "手機簡訊"
-          : "電子信箱"}。
-      </p>
-      <div class="mt-2 flex flex-wrap gap-2">
-        <Input
-          class="min-w-40 flex-1"
-          placeholder="輸入驗證碼"
-          bind:value={otp}
-        /><Button
+      <div class="flex items-start gap-3 border-b border-steel/15 px-4 py-3">
+        <span
+          class="grid size-9 shrink-0 place-items-center rounded-full bg-steel/10 text-steel"
+        >
+          {#if tdccSetupStep === "sms"}<Smartphone
+              class="size-4.5"
+            />{:else}<Mail class="size-4.5" />{/if}
+        </span>
+        <div>
+          <p class="text-sm font-semibold text-ink">
+            {tdccSetupStep === "sms"
+              ? "簡訊驗證碼已寄出"
+              : "Email 驗證碼已寄出"}
+          </p>
+          <p class="mt-0.5 text-xs leading-relaxed text-ink/60">
+            {tdccSetupStep === "sms"
+              ? "Email 驗證已通過；請輸入集保寄到手機的驗證碼。"
+              : "請查看集保帳號登記的電子信箱，也別忘了檢查垃圾郵件匣。"}
+          </p>
+        </div>
+      </div>
+      <div class="grid gap-3 p-4 sm:grid-cols-[minmax(0,1fr)_auto]">
+        <label class="grid gap-1.5 text-sm font-medium">
+          一次性驗證碼
+          <Input
+            class="bg-white/80 tracking-[0.2em]"
+            inputmode="numeric"
+            autocomplete="one-time-code"
+            placeholder="輸入驗證碼"
+            bind:value={otp}
+          />
+        </label>
+        <Button
+          class="self-end"
           size="sm"
-          disabled={$verifyOtp.isPending}
-          onclick={() => $verifyOtp.mutate()}
-          ><RefreshCw class="size-4" />驗證並同步</Button
+          disabled={$verifyOtp.isPending || !otp.trim()}
+          onclick={() => {
+            error = "";
+            $verifyOtp.mutate();
+          }}
+          ><ShieldCheck class="size-4" />{$verifyOtp.isPending
+            ? "驗證與同步中…"
+            : "驗證並完成首次同步"}</Button
         >
       </div>
+      <div
+        class="flex flex-wrap items-center justify-between gap-2 border-t border-steel/15 px-4 py-2.5"
+      >
+        <button
+          type="button"
+          class="text-xs font-semibold text-ink/55 underline-offset-4 hover:text-ink hover:underline"
+          onclick={() => {
+            otp = "";
+            tdccSetupStep = "credentials";
+          }}>返回修改帳密</button
+        >
+        {#if tdccSetupStep === "email"}<Button
+            size="sm"
+            variant="outline"
+            disabled={$sync.isPending}
+            onclick={() => {
+              error = "";
+              $sync.mutate("default");
+            }}
+            ><RefreshCw class="size-4" />{$sync.isPending
+              ? "重新寄送中…"
+              : "重新寄送 Email"}</Button
+          >{/if}
+      </div>
     </div>{/if}
+  {#if connectorId === "tdcc" && error}<p
+      class="mt-3 rounded-lg border border-coral/20 bg-coral/[0.06] px-3 py-2 text-xs font-medium text-coral"
+    >
+      {error}
+    </p>{/if}
   <p class="mt-3 text-xs text-ink/50">
     {connectorId === "sinopac"
       ? "永豐首次驗證成功後，正式同步會直接呼叫 App JSON API；只有銀行要求重新登入時才需再輸入驗證碼。"
-      : "輸入完帳號密碼後，請先按「儲存設定」，再按「同步」。"}
+      : connectorId === "tdcc"
+        ? "排程同步不會在背景寄送驗證碼；登入失效時會標記為需要重新驗證。"
+        : "輸入完帳號密碼後，請先按「儲存設定」，再按「同步」。"}
   </p>
 </Card>

--- a/apps/web/src/features/settings/Settings.svelte
+++ b/apps/web/src/features/settings/Settings.svelte
@@ -67,7 +67,7 @@
       { key: "fetchDetails", label: "同步品項明細", type: "checkbox" },
     ],
     tdcc: [
-      { key: "identity", label: "身分證字號", type: "text" },
+      { key: "userId", label: "身分證字號", type: "text" },
       { key: "password", label: "集保 App 密碼", type: "password" },
     ],
     esun: [

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createApiClient } from "./api";
+import { ApiRequestError, createApiClient } from "./api";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -46,5 +46,34 @@ describe("API client", () => {
         headers: { "Content-Type": "application/json" },
       }),
     );
+  });
+
+  it("preserves structured API error codes", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            success: false,
+            error: {
+              code: "TDCC_EMAIL_OTP_REQUIRED",
+              message: "驗證碼已寄出。",
+            },
+          }),
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const error = await createApiClient()
+      .post("/api/connectors/tdcc/sync")
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect(error).toMatchObject({
+      code: "TDCC_EMAIL_OTP_REQUIRED",
+      message: "驗證碼已寄出。",
+      status: 400,
+    });
   });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -12,6 +12,17 @@ function isApiError(value: unknown): value is ApiError {
   return typeof value === "object" && value !== null && "error" in value;
 }
 
+export class ApiRequestError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = "ApiRequestError";
+  }
+}
+
 export function createApiClient(): ApiClient {
   async function request<T>(path: string, init: RequestInit = {}) {
     const headers =
@@ -33,8 +44,12 @@ export function createApiClient(): ApiClient {
           : `伺服器暫時無法完成請求（HTTP ${response.status}）。`,
       );
     }
-    if (!response.ok)
-      throw new Error(isApiError(data) ? data.error.message : "請求失敗。");
+    if (!response.ok) {
+      const error = isApiError(data)
+        ? data.error
+        : { code: "REQUEST_FAILED", message: "請求失敗。" };
+      throw new ApiRequestError(error.code, error.message, response.status);
+    }
     return data as T;
   }
   return {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -186,6 +186,7 @@ export interface ConnectorSettings {
   configured: boolean;
   updatedAt?: string;
   publicConfig?: Record<string, unknown> | null;
+  credentialsComplete?: boolean;
   sessionAvailable?: boolean;
 }
 export interface SyncJobRow {

--- a/apps/worker/src/features/connectors/service.ts
+++ b/apps/worker/src/features/connectors/service.ts
@@ -1,5 +1,6 @@
 import { parseConnectorConfig } from "@taiwan-fin-hub/connectors";
 import type { ConnectorId } from "@taiwan-fin-hub/core";
+import { clearConnectorCursor } from "@taiwan-fin-hub/db";
 import { configEncryptionKey } from "../../platform/config";
 import { decryptJson, encryptJson } from "../../platform/crypto";
 import type { Env } from "../../platform/env";
@@ -21,6 +22,7 @@ export async function getConnectorSettingsView(
 ) {
   const settings = await findConnectorSettings(env.DB, connectorId);
   let sessionAvailable = false;
+  let credentialsComplete = Boolean(settings);
   if (connectorId === "sinopac" && settings) {
     const stored = await decryptJson<Record<string, unknown>>(
       settings.encrypted_config,
@@ -31,6 +33,18 @@ export async function getConnectorSettingsView(
       stored.sessionCookies.length > 0 &&
       stored.protocol === "sinopac-mobile-app-json-v1";
   }
+  if (connectorId === "tdcc" && settings) {
+    const stored = await decryptJson<Record<string, unknown>>(
+      settings.encrypted_config,
+      configEncryptionKey(env),
+    );
+    credentialsComplete =
+      typeof stored.userId === "string" &&
+      stored.userId.length > 0 &&
+      typeof stored.password === "string" &&
+      stored.password.length > 0;
+    sessionAvailable = credentialsComplete && Boolean(settings.sync_cursor);
+  }
   return {
     connectorId,
     configured: Boolean(settings),
@@ -38,6 +52,7 @@ export async function getConnectorSettingsView(
     publicConfig: settings?.public_config
       ? JSON.parse(settings.public_config)
       : null,
+    credentialsComplete,
     sessionAvailable,
   };
 }
@@ -64,6 +79,7 @@ export async function updateConnectorSettings(
 
   let parsedConfig: unknown;
   let mergedPublic: Record<string, unknown>;
+  let shouldClearTdccSession = false;
   try {
     const storedConfig = existing
       ? await decryptJson<Record<string, unknown>>(
@@ -116,6 +132,10 @@ export async function updateConnectorSettings(
       ])
         delete mergedConfig[key];
     }
+    shouldClearTdccSession =
+      connectorId === "tdcc" &&
+      Boolean(existing) &&
+      tdccCredentialsChanged(storedConfig, rawConfig);
     parsedConfig = parseConnectorConfig(connectorId, mergedConfig);
     mergedPublic = { ...storedPublic, ...publicConfig };
   } catch {
@@ -132,6 +152,9 @@ export async function updateConnectorSettings(
         : null,
     now,
   });
+  if (shouldClearTdccSession) {
+    await clearConnectorCursor(env.DB, connectorId, now);
+  }
   return { connectorId, configured: true, updatedAt: now };
 }
 
@@ -153,6 +176,19 @@ function sinopacCredentialsChanged(
   incoming: Record<string, unknown>,
 ) {
   return ["userId", "account", "password"].some(
+    (key) =>
+      key in incoming &&
+      incoming[key] !== undefined &&
+      incoming[key] !== "" &&
+      incoming[key] !== stored[key],
+  );
+}
+
+function tdccCredentialsChanged(
+  stored: Record<string, unknown>,
+  incoming: Record<string, unknown>,
+) {
+  return ["userId", "password"].some(
     (key) =>
       key in incoming &&
       incoming[key] !== undefined &&

--- a/apps/worker/src/features/sync/route.ts
+++ b/apps/worker/src/features/sync/route.ts
@@ -1,4 +1,8 @@
-import { EInvoiceProtocolUnavailableError } from "@taiwan-fin-hub/connectors";
+import {
+  EInvoiceProtocolUnavailableError,
+  TdccConnectionError,
+  TdccVerificationRequiredError,
+} from "@taiwan-fin-hub/connectors";
 import { zValidator } from "@hono/zod-validator";
 import { type Context, type Hono } from "hono";
 import { z } from "zod";
@@ -208,6 +212,18 @@ async function syncRouteResponse(
   } catch (error) {
     if (error instanceof SyncAlreadyRunningError) {
       return jsonError("SYNC_ALREADY_RUNNING", error.message, 409);
+    }
+    if (error instanceof TdccVerificationRequiredError) {
+      return jsonError(
+        error.channel === "sms"
+          ? "TDCC_SMS_OTP_REQUIRED"
+          : "TDCC_EMAIL_OTP_REQUIRED",
+        error.message,
+        400,
+      );
+    }
+    if (error instanceof TdccConnectionError) {
+      return jsonError("TDCC_CONNECTION_FAILED", error.message, 400);
     }
     if (error instanceof NeedsUserActionError) {
       return jsonError("USER_ACTION_REQUIRED", error.message, 400);

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -9,6 +9,7 @@ import {
   syncTdccTradeHistory,
   tdccConnector,
   TdccOtpExpiredError,
+  TdccVerificationRequiredError,
 } from "@taiwan-fin-hub/connectors";
 import { createCathaybkConnector } from "../../connectors/cathaybk";
 import { createEsunConnector } from "../../connectors/esun";
@@ -125,8 +126,13 @@ export async function maintainSinopacSession(
     "SELECT enabled, next_run_at, last_status FROM sync_jobs WHERE connector_id = ? AND scope = ?",
   )
     .bind(connectorId, scope)
-    .first<{ enabled: number; next_run_at: string; last_status: SyncStatus | null }>();
-  if (!job?.enabled || job.last_status === "needs_user_action") return "disabled";
+    .first<{
+      enabled: number;
+      next_run_at: string;
+      last_status: SyncStatus | null;
+    }>();
+  if (!job?.enabled || job.last_status === "needs_user_action")
+    return "disabled";
 
   // A full sync that is already due will refresh the session itself.
   if (new Date(job.next_run_at) <= now) return "not-needed";
@@ -165,7 +171,9 @@ export async function maintainSinopacSession(
       : {};
     const config = parseSinopacConfig({ ...stored, ...publicStored });
     try {
-      const refreshed = await createSinopacConnector(env.BROWSER).refreshSession(config);
+      const refreshed = await createSinopacConnector(
+        env.BROWSER,
+      ).refreshSession(config);
       const {
         candidateSessionCookies: _oldCandidateSessionCookies,
         candidateSessionCreatedAt: _oldCandidateSessionCreatedAt,
@@ -197,7 +205,9 @@ export async function maintainSinopacSession(
             configEncryptionKey(env),
           ),
         );
-        console.warn("[sinopac] keep-alive verification failed once; retrying on the next cron tick");
+        console.warn(
+          "[sinopac] keep-alive verification failed once; retrying on the next cron tick",
+        );
         return "retry-pending";
       }
 
@@ -221,7 +231,9 @@ export async function maintainSinopacSession(
            WHERE connector_id = ? AND scope = ?`,
         ).bind(error.message, now.toISOString(), connectorId, scope),
       ]);
-      console.warn("[sinopac] scheduled-sync session expired during keep-alive");
+      console.warn(
+        "[sinopac] scheduled-sync session expired during keep-alive",
+      );
       return "needs-user-action";
     }
   } finally {
@@ -234,14 +246,17 @@ export function sinopacSessionNeedsRefresh(
   now = new Date(),
 ) {
   if (
-    typeof config.sessionCookies !== "string"
-    || !config.sessionCookies
-    || config.protocol !== "sinopac-mobile-app-json-v1"
-  ) return false;
+    typeof config.sessionCookies !== "string" ||
+    !config.sessionCookies ||
+    config.protocol !== "sinopac-mobile-app-json-v1"
+  )
+    return false;
   if (typeof config.sessionExpiresAt !== "string") return true;
   const expiresAt = new Date(config.sessionExpiresAt).getTime();
-  return !Number.isFinite(expiresAt)
-    || expiresAt <= now.getTime() + SINOPAC_SESSION_REFRESH_MARGIN_MS;
+  return (
+    !Number.isFinite(expiresAt) ||
+    expiresAt <= now.getTime() + SINOPAC_SESSION_REFRESH_MARGIN_MS
+  );
 }
 
 export type TdccSyncOverrides = {
@@ -762,7 +777,11 @@ async function syncTdccPositionsAndBank(
     configEncryptionKey(env),
   );
   const mergedConfig = { ...(config as Record<string, unknown>), ...overrides };
-  const parsedConfig = parseTdccConfig(mergedConfig);
+  const parsedConfig = parseTdccConfig({
+    ...mergedConfig,
+    requestOtp: trigger === "manual",
+  });
+  requireTdccCredentials(parsedConfig);
   const syncScope = options.scope;
   console.log(
     `[sync] ${connectorId}/${syncScope}: starting trigger=${trigger} (cursor=${settings.sync_cursor ? "set" : "none"})`,
@@ -872,7 +891,11 @@ async function syncTdccTrades(
     configEncryptionKey(env),
   );
   const mergedConfig = { ...(config as Record<string, unknown>), ...overrides };
-  const parsedConfig = parseTdccConfig(mergedConfig);
+  const parsedConfig = parseTdccConfig({
+    ...mergedConfig,
+    requestOtp: trigger === "manual",
+  });
+  requireTdccCredentials(parsedConfig);
   console.log(
     `[sync] ${connectorId}/${scope}: starting trigger=${trigger} (cursor=${settings.sync_cursor ? "set" : "none"})`,
   );
@@ -931,6 +954,17 @@ function tdccOutcomeScope(scopes: Set<string>): SyncScope {
   if (allScopes.every((scope) => scopes.has(scope))) return SYNC_SCOPE_ALL;
   return (allScopes.filter((scope) => scopes.has(scope)).join("+") ||
     SYNC_SCOPE_ALL) as SyncScope;
+}
+
+function requireTdccCredentials(config: {
+  userId?: string;
+  password?: string;
+}) {
+  if (!config.userId || !config.password) {
+    throw new NeedsUserActionError(
+      "請重新輸入身分證字號與集保 App 密碼，再開始連線。",
+    );
+  }
 }
 
 async function requireConnectorSettings(
@@ -1047,6 +1081,7 @@ export function isUserActionError(error: unknown) {
   if (
     error instanceof NeedsUserActionError ||
     error instanceof TdccOtpExpiredError ||
+    error instanceof TdccVerificationRequiredError ||
     error instanceof EInvoiceProtocolUnavailableError ||
     error instanceof SinopacVerificationRequiredError
   )

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -7,7 +7,7 @@ export { EInvoiceProtocolUnavailableError } from "./tw-einvoice-api";
 export { EInvoiceV2Client, decryptLoginData, encryptLoginData, signInvoiceJwt } from "./tw-einvoice-v2";
 export type { EInvoiceV2Options, EInvoiceV2Session } from "./tw-einvoice-v2";
 
-export { tdccConnector, createTdccConnector, tdccConfigSchema, parseTdccConfig, syncTdccTradeHistory, TdccOtpExpiredError } from "./tdcc";
+export { tdccConnector, createTdccConnector, tdccConfigSchema, parseTdccConfig, syncTdccTradeHistory, TdccConnectionError, TdccOtpExpiredError, TdccVerificationRequiredError } from "./tdcc";
 export type { TdccConfig, TdccHolding, TdccCashBalance, TdccCashMovement, TdccClient } from "./tdcc";
 import { tdccConfigSchema } from "./tdcc";
 

--- a/packages/connectors/src/tdcc.ts
+++ b/packages/connectors/src/tdcc.ts
@@ -68,6 +68,7 @@ export const tdccConfigSchema = z.object({
   devModel: z.string().min(1).optional(),
   otp: z.string().min(1).optional(),
   otpChannel: z.enum(["email", "sms"]).optional(),
+  requestOtp: z.boolean().default(true),
   tradeHistoryMaxPages: z.number().int().min(1).max(100).default(20)
 });
 
@@ -173,6 +174,29 @@ const SESSION_EXPIRED_CODES = new Set(["D0006", "D0007", "A0001", "A0002", "T800
 const OTP_EXPIRED_CODES = new Set(["V0017"]);
 
 export class TdccOtpExpiredError extends Error {}
+
+export class TdccConnectionError extends Error {
+  constructor(public readonly code: string, message: string) {
+    super(`TDCC 登入或同步失敗（${code}）：${message}`);
+    this.name = "TdccConnectionError";
+  }
+}
+
+export class TdccVerificationRequiredError extends Error {
+  constructor(
+    public readonly channel: "email" | "sms",
+    public readonly deliveryTriggered: boolean
+  ) {
+    super(
+      deliveryTriggered
+        ? channel === "email"
+          ? "TDCC 驗證碼已寄至電子信箱，請輸入驗證碼以完成連線。"
+          : "TDCC 驗證碼已寄至手機簡訊，請輸入驗證碼以完成連線。"
+        : "TDCC 登入狀態已失效，請回到設定頁重新驗證。"
+    );
+    this.name = "TdccVerificationRequiredError";
+  }
+}
 
 type TdccIdentity = { deviceId: string; devType: string; devModel: string; session?: EPassbookSession };
 
@@ -446,26 +470,22 @@ async function loginWithDeviceVerification(client: EPassbookClient, config: Tdcc
   if (!needsOtp) return;
 
   if (!config.otp) {
-    await client.requestEmailOtp(config.userId!);
-    throw new Error(
-      "TDCC requires OTP verification for this device. Check your email and retry sync with config.otp set."
-    );
+    if (config.requestOtp) await client.requestEmailOtp(config.userId!);
+    throw new TdccVerificationRequiredError("email", config.requestOtp);
   }
 
   const otpResult = await client.verifyOtp(config.userId!, config.otp, config.otpChannel ?? "email");
   if (otpResult.isMobileValid === "N" && config.otpChannel !== "sms") {
-    await client.requestMobileOtp(config.userId!);
-    throw new Error(
-      'TDCC also requires SMS verification. Check your phone and retry sync with config.otp set to the SMS code and config.otpChannel: "sms".'
-    );
+    if (config.requestOtp) await client.requestMobileOtp(config.userId!);
+    throw new TdccVerificationRequiredError("sms", config.requestOtp);
   }
 }
 
 function wrapTdccError(error: unknown): never {
   if (error instanceof EPassbookError) {
-    const message = `TDCC ePassbook login/sync failed: ${error.message}`;
+    const message = `TDCC 登入或同步失敗（${error.code}）：${error.message}`;
     if (OTP_EXPIRED_CODES.has(error.code)) throw new TdccOtpExpiredError(message);
-    throw new Error(message);
+    throw new TdccConnectionError(error.code, error.message);
   }
   throw error;
 }

--- a/packages/connectors/tests/selfcheck/tdcc.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/tdcc.selfcheck.ts
@@ -2,7 +2,7 @@
 // Mocks the TDCC ePassbook API and exercises login -> OTP gate -> holdings/cash -> session reuse,
 // plus device-verification-by-error-code and stale-session recovery.
 import assert from "node:assert/strict";
-import { createTdccConnector, parseTdccConfig, TdccOtpExpiredError } from "../../src/tdcc";
+import { createTdccConnector, parseTdccConfig, TdccOtpExpiredError, TdccVerificationRequiredError } from "../../src/tdcc";
 
 const calls: string[] = [];
 const tspPageTokens: string[] = [];
@@ -113,7 +113,21 @@ async function main() {
   const connector = createTdccConnector();
   const config = parseTdccConfig({ userId: "A123456789", password: "secret" });
 
-  await assert.rejects(connector.sync(config, undefined), /OTP/, "first sync without OTP should be rejected");
+  await assert.rejects(
+    connector.sync(config, undefined),
+    (error: unknown) => error instanceof TdccVerificationRequiredError && error.channel === "email" && error.deliveryTriggered,
+    "first sync should request and wait for the email OTP"
+  );
+  assert.ok(calls.includes("AU013"), "manual sync should trigger the email OTP endpoint");
+
+  calls.length = 0;
+  const scheduledConfig = parseTdccConfig({ userId: "A123456789", password: "secret", requestOtp: false });
+  await assert.rejects(
+    connector.sync(scheduledConfig, undefined),
+    (error: unknown) => error instanceof TdccVerificationRequiredError && !error.deliveryTriggered,
+    "scheduled sync should require user action without sending OTP"
+  );
+  assert.ok(!calls.includes("AU013"), "scheduled sync must not trigger an unexpected email");
 
   const configWithOtp = parseTdccConfig({ userId: "A123456789", password: "secret", otp: "123456" });
   const result = await connector.sync(configWithOtp, undefined);
@@ -179,7 +193,11 @@ async function main() {
   // Device verification can also arrive as an error code thrown from the login call
   // itself, instead of a flag on a successful response.
   mode = "error_code_otp";
-  await assert.rejects(connector.sync(config, undefined), /OTP/, "error-code device verification should also gate on OTP");
+  await assert.rejects(
+    connector.sync(config, undefined),
+    TdccVerificationRequiredError,
+    "error-code device verification should also gate on OTP"
+  );
   const errorCodeResult = await connector.sync(configWithOtp, undefined);
   assert.equal(errorCodeResult.records.length, 3, "error-code OTP path should still fetch holdings once verified");
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -76,6 +76,21 @@ export async function updateConnectorCursor(
     .run();
 }
 
+export async function clearConnectorCursor(
+  db: D1Database,
+  connectorId: string,
+  now: string
+) {
+  await db
+    .prepare(
+      `UPDATE connector_settings
+      SET sync_cursor = NULL, updated_at = ?
+      WHERE connector_id = ?`
+    )
+    .bind(now, connectorId)
+    .run();
+}
+
 export {
   acquireSyncJobLock,
   completeSyncJob,


### PR DESCRIPTION
## 變更內容

- 修正 TDCC 身分證欄位由 `identity` 寫入、connector 卻讀取 `userId`，導致正式登入未被觸發的問題。
- 將首次連線改為「確認帳密 → Email／SMS OTP → 首次同步」的明確流程，並以結構化 API 錯誤碼傳遞驗證狀態。
- TDCC 已連線後只顯示一個「同步」按鈕，一次更新持倉、銀行資料與投資交易。
- 更新帳密時清除舊 session；排程遇到失效 session 時只標記需要人工處理，不在背景寄送 OTP。
- 補上 API 錯誤碼與 TDCC 手動／排程 OTP 行為測試。

## 原因與影響

原設定頁使用 `identity` 作為身分證欄位，但 TDCC schema 只接受 `userId`，未知欄位解析後會被移除，因此設定可能只剩密碼，按同步也不會真的登入或寄送 OTP。此外，舊流程依賴英文錯誤文字判斷驗證階段，且三個手動同步按鈕容易讓使用者誤以為必須分別操作。

既有 TDCC 設定若缺少 `userId`，更新後會提示重新輸入身分證字號與集保 App 密碼。

## 驗證

- `npm run typecheck --workspaces`：通過，Svelte 0 errors / 0 warnings。
- Web 單元測試：7 files、38 tests 通過。
- Worker 測試：14 files、79 tests 通過。
- DB 測試：1 file、4 tests 通過。
- TDCC、電子發票與電子發票 v2 self-check：通過。
- Web production build：通過。

## 風險

- 需要人工確認 TDCC 正式環境的 Email／SMS OTP 寄送順序及錯誤碼是否與 mock 行為一致。
- 已受舊欄位錯置影響的使用者，需要重新輸入一次完整帳密。
