### PR TITLE
修正資產走勢並新增專案指引

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# Taiwan Fin Hub 專案指引
+
+## 專案概況
+
+- 本專案是使用 TypeScript ESM 與 npm workspaces 管理的 monorepo。
+- 前端位於 `apps/web`，使用 Svelte 5、Vite、Tailwind CSS 4 與 TanStack Svelte Query。
+- 後端位於 `apps/worker`，執行於 Cloudflare Workers，使用 Hono 提供 API。
+- 資料庫使用 Cloudflare D1；schema 變更由 `packages/db/migrations` 管理。
+- 身分驗證使用 Cloudflare Access，由 Worker 驗證 Access JWT。
+- 需要瀏覽器操作的銀行連接器使用 Cloudflare Browser Rendering 與 Puppeteer。
+- 驗證碼辨識使用 Cloudflare Workers AI。
+- 排程同步使用 Workers Cron Triggers 與 D1 sync jobs。
+
+## 目錄責任
+
+- `apps/web`：Svelte 前端、頁面、元件、資料查詢與前端測試。
+- `apps/worker`：Hono API、同步流程、Cloudflare bindings 與靜態網站服務。
+- `apps/worker/src/features`：依業務功能組織的後端 vertical slices。
+- `apps/worker/src/connectors`：依賴 Browser Rendering、Workers AI 等 Worker bindings 的連接器 adapter。
+- `packages/core`：前後端、資料庫與連接器共用的穩定型別及契約。
+- `packages/connectors`：不依賴 Hono、D1 或 Worker `Env` 的外部資料來源邏輯。
+- `packages/db`：跨 feature 共用的 D1 基礎能力與 migrations。
+- `docs/002-backend-architecture.md`：後端分層、相依方向與維護約定的詳細文件。
+
+## 架構約定
+
+- 後端採 feature-oriented Vertical Slice Architecture。
+- `apps/worker/src/index.ts` 是 Composition Root，只負責 middleware、routes、錯誤處理、靜態資源與 scheduled event 的組裝。
+- HTTP concerns 放在 `route.ts`，use case 與商業流程放在 `service.ts`，feature 專用 SQL 放在 `repository.ts`。
+- 共用 API contract 與金融資料型別放在 `packages/core`，不得混入 Hono `Context`、D1 row 或 Puppeteer object。
+- 詳細後端變更開始前，先閱讀 `docs/002-backend-architecture.md` 的相關章節。
+
+## 常用驗證指令
+
+- 全部型別檢查：`npm run typecheck`
+- 前端驗證：`npm run verify:web`
+- 後端測試：`npm run test:backend`
+- 全部 workspace 建置：`npm run build`
+
+## 文件維護
+
+- 架構判斷以實際程式碼及各 workspace 的 `package.json` 為最終依據。
+- 技術棧、目錄責任或主要驗證指令改變時，應同步更新本文件。
+- `README.md` 用於產品介紹、部署與使用說明；本文件維持精簡，作為開發工作的快速架構索引。

--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -23,7 +23,7 @@ test.beforeEach(async ({ page }) => {
     else if (path === "/api/activity/invoice-mappings") body = [];
     else if (path === "/api/manual-assets") body = [];
     else if (path === "/api/exchange-rates") body = [];
-    else if (path === "/api/history/net-worth") body = [];
+    else if (path === "/api/history/net-worth/chart") body = [];
     else if (path === "/api/sync-jobs") body = [];
     else if (path === "/api/classification/categories")
       body = [

--- a/apps/web/src/features/overview/NetWorthHistoryChart.svelte
+++ b/apps/web/src/features/overview/NetWorthHistoryChart.svelte
@@ -84,7 +84,7 @@
             label: "總和",
             value: "selectedTotal",
             color: "var(--color-selectedTotal)",
-            props: { strokeDasharray: "6 4", strokeWidth: 2.5 },
+            props: { "stroke-dasharray": "6 4", strokeWidth: 2.5 },
           },
         ],
   );

--- a/apps/web/src/lib/net-worth-chart.test.ts
+++ b/apps/web/src/lib/net-worth-chart.test.ts
@@ -36,9 +36,9 @@ describe("net worth chart data", () => {
       {
         date: "2026-01-01",
         stock: 100,
-        fund: 0,
-        deposit: 0,
-        manual: 0,
+        fund: undefined,
+        deposit: undefined,
+        manual: undefined,
         selectedTotal: 100,
       },
       {
@@ -46,7 +46,7 @@ describe("net worth chart data", () => {
         stock: 100,
         fund: 40,
         deposit: 500,
-        manual: 0,
+        manual: undefined,
         selectedTotal: 640,
       },
       {
@@ -56,6 +56,32 @@ describe("net worth chart data", () => {
         deposit: 500,
         manual: 250,
         selectedTotal: 650,
+      },
+    ]);
+  });
+
+  it("starts each category at its own first valuation date", () => {
+    const points = buildNetWorthChartData(rows, ["stock", "manual"], "ALL");
+
+    expect(
+      points.map(({ date, stock, manual, selectedTotal }) => ({
+        date,
+        stock,
+        manual,
+        selectedTotal,
+      })),
+    ).toEqual([
+      {
+        date: "2026-01-01",
+        stock: 100,
+        manual: undefined,
+        selectedTotal: 100,
+      },
+      {
+        date: "2026-01-03",
+        stock: 110,
+        manual: 250,
+        selectedTotal: 360,
       },
     ]);
   });

--- a/apps/web/src/lib/net-worth-chart.ts
+++ b/apps/web/src/lib/net-worth-chart.ts
@@ -6,10 +6,10 @@ export type NetWorthTimeframe = "1M" | "3M" | "6M" | "1Y" | "ALL";
 
 export interface NetWorthChartPoint {
   date: string;
-  stock: number;
-  fund: number;
-  deposit: number;
-  manual: number;
+  stock?: number;
+  fund?: number;
+  deposit?: number;
+  manual?: number;
   selectedTotal: number;
 }
 
@@ -66,7 +66,7 @@ function cutoffDate(timeframe: NetWorthTimeframe, now: Date) {
 }
 
 function latestValue(rows: NetWorthHistoryRow[], date: string) {
-  let value = 0;
+  let value: number | undefined;
   for (const row of rows) {
     if (row.date > date) break;
     value = row.netWorth;
@@ -96,10 +96,10 @@ function buildAssetSeries(
   return new Map(
     dates.map((date) => [
       date,
-      [...identities.values()].reduce(
-        (sum, values) => sum + latestValue(values, date),
-        0,
-      ),
+      [...identities.values()].reduce<number | undefined>((sum, values) => {
+        const value = latestValue(values, date);
+        return value === undefined ? sum : (sum ?? 0) + value;
+      }, undefined),
     ]),
   );
 }
@@ -139,19 +139,19 @@ export function buildNetWorthChartData(
       key,
       buildAssetSeries(sortedRows, key, dates),
     ]),
-  ) as Record<NetWorthAssetType, Map<string, number>>;
+  ) as Record<NetWorthAssetType, Map<string, number | undefined>>;
 
   return dates.map((date) => {
     const point: NetWorthChartPoint = {
       date,
-      stock: valuesByType.stock.get(date) ?? 0,
-      fund: valuesByType.fund.get(date) ?? 0,
-      deposit: valuesByType.deposit.get(date) ?? 0,
-      manual: valuesByType.manual.get(date) ?? 0,
+      stock: valuesByType.stock.get(date),
+      fund: valuesByType.fund.get(date),
+      deposit: valuesByType.deposit.get(date),
+      manual: valuesByType.manual.get(date),
       selectedTotal: 0,
     };
     point.selectedTotal = includedAssets.reduce(
-      (sum, key) => sum + point[key],
+      (sum, key) => sum + (point[key] ?? 0),
       0,
     );
     return point;

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -89,7 +89,8 @@ export const exchangeRatesQuery = (getApi: ApiProvider) =>
 export const netWorthHistoryQuery = (getApi: ApiProvider) =>
   queryOptions({
     queryKey: queryKeys.netWorthHistory,
-    queryFn: () => getApi().get<NetWorthHistoryRow[]>("/api/history/net-worth"),
+    queryFn: () =>
+      getApi().get<NetWorthHistoryRow[]>("/api/history/net-worth/chart"),
   });
 
 export const syncJobsQuery = (getApi: ApiProvider) =>

--- a/apps/worker/src/features/net-worth/repository.ts
+++ b/apps/worker/src/features/net-worth/repository.ts
@@ -5,6 +5,25 @@ export type NetWorthPageCursor = {
   id: string;
 };
 
+export async function listNetWorthChartHistory(db: D1Database) {
+  const result = await db
+    .prepare(
+      `SELECT date, net_worth AS netWorth, asset_type AS assetType, source
+       FROM net_worth_history
+       WHERE source = 'manual'
+          OR (source = 'bank' AND asset_type = 'deposit')
+          OR asset_type IN ('stock', 'fund')
+       ORDER BY date ASC, source ASC, asset_type ASC, id ASC`,
+    )
+    .all<{
+      date: string;
+      netWorth: number;
+      assetType: string;
+      source: string;
+    }>();
+  return result.results;
+}
+
 export async function listNetWorthHistory(
   db: D1Database,
   limit: number,

--- a/apps/worker/src/features/net-worth/route.ts
+++ b/apps/worker/src/features/net-worth/route.ts
@@ -9,7 +9,11 @@ import {
   parseKeysetPagination,
   setKeysetPaginationHeaders,
 } from "../../platform/http";
-import { getNetWorthPage, rebuildBankDepositHistoryRange } from "./service";
+import {
+  getNetWorthChartHistory,
+  getNetWorthPage,
+  rebuildBankDepositHistoryRange,
+} from "./service";
 
 const netWorthPageCursorSchema = z.object({
   date: z.string(),
@@ -33,6 +37,10 @@ export const netWorthRoutes = honoFactory.createApp();
 registerNetWorthRoutes(netWorthRoutes);
 
 function registerNetWorthRoutes(api: Hono<AppBindings>) {
+  api.get("/history/net-worth/chart", async (c) =>
+    c.json(await getNetWorthChartHistory(c.env.DB)),
+  );
+
   api.get("/history/net-worth", async (c) => {
     const { limit, cursor } = parseKeysetPagination(
       c.req.query(),

--- a/apps/worker/src/features/net-worth/service.ts
+++ b/apps/worker/src/features/net-worth/service.ts
@@ -1,10 +1,15 @@
 import {
   calculateBankDepositValue,
   findBankHistoryDateBounds,
+  listNetWorthChartHistory,
   listNetWorthHistory,
   upsertBankDepositHistory,
   type NetWorthPageCursor,
 } from "./repository";
+
+export function getNetWorthChartHistory(db: D1Database) {
+  return listNetWorthChartHistory(db);
+}
 
 export async function getNetWorthPage(
   db: D1Database,


### PR DESCRIPTION
## Description

- 新增 `AGENTS.md`，整理 monorepo 技術棧、目錄責任、後端分層與常用驗證指令。
- 新增資產走勢專用的 `GET /api/history/net-worth/chart`，以前端單一 request、後端單一 D1 query 取得圖表需要的完整分類歷史，並排除未使用的 `total` 資料。
- 修正其他資產金額不足與各資產開始日期錯誤；尚未有估值的分類不再從 0 提前畫線。
- 修正分類模式的總和線樣式，使實際虛線與下方圖例一致。

## Architecture

- 資料流程：`Overview` → TanStack Query → `/api/history/net-worth/chart` → net-worth route → service → repository → D1。
- Repository 以單一 SQL 讀取股票、基金、存款與手動資產歷史；前端依資產 identity 延續最近估值，再計算所選分類總和。
- 原有分頁端點 `/api/history/net-worth` 保留不變，專用端點只服務圖表完整歷史需求。

## Breaking Changes (optional)

無。既有 API 契約、資料庫 schema 與設定皆未變更。

## Test & Risk

- `vitest run src/lib/net-worth-chart.test.ts --pool=threads --maxWorkers=1 --no-file-parallelism`：1 個 test file、5 項測試通過。
- `vitest run src/lib/api.test.ts --pool=threads --maxWorkers=1 --no-file-parallelism`：1 個 test file、3 項測試通過。
- `npm run typecheck -w @taiwan-fin-hub/worker`：通過。
- 變更檔案 Prettier check 與 `git diff --check origin/main...HEAD`：通過。
- Regression scope：總覽資產走勢的分類篩選、時間範圍、總和計算、圖例樣式，以及 net-worth history 查詢。
- 人工驗證重點：資料量持續增加時專用端點的回應大小；切換「全部」時各手動資產應從自己的第一筆估值日期開始影響其他資產總額。
- 尚未執行完整 `npm run verify:web`；本機實際端點已確認以一次 request 回傳完整圖表資料。

## Checklist

- [x] 代碼符合本專案風格 (Lint / Formatter 通過)
- [x] 自我 Review 並移除無用程式、除錯訊息
- [x] 文件 / Release Note 已更新
- [ ] 無新增 ESLint / Lint 警告
- [ ] 相依變更（API、DB、Config）已通知利害關係人
- [ ] 拼字檢查通過