### PR TITLE
支援信用卡 Pending／Posted 生命週期與永豐最新消費

### DIFF
--- a/apps/web/src/features/activity/Activity.svelte
+++ b/apps/web/src/features/activity/Activity.svelte
@@ -163,7 +163,7 @@
         return {
           id: t.id,
           source: isCard ? ("card" as const) : ("bank" as const),
-          date: t.postedDate ?? t.authorizedAt ?? "",
+          date: t.authorizedAt ?? t.postedDate ?? "",
           title:
             matchedInvoice?.sellerName ??
             t.description ??
@@ -1249,8 +1249,8 @@
                         >
                         <span class="mt-1 block truncate text-xs text-ink/50"
                           >{mappingAccount(transaction)} · {formatDate(
-                            transaction.postedDate ??
-                              transaction.authorizedAt ??
+                            transaction.authorizedAt ??
+                              transaction.postedDate ??
                               "",
                           )}</span
                         >

--- a/apps/web/src/lib/activity-matching.test.ts
+++ b/apps/web/src/lib/activity-matching.test.ts
@@ -269,7 +269,7 @@ describe("invoice transaction matching", () => {
     expect(result.invoiceToTransactionId.size).toBe(0);
   });
 
-  it("does not match an otherwise identical transaction from another day", () => {
+  it("uses the authorization day when the posting day differs", () => {
     const result = matchInvoicesToTransactions(
       [
         transaction({
@@ -280,7 +280,9 @@ describe("invoice transaction matching", () => {
       [invoice()],
     );
 
-    expect(result.invoiceToTransactionId.size).toBe(0);
+    expect(result.invoiceToTransactionId.get("invoice-1")).toBe(
+      "transaction-1",
+    );
   });
 
   it("uses the Taipei calendar day for ISO timestamps near midnight", () => {
@@ -390,6 +392,7 @@ describe("bank transaction deduplication", () => {
         "2026-07-05T00:00:00.000Z:credit:esun:1204:全支付﹘全聯:252:TWD:未入帳:1",
       accountType: "credit",
       postedDate: "2026-07-05T00:00:00.000Z",
+      authorizedAt: "2026-07-05T00:00:00.000Z",
       amount: 252,
       description: "全支付﹘全聯",
       counterparty: "全支付﹘全聯",

--- a/apps/web/src/lib/activity-matching.ts
+++ b/apps/web/src/lib/activity-matching.ts
@@ -218,7 +218,7 @@ function isSameDayTwdExpense(
     return false;
 
   const transactionDate = dayNumber(
-    transaction.postedDate ?? transaction.authorizedAt,
+    transaction.authorizedAt ?? transaction.postedDate,
   );
   const invoiceDate = dayNumber(invoice.invoiceDate);
   return invoiceDate != null && transactionDate === invoiceDate;

--- a/apps/worker/src/connectors/esun.ts
+++ b/apps/worker/src/connectors/esun.ts
@@ -427,12 +427,14 @@ type EsunTimelineCandidate = {
   timelinePage: EsunTimelinePage;
   timelineMonth: EsunTimelineMonth;
   accountId: string;
-  postedDate: string;
+  authorizedAt: string;
+  postedDate?: string;
   amount: number;
   currency: string;
   description: string;
   sourceKey: string;
   lifecycle: string;
+  status: "pending" | "posted";
   order: number;
 };
 
@@ -447,16 +449,20 @@ export function normalizeEsunTimelineTransactions(
       if (!year) continue;
 
       for (const txn of month.txnList ?? []) {
-        const postedDate = normalizeEsunMonthDay(
+        const lifecycle = txn.acfg?.trim() ?? "";
+        const authorizedAt = normalizeEsunMonthDay(
           year,
           txn.consumerDt ?? txn.postingDt ?? "",
         );
+        const postedDate = lifecycle === "未入帳"
+          ? undefined
+          : normalizeEsunMonthDay(year, txn.postingDt ?? txn.consumerDt ?? "");
         const amount = parseTwd(txn.payAmt ?? txn.consumerAmt ?? "0");
         const currency = txn.payCur?.trim() || txn.consumerCur?.trim() || "TWD";
         const description = txn.storeName?.trim() || "玉山信用卡交易";
         const accountId = creditCardSourceId(txn.cardNo);
         const sourceKey = [
-          postedDate,
+          authorizedAt,
           accountId,
           description,
           amount,
@@ -467,12 +473,14 @@ export function normalizeEsunTimelineTransactions(
           timelinePage,
           timelineMonth: month,
           accountId,
+          authorizedAt,
           postedDate,
           amount,
           currency,
           description,
           sourceKey,
-          lifecycle: txn.acfg?.trim() ?? "",
+          lifecycle,
+          status: lifecycle === "未入帳" ? "pending" : "posted",
           order: candidates.length,
         });
       }
@@ -507,10 +515,12 @@ export function normalizeEsunTimelineTransactions(
       accountId: candidate.accountId,
       sourceId: `${candidate.sourceKey}:${occurrence}`,
       postedDate: candidate.postedDate,
+      authorizedAt: candidate.authorizedAt,
       amount: candidate.amount,
       currency: candidate.currency,
       description: candidate.description,
       counterparty: candidate.description,
+      status: candidate.status,
       raw: {
         ...candidate.transaction,
         timelineYear: candidate.timelineMonth.year,

--- a/apps/worker/src/connectors/sinopac.ts
+++ b/apps/worker/src/connectors/sinopac.ts
@@ -669,10 +669,10 @@ function parseTransactions(payload: unknown) {
       amount,
       currency,
       description,
+      status: "posted",
       raw: {
         ...(sanitizeValue(record) as JsonRecord),
-        duplicateOccurrence: occurrence,
-        pending: true
+        duplicateOccurrence: occurrence
       }
     });
   }

--- a/apps/worker/src/connectors/sinopac.ts
+++ b/apps/worker/src/connectors/sinopac.ts
@@ -13,7 +13,10 @@ const MOBILE_HOST = "https://m.sinopac.com";
 const LOGIN_URL = `${MOBILE_HOST}/m/member/login/m_login.aspx?RequestTrans=MobileCard`;
 const CARD_SUMMARY_PATH = "/ws/card/cardqry/ws_cardsum.ashx";
 const CARD_BILLS_PATH = "/ws/card/cardqry/ws_cardbilling_sp.ashx";
-const CARD_UNBILLED_PATH = "/ws/card/cardqry/ws_nonbilling.ashx";
+const CARD_SSO_PATH = "/m/SinoCard/api/security/sso";
+const CARD_AUTH_PATH = "/m/SinoCard/api/security/auth";
+const CARD_LATEST_TX_PATH = "/m/SinoCard/api/Accounting/LatestTx";
+const CARD_OUTSTANDING_DETAIL_PATH = "/m/SinoCard/api/Accounting/OutstandingDetail";
 export const SINOPAC_SESSION_PROTOCOL = "sinopac-mobile-app-json-v1";
 export const SINOPAC_AUTO_LOGIN_ATTEMPTS = 3;
 const CAPTCHA_BROWSER_KEEP_ALIVE_MS = 150_000;
@@ -27,7 +30,9 @@ type FetchImpl = typeof fetch;
 type SinopacApiPayloads = {
   summary: unknown;
   bills: unknown;
-  unbilled: unknown;
+  latest?: unknown;
+  outstanding?: unknown;
+  unbilled?: unknown;
 };
 type Scraped = {
   bankAccounts: Array<Omit<BankAccount, "id" | "connectorId">>;
@@ -109,7 +114,10 @@ export function createSinopacConnector(browser?: Fetcher, fetchImpl: FetchImpl =
       }
 
       const lookbackMonths = config.lookbackMonths ?? 3;
-      const client = new SinopacAppClient(sessionCookies, fetchImpl);
+      if (!config.userId) {
+        throw new SinopacVerificationRequiredError("永豐最新消費同步需要重新登入以取得身分識別資料。");
+      }
+      const client = new SinopacAppClient(sessionCookies, config.userId, fetchImpl);
       const payloads = await client.fetchCreditCards(lookbackMonths);
       const cards = parseSinopacCardData(payloads, lookbackMonths);
       const now = new Date();
@@ -129,12 +137,15 @@ export function createSinopacConnector(browser?: Fetcher, fetchImpl: FetchImpl =
 
 class SinopacAppClient {
   private readonly cookieHeader: string;
+  private readonly sinoCardCookies: Map<string, string>;
 
   constructor(
     serializedCookies: string,
+    private readonly userId: string,
     private readonly fetchImpl: FetchImpl
   ) {
     this.cookieHeader = cookieHeaderFromSerialized(serializedCookies);
+    this.sinoCardCookies = cookieMapFromHeader(this.cookieHeader);
   }
 
   fetchSummary() {
@@ -149,8 +160,17 @@ class SinopacAppClient {
     for (const month of billMonths) {
       olderBills.push(await this.post(`${CARD_BILLS_PATH}?TxDate=${month}&TxType=01`, `${month} 帳單`));
     }
-    const unbilled = await this.post(CARD_UNBILLED_PATH, "未出帳明細");
-    return { summary, bills: [initialBills, ...olderBills], unbilled };
+    const sso = await this.postSinoCard(CARD_SSO_PATH, "信用卡單一登入", {});
+    const customerId = sinoCardCustomerId(sso) ?? this.userId;
+    await this.postSinoCard(CARD_AUTH_PATH, "信用卡授權", {}, customerId);
+    const latest = await this.postSinoCard(CARD_LATEST_TX_PATH, "最新消費", { ID: customerId }, customerId);
+    const outstanding = await this.postSinoCard(
+      CARD_OUTSTANDING_DETAIL_PATH,
+      "已請款消費明細",
+      { IsExcludePaidUp: false, ID: customerId, DateYYYYMMDD: "" },
+      customerId
+    );
+    return { summary, bills: [initialBills, ...olderBills], latest, outstanding };
   }
 
   private async post(path: string, label: string) {
@@ -181,6 +201,45 @@ class SinopacAppClient {
       throw new Error(`永豐${label} API 回應不是有效 JSON。`);
     }
     assertSinopacApiSuccess(payload, label);
+    return payload;
+  }
+
+  private async postSinoCard(path: string, label: string, content: JsonRecord, userId = this.userId) {
+    const response = await this.fetchImpl.call(globalThis, `${MOBILE_HOST}${path}`, {
+      method: "POST",
+      headers: {
+        Accept: "application/json, text/plain, */*",
+        "Content-Type": "application/json",
+        Cookie: cookieHeaderFromMap(this.sinoCardCookies),
+        Referer: `${MOBILE_HOST}/m/SinoCard/Account/UnbilledTxInquiry`,
+        "User-Agent": ANDROID_USER_AGENT
+      },
+      body: JSON.stringify({
+        Content: content,
+        Header: {
+          ApplicationName: "MWEB",
+          UserID: userId,
+          ClientRefNo: crypto.randomUUID().replaceAll("-", ""),
+          ClientTimestamp: new Date().toISOString()
+        }
+      })
+    });
+    storeSetCookies(this.sinoCardCookies, response.headers);
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`永豐${label} API 回應 HTTP ${response.status}。`);
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      if (/m_login|尚未登入|登入\/Login/i.test(text)) {
+        throw new SinopacVerificationRequiredError("永豐銀行 session 已失效，請重新完成圖形驗證。");
+      }
+      throw new Error(`永豐${label} API 回應不是有效 JSON。`);
+    }
+    assertSinoCardApiSuccess(payload, label);
     return payload;
   }
 }
@@ -488,6 +547,42 @@ function cookieHeaderFromSerialized(serialized: string) {
   return header;
 }
 
+function cookieMapFromHeader(header: string) {
+  return new Map(
+    header.split(";").flatMap((part) => {
+      const separator = part.indexOf("=");
+      if (separator <= 0) return [];
+      const name = part.slice(0, separator).trim();
+      const value = part.slice(separator + 1).trim();
+      return name && value ? [[name, value] as const] : [];
+    })
+  );
+}
+
+function cookieHeaderFromMap(cookies: Map<string, string>) {
+  return Array.from(cookies, ([name, value]) => `${name}=${value}`).join("; ");
+}
+
+function storeSetCookies(cookies: Map<string, string>, headers: Headers) {
+  const withGetter = headers as Headers & { getSetCookie?: () => string[] };
+  const values = typeof withGetter.getSetCookie === "function"
+    ? withGetter.getSetCookie()
+    : splitCombinedSetCookie(headers.get("set-cookie") ?? "");
+  for (const value of values) {
+    const [pair] = value.split(";");
+    const separator = pair.indexOf("=");
+    if (separator <= 0) continue;
+    const name = pair.slice(0, separator).trim();
+    const cookieValue = pair.slice(separator + 1).trim();
+    if (cookieValue) cookies.set(name, cookieValue);
+    else cookies.delete(name);
+  }
+}
+
+function splitCombinedSetCookie(value: string) {
+  return value ? value.split(/,(?=\s*[^;,=]+=[^;,]+)/g).map((cookie) => cookie.trim()).filter(Boolean) : [];
+}
+
 function assertSinopacApiSuccess(payload: unknown, label: string) {
   const envelope = flattenRecords(payload).find((record) => typeof record.Header === "string");
   if (!envelope) throw new Error(`永豐${label} API 回應缺少 Header。`);
@@ -499,10 +594,28 @@ function assertSinopacApiSuccess(payload: unknown, label: string) {
   if (header !== "SUCCESS") throw new Error(`永豐${label} API 失敗：${message}`);
 }
 
+function assertSinoCardApiSuccess(payload: unknown, label: string) {
+  if (!isRecord(payload)) throw new Error(`永豐${label} API 回應格式無效。`);
+  const resultCode = stringValue(payload.ResultCode);
+  const message = stringValue(payload.ResultMessage) || stringValue(payload.Error) || "銀行未提供錯誤訊息";
+  if (resultCode === "00") return;
+  if (/尚未登入|登入|逾時|session|授權|驗證/i.test(message) || /單一登入|信用卡授權/.test(label)) {
+    throw new SinopacVerificationRequiredError("永豐銀行 session 已失效，請重新完成圖形驗證。");
+  }
+  throw new Error(`永豐${label} API 失敗：${message}`);
+}
+
+function sinoCardCustomerId(payload: unknown) {
+  if (!isRecord(payload) || !isRecord(payload.Result)) return undefined;
+  return stringValue(payload.Result.ID) || undefined;
+}
+
 export function parseSinopacCardData(payloads: SinopacApiPayloads, lookbackMonths: number, now = new Date()): Scraped {
   const summary = parseSummary(payloads.summary);
   const bills = parseBills(payloads.bills, lookbackMonths, now);
-  const transactions = parseTransactions(payloads.unbilled);
+  const transactions = payloads.outstanding != null || payloads.latest != null
+    ? parseSinoCardTransactions(payloads.latest, payloads.outstanding)
+    : parseTransactions(payloads.unbilled);
   const latestTwdBill = bills
     .filter((bill) => bill.currency === "TWD")
     .sort((left, right) => right.billingPeriod.localeCompare(left.billingPeriod))[0];
@@ -678,6 +791,114 @@ function parseTransactions(payload: unknown) {
   }
 
   return out;
+}
+
+type SinoCardTransactionCandidate = Omit<BankTransaction, "id" | "connectorId" | "accountId" | "sourceId"> & {
+  matchKey: string;
+};
+
+function parseSinoCardTransactions(latestPayload: unknown, outstandingPayload: unknown) {
+  const pending = sinoCardResultRecords(latestPayload, "Items").flatMap<SinoCardTransactionCandidate>((record) => {
+    const transactionDate = parseDate(stringValue(record.AuthDate));
+    const rawAmount = parseAmount(stringValue(record.AuthAmt)) ?? parseAmount(stringValue(record.AuthAmtDesc));
+    if (!transactionDate || rawAmount == null || rawAmount === 0) return [];
+    const description = stringValue(record.Memo).trim() || "永豐信用卡消費";
+    const amount = signedTransactionAmount(rawAmount, description, recordText(record));
+    const cardLast4 = last4FromValue(record.CardNo);
+    const authorizedAt = dateTimeWithTaipeiOffset(transactionDate, stringValue(record.AuthTime));
+    return [{
+      matchKey: sinoCardTransactionMatchKey("TWD", transactionDate, amount, cardLast4),
+      authorizedAt,
+      amount,
+      currency: "TWD",
+      description,
+      counterparty: description,
+      status: "pending",
+      raw: sanitizeValue(record)
+    }];
+  });
+
+  const posted = sinoCardResultRecords(outstandingPayload, "Detail").flatMap<SinoCardTransactionCandidate>((record) => {
+    const transactionDate = parseDate(stringValue(record.TXDATE));
+    const rawAmount = parseAmount(stringValue(record.AMT)) ?? parseAmount(stringValue(record.TXAMT));
+    if (!transactionDate || rawAmount == null || rawAmount === 0) return [];
+    const description = stringValue(record.MEMO).trim() || "永豐信用卡消費";
+    const amount = signedTransactionAmount(rawAmount, description, recordText(record));
+    const currency = normalizeCurrency(stringValue(record.CurrencyCode) || stringValue(record.TXCUR));
+    const cardLast4 = last4FromValue(record.CardNoLast4) ?? last4FromValue(record.CardLast4);
+    return [{
+      matchKey: sinoCardTransactionMatchKey(currency, transactionDate, amount, cardLast4),
+      authorizedAt: transactionDate,
+      postedDate: parseDate(stringValue(record.DEDATE)) ?? transactionDate,
+      amount,
+      currency,
+      description,
+      counterparty: description,
+      status: "posted",
+      raw: sanitizeValue(record)
+    }];
+  });
+
+  const postedTransactions = assignSinoCardSourceIds(posted);
+  const pendingTransactions = assignSinoCardSourceIds(pending);
+  const postedCounts = new Map<string, number>();
+  for (const transaction of postedTransactions) {
+    postedCounts.set(transaction.matchKey, (postedCounts.get(transaction.matchKey) ?? 0) + 1);
+  }
+  const pendingCounts = new Map<string, number>();
+  const unmatchedPending = pendingTransactions.filter((transaction) => {
+    const occurrence = (pendingCounts.get(transaction.matchKey) ?? 0) + 1;
+    pendingCounts.set(transaction.matchKey, occurrence);
+    return occurrence > (postedCounts.get(transaction.matchKey) ?? 0);
+  });
+
+  return [...postedTransactions, ...unmatchedPending].map(({ matchKey: _matchKey, ...transaction }) => transaction);
+}
+
+function sinoCardResultRecords(payload: unknown, key: "Items" | "Detail") {
+  if (!isRecord(payload) || !isRecord(payload.Result) || !Array.isArray(payload.Result[key])) return [];
+  return payload.Result[key].filter(isRecord);
+}
+
+function assignSinoCardSourceIds(candidates: SinoCardTransactionCandidate[]) {
+  const occurrences = new Map<string, number>();
+  return candidates.map((candidate) => {
+    const occurrence = (occurrences.get(candidate.matchKey) ?? 0) + 1;
+    occurrences.set(candidate.matchKey, occurrence);
+    return {
+      ...candidate,
+      sourceId: `sinopac:card:tx:v2:${candidate.matchKey}:${occurrence}`,
+      raw: {
+        ...(candidate.raw as JsonRecord),
+        duplicateOccurrence: occurrence
+      }
+    };
+  });
+}
+
+function sinoCardTransactionMatchKey(currency: string, transactionDate: string, amount: number, cardLast4?: string) {
+  return [currency, transactionDate, amount, cardLast4 || "unknown"].join(":");
+}
+
+function signedTransactionAmount(rawAmount: number, description: string, statusText: string) {
+  const isCredit =
+    rawAmount < 0 ||
+    /退款|退貨|折讓|回饋|沖銷|貸方|繳款|自扣|payment|credit|refund/i.test(`${description} ${statusText}`);
+  return isCredit ? Math.abs(rawAmount) : -Math.abs(rawAmount);
+}
+
+function last4FromValue(value: unknown) {
+  return stringValue(value).match(/(\d{4})\D*$/)?.[1];
+}
+
+function dateTimeWithTaipeiOffset(date: string, time: string) {
+  const match = time.trim().match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/);
+  if (!match) return date;
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  const second = Number(match[3] ?? "0");
+  if (hour > 23 || minute > 59 || second > 59) return date;
+  return `${date}T${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}:${String(second).padStart(2, "0")}+08:00`;
 }
 
 function extractAdvertisedBillMonths(payload: unknown) {

--- a/apps/worker/src/features/activity/service.ts
+++ b/apps/worker/src/features/activity/service.ts
@@ -45,7 +45,7 @@ export async function linkInvoiceToTransaction(
 
   const invoiceDay = financialDay(invoice.invoiceDate);
   const transactionDay = financialDay(
-    transaction.postedDate ?? transaction.authorizedAt,
+    transaction.authorizedAt ?? transaction.postedDate,
   );
   if (!invoiceDay || invoiceDay !== transactionDay)
     throw new MappingDateMismatchError();

--- a/apps/worker/src/features/bank/repository.ts
+++ b/apps/worker/src/features/bank/repository.ts
@@ -17,6 +17,7 @@ export type BankTransactionPageRow = {
   currency: string;
   description: string | null;
   counterparty: string | null;
+  status: "pending" | "posted";
   effectiveDate: string;
   updatedAt: string;
   calculationPreference: number | null;
@@ -88,6 +89,7 @@ export async function listBankTransactions(
       txn.currency,
       txn.description,
       txn.counterparty,
+      txn.status,
       txn.effective_date AS effectiveDate,
       txn.updated_at AS updatedAt,
       preference.excluded_from_calculation AS calculationPreference

--- a/apps/worker/src/features/sync/persistence.ts
+++ b/apps/worker/src/features/sync/persistence.ts
@@ -389,6 +389,14 @@ function promotionStatement(
         return `${column} = excluded.${column}`;
       if (column === "status")
         return "status = CASE WHEN bank_transactions.status = 'posted' OR excluded.status = 'posted' THEN 'posted' ELSE 'pending' END";
+      if (column === "authorized_at")
+        return `authorized_at = CASE
+          WHEN bank_transactions.status = 'pending' AND excluded.status = 'posted'
+            THEN COALESCE(bank_transactions.authorized_at, excluded.authorized_at)
+          WHEN bank_transactions.status = 'posted' AND excluded.status = 'pending'
+            THEN bank_transactions.authorized_at
+          ELSE excluded.authorized_at
+        END`;
       return `${column} = CASE WHEN bank_transactions.status = 'posted' AND excluded.status = 'pending' THEN bank_transactions.${column} ELSE excluded.${column} END`;
     })
     .join(", ");

--- a/apps/worker/src/features/sync/persistence.ts
+++ b/apps/worker/src/features/sync/persistence.ts
@@ -164,6 +164,7 @@ const ENTITY_CONFIG: Record<SyncEntityType, EntityConfig> = {
       "currency",
       "description",
       "counterparty",
+      "status",
       "raw_payload",
       "created_at",
       "updated_at",
@@ -176,6 +177,7 @@ const ENTITY_CONFIG: Record<SyncEntityType, EntityConfig> = {
       "currency",
       "description",
       "counterparty",
+      "status",
       "raw_payload",
       "updated_at",
     ],
@@ -382,7 +384,13 @@ function promotionStatement(
     .map((column) => `json_extract(payload, '$.${column}')`)
     .join(", ");
   const updates = config.updateColumns
-    .map((column) => `${column} = excluded.${column}`)
+    .map((column) => {
+      if (entityType !== "bank_transaction")
+        return `${column} = excluded.${column}`;
+      if (column === "status")
+        return "status = CASE WHEN bank_transactions.status = 'posted' OR excluded.status = 'posted' THEN 'posted' ELSE 'pending' END";
+      return `${column} = CASE WHEN bank_transactions.status = 'posted' AND excluded.status = 'pending' THEN bank_transactions.${column} ELSE excluded.${column} END`;
+    })
     .join(", ");
 
   return db

--- a/apps/worker/src/features/sync/record-mapper.ts
+++ b/apps/worker/src/features/sync/record-mapper.ts
@@ -182,6 +182,7 @@ export function bankTransactionRecord(
       currency: transaction.currency || "TWD",
       description: transaction.description ?? null,
       counterparty: transaction.counterparty ?? null,
+      status: transaction.status ?? "posted",
       raw_payload: JSON.stringify(transaction.raw ?? transaction),
       created_at: now,
       updated_at: now,

--- a/apps/worker/src/features/sync/repository.ts
+++ b/apps/worker/src/features/sync/repository.ts
@@ -130,6 +130,81 @@ export function reconcileEsunLifecycleShadowStatements(db: D1Database) {
   ];
 }
 
+export function reconcileSinopacLegacyTransactionStatements(db: D1Database) {
+  const match = `canonical.connector_id = legacy.connector_id
+      AND canonical.account_id = legacy.account_id
+      AND (
+        substr(canonical.authorized_at, 1, 10) = substr(legacy.posted_date, 1, 10)
+        OR substr(canonical.posted_date, 1, 10) = substr(legacy.posted_date, 1, 10)
+      )
+      AND canonical.amount = legacy.amount
+      AND canonical.currency = legacy.currency
+      AND COALESCE(canonical.description, '') = COALESCE(legacy.description, '')`;
+  const isLegacy = `legacy.connector_id = 'sinopac'
+      AND legacy.source_id LIKE 'sinopac:card:tx:%'
+      AND legacy.source_id NOT LIKE 'sinopac:card:tx:v2:%'`;
+  const isCanonical = `canonical.connector_id = 'sinopac'
+      AND canonical.source_id LIKE 'sinopac:card:tx:v2:%'
+      AND canonical.status = 'posted'`;
+
+  return [
+    db.prepare(
+      `INSERT INTO bank_transaction_preferences
+        (transaction_id, excluded_from_calculation, created_at, updated_at)
+       SELECT canonical.id, preference.excluded_from_calculation,
+              preference.created_at, preference.updated_at
+       FROM bank_transactions legacy
+       JOIN bank_transactions canonical ON ${match}
+       JOIN bank_transaction_preferences preference
+         ON preference.transaction_id = legacy.id
+       WHERE ${isLegacy} AND ${isCanonical}
+       ON CONFLICT(transaction_id) DO NOTHING`,
+    ),
+    db.prepare(
+      `INSERT INTO classification_overrides
+        (id, target_type, target_id, category_id, created_at, updated_at)
+       SELECT 'override:bank_transaction:' || canonical.id,
+              'bank_transaction', canonical.id, override.category_id,
+              override.created_at, override.updated_at
+       FROM bank_transactions legacy
+       JOIN bank_transactions canonical ON ${match}
+       JOIN classification_overrides override
+         ON override.target_type = 'bank_transaction'
+        AND override.target_id = legacy.id
+       WHERE ${isLegacy} AND ${isCanonical}
+       ON CONFLICT(target_type, target_id) DO NOTHING`,
+    ),
+    db.prepare(
+      `DELETE FROM bank_transaction_preferences
+       WHERE transaction_id IN (
+         SELECT legacy.id
+         FROM bank_transactions legacy
+         JOIN bank_transactions canonical ON ${match}
+         WHERE ${isLegacy} AND ${isCanonical}
+       )`,
+    ),
+    db.prepare(
+      `DELETE FROM classification_overrides
+       WHERE target_type = 'bank_transaction'
+         AND target_id IN (
+           SELECT legacy.id
+           FROM bank_transactions legacy
+           JOIN bank_transactions canonical ON ${match}
+           WHERE ${isLegacy} AND ${isCanonical}
+         )`,
+    ),
+    db.prepare(
+      `DELETE FROM bank_transactions
+       WHERE id IN (
+         SELECT legacy.id
+         FROM bank_transactions legacy
+         JOIN bank_transactions canonical ON ${match}
+         WHERE ${isLegacy} AND ${isCanonical}
+       )`,
+    ),
+  ];
+}
+
 export function linkCanonicalBankAccountsStatement(db: D1Database) {
   return db.prepare(
     `UPDATE bank_accounts

--- a/apps/worker/src/features/sync/repository.ts
+++ b/apps/worker/src/features/sync/repository.ts
@@ -59,20 +59,6 @@ export function connectorCursorStatement(
     .bind(cursor, now, connectorId);
 }
 
-export function deleteSyncedBankDataStatements(
-  db: D1Database,
-  connectorId: ConnectorId,
-) {
-  return [
-    db
-      .prepare(`DELETE FROM bank_transactions WHERE connector_id = ?`)
-      .bind(connectorId),
-    db
-      .prepare(`DELETE FROM credit_card_bills WHERE connector_id = ?`)
-      .bind(connectorId),
-  ];
-}
-
 export function reconcileEsunLifecycleShadowStatements(db: D1Database) {
   const shadowJoin = `canonical.connector_id = shadow.connector_id
       AND canonical.account_id = shadow.account_id

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -44,6 +44,7 @@ import {
   connectorStateStatement,
   linkCanonicalBankAccountsStatement,
   reconcileEsunLifecycleShadowStatements,
+  reconcileSinopacLegacyTransactionStatements,
   updateConnectorEncryptedConfig,
 } from "./repository";
 import {
@@ -554,10 +555,12 @@ export async function syncSinopac(
   }
   await persistStagedSyncWrite(env.DB, {
     records,
-    afterPromoteStatements:
-      bankAccounts.length > 0
+    afterPromoteStatements: [
+      ...reconcileSinopacLegacyTransactionStatements(env.DB),
+      ...(bankAccounts.length > 0
         ? [linkCanonicalBankAccountsStatement(env.DB)]
-        : [],
+        : []),
+    ],
     finalizeStatements,
   });
   if (bankBalanceSnapshots.length > 0)

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -42,7 +42,6 @@ import {
   connectorCursorStatement,
   connectorEncryptedConfigStatement,
   connectorStateStatement,
-  deleteSyncedBankDataStatements,
   linkCanonicalBankAccountsStatement,
   reconcileEsunLifecycleShadowStatements,
   updateConnectorEncryptedConfig,
@@ -555,10 +554,6 @@ export async function syncSinopac(
   }
   await persistStagedSyncWrite(env.DB, {
     records,
-    beforePromoteStatements: deleteSyncedBankDataStatements(
-      env.DB,
-      connectorId,
-    ),
     afterPromoteStatements:
       bankAccounts.length > 0
         ? [linkCanonicalBankAccountsStatement(env.DB)]

--- a/apps/worker/tests/connectors/esun.test.ts
+++ b/apps/worker/tests/connectors/esun.test.ts
@@ -42,6 +42,11 @@ describe("E.SUN credit card timeline normalization", () => {
     expect(rows[0].sourceId).toBe(
       "2026-07-05T00:00:00.000Z:credit:esun:1204:全支付﹘全聯:252:TWD:1",
     );
+    expect(rows[0]).toMatchObject({
+      status: "posted",
+      authorizedAt: "2026-07-05T00:00:00.000Z",
+      postedDate: "2026-07-05T00:00:00.000Z",
+    });
     expect((rows[0].raw as EsunTimelineTransaction).acfg).toBe("已入帳");
   });
 
@@ -62,6 +67,7 @@ describe("E.SUN credit card timeline normalization", () => {
     expect(
       rows.map(({ raw }) => (raw as EsunTimelineTransaction).acfg),
     ).toEqual(["已入帳", "已入帳"]);
+    expect(rows.map(({ status }) => status)).toEqual(["posted", "posted"]);
   });
 
   it("keeps all pending purchases while no posted copy exists", () => {
@@ -70,5 +76,44 @@ describe("E.SUN credit card timeline normalization", () => {
     ]);
 
     expect(rows).toHaveLength(2);
+    expect(rows).toEqual([
+      expect.objectContaining({ status: "pending", postedDate: undefined }),
+      expect.objectContaining({ status: "pending", postedDate: undefined }),
+    ]);
+  });
+
+  it("upgrades a cross-day pending purchase to posted without changing its source id", () => {
+    const rows = normalizeEsunTimelineTransactions([
+      page([
+        transaction("未入帳", { consumerDt: "07/05" }),
+        transaction("已入帳", { consumerDt: "07/05", postingDt: "07/07" }),
+      ]),
+    ]);
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        sourceId: "2026-07-05T00:00:00.000Z:credit:esun:1204:全支付﹘全聯:252:TWD:1",
+        status: "posted",
+        authorizedAt: "2026-07-05T00:00:00.000Z",
+        postedDate: "2026-07-07T00:00:00.000Z",
+      }),
+    ]);
+  });
+
+  it("keeps equal purchases on different cards separate", () => {
+    const rows = normalizeEsunTimelineTransactions([
+      page([
+        transaction("未入帳", { cardNo: "****1204" }),
+        transaction("未入帳", { cardNo: "****9876" }),
+        transaction("已入帳", { cardNo: "****1204" }),
+        transaction("已入帳", { cardNo: "****9876" }),
+      ]),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map(({ accountId, status }) => ({ accountId, status }))).toEqual([
+      { accountId: "credit:esun:1204", status: "posted" },
+      { accountId: "credit:esun:9876", status: "posted" },
+    ]);
   });
 });

--- a/apps/worker/tests/connectors/sinopac.test.ts
+++ b/apps/worker/tests/connectors/sinopac.test.ts
@@ -125,11 +125,56 @@ const mobileUnbilledPayload = [{
   ]
 }];
 
+const sinoCardSsoPayload = {
+  Result: { ID: "A123456789" }, Header: {}, ResultCode: "00", ResultMessage: "", Error: null
+};
+const sinoCardAuthPayload = { Result: {}, Header: {}, ResultCode: "00", ResultMessage: "", Error: null };
+const sinoCardLatestPayload = {
+  Result: {
+    IsCompanyUser: false,
+    Items: [
+      {
+        CardFlag: "P", CardNo: "************8000", IsMobileCard: false,
+        AuthDate: "2026/07/19", AuthTime: "18:35:13", Memo: "餐廳/LINE Pay",
+        AuthAmt: 260, AuthAmtDesc: "260", CountryCode: "TW", AuthResult: "Y"
+      },
+      {
+        CardFlag: "P", CardNo: "************1234", IsMobileCard: false,
+        AuthDate: "2026/07/19", AuthTime: "20:10:00", Memo: "另一張卡的同額消費",
+        AuthAmt: 260, AuthAmtDesc: "260", CountryCode: "TW", AuthResult: "Y"
+      }
+    ]
+  }, Header: {}, ResultCode: "00", ResultMessage: "", Error: null
+};
+const sinoCardOutstandingPayload = {
+  Result: {
+    IsExcludePaidUp: false,
+    Detail: [{
+      CurrencyCode: "TWD", CurrencyName: "臺幣", PID: "", CARD_TYPE: "正卡", CardLast4: "8000",
+      TXDATE: "2026/07/19", DEDATE: "2026/07/22", TXCODE: "", MEMO: "連支＊餐廳",
+      TXCUR: "TWD", TXAMT: "260", AMT: "260", PROD: "", EMBOSSING_TYPE: "",
+      CardNoLast4: "8000", CARDNAME: "測試信用卡"
+    }],
+    SubTotal: [{ CurrencyCode: "TWD", CurrencyName: "臺幣", Count: 1, SubTotalAmt: "260" }],
+    IsCompanyUser: false
+  }, Header: {}, ResultCode: "00", ResultMessage: "", Error: null
+};
+
 const sessionCookies = JSON.stringify([{
   name: "ASP.NET_SessionId",
   value: "test-session",
   domain: "m.sinopac.com"
 }]);
+
+function payloadForUrl(url: string) {
+  if (url.includes("ws_cardsum")) return summaryPayload;
+  if (url.includes("ws_cardbilling_sp")) return billPayload;
+  if (url.endsWith("/security/sso")) return sinoCardSsoPayload;
+  if (url.endsWith("/security/auth")) return sinoCardAuthPayload;
+  if (url.endsWith("/Accounting/LatestTx")) return sinoCardLatestPayload;
+  if (url.endsWith("/Accounting/OutstandingDetail")) return sinoCardOutstandingPayload;
+  throw new Error(`Unexpected URL: ${url}`);
+}
 
 describe("sinopac App JSON parser", () => {
   it("parses Taiwan amounts and ROC dates", () => {
@@ -219,30 +264,66 @@ describe("sinopac App JSON parser", () => {
     ]);
   });
 
-  it("uses the three App endpoints without acquiring a browser when session cookies exist", async () => {
-    const fetchMock = vi.fn(async function(this: unknown, input: RequestInfo | URL) {
+  it("maps latest authorizations to pending and upgrades matching card transactions to posted", () => {
+    const result = parseSinopacCardData({
+      summary: mobileSummaryPayload,
+      bills: mobileBillPayload,
+      latest: sinoCardLatestPayload,
+      outstanding: sinoCardOutstandingPayload
+    }, 3, new Date("2026-07-22T12:00:00.000Z"));
+
+    expect(result.bankTransactions).toHaveLength(2);
+    expect(result.bankTransactions).toEqual([
+      expect.objectContaining({
+        sourceId: "sinopac:card:tx:v2:TWD:2026-07-19:-260:8000:1",
+        authorizedAt: "2026-07-19",
+        postedDate: "2026-07-22",
+        description: "連支＊餐廳",
+        amount: -260,
+        status: "posted"
+      }),
+      expect.objectContaining({
+        sourceId: "sinopac:card:tx:v2:TWD:2026-07-19:-260:1234:1",
+        authorizedAt: "2026-07-19T20:10:00+08:00",
+        description: "另一張卡的同額消費",
+        amount: -260,
+        status: "pending"
+      })
+    ]);
+    expect(result.bankTransactions[0]?.raw).toMatchObject({ CardNoLast4: "8000" });
+    expect(result.bankTransactions[1]?.raw).toMatchObject({ CardNo: "************1234" });
+  });
+
+  it("uses the App and SinoCard endpoints without acquiring a browser when session cookies exist", async () => {
+    const fetchMock = vi.fn(async function(this: unknown, input: RequestInfo | URL, _init?: RequestInit) {
       expect(this).toBe(globalThis);
       const url = String(input);
-      const payload = url.includes("ws_cardsum")
-        ? summaryPayload
-        : url.includes("ws_cardbilling_sp")
-          ? billPayload
-          : unbilledPayload;
-      return new Response(JSON.stringify(payload), { status: 200 });
+      return new Response(JSON.stringify(payloadForUrl(url)), { status: 200 });
     });
 
     const result = await createSinopacConnector(undefined, fetchMock as typeof fetch).sync({
+      userId: "A123456789",
       sessionCookies,
       protocol: "sinopac-mobile-app-json-v1",
       lookbackMonths: 3
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
     expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual([
       "https://m.sinopac.com/ws/card/cardqry/ws_cardsum.ashx",
       "https://m.sinopac.com/ws/card/cardqry/ws_cardbilling_sp.ashx?TxDate=default&TxType=01",
-      "https://m.sinopac.com/ws/card/cardqry/ws_nonbilling.ashx"
+      "https://m.sinopac.com/m/SinoCard/api/security/sso",
+      "https://m.sinopac.com/m/SinoCard/api/security/auth",
+      "https://m.sinopac.com/m/SinoCard/api/Accounting/LatestTx",
+      "https://m.sinopac.com/m/SinoCard/api/Accounting/OutstandingDetail"
     ]);
+    expect(JSON.parse(String(fetchMock.mock.calls[4]?.[1]?.body))).toMatchObject({
+      Content: { ID: "A123456789" },
+      Header: { ApplicationName: "MWEB", UserID: "A123456789" }
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[5]?.[1]?.body))).toMatchObject({
+      Content: { IsExcludePaidUp: false, ID: "A123456789", DateYYYYMMDD: "" }
+    });
     expect(result.records).toEqual([]);
     expect(result.bankTransactions).toHaveLength(2);
     expect(JSON.parse(result.cursor ?? "{}")).toMatchObject({
@@ -251,30 +332,32 @@ describe("sinopac App JSON parser", () => {
     });
   });
 
-  it("keeps the original auth cookies when App APIs return sinopac_cookie", async () => {
+  it("isolates App cookies and follows SinoCard cookie rotation", async () => {
     const authCookies = JSON.stringify([
       ...JSON.parse(sessionCookies),
       { name: "sinopac_cookie", value: "browser-cookie", domain: "m.sinopac.com", path: "/" }
     ]);
     const requestCookies: string[] = [];
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       requestCookies.push(new Headers(init?.headers).get("cookie") ?? "");
       const call = requestCookies.length;
-      const payload = call === 1 ? summaryPayload : call === 2 ? billPayload : unbilledPayload;
-      return new Response(JSON.stringify(payload), {
+      return new Response(JSON.stringify(payloadForUrl(String(input))), {
         status: 200,
         headers: { "Set-Cookie": `sinopac_cookie=api-cookie-${call}; Path=/; HttpOnly; Secure` }
       });
     });
 
     const result = await createSinopacConnector(undefined, fetchMock as typeof fetch).sync({
+      userId: "A123456789",
       sessionCookies: authCookies,
       protocol: "sinopac-mobile-app-json-v1"
     });
 
-    expect(requestCookies).toHaveLength(3);
-    expect(requestCookies.every((cookie) => cookie.includes("sinopac_cookie=browser-cookie"))).toBe(true);
-    expect(requestCookies.some((cookie) => cookie.includes("api-cookie"))).toBe(false);
+    expect(requestCookies).toHaveLength(6);
+    expect(requestCookies.slice(0, 3).every((cookie) => cookie.includes("sinopac_cookie=browser-cookie"))).toBe(true);
+    expect(requestCookies[3]).toContain("sinopac_cookie=api-cookie-3");
+    expect(requestCookies[4]).toContain("sinopac_cookie=api-cookie-4");
+    expect(requestCookies[5]).toContain("sinopac_cookie=api-cookie-5");
     expect(JSON.parse(result.cursor ?? "{}")).toMatchObject({
       sessionCookies: authCookies,
       protocol: "sinopac-mobile-app-json-v1"
@@ -286,13 +369,14 @@ describe("sinopac App JSON parser", () => {
       const url = String(input);
       const payload = url.includes("ws_cardsum")
         ? mobileSummaryPayload
-        : url.includes("ws_nonbilling")
-          ? mobileUnbilledPayload
-          : mobileBillPayload;
+        : url.includes("ws_cardbilling_sp")
+          ? mobileBillPayload
+          : payloadForUrl(url);
       return new Response(JSON.stringify(payload), { status: 200 });
     });
 
     await createSinopacConnector(undefined, fetchMock as typeof fetch).sync({
+      userId: "A123456789",
       sessionCookies,
       protocol: "sinopac-mobile-app-json-v1",
       lookbackMonths: 3
@@ -303,7 +387,10 @@ describe("sinopac App JSON parser", () => {
       "https://m.sinopac.com/ws/card/cardqry/ws_cardbilling_sp.ashx?TxDate=default&TxType=01",
       "https://m.sinopac.com/ws/card/cardqry/ws_cardbilling_sp.ashx?TxDate=202605&TxType=01",
       "https://m.sinopac.com/ws/card/cardqry/ws_cardbilling_sp.ashx?TxDate=202604&TxType=01",
-      "https://m.sinopac.com/ws/card/cardqry/ws_nonbilling.ashx"
+      "https://m.sinopac.com/m/SinoCard/api/security/sso",
+      "https://m.sinopac.com/m/SinoCard/api/security/auth",
+      "https://m.sinopac.com/m/SinoCard/api/Accounting/LatestTx",
+      "https://m.sinopac.com/m/SinoCard/api/Accounting/OutstandingDetail"
     ]);
   });
 
@@ -314,6 +401,7 @@ describe("sinopac App JSON parser", () => {
     }])));
 
     await expect(createSinopacConnector(undefined, fetchMock as typeof fetch).sync({
+      userId: "A123456789",
       sessionCookies,
       protocol: "sinopac-mobile-app-json-v1"
     })).rejects.toBeInstanceOf(SinopacVerificationRequiredError);

--- a/apps/worker/tests/connectors/sinopac.test.ts
+++ b/apps/worker/tests/connectors/sinopac.test.ts
@@ -172,12 +172,14 @@ describe("sinopac App JSON parser", () => {
       expect.objectContaining({
         postedDate: "2026-07-16",
         amount: -1280,
-        description: "全聯福利中心"
+        description: "全聯福利中心",
+        status: "posted"
       }),
       expect.objectContaining({
         postedDate: "2026-07-16",
         amount: 500,
-        description: "網購退貨退款"
+        description: "網購退貨退款",
+        status: "posted"
       })
     ]);
   });

--- a/apps/worker/tests/features/activity/route.test.ts
+++ b/apps/worker/tests/features/activity/route.test.ts
@@ -22,8 +22,8 @@ function createDb() {
       "transaction-1",
       {
         id: "transaction-1",
-        postedDate: "2026-07-06",
-        authorizedAt: null,
+        postedDate: "2026-07-07",
+        authorizedAt: "2026-07-06",
         amount: 37,
         currency: "TWD",
         accountType: "credit",

--- a/apps/worker/tests/features/sync/persistence.test.ts
+++ b/apps/worker/tests/features/sync/persistence.test.ts
@@ -6,7 +6,10 @@ import {
   persistStagedSyncWrite,
   type SyncWriteRecord,
 } from "../../../src/features/sync/persistence";
-import { reconcileEsunLifecycleShadowStatements } from "../../../src/features/sync/repository";
+import {
+  reconcileEsunLifecycleShadowStatements,
+  reconcileSinopacLegacyTransactionStatements,
+} from "../../../src/features/sync/repository";
 
 class SqliteStatement {
   private values: unknown[] = [];
@@ -198,6 +201,53 @@ describe("staged sync persistence", () => {
     ).toEqual({ target_id: "canonical", category_id: "shopping" });
   });
 
+  it("migrates preferences and removes matching legacy Sinopac transaction ids", async () => {
+    const db = createDb();
+    db.database.exec(`
+      INSERT INTO bank_accounts
+        (id, connector_id, source_id, account_type, currency, raw_payload, created_at, updated_at)
+      VALUES
+        ('sinopac:credit:sinopac:main', 'sinopac', 'credit:sinopac:main', 'credit', 'TWD', '{}', '2026-07-01', '2026-07-01');
+
+      INSERT INTO bank_transactions
+        (id, connector_id, account_id, source_id, posted_date, authorized_at, amount, currency, description, status, raw_payload, created_at, updated_at)
+      VALUES
+        ('sinopac-legacy', 'sinopac', 'sinopac:credit:sinopac:main', 'sinopac:card:tx:TWD:legacy', '2026-07-19', NULL, -260, 'TWD', '連支＊餐廳', 'posted', '{}', '2026-07-19', '2026-07-19'),
+        ('sinopac-canonical', 'sinopac', 'sinopac:credit:sinopac:main', 'sinopac:card:tx:v2:TWD:2026-07-19:-260:8000:1', '2026-07-22', '2026-07-19', -260, 'TWD', '連支＊餐廳', 'posted', '{}', '2026-07-22', '2026-07-22');
+
+      INSERT INTO bank_transaction_preferences
+        (transaction_id, excluded_from_calculation, created_at, updated_at)
+      VALUES ('sinopac-legacy', 1, '2026-07-19', '2026-07-19');
+
+      INSERT INTO classification_overrides
+        (id, target_type, target_id, category_id, created_at, updated_at)
+      VALUES ('sinopac-legacy-override', 'bank_transaction', 'sinopac-legacy', 'shopping', '2026-07-19', '2026-07-19');
+    `);
+
+    await db.batch(
+      reconcileSinopacLegacyTransactionStatements(db as unknown as D1Database),
+    );
+
+    expect(
+      db.database
+        .prepare("SELECT id FROM bank_transactions ORDER BY id")
+        .all()
+        .map((row) => row.id),
+    ).toEqual(["sinopac-canonical"]);
+    expect(
+      db.database
+        .prepare(
+          "SELECT transaction_id AS transactionId FROM bank_transaction_preferences",
+        )
+        .get(),
+    ).toEqual({ transactionId: "sinopac-canonical" });
+    expect(
+      db.database
+        .prepare("SELECT target_id AS targetId FROM classification_overrides")
+        .get(),
+    ).toEqual({ targetId: "sinopac-canonical" });
+  });
+
   it("stages records in bounded JSON chunks and advances the cursor only after promotion", async () => {
     const db = createDb();
     const records = Array.from({ length: 205 }, (_, index) =>
@@ -284,7 +334,7 @@ describe("staged sync persistence", () => {
     await persistStagedSyncWrite(db as unknown as D1Database, {
       records: [
         bankTransactionRecord("purchase-1", "posted", {
-          authorizedAt: "2026-07-05T00:00:00.000Z",
+          authorizedAt: "2026-07-05",
           postedDate: "2026-07-07T00:00:00.000Z",
         }),
       ],
@@ -324,6 +374,7 @@ describe("staged sync persistence", () => {
         }),
       ],
     });
+    await persistStagedSyncWrite(db as unknown as D1Database, { records: [] });
     expect(
       db.database
         .prepare("SELECT COUNT(*) AS count FROM bank_transactions")

--- a/apps/worker/tests/features/sync/persistence.test.ts
+++ b/apps/worker/tests/features/sync/persistence.test.ts
@@ -121,6 +121,34 @@ function bankAccountRecord(index: number): SyncWriteRecord {
   };
 }
 
+function bankTransactionRecord(
+  sourceId: string,
+  status: "pending" | "posted",
+  dates: { authorizedAt: string; postedDate?: string },
+): SyncWriteRecord {
+  const id = `tdcc:account-0:${sourceId}`;
+  return {
+    entityType: "bank_transaction",
+    recordKey: id,
+    payload: {
+      id,
+      connector_id: "tdcc",
+      account_id: "tdcc:account-0",
+      source_id: sourceId,
+      posted_date: dates.postedDate ?? null,
+      authorized_at: dates.authorizedAt,
+      amount: -252,
+      currency: "TWD",
+      description: "全支付﹘全聯",
+      counterparty: "全支付﹘全聯",
+      status,
+      raw_payload: JSON.stringify({ status }),
+      created_at: "2026-07-05T00:00:00.000Z",
+      updated_at: dates.postedDate ?? dates.authorizedAt,
+    },
+  };
+}
+
 describe("staged sync persistence", () => {
   it("migrates preferences and removes E.SUN lifecycle shadow transactions", async () => {
     const db = createDb();
@@ -189,6 +217,7 @@ describe("staged sync persistence", () => {
         currency: "TWD",
         description: null,
         counterparty: null,
+        status: "posted",
         raw_payload: "{}",
         created_at: "2026-07-19T00:00:00.000Z",
         updated_at: "2026-07-19T00:00:00.000Z",
@@ -235,6 +264,73 @@ describe("staged sync persistence", () => {
     ).toMatchObject({ cursor: "new-cursor" });
   });
 
+  it("upgrades pending to posted in place and never downgrades posted history", async () => {
+    const db = createDb();
+    const pending = bankTransactionRecord("purchase-1", "pending", {
+      authorizedAt: "2026-07-05T00:00:00.000Z",
+    });
+
+    await persistStagedSyncWrite(db as unknown as D1Database, {
+      records: [bankAccountRecord(0), pending],
+    });
+    db.database
+      .prepare(
+        `INSERT INTO bank_transaction_preferences
+         (transaction_id, excluded_from_calculation, created_at, updated_at)
+         VALUES (?, 1, '2026-07-05', '2026-07-05')`,
+      )
+      .run(pending.recordKey);
+
+    await persistStagedSyncWrite(db as unknown as D1Database, {
+      records: [
+        bankTransactionRecord("purchase-1", "posted", {
+          authorizedAt: "2026-07-05T00:00:00.000Z",
+          postedDate: "2026-07-07T00:00:00.000Z",
+        }),
+      ],
+    });
+    await persistStagedSyncWrite(db as unknown as D1Database, {
+      records: [pending],
+    });
+
+    expect(
+      db.database
+        .prepare(
+          `SELECT id, status, authorized_at AS authorizedAt,
+                  posted_date AS postedDate,
+                  json_extract(raw_payload, '$.status') AS rawStatus
+           FROM bank_transactions WHERE source_id = 'purchase-1'`,
+        )
+        .get(),
+    ).toEqual({
+      id: pending.recordKey,
+      status: "posted",
+      authorizedAt: "2026-07-05T00:00:00.000Z",
+      postedDate: "2026-07-07T00:00:00.000Z",
+      rawStatus: "posted",
+    });
+    expect(
+      db.database
+        .prepare(
+          "SELECT excluded_from_calculation AS excluded FROM bank_transaction_preferences WHERE transaction_id = ?",
+        )
+        .get(pending.recordKey),
+    ).toEqual({ excluded: 1 });
+
+    await persistStagedSyncWrite(db as unknown as D1Database, {
+      records: [
+        bankTransactionRecord("purchase-2", "pending", {
+          authorizedAt: "2026-07-08T00:00:00.000Z",
+        }),
+      ],
+    });
+    expect(
+      db.database
+        .prepare("SELECT COUNT(*) AS count FROM bank_transactions")
+        .get(),
+    ).toEqual({ count: 2 });
+  });
+
   it("rolls back promotion and leaves the cursor unchanged when a staged record is invalid", async () => {
     const db = createDb();
     const invalidTransaction: SyncWriteRecord = {
@@ -251,6 +347,7 @@ describe("staged sync persistence", () => {
         currency: "TWD",
         description: null,
         counterparty: null,
+        status: "posted",
         raw_payload: "{}",
         created_at: "2026-07-19T00:00:00.000Z",
         updated_at: "2026-07-19T00:00:00.000Z",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -140,6 +140,8 @@ export interface BankBalanceSnapshot {
   raw?: unknown;
 }
 
+export type BankTransactionStatus = "pending" | "posted";
+
 export interface BankTransaction {
   id: string;
   connectorId: string;
@@ -151,6 +153,7 @@ export interface BankTransaction {
   currency: string;
   description?: string;
   counterparty?: string;
+  status?: BankTransactionStatus;
   raw?: unknown;
 }
 

--- a/packages/db/migrations/0014_bank_transaction_status.sql
+++ b/packages/db/migrations/0014_bank_transaction_status.sql
@@ -1,0 +1,14 @@
+ALTER TABLE bank_transactions
+  ADD COLUMN status TEXT NOT NULL DEFAULT 'posted'
+  CHECK (status IN ('pending', 'posted'));
+
+UPDATE bank_transactions
+SET status = 'pending'
+WHERE connector_id = 'esun'
+  AND json_extract(
+    CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+    '$.acfg'
+  ) = '未入帳';
+
+CREATE INDEX IF NOT EXISTS idx_bank_transactions_status
+  ON bank_transactions (connector_id, account_id, status);


### PR DESCRIPTION
## 變更內容

- 為信用卡交易新增 `pending`／`posted` 狀態與 D1 migration。
- 調整同步 upsert，讓 Pending 可原地升級為 Posted，且 Posted 不會被後續 Pending 降級。
- 整理玉山同筆交易的生命週期鍵，避免待入帳與已入帳各存一筆。
- 串接永豐 SinoCard SSO/Auth、`LatestTx` 與 `OutstandingDetail`：
  - 最新授權交易建立為 Pending。
  - 已請款交易以交易日、金額與卡片末四碼更新為 Posted。
  - 支援多卡、同額交易與跨日入帳。
  - 保留 API 暫時未回傳的 Pending，不因單次快照缺少而刪除。
- 遷移可確認重複的永豐舊交易鍵，保留既有分類與排除計算設定。
- 活動頁、發票自動配對與人工配對統一優先使用交易／授權日期，沒有時才使用入帳日期。

## 原因

原本的同步資料沒有明確的 Pending／Posted 生命週期，待入帳交易轉為已入帳後可能形成重複紀錄。永豐連接器也只取得既有帳單資料，未取得頁面上的最新授權消費；此外活動頁優先顯示入帳日期，會把 6/17 交易、6/24 入帳的消費顯示成 6/24。

## 影響

- Posted 歷史交易會持續保留。
- Pending 會持續 upsert，取得已請款資料後更新同一筆為 Posted。
- 活動紀錄與發票配對會以實際交易日為準。
- 既有永豐交易只會清理能與新 canonical 交易明確配對的重複資料。

## 驗證

- `npm run test:backend`
- `npm run typecheck`
- `npm run test:unit -w @taiwan-fin-hub/web`
- `npm run format:check -w @taiwan-fin-hub/web`
- Svelte autofixer：無問題
- `git diff --check`

目前尚未觸發正式環境的銀行同步寫入；API 欄位與請求流程是依登入後的唯讀 Network 回應實作。