### PR TITLE
新增具備欄位語意的 schema 資料字典產生流程

### DIFF
--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,0 +1,1047 @@
+# Database Schema
+
+> 此文件由 `npm run db:schema:docs` 自動產生，請勿直接編輯。
+>
+> Schema 來源是套用 `packages/db/migrations/*.sql` 後的隔離 local D1；不包含任何正式環境資料。
+> Wrangler 管理的 `d1_migrations` metadata table 刻意省略。
+> Table 與欄位的業務語意來自 `packages/db/schema-metadata.json`。
+
+## 目錄
+
+- Tables：20
+- Explicit indexes：30
+- Other objects：0
+- Migrations：13
+
+## Tables
+
+| Table | 用途 | Columns | Foreign keys | Indexes |
+| --- | --- | ---: | ---: | ---: |
+| [`bank_accounts`](#bank_accounts) | 各銀行與信用卡連接器同步回來的帳戶主檔；同一個實體帳戶可能同時存在多個來源記錄。 | 14 | 1 | 1 |
+| [`bank_balance_snapshots`](#bank_balance_snapshots) | 帳戶在特定時間點的餘額快照，供資產總值與歷史圖表計算。 | 15 | 1 | 2 |
+| [`bank_transaction_preferences`](#bank_transaction_preferences) | 使用者對銀行交易計算方式的個別偏好。 | 4 | 0 | 1 |
+| [`bank_transactions`](#bank_transactions) | 銀行帳戶、信用卡與其他存款型連接器同步回來的交易明細。 | 15 | 1 | 4 |
+| [`classification_categories`](#classification_categories) | 交易與發票使用的分類字典，包含系統預設分類與使用者分類。 | 6 | 0 | 1 |
+| [`classification_overrides`](#classification_overrides) | 使用者對單筆目標資料指定的分類覆寫。 | 6 | 1 | 1 |
+| [`classification_rules`](#classification_rules) | 以文字條件自動判斷交易或其他資料分類的規則。 | 14 | 1 | 2 |
+| [`connector_settings`](#connector_settings) | 每個外部金融資料連接器的認證設定、公開設定與同步游標。 | 7 | 0 | 0 |
+| [`credit_card_bills`](#credit_card_bills) | 信用卡依帳單週期整理的帳單主檔。 | 15 | 1 | 2 |
+| [`exchange_rates`](#exchange_rates) | 將外幣換算為新台幣時使用的最新匯率。 | 3 | 0 | 0 |
+| [`investment_positions`](#investment_positions) | 投資帳戶在特定日期的持倉與資產市值快照。 | 14 | 0 | 4 |
+| [`investment_transactions`](#investment_transactions) | 投資帳戶的買賣、配息或其他證券交易明細。 | 22 | 0 | 3 |
+| [`invoice_line_items`](#invoice_line_items) | 電子發票底下的商品或服務明細。 | 13 | 1 | 2 |
+| [`invoice_transaction_preferences`](#invoice_transaction_preferences) | 使用者對電子發票與銀行交易是否關聯的決策。 | 5 | 0 | 1 |
+| [`invoices`](#invoices) | 電子發票的抬頭與總額主檔。 | 10 | 0 | 2 |
+| [`manual_assets`](#manual_assets) | 使用者手動登錄、無法由銀行或投資連接器同步的資產。 | 5 | 0 | 0 |
+| [`net_worth_history`](#net_worth_history) | 按日期保存的淨資產或資產類別歷史數值，用於圖表與歷史查詢。 | 6 | 0 | 2 |
+| [`sync_jobs`](#sync_jobs) | 每個連接器與同步範圍的排程、鎖定狀態與最近執行結果。 | 19 | 0 | 1 |
+| [`sync_schedule_settings`](#sync_schedule_settings) | 所有使用 inherit 模式之同步工作的全域預設排程。 | 6 | 0 | 0 |
+| [`sync_write_staging`](#sync_write_staging) | 同步流程寫入正式資料表前的暫存資料。 | 5 | 0 | 1 |
+
+### `bank_accounts`
+
+> 用途：各銀行與信用卡連接器同步回來的帳戶主檔；同一個實體帳戶可能同時存在多個來源記錄。
+> 注意：canonical_account_id 為 NULL 的記錄是主要帳戶；有值的記錄是用於跨連接器對應的來源帳戶。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 系統內部使用的穩定帳戶識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `connector_id` | 建立此記錄的外部連接器識別碼。 | TEXT | NO | — | — | — |
+| 3 | `source_id` | 外部銀行或連接器提供的帳戶識別碼。 | TEXT | NO | — | — | — |
+| 4 | `institution_name` | 銀行、發卡機構或金融機構名稱。 | TEXT | YES | — | — | — |
+| 5 | `account_name` | 前端顯示用的帳戶名稱。 | TEXT | YES | — | — | — |
+| 6 | `account_type` | 帳戶類型，例如 checking、savings、credit 或 loan。 | TEXT | YES | — | — | — |
+| 7 | `currency` | 帳戶金額使用的幣別，預設為 TWD。 | TEXT | NO | 'TWD' | — | — |
+| 8 | `raw_payload` | 連接器回傳的原始或正規化 JSON，供除錯與重新解析使用。 | TEXT | YES | — | — | — |
+| 9 | `created_at` | 此帳戶記錄首次寫入的時間。 | TEXT | NO | — | — | — |
+| 10 | `updated_at` | 此帳戶記錄最後更新的時間。 | TEXT | NO | — | — | — |
+| 11 | `bank_code` | 金融機構代碼，用於跨連接器辨識同一帳戶。 | TEXT | YES | — | — | — |
+| 12 | `account_last4` | 帳號末四碼，用於顯示與帳戶比對。 | TEXT | YES | — | — | — |
+| 13 | `canonical_account_id` | 指向同一實體的主要帳戶；NULL 表示此記錄本身就是主要帳戶。 | TEXT | YES | — | — | — |
+| 14 | `credit_limit` | 信用卡或授信帳戶的額度；非授信帳戶通常為 NULL。 | INTEGER | YES | — | — | — |
+
+#### Foreign keys
+
+| 欄位 | 參照表 | 參照欄位 | ON UPDATE | ON DELETE |
+| --- | --- | --- | --- | --- |
+| `canonical_account_id` | `bank_accounts` | `id` | NO ACTION | NO ACTION |
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_bank_accounts_match` | 否 | 否 | `bank_code`, `account_last4`, `currency` | `CREATE INDEX idx_bank_accounts_match<br>  ON bank_accounts (bank_code, account_last4, currency)` |
+
+#### DDL
+
+```sql
+CREATE TABLE bank_accounts (
+  id TEXT PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  institution_name TEXT,
+  account_name TEXT,
+  account_type TEXT CHECK (
+    account_type IS NULL
+    OR account_type IN ('checking', 'savings', 'credit', 'loan', 'settlement_cash', 'stored_value', 'unknown')
+  ),
+  currency TEXT NOT NULL DEFAULT 'TWD',
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  bank_code TEXT,
+  account_last4 TEXT,
+  canonical_account_id TEXT REFERENCES bank_accounts (id), credit_limit INTEGER,
+  UNIQUE (connector_id, source_id)
+)
+```
+
+### `bank_balance_snapshots`
+
+> 用途：帳戶在特定時間點的餘額快照，供資產總值與歷史圖表計算。
+> 注意：同一帳戶可以有多個時間點的快照；查詢最新餘額時會依 as_of_at 與 updated_at 排序。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 餘額快照的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `connector_id` | 產生此快照的外部連接器識別碼。 | TEXT | NO | — | — | — |
+| 3 | `account_id` | 所屬 bank_accounts 記錄的識別碼。 | TEXT | NO | — | — | — |
+| 4 | `source_id` | 外部來源對此餘額或帳戶的識別碼。 | TEXT | NO | — | — | — |
+| 5 | `balance` | 連接器回報的帳戶餘額。 | INTEGER | NO | — | — | — |
+| 6 | `available_balance` | 可立即使用的餘額；部分金融機構不提供時為 NULL。 | INTEGER | YES | — | — | — |
+| 7 | `currency` | 餘額使用的幣別，預設為 TWD。 | TEXT | NO | 'TWD' | — | — |
+| 8 | `as_of_at` | 餘額實際觀測或結算的時間。 | TEXT | NO | — | — | — |
+| 9 | `raw_payload` | 連接器回傳的原始或正規化 JSON。 | TEXT | YES | — | — | — |
+| 10 | `created_at` | 此快照首次寫入的時間。 | TEXT | NO | — | — | — |
+| 11 | `updated_at` | 此快照最後更新的時間。 | TEXT | NO | — | — | — |
+| 12 | `statement_balance` | 信用卡帳單上的應繳金額。 | INTEGER | YES | — | — | — |
+| 13 | `payment_due_date` | 信用卡帳單繳款期限。 | TEXT | YES | — | — | — |
+| 14 | `no_payment_needed` | 是否標示為本期不需要繳款的旗標。 | INTEGER | YES | — | — | — |
+| 15 | `statement_closing_date` | 信用卡帳單結帳日。 | TEXT | YES | — | — | — |
+
+#### Foreign keys
+
+| 欄位 | 參照表 | 參照欄位 | ON UPDATE | ON DELETE |
+| --- | --- | --- | --- | --- |
+| `account_id` | `bank_accounts` | `id` | NO ACTION | NO ACTION |
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_bank_balance_snapshots_as_of` | 否 | 否 | `as_of_at` | `CREATE INDEX idx_bank_balance_snapshots_as_of<br>  ON bank_balance_snapshots (as_of_at)` |
+| `idx_bank_balance_snapshots_account_as_of` | 否 | 否 | `account_id`, `as_of_at` | `CREATE INDEX idx_bank_balance_snapshots_account_as_of<br>  ON bank_balance_snapshots (account_id, as_of_at)` |
+
+#### DDL
+
+```sql
+CREATE TABLE bank_balance_snapshots (
+  id TEXT PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  balance INTEGER NOT NULL,
+  available_balance INTEGER,
+  currency TEXT NOT NULL DEFAULT 'TWD',
+  as_of_at TEXT NOT NULL,
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL, statement_balance INTEGER, payment_due_date TEXT, no_payment_needed INTEGER, statement_closing_date TEXT,
+  UNIQUE (connector_id, account_id, source_id),
+  FOREIGN KEY (account_id) REFERENCES bank_accounts (id)
+)
+```
+
+### `bank_transaction_preferences`
+
+> 用途：使用者對銀行交易計算方式的個別偏好。
+> 注意：目前主要用來記錄交易是否排除於資產或支出計算之外；沒有偏好的交易不會建立記錄。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `transaction_id` | 套用偏好的 bank_transactions 記錄識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `excluded_from_calculation` | 是否將此交易排除於計算，0 表示納入、1 表示排除。 | INTEGER | NO | 0 | — | — |
+| 3 | `created_at` | 偏好首次建立的時間。 | TEXT | NO | — | — | — |
+| 4 | `updated_at` | 偏好最後更新的時間。 | TEXT | NO | — | — | — |
+
+#### Foreign keys
+
+—
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_bank_transaction_preferences_excluded` | 否 | 否 | `excluded_from_calculation` | `CREATE INDEX idx_bank_transaction_preferences_excluded<br>  ON bank_transaction_preferences (excluded_from_calculation)` |
+
+#### DDL
+
+```sql
+CREATE TABLE bank_transaction_preferences (
+  transaction_id TEXT PRIMARY KEY,
+  excluded_from_calculation INTEGER NOT NULL DEFAULT 0 CHECK (excluded_from_calculation IN (0, 1)),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+)
+```
+
+### `bank_transactions`
+
+> 用途：銀行帳戶、信用卡與其他存款型連接器同步回來的交易明細。
+> 注意：effective_date 統一有 posted_date 與 authorized_at 的交易排序；status 用來區分 pending 與 posted。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 交易的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `connector_id` | 產生此交易的外部連接器識別碼。 | TEXT | NO | — | — | — |
+| 3 | `account_id` | 所屬 bank_accounts 記錄的識別碼。 | TEXT | NO | — | — | — |
+| 4 | `source_id` | 外部來源系統提供的交易識別碼。 | TEXT | NO | — | — | — |
+| 5 | `posted_date` | 交易正式入帳的日期或時間；尚未入帳時可能為 NULL。 | TEXT | YES | — | — | — |
+| 6 | `authorized_at` | 交易授權或刷卡發生的時間。 | TEXT | YES | — | — | — |
+| 7 | `amount` | 交易金額；正負方向依連接器正規化規則表示。 | INTEGER | NO | — | — | — |
+| 8 | `currency` | 交易使用的幣別，預設為 TWD。 | TEXT | NO | 'TWD' | — | — |
+| 9 | `description` | 銀行或商店提供的交易說明。 | TEXT | YES | — | — | — |
+| 10 | `counterparty` | 交易對手、商店或收付款方名稱。 | TEXT | YES | — | — | — |
+| 11 | `raw_payload` | 連接器回傳的原始或正規化 JSON。 | TEXT | YES | — | — | — |
+| 12 | `created_at` | 交易首次寫入的時間。 | TEXT | NO | — | — | — |
+| 13 | `updated_at` | 交易最後更新的時間。 | TEXT | NO | — | — | — |
+| 14 | `effective_date` | 由 posted_date 優先、authorized_at 備援產生的查詢排序日期。 | TEXT | YES | — | — | virtual |
+| 15 | `status` | 交易狀態，目前限制為 pending 或 posted。 | TEXT | NO | 'posted' | — | — |
+
+#### Foreign keys
+
+| 欄位 | 參照表 | 參照欄位 | ON UPDATE | ON DELETE |
+| --- | --- | --- | --- | --- |
+| `account_id` | `bank_accounts` | `id` | NO ACTION | NO ACTION |
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_bank_transactions_status` | 否 | 否 | `connector_id`, `account_id`, `status` | `CREATE INDEX idx_bank_transactions_status<br>  ON bank_transactions (connector_id, account_id, status)` |
+| `idx_bank_transactions_effective_updated` | 否 | 否 | `effective_date`, `updated_at`, `id` | `CREATE INDEX idx_bank_transactions_effective_updated<br>  ON bank_transactions (effective_date DESC, updated_at DESC, id DESC)` |
+| `idx_bank_transactions_posted_date` | 否 | 否 | `posted_date` | `CREATE INDEX idx_bank_transactions_posted_date<br>  ON bank_transactions (posted_date)` |
+| `idx_bank_transactions_account_posted_date` | 否 | 否 | `account_id`, `posted_date` | `CREATE INDEX idx_bank_transactions_account_posted_date<br>  ON bank_transactions (account_id, posted_date)` |
+
+#### DDL
+
+```sql
+CREATE TABLE bank_transactions (
+  id TEXT PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  posted_date TEXT,
+  authorized_at TEXT,
+  amount INTEGER NOT NULL,
+  currency TEXT NOT NULL DEFAULT 'TWD',
+  description TEXT,
+  counterparty TEXT,
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL, effective_date TEXT AS (COALESCE(posted_date, authorized_at, '')), status TEXT NOT NULL DEFAULT 'posted'
+  CHECK (status IN ('pending', 'posted')),
+  UNIQUE (connector_id, account_id, source_id),
+  FOREIGN KEY (account_id) REFERENCES bank_accounts (id)
+)
+```
+
+### `classification_categories`
+
+> 用途：交易與發票使用的分類字典，包含系統預設分類與使用者分類。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 分類的穩定識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `label` | 前端顯示的分類名稱。 | TEXT | NO | — | — | — |
+| 3 | `sort_order` | 分類在介面中的排序順序。 | INTEGER | NO | 0 | — | — |
+| 4 | `is_system` | 是否為系統內建分類；1 表示不可視為一般使用者資料刪除。 | INTEGER | NO | 1 | — | — |
+| 5 | `created_at` | 分類建立的時間。 | TEXT | NO | — | — | — |
+| 6 | `updated_at` | 分類最後更新的時間。 | TEXT | NO | — | — | — |
+
+#### Foreign keys
+
+—
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_classification_categories_label_nocase` | 是 | 否 | `label` | `CREATE UNIQUE INDEX idx_classification_categories_label_nocase<br>  ON classification_categories (label COLLATE NOCASE)` |
+
+#### DDL
+
+```sql
+CREATE TABLE classification_categories (
+  id TEXT PRIMARY KEY,
+  label TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  is_system INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+)
+```
+
+### `classification_overrides`
+
+> 用途：使用者對單筆目標資料指定的分類覆寫。
+> 注意：同一個 target_type 與 target_id 只能有一個覆寫，優先於自動分類規則。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 覆寫記錄的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `target_type` | 被分類資料的類型，例如 bank_transaction。 | TEXT | NO | — | — | — |
+| 3 | `target_id` | 被分類資料的識別碼。 | TEXT | NO | — | — | — |
+| 4 | `category_id` | 指定的 classification_categories 識別碼。 | TEXT | NO | — | — | — |
+| 5 | `created_at` | 覆寫建立的時間。 | TEXT | NO | — | — | — |
+| 6 | `updated_at` | 覆寫最後更新的時間。 | TEXT | NO | — | — | — |
+
+#### Foreign keys
+
+| 欄位 | 參照表 | 參照欄位 | ON UPDATE | ON DELETE |
+| --- | --- | --- | --- | --- |
+| `category_id` | `classification_categories` | `id` | NO ACTION | NO ACTION |
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_classification_overrides_category` | 否 | 否 | `category_id` | `CREATE INDEX idx_classification_overrides_category<br>  ON classification_overrides (category_id)` |
+
+#### DDL
+
+```sql
+CREATE TABLE classification_overrides (
+  id TEXT PRIMARY KEY,
+  target_type TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  category_id TEXT NOT NULL REFERENCES classification_categories(id),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE (target_type, target_id)
+)
+```
+
+### `classification_rules`
+
+> 用途：以文字條件自動判斷交易或其他資料分類的規則。
+> 注意：規則依 enabled、target_type 與 priority 套用；system 規則由程式提供，user 規則可由使用者管理。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 規則的穩定識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `category_id` | 符合規則時套用的分類識別碼。 | TEXT | NO | — | — | — |
+| 3 | `target_type` | 規則適用的資料類型；NULL 表示可套用於共用目標。 | TEXT | YES | — | — | — |
+| 4 | `field` | 要比對的欄位或欄位集合，例如 any_text。 | TEXT | NO | — | — | — |
+| 5 | `operator` | 比對運算子，例如 regex。 | TEXT | NO | — | — | — |
+| 6 | `pattern` | 運算子使用的比對模式或關鍵字。 | TEXT | NO | — | — | — |
+| 7 | `priority` | 規則套用的優先序。 | INTEGER | NO | 100 | — | — |
+| 8 | `enabled` | 規則是否啟用，0 表示停用。 | INTEGER | NO | 1 | — | — |
+| 9 | `is_system` | 是否為系統內建規則。 | INTEGER | NO | 0 | — | — |
+| 10 | `source` | 規則來源，例如 system 或 user。 | TEXT | NO | 'user' | — | — |
+| 11 | `description` | 規則用途的可讀說明。 | TEXT | YES | — | — | — |
+| 12 | `created_at` | 規則建立的時間。 | TEXT | NO | — | — | — |
+| 13 | `updated_at` | 規則最後更新的時間。 | TEXT | NO | — | — | — |
+| 14 | `excluded_from_calculation` | 符合規則的交易是否預設排除於計算，0 表示納入、1 表示排除。 | INTEGER | NO | 0 | — | — |
+
+#### Foreign keys
+
+| 欄位 | 參照表 | 參照欄位 | ON UPDATE | ON DELETE |
+| --- | --- | --- | --- | --- |
+| `category_id` | `classification_categories` | `id` | NO ACTION | NO ACTION |
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_classification_rules_category` | 否 | 否 | `category_id` | `CREATE INDEX idx_classification_rules_category<br>  ON classification_rules (category_id)` |
+| `idx_classification_rules_enabled_priority` | 否 | 否 | `enabled`, `target_type`, `priority` | `CREATE INDEX idx_classification_rules_enabled_priority<br>  ON classification_rules (enabled, target_type, priority)` |
+
+#### DDL
+
+```sql
+CREATE TABLE classification_rules (
+  id TEXT PRIMARY KEY,
+  category_id TEXT NOT NULL REFERENCES classification_categories(id),
+  target_type TEXT,
+  field TEXT NOT NULL,
+  operator TEXT NOT NULL,
+  pattern TEXT NOT NULL,
+  priority INTEGER NOT NULL DEFAULT 100,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  is_system INTEGER NOT NULL DEFAULT 0,
+  source TEXT NOT NULL DEFAULT 'user',
+  description TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+, excluded_from_calculation INTEGER NOT NULL DEFAULT 0
+CHECK (excluded_from_calculation IN (0, 1)))
+```
+
+### `connector_settings`
+
+> 用途：每個外部金融資料連接器的認證設定、公開設定與同步游標。
+> 注意：encrypted_config 儲存敏感憑證；public_config 僅供非敏感的連接器設定使用。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 設定記錄的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `connector_id` | 連接器的穩定識別碼，每個連接器只有一筆設定。 | TEXT | NO | — | — | — |
+| 3 | `encrypted_config` | 使用 Worker 設定的金鑰加密後的認證與私密設定。 | TEXT | NO | — | — | — |
+| 4 | `sync_cursor` | 連接器下次增量同步使用的游標或狀態。 | TEXT | YES | — | — | — |
+| 5 | `created_at` | 連接器設定首次建立的時間。 | TEXT | NO | — | — | — |
+| 6 | `updated_at` | 連接器設定最後更新的時間。 | TEXT | NO | — | — | — |
+| 7 | `public_config` | 不含敏感資訊、可供前端或同步流程讀取的 JSON 設定。 | TEXT | YES | — | — | — |
+
+#### Foreign keys
+
+—
+
+#### Indexes
+
+—
+
+#### DDL
+
+```sql
+CREATE TABLE connector_settings (
+  id TEXT PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  encrypted_config TEXT NOT NULL,
+  sync_cursor TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL, public_config TEXT,
+  UNIQUE (connector_id)
+)
+```
+
+### `credit_card_bills`
+
+> 用途：信用卡依帳單週期整理的帳單主檔。
+> 注意：此表描述帳單，不是逐筆交易；逐筆刷卡資料仍位於 bank_transactions。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 帳單的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `connector_id` | 產生此帳單的外部連接器識別碼。 | TEXT | NO | — | — | — |
+| 3 | `account_id` | 所屬信用卡帳戶的 bank_accounts 識別碼。 | TEXT | NO | — | — | — |
+| 4 | `source_id` | 外部來源系統提供的帳單識別碼。 | TEXT | NO | — | — | — |
+| 5 | `billing_period` | 帳單週期，格式通常為 YYYY-MM。 | TEXT | NO | — | — | — |
+| 6 | `statement_amount` | 本期帳單總額。 | INTEGER | YES | — | — | — |
+| 7 | `minimum_payment` | 本期最低應繳金額。 | INTEGER | YES | — | — | — |
+| 8 | `paid_amount` | 目前已繳付的金額。 | INTEGER | YES | — | — | — |
+| 9 | `is_paid` | 帳單是否已繳清的旗標。 | INTEGER | YES | — | — | — |
+| 10 | `payment_due_date` | 帳單繳款期限。 | TEXT | YES | — | — | — |
+| 11 | `statement_closing_date` | 帳單結帳日。 | TEXT | YES | — | — | — |
+| 12 | `currency` | 帳單金額使用的幣別，預設為 TWD。 | TEXT | NO | 'TWD' | — | — |
+| 13 | `raw_payload` | 連接器回傳的原始或正規化 JSON。 | TEXT | YES | — | — | — |
+| 14 | `created_at` | 帳單首次寫入的時間。 | TEXT | NO | — | — | — |
+| 15 | `updated_at` | 帳單最後更新的時間。 | TEXT | NO | — | — | — |
+
+#### Foreign keys
+
+| 欄位 | 參照表 | 參照欄位 | ON UPDATE | ON DELETE |
+| --- | --- | --- | --- | --- |
+| `account_id` | `bank_accounts` | `id` | NO ACTION | NO ACTION |
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_credit_card_bills_page` | 否 | 否 | `billing_period`, `account_id`, `id` | `CREATE INDEX idx_credit_card_bills_page<br>  ON credit_card_bills (billing_period DESC, account_id ASC, id ASC)` |
+| `idx_credit_card_bills_account_period` | 否 | 否 | `account_id`, `billing_period` | `CREATE INDEX idx_credit_card_bills_account_period<br>  ON credit_card_bills (account_id, billing_period)` |
+
+#### DDL
+
+```sql
+CREATE TABLE credit_card_bills (
+  id TEXT PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  account_id TEXT NOT NULL REFERENCES bank_accounts(id),
+  source_id TEXT NOT NULL,
+  billing_period TEXT NOT NULL,
+  statement_amount INTEGER,
+  minimum_payment INTEGER,
+  paid_amount INTEGER,
+  is_paid INTEGER,
+  payment_due_date TEXT,
+  statement_closing_date TEXT,
+  currency TEXT NOT NULL DEFAULT 'TWD',
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(connector_id, account_id, billing_period)
+)
+```
+
+### `exchange_rates`
+
+> 用途：將外幣換算為新台幣時使用的最新匯率。
+> 注意：net_worth 計算會使用 rate_to_twd；找不到非 TWD 匯率時不會硬算。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `currency` | 外幣幣別代碼，也是此表的主鍵。 | TEXT | YES | — | 1 | — |
+| 2 | `rate_to_twd` | 一單位該幣別換算成 TWD 的匯率。 | REAL | NO | — | — | — |
+| 3 | `updated_at` | 匯率最後更新的時間。 | TEXT | NO | — | — | — |
+
+#### Foreign keys
+
+—
+
+#### Indexes
+
+—
+
+#### DDL
+
+```sql
+CREATE TABLE exchange_rates (
+  currency TEXT PRIMARY KEY,
+  rate_to_twd REAL NOT NULL,
+  updated_at TEXT NOT NULL
+)
+```
+
+### `investment_positions`
+
+> 用途：投資帳戶在特定日期的持倉與資產市值快照。
+> 注意：同一 connector、source 與日期可有一組持倉；最新持倉與分頁查詢依 as_of_date。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 持倉快照的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `connector_id` | 產生此持倉的外部連接器識別碼。 | TEXT | NO | — | — | — |
+| 3 | `source_id` | 外部來源系統提供的持倉識別碼。 | TEXT | NO | — | — | — |
+| 4 | `asset_type` | 資產類型，目前限制為 stock、etf 或 fund。 | TEXT | NO | — | — | — |
+| 5 | `symbol` | 證券、基金或 ETF 的代號。 | TEXT | YES | — | — | — |
+| 6 | `name` | 投資標的名稱。 | TEXT | NO | — | — | — |
+| 7 | `quantity` | 持有數量。 | REAL | YES | — | — | — |
+| 8 | `market_value` | 持倉的市場價值。 | INTEGER | YES | — | — | — |
+| 9 | `cash_balance` | 此投資帳戶或資產項目中的現金餘額。 | INTEGER | YES | — | — | — |
+| 10 | `currency` | 市值與現金使用的幣別，預設為 TWD。 | TEXT | NO | 'TWD' | — | — |
+| 11 | `as_of_date` | 持倉快照所代表的日期。 | TEXT | NO | — | — | — |
+| 12 | `raw_payload` | 連接器回傳的原始或正規化 JSON。 | TEXT | YES | — | — | — |
+| 13 | `created_at` | 持倉首次寫入的時間。 | TEXT | NO | — | — | — |
+| 14 | `updated_at` | 持倉最後更新的時間。 | TEXT | NO | — | — | — |
+
+#### Foreign keys
+
+—
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_investment_positions_page` | 否 | 否 | `as_of_date`, `asset_type`, `name`, `id` | `CREATE INDEX idx_investment_positions_page<br>  ON investment_positions (as_of_date DESC, asset_type ASC, name ASC, id ASC)` |
+| `idx_investment_positions_latest_scope` | 否 | 否 | `connector_id`, `asset_type`, `as_of_date` | `CREATE INDEX idx_investment_positions_latest_scope<br>  ON investment_positions (connector_id, asset_type, as_of_date DESC)` |
+| `idx_investment_positions_asset_type` | 否 | 否 | `asset_type` | `CREATE INDEX idx_investment_positions_asset_type<br>  ON investment_positions (asset_type)` |
+| `idx_investment_positions_as_of_date` | 否 | 否 | `as_of_date` | `CREATE INDEX idx_investment_positions_as_of_date<br>  ON investment_positions (as_of_date)` |
+
+#### DDL
+
+```sql
+CREATE TABLE investment_positions (
+  id TEXT PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  asset_type TEXT NOT NULL CHECK (asset_type IN ('stock', 'etf', 'fund')),
+  symbol TEXT,
+  name TEXT NOT NULL,
+  quantity REAL,
+  market_value INTEGER,
+  cash_balance INTEGER,
+  currency TEXT NOT NULL DEFAULT 'TWD',
+  as_of_date TEXT NOT NULL,
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE (connector_id, source_id, as_of_date)
+)
+```
+
+### `investment_transactions`
+
+> 用途：投資帳戶的買賣、配息或其他證券交易明細。
+> 注意：account_id 是外部投資帳戶識別碼，不直接 FK 到 bank_accounts；effective_date 用於列表排序。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 投資交易的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `connector_id` | 產生此交易的外部連接器識別碼。 | TEXT | NO | — | — | — |
+| 3 | `account_id` | 外部券商或投資帳戶識別碼。 | TEXT | NO | — | — | — |
+| 4 | `source_id` | 外部來源系統提供的交易識別碼。 | TEXT | NO | — | — | — |
+| 5 | `broker_no` | 券商或分公司代碼。 | TEXT | YES | — | — | — |
+| 6 | `broker_account` | 券商帳號或交割帳號。 | TEXT | YES | — | — | — |
+| 7 | `broker_name` | 券商或交易機構名稱。 | TEXT | YES | — | — | — |
+| 8 | `symbol` | 交易標的代號。 | TEXT | YES | — | — | — |
+| 9 | `name` | 交易標的名稱。 | TEXT | YES | — | — | — |
+| 10 | `asset_type` | 資產類型，例如 stock、etf、fund、bond 或 unknown。 | TEXT | YES | — | — | — |
+| 11 | `trade_date` | 交易發生日期。 | TEXT | YES | — | — | — |
+| 12 | `posted_date` | 交易正式入帳日期。 | TEXT | YES | — | — | — |
+| 13 | `transaction_code` | 外部系統的交易類型代碼。 | TEXT | YES | — | — | — |
+| 14 | `transaction_name` | 外部系統的交易類型名稱。 | TEXT | YES | — | — | — |
+| 15 | `quantity` | 交易數量。 | REAL | YES | — | — | — |
+| 16 | `price` | 每單位成交或計算價格。 | REAL | YES | — | — | — |
+| 17 | `amount` | 交易總金額。 | INTEGER | YES | — | — | — |
+| 18 | `currency` | 交易金額使用的幣別，預設為 TWD。 | TEXT | NO | 'TWD' | — | — |
+| 19 | `raw_payload` | 連接器回傳的原始或正規化 JSON。 | TEXT | YES | — | — | — |
+| 20 | `created_at` | 交易首次寫入的時間。 | TEXT | NO | — | — | — |
+| 21 | `updated_at` | 交易最後更新的時間。 | TEXT | NO | — | — | — |
+| 22 | `effective_date` | 由 trade_date 優先、posted_date 備援產生的排序日期。 | TEXT | YES | — | — | virtual |
+
+#### Foreign keys
+
+—
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_investment_transactions_effective_updated` | 否 | 否 | `effective_date`, `updated_at`, `id` | `CREATE INDEX idx_investment_transactions_effective_updated<br>  ON investment_transactions (effective_date DESC, updated_at DESC, id DESC)` |
+| `idx_investment_transactions_symbol` | 否 | 否 | `symbol` | `CREATE INDEX idx_investment_transactions_symbol<br>  ON investment_transactions (symbol)` |
+| `idx_investment_transactions_trade_date` | 否 | 否 | `trade_date` | `CREATE INDEX idx_investment_transactions_trade_date<br>  ON investment_transactions (trade_date)` |
+
+#### DDL
+
+```sql
+CREATE TABLE investment_transactions (
+  id TEXT PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  broker_no TEXT,
+  broker_account TEXT,
+  broker_name TEXT,
+  symbol TEXT,
+  name TEXT,
+  asset_type TEXT CHECK (asset_type IN ('stock', 'etf', 'fund', 'bond', 'unknown')),
+  trade_date TEXT,
+  posted_date TEXT,
+  transaction_code TEXT,
+  transaction_name TEXT,
+  quantity REAL,
+  price REAL,
+  amount INTEGER,
+  currency TEXT NOT NULL DEFAULT 'TWD',
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL, effective_date TEXT AS (COALESCE(trade_date, posted_date, '')),
+  UNIQUE (connector_id, account_id, source_id)
+)
+```
+
+### `invoice_line_items`
+
+> 用途：電子發票底下的商品或服務明細。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 發票明細的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `invoice_id` | 所屬 invoices 記錄的識別碼。 | TEXT | NO | — | — | — |
+| 3 | `connector_id` | 取得此明細的外部連接器識別碼。 | TEXT | NO | — | — | — |
+| 4 | `invoice_source_id` | 外部來源發票識別碼，用於同步比對。 | TEXT | NO | — | — | — |
+| 5 | `source_id` | 外部來源明細識別碼。 | TEXT | NO | — | — | — |
+| 6 | `line_number` | 明細在發票中的順序。 | INTEGER | NO | — | — | — |
+| 7 | `description` | 商品或服務描述。 | TEXT | NO | — | — | — |
+| 8 | `quantity` | 購買數量。 | REAL | YES | — | — | — |
+| 9 | `unit_price` | 單位價格。 | INTEGER | YES | — | — | — |
+| 10 | `amount` | 此明細的小計金額。 | INTEGER | NO | — | — | — |
+| 11 | `raw_payload` | 連接器回傳的原始或正規化 JSON。 | TEXT | YES | — | — | — |
+| 12 | `created_at` | 明細首次寫入的時間。 | TEXT | NO | — | — | — |
+| 13 | `updated_at` | 明細最後更新的時間。 | TEXT | NO | — | — | — |
+
+#### Foreign keys
+
+| 欄位 | 參照表 | 參照欄位 | ON UPDATE | ON DELETE |
+| --- | --- | --- | --- | --- |
+| `invoice_id` | `invoices` | `id` | NO ACTION | CASCADE |
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_invoice_line_items_invoice_source` | 否 | 否 | `connector_id`, `invoice_source_id` | `CREATE INDEX idx_invoice_line_items_invoice_source<br>  ON invoice_line_items (connector_id, invoice_source_id)` |
+| `idx_invoice_line_items_invoice_id` | 否 | 否 | `invoice_id` | `CREATE INDEX idx_invoice_line_items_invoice_id<br>  ON invoice_line_items (invoice_id)` |
+
+#### DDL
+
+```sql
+CREATE TABLE invoice_line_items (
+  id TEXT PRIMARY KEY,
+  invoice_id TEXT NOT NULL,
+  connector_id TEXT NOT NULL,
+  invoice_source_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  line_number INTEGER NOT NULL,
+  description TEXT NOT NULL,
+  quantity REAL,
+  unit_price INTEGER,
+  amount INTEGER NOT NULL,
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE CASCADE,
+  UNIQUE (connector_id, invoice_source_id, source_id)
+)
+```
+
+### `invoice_transaction_preferences`
+
+> 用途：使用者對電子發票與銀行交易是否關聯的決策。
+> 注意：decision=linked 時 transaction_id 必須存在；decision=separate 表示刻意維持兩筆獨立資料。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `invoice_id` | 套用決策的 invoices 記錄識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `transaction_id` | 被關聯的 bank_transactions 識別碼；separate 時為 NULL。 | TEXT | YES | — | — | — |
+| 3 | `decision` | 關聯決策，目前限制為 linked 或 separate。 | TEXT | NO | — | — | — |
+| 4 | `created_at` | 決策首次建立的時間。 | TEXT | NO | — | — | — |
+| 5 | `updated_at` | 決策最後更新的時間。 | TEXT | NO | — | — | — |
+
+#### Foreign keys
+
+—
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_invoice_transaction_preferences_linked_transaction` | 是 | 是 | `transaction_id` | `CREATE UNIQUE INDEX idx_invoice_transaction_preferences_linked_transaction<br>  ON invoice_transaction_preferences (transaction_id)<br>  WHERE decision = 'linked'` |
+
+#### DDL
+
+```sql
+CREATE TABLE invoice_transaction_preferences (
+  invoice_id TEXT PRIMARY KEY,
+  transaction_id TEXT,
+  decision TEXT NOT NULL CHECK (decision IN ('linked', 'separate')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  CHECK (
+    (decision = 'linked' AND transaction_id IS NOT NULL)
+    OR decision = 'separate'
+  )
+)
+```
+
+### `invoices`
+
+> 用途：電子發票的抬頭與總額主檔。
+> 注意：商品明細另存於 invoice_line_items；同一 connector 與 source_id 只保留一張發票。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 發票的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `connector_id` | 取得此發票的外部連接器識別碼。 | TEXT | NO | — | — | — |
+| 3 | `source_id` | 外部來源系統提供的發票識別碼。 | TEXT | NO | — | — | — |
+| 4 | `invoice_number` | 發票字軌號碼或發票號碼。 | TEXT | YES | — | — | — |
+| 5 | `invoice_date` | 發票開立日期。 | TEXT | NO | — | — | — |
+| 6 | `seller_name` | 賣方或開立人名稱。 | TEXT | YES | — | — | — |
+| 7 | `amount` | 發票總金額。 | INTEGER | NO | — | — | — |
+| 8 | `raw_payload` | 連接器回傳的原始或正規化 JSON。 | TEXT | YES | — | — | — |
+| 9 | `created_at` | 發票首次寫入的時間。 | TEXT | NO | — | — | — |
+| 10 | `updated_at` | 發票最後更新的時間。 | TEXT | NO | — | — | — |
+
+#### Foreign keys
+
+—
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_invoices_page` | 否 | 否 | `invoice_date`, `updated_at`, `id` | `CREATE INDEX idx_invoices_page<br>  ON invoices (invoice_date DESC, updated_at DESC, id DESC)` |
+| `idx_invoices_invoice_date` | 否 | 否 | `invoice_date` | `CREATE INDEX idx_invoices_invoice_date<br>  ON invoices (invoice_date)` |
+
+#### DDL
+
+```sql
+CREATE TABLE invoices (
+  id TEXT PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  invoice_number TEXT,
+  invoice_date TEXT NOT NULL,
+  seller_name TEXT,
+  amount INTEGER NOT NULL,
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE (connector_id, source_id)
+)
+```
+
+### `manual_assets`
+
+> 用途：使用者手動登錄、無法由銀行或投資連接器同步的資產。
+> 注意：資產目前的金額與歷史值存於 net_worth_history，asset_type 對應此表的 id。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 手動資產的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `name` | 前端顯示的資產名稱。 | TEXT | NO | — | — | — |
+| 3 | `category` | 資產分類，例如房產、現金或其他。 | TEXT | NO | — | — | — |
+| 4 | `note` | 使用者補充的備註。 | TEXT | YES | — | — | — |
+| 5 | `created_at` | 手動資產建立的時間。 | TEXT | NO | — | — | — |
+
+#### Foreign keys
+
+—
+
+#### Indexes
+
+—
+
+#### DDL
+
+```sql
+CREATE TABLE manual_assets (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  category TEXT NOT NULL,
+  note TEXT,
+  created_at TEXT NOT NULL
+)
+```
+
+### `net_worth_history`
+
+> 用途：按日期保存的淨資產或資產類別歷史數值，用於圖表與歷史查詢。
+> 注意：這是由銀行餘額、投資持倉與手動資產等來源整理出的讀模型，不是單一連接器的原始資料。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 歷史點的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 2 | `date` | 此數值所代表的日期。 | TEXT | NO | — | — | — |
+| 3 | `net_worth` | 該日期與資產類型的金額，通常以 TWD 表示。 | INTEGER | NO | — | — | — |
+| 4 | `asset_type` | 資產類型，例如 total、deposit、stock、fund 或手動資產 id。 | TEXT | NO | 'total' | — | — |
+| 5 | `source` | 數值來源，例如 bank 或 manual。 | TEXT | NO | — | — | — |
+| 6 | `snapshotted_at` | 此歷史點實際建立或重算的時間。 | TEXT | NO | — | — | — |
+
+#### Foreign keys
+
+—
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_net_worth_history_page` | 否 | 否 | `date`, `source`, `asset_type`, `id` | `CREATE INDEX idx_net_worth_history_page<br>  ON net_worth_history (date DESC, source ASC, asset_type ASC, id ASC)` |
+| `idx_net_worth_history_date` | 否 | 否 | `date` | `CREATE INDEX idx_net_worth_history_date<br>  ON net_worth_history (date)` |
+
+#### DDL
+
+```sql
+CREATE TABLE net_worth_history (
+  id TEXT PRIMARY KEY,
+  date TEXT NOT NULL,
+  net_worth INTEGER NOT NULL,
+  asset_type TEXT NOT NULL DEFAULT 'total',
+  source TEXT NOT NULL,
+  snapshotted_at TEXT NOT NULL,
+  UNIQUE (source, asset_type, date)
+)
+```
+
+### `sync_jobs`
+
+> 用途：每個連接器與同步範圍的排程、鎖定狀態與最近執行結果。
+> 注意：Worker Cron 會依 next_run_at 找到工作並取得 lease；locked_* 欄位用來避免同一工作重複執行。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 同步工作的系統識別碼，通常由 connector_id 與 scope 組成。 | TEXT | YES | — | 1 | — |
+| 2 | `connector_id` | 要執行同步的連接器識別碼。 | TEXT | NO | — | — | — |
+| 3 | `scope` | 同步範圍，例如 all 或特定帳戶範圍。 | TEXT | NO | — | — | — |
+| 4 | `enabled` | 是否啟用此同步工作。 | INTEGER | NO | 1 | — | — |
+| 5 | `interval_minutes` | 同步間隔，單位為分鐘。 | INTEGER | NO | — | — | — |
+| 6 | `next_run_at` | 下一次允許執行的時間。 | TEXT | NO | — | — | — |
+| 7 | `locked_until` | 目前 lease 鎖定到期時間。 | TEXT | YES | — | — | — |
+| 8 | `locked_by` | 取得 lease 的同步執行識別碼。 | TEXT | YES | — | — | — |
+| 9 | `lock_trigger` | 取得鎖定的觸發來源，例如 manual 或 scheduled。 | TEXT | YES | — | — | — |
+| 10 | `lock_scope` | 此次執行實際鎖定的細部範圍。 | TEXT | YES | — | — | — |
+| 11 | `last_run_at` | 最近一次開始執行的時間。 | TEXT | YES | — | — | — |
+| 12 | `last_success_at` | 最近一次成功完成的時間。 | TEXT | YES | — | — | — |
+| 13 | `last_status` | 最近一次結果，例如 success、failed 或 needs_user_action。 | TEXT | YES | — | — | — |
+| 14 | `last_error` | 最近一次失敗或需要使用者處理的錯誤訊息。 | TEXT | YES | — | — | — |
+| 15 | `created_at` | 同步工作建立的時間。 | TEXT | NO | — | — | — |
+| 16 | `updated_at` | 同步工作最後更新的時間。 | TEXT | NO | — | — | — |
+| 17 | `schedule_mode` | 排程模式；inherit 使用全域設定，custom 使用工作自己的設定。 | TEXT | NO | 'inherit' | — | — |
+| 18 | `preferred_time` | 每日或每週排程偏好的台北時間。 | TEXT | NO | '06:00' | — | — |
+| 19 | `preferred_weekday` | 每週排程的星期，0 代表週日、6 代表週六。 | INTEGER | NO | 1 | — | — |
+
+#### Foreign keys
+
+—
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_sync_jobs_due` | 否 | 否 | `enabled`, `next_run_at` | `CREATE INDEX idx_sync_jobs_due<br>  ON sync_jobs (enabled, next_run_at)` |
+
+#### DDL
+
+```sql
+CREATE TABLE sync_jobs (
+  id TEXT PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  scope TEXT NOT NULL,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  interval_minutes INTEGER NOT NULL,
+  next_run_at TEXT NOT NULL,
+  locked_until TEXT,
+  locked_by TEXT,
+  lock_trigger TEXT CHECK (lock_trigger IS NULL OR lock_trigger IN ('manual', 'scheduled')),
+  lock_scope TEXT,
+  last_run_at TEXT,
+  last_success_at TEXT,
+  last_status TEXT,
+  last_error TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL, schedule_mode TEXT NOT NULL DEFAULT 'inherit'
+  CHECK (schedule_mode IN ('inherit', 'custom')), preferred_time TEXT NOT NULL DEFAULT '06:00', preferred_weekday INTEGER NOT NULL DEFAULT 1
+  CHECK (preferred_weekday BETWEEN 0 AND 6),
+  UNIQUE (connector_id, scope)
+)
+```
+
+### `sync_schedule_settings`
+
+> 用途：所有使用 inherit 模式之同步工作的全域預設排程。
+> 注意：id 固定為 default；修改設定時會同步重算繼承此設定的 sync_jobs。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `id` | 設定識別碼，固定為 default。 | TEXT | YES | — | 1 | — |
+| 2 | `interval_minutes` | 預設同步間隔，單位為分鐘。 | INTEGER | NO | — | — | — |
+| 3 | `preferred_time` | 預設每日或每週執行時間，使用台北時間。 | TEXT | NO | — | — | — |
+| 4 | `timezone` | 排程使用的時區，目前為 Asia/Taipei。 | TEXT | NO | — | — | — |
+| 5 | `updated_at` | 全域排程最後更新的時間。 | TEXT | NO | — | — | — |
+| 6 | `preferred_weekday` | 每週排程的預設星期，0 代表週日、6 代表週六。 | INTEGER | NO | 1 | — | — |
+
+#### Foreign keys
+
+—
+
+#### Indexes
+
+—
+
+#### DDL
+
+```sql
+CREATE TABLE sync_schedule_settings (
+  id TEXT PRIMARY KEY CHECK (id = 'default'),
+  interval_minutes INTEGER NOT NULL,
+  preferred_time TEXT NOT NULL,
+  timezone TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+, preferred_weekday INTEGER NOT NULL DEFAULT 1
+  CHECK (preferred_weekday BETWEEN 0 AND 6))
+```
+
+### `sync_write_staging`
+
+> 用途：同步流程寫入正式資料表前的暫存資料。
+> 注意：payload 必須是合法 JSON；同步完成或失敗後會清理，避免部分同步結果直接暴露為正式資料。
+
+#### Columns
+
+| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
+| ---: | --- | --- | --- | :---: | --- | ---: | --- |
+| 1 | `run_id` | 此次同步執行的識別碼。 | TEXT | NO | — | 1 | — |
+| 2 | `entity_type` | 暫存資料的實體類型，例如 bank_transaction。 | TEXT | NO | — | 2 | — |
+| 3 | `record_key` | 該實體在此次同步中的去重與覆寫鍵。 | TEXT | NO | — | 3 | — |
+| 4 | `payload` | 待寫入正式表的正規化 JSON 資料。 | TEXT | NO | — | — | — |
+| 5 | `created_at` | 暫存資料建立的時間。 | TEXT | NO | — | — | — |
+
+#### Foreign keys
+
+—
+
+#### Indexes
+
+| Index | Unique | Partial | 欄位 | 定義 |
+| --- | :---: | :---: | --- | --- |
+| `idx_sync_write_staging_created_at` | 否 | 否 | `created_at` | `CREATE INDEX idx_sync_write_staging_created_at<br>  ON sync_write_staging (created_at)` |
+
+#### DDL
+
+```sql
+CREATE TABLE sync_write_staging (
+  run_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  record_key TEXT NOT NULL,
+  payload TEXT NOT NULL CHECK (json_valid(payload)),
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (run_id, entity_type, record_key)
+)
+```
+
+## Other database objects
+
+目前沒有 view 或 trigger。
+
+## Migration history
+
+Migration 是 schema 演進的 source of truth；若要了解某欄位的變更原因，請從對應 migration 檔案與 Git history 追查。
+
+- [`0001_initial.sql`](../packages/db/migrations/0001_initial.sql)
+- [`0002_bank_account_credit.sql`](../packages/db/migrations/0002_bank_account_credit.sql)
+- [`0003_sync_jobs.sql`](../packages/db/migrations/0003_sync_jobs.sql)
+- [`0004_sync_job_defaults.sql`](../packages/db/migrations/0004_sync_job_defaults.sql)
+- [`0005_sinopac_sync_job.sql`](../packages/db/migrations/0005_sinopac_sync_job.sql)
+- [`0006_sinopac_app_json_cleanup.sql`](../packages/db/migrations/0006_sinopac_app_json_cleanup.sql)
+- [`0008_default_sync_schedule.sql`](../packages/db/migrations/0008_default_sync_schedule.sql)
+- [`0009_weekly_sync_weekday.sql`](../packages/db/migrations/0009_weekly_sync_weekday.sql)
+- [`0010_bank_transaction_preferences.sql`](../packages/db/migrations/0010_bank_transaction_preferences.sql)
+- [`0011_classification_rule_actions.sql`](../packages/db/migrations/0011_classification_rule_actions.sql)
+- [`0012_sync_staging_and_query_indexes.sql`](../packages/db/migrations/0012_sync_staging_and_query_indexes.sql)
+- [`0013_invoice_transaction_preferences.sql`](../packages/db/migrations/0013_invoice_transaction_preferences.sql)
+- [`0014_bank_transaction_status.sql`](../packages/db/migrations/0014_bank_transaction_status.sql)
+
+## 程式碼導覽
+
+- Feature-specific SQL：`apps/worker/src/features/*/repository.ts`
+- 共用 D1 能力：`packages/db/src/`
+- 共用資料契約：`packages/core/`

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "dev": "npm run dev -w @taiwan-fin-hub/worker",
     "deploy": "npm run db:migrate:remote && XDG_CONFIG_HOME=.wrangler-config wrangler deploy",
     "db:migrate:local": "XDG_CONFIG_HOME=.wrangler-config wrangler d1 migrations apply DB --local",
-    "db:migrate:remote": "XDG_CONFIG_HOME=.wrangler-config wrangler d1 migrations apply DB --remote"
+    "db:migrate:remote": "XDG_CONFIG_HOME=.wrangler-config wrangler d1 migrations apply DB --remote",
+    "db:schema:docs": "node scripts/generate-database-schema.mjs"
   },
   "cloudflare": {
     "bindings": {

--- a/packages/db/schema-metadata.json
+++ b/packages/db/schema-metadata.json
@@ -1,0 +1,326 @@
+{
+  "tables": {
+    "bank_accounts": {
+      "description": "各銀行與信用卡連接器同步回來的帳戶主檔；同一個實體帳戶可能同時存在多個來源記錄。",
+      "notes": "canonical_account_id 為 NULL 的記錄是主要帳戶；有值的記錄是用於跨連接器對應的來源帳戶。",
+      "columns": {
+        "id": "系統內部使用的穩定帳戶識別碼。",
+        "connector_id": "建立此記錄的外部連接器識別碼。",
+        "source_id": "外部銀行或連接器提供的帳戶識別碼。",
+        "institution_name": "銀行、發卡機構或金融機構名稱。",
+        "account_name": "前端顯示用的帳戶名稱。",
+        "account_type": "帳戶類型，例如 checking、savings、credit 或 loan。",
+        "currency": "帳戶金額使用的幣別，預設為 TWD。",
+        "raw_payload": "連接器回傳的原始或正規化 JSON，供除錯與重新解析使用。",
+        "created_at": "此帳戶記錄首次寫入的時間。",
+        "updated_at": "此帳戶記錄最後更新的時間。",
+        "bank_code": "金融機構代碼，用於跨連接器辨識同一帳戶。",
+        "account_last4": "帳號末四碼，用於顯示與帳戶比對。",
+        "canonical_account_id": "指向同一實體的主要帳戶；NULL 表示此記錄本身就是主要帳戶。",
+        "credit_limit": "信用卡或授信帳戶的額度；非授信帳戶通常為 NULL。"
+      }
+    },
+    "bank_balance_snapshots": {
+      "description": "帳戶在特定時間點的餘額快照，供資產總值與歷史圖表計算。",
+      "notes": "同一帳戶可以有多個時間點的快照；查詢最新餘額時會依 as_of_at 與 updated_at 排序。",
+      "columns": {
+        "id": "餘額快照的系統識別碼。",
+        "connector_id": "產生此快照的外部連接器識別碼。",
+        "account_id": "所屬 bank_accounts 記錄的識別碼。",
+        "source_id": "外部來源對此餘額或帳戶的識別碼。",
+        "balance": "連接器回報的帳戶餘額。",
+        "available_balance": "可立即使用的餘額；部分金融機構不提供時為 NULL。",
+        "currency": "餘額使用的幣別，預設為 TWD。",
+        "as_of_at": "餘額實際觀測或結算的時間。",
+        "raw_payload": "連接器回傳的原始或正規化 JSON。",
+        "created_at": "此快照首次寫入的時間。",
+        "updated_at": "此快照最後更新的時間。",
+        "statement_balance": "信用卡帳單上的應繳金額。",
+        "payment_due_date": "信用卡帳單繳款期限。",
+        "no_payment_needed": "是否標示為本期不需要繳款的旗標。",
+        "statement_closing_date": "信用卡帳單結帳日。"
+      }
+    },
+    "bank_transaction_preferences": {
+      "description": "使用者對銀行交易計算方式的個別偏好。",
+      "notes": "目前主要用來記錄交易是否排除於資產或支出計算之外；沒有偏好的交易不會建立記錄。",
+      "columns": {
+        "transaction_id": "套用偏好的 bank_transactions 記錄識別碼。",
+        "excluded_from_calculation": "是否將此交易排除於計算，0 表示納入、1 表示排除。",
+        "created_at": "偏好首次建立的時間。",
+        "updated_at": "偏好最後更新的時間。"
+      }
+    },
+    "bank_transactions": {
+      "description": "銀行帳戶、信用卡與其他存款型連接器同步回來的交易明細。",
+      "notes": "effective_date 統一有 posted_date 與 authorized_at 的交易排序；status 用來區分 pending 與 posted。",
+      "columns": {
+        "id": "交易的系統識別碼。",
+        "connector_id": "產生此交易的外部連接器識別碼。",
+        "account_id": "所屬 bank_accounts 記錄的識別碼。",
+        "source_id": "外部來源系統提供的交易識別碼。",
+        "posted_date": "交易正式入帳的日期或時間；尚未入帳時可能為 NULL。",
+        "authorized_at": "交易授權或刷卡發生的時間。",
+        "amount": "交易金額；正負方向依連接器正規化規則表示。",
+        "currency": "交易使用的幣別，預設為 TWD。",
+        "description": "銀行或商店提供的交易說明。",
+        "counterparty": "交易對手、商店或收付款方名稱。",
+        "raw_payload": "連接器回傳的原始或正規化 JSON。",
+        "created_at": "交易首次寫入的時間。",
+        "updated_at": "交易最後更新的時間。",
+        "effective_date": "由 posted_date 優先、authorized_at 備援產生的查詢排序日期。",
+        "status": "交易狀態，目前限制為 pending 或 posted。"
+      }
+    },
+    "classification_categories": {
+      "description": "交易與發票使用的分類字典，包含系統預設分類與使用者分類。",
+      "columns": {
+        "id": "分類的穩定識別碼。",
+        "label": "前端顯示的分類名稱。",
+        "sort_order": "分類在介面中的排序順序。",
+        "is_system": "是否為系統內建分類；1 表示不可視為一般使用者資料刪除。",
+        "created_at": "分類建立的時間。",
+        "updated_at": "分類最後更新的時間。"
+      }
+    },
+    "classification_overrides": {
+      "description": "使用者對單筆目標資料指定的分類覆寫。",
+      "notes": "同一個 target_type 與 target_id 只能有一個覆寫，優先於自動分類規則。",
+      "columns": {
+        "id": "覆寫記錄的系統識別碼。",
+        "target_type": "被分類資料的類型，例如 bank_transaction。",
+        "target_id": "被分類資料的識別碼。",
+        "category_id": "指定的 classification_categories 識別碼。",
+        "created_at": "覆寫建立的時間。",
+        "updated_at": "覆寫最後更新的時間。"
+      }
+    },
+    "classification_rules": {
+      "description": "以文字條件自動判斷交易或其他資料分類的規則。",
+      "notes": "規則依 enabled、target_type 與 priority 套用；system 規則由程式提供，user 規則可由使用者管理。",
+      "columns": {
+        "id": "規則的穩定識別碼。",
+        "category_id": "符合規則時套用的分類識別碼。",
+        "target_type": "規則適用的資料類型；NULL 表示可套用於共用目標。",
+        "field": "要比對的欄位或欄位集合，例如 any_text。",
+        "operator": "比對運算子，例如 regex。",
+        "pattern": "運算子使用的比對模式或關鍵字。",
+        "priority": "規則套用的優先序。",
+        "enabled": "規則是否啟用，0 表示停用。",
+        "is_system": "是否為系統內建規則。",
+        "source": "規則來源，例如 system 或 user。",
+        "description": "規則用途的可讀說明。",
+        "created_at": "規則建立的時間。",
+        "updated_at": "規則最後更新的時間。",
+        "excluded_from_calculation": "符合規則的交易是否預設排除於計算，0 表示納入、1 表示排除。"
+      }
+    },
+    "connector_settings": {
+      "description": "每個外部金融資料連接器的認證設定、公開設定與同步游標。",
+      "notes": "encrypted_config 儲存敏感憑證；public_config 僅供非敏感的連接器設定使用。",
+      "columns": {
+        "id": "設定記錄的系統識別碼。",
+        "connector_id": "連接器的穩定識別碼，每個連接器只有一筆設定。",
+        "encrypted_config": "使用 Worker 設定的金鑰加密後的認證與私密設定。",
+        "sync_cursor": "連接器下次增量同步使用的游標或狀態。",
+        "created_at": "連接器設定首次建立的時間。",
+        "updated_at": "連接器設定最後更新的時間。",
+        "public_config": "不含敏感資訊、可供前端或同步流程讀取的 JSON 設定。"
+      }
+    },
+    "credit_card_bills": {
+      "description": "信用卡依帳單週期整理的帳單主檔。",
+      "notes": "此表描述帳單，不是逐筆交易；逐筆刷卡資料仍位於 bank_transactions。",
+      "columns": {
+        "id": "帳單的系統識別碼。",
+        "connector_id": "產生此帳單的外部連接器識別碼。",
+        "account_id": "所屬信用卡帳戶的 bank_accounts 識別碼。",
+        "source_id": "外部來源系統提供的帳單識別碼。",
+        "billing_period": "帳單週期，格式通常為 YYYY-MM。",
+        "statement_amount": "本期帳單總額。",
+        "minimum_payment": "本期最低應繳金額。",
+        "paid_amount": "目前已繳付的金額。",
+        "is_paid": "帳單是否已繳清的旗標。",
+        "payment_due_date": "帳單繳款期限。",
+        "statement_closing_date": "帳單結帳日。",
+        "currency": "帳單金額使用的幣別，預設為 TWD。",
+        "raw_payload": "連接器回傳的原始或正規化 JSON。",
+        "created_at": "帳單首次寫入的時間。",
+        "updated_at": "帳單最後更新的時間。"
+      }
+    },
+    "exchange_rates": {
+      "description": "將外幣換算為新台幣時使用的最新匯率。",
+      "notes": "net_worth 計算會使用 rate_to_twd；找不到非 TWD 匯率時不會硬算。",
+      "columns": {
+        "currency": "外幣幣別代碼，也是此表的主鍵。",
+        "rate_to_twd": "一單位該幣別換算成 TWD 的匯率。",
+        "updated_at": "匯率最後更新的時間。"
+      }
+    },
+    "investment_positions": {
+      "description": "投資帳戶在特定日期的持倉與資產市值快照。",
+      "notes": "同一 connector、source 與日期可有一組持倉；最新持倉與分頁查詢依 as_of_date。",
+      "columns": {
+        "id": "持倉快照的系統識別碼。",
+        "connector_id": "產生此持倉的外部連接器識別碼。",
+        "source_id": "外部來源系統提供的持倉識別碼。",
+        "asset_type": "資產類型，目前限制為 stock、etf 或 fund。",
+        "symbol": "證券、基金或 ETF 的代號。",
+        "name": "投資標的名稱。",
+        "quantity": "持有數量。",
+        "market_value": "持倉的市場價值。",
+        "cash_balance": "此投資帳戶或資產項目中的現金餘額。",
+        "currency": "市值與現金使用的幣別，預設為 TWD。",
+        "as_of_date": "持倉快照所代表的日期。",
+        "raw_payload": "連接器回傳的原始或正規化 JSON。",
+        "created_at": "持倉首次寫入的時間。",
+        "updated_at": "持倉最後更新的時間。"
+      }
+    },
+    "investment_transactions": {
+      "description": "投資帳戶的買賣、配息或其他證券交易明細。",
+      "notes": "account_id 是外部投資帳戶識別碼，不直接 FK 到 bank_accounts；effective_date 用於列表排序。",
+      "columns": {
+        "id": "投資交易的系統識別碼。",
+        "connector_id": "產生此交易的外部連接器識別碼。",
+        "account_id": "外部券商或投資帳戶識別碼。",
+        "source_id": "外部來源系統提供的交易識別碼。",
+        "broker_no": "券商或分公司代碼。",
+        "broker_account": "券商帳號或交割帳號。",
+        "broker_name": "券商或交易機構名稱。",
+        "symbol": "交易標的代號。",
+        "name": "交易標的名稱。",
+        "asset_type": "資產類型，例如 stock、etf、fund、bond 或 unknown。",
+        "trade_date": "交易發生日期。",
+        "posted_date": "交易正式入帳日期。",
+        "transaction_code": "外部系統的交易類型代碼。",
+        "transaction_name": "外部系統的交易類型名稱。",
+        "quantity": "交易數量。",
+        "price": "每單位成交或計算價格。",
+        "amount": "交易總金額。",
+        "currency": "交易金額使用的幣別，預設為 TWD。",
+        "raw_payload": "連接器回傳的原始或正規化 JSON。",
+        "created_at": "交易首次寫入的時間。",
+        "updated_at": "交易最後更新的時間。",
+        "effective_date": "由 trade_date 優先、posted_date 備援產生的排序日期。"
+      }
+    },
+    "invoice_line_items": {
+      "description": "電子發票底下的商品或服務明細。",
+      "columns": {
+        "id": "發票明細的系統識別碼。",
+        "invoice_id": "所屬 invoices 記錄的識別碼。",
+        "connector_id": "取得此明細的外部連接器識別碼。",
+        "invoice_source_id": "外部來源發票識別碼，用於同步比對。",
+        "source_id": "外部來源明細識別碼。",
+        "line_number": "明細在發票中的順序。",
+        "description": "商品或服務描述。",
+        "quantity": "購買數量。",
+        "unit_price": "單位價格。",
+        "amount": "此明細的小計金額。",
+        "raw_payload": "連接器回傳的原始或正規化 JSON。",
+        "created_at": "明細首次寫入的時間。",
+        "updated_at": "明細最後更新的時間。"
+      }
+    },
+    "invoice_transaction_preferences": {
+      "description": "使用者對電子發票與銀行交易是否關聯的決策。",
+      "notes": "decision=linked 時 transaction_id 必須存在；decision=separate 表示刻意維持兩筆獨立資料。",
+      "columns": {
+        "invoice_id": "套用決策的 invoices 記錄識別碼。",
+        "transaction_id": "被關聯的 bank_transactions 識別碼；separate 時為 NULL。",
+        "decision": "關聯決策，目前限制為 linked 或 separate。",
+        "created_at": "決策首次建立的時間。",
+        "updated_at": "決策最後更新的時間。"
+      }
+    },
+    "invoices": {
+      "description": "電子發票的抬頭與總額主檔。",
+      "notes": "商品明細另存於 invoice_line_items；同一 connector 與 source_id 只保留一張發票。",
+      "columns": {
+        "id": "發票的系統識別碼。",
+        "connector_id": "取得此發票的外部連接器識別碼。",
+        "source_id": "外部來源系統提供的發票識別碼。",
+        "invoice_number": "發票字軌號碼或發票號碼。",
+        "invoice_date": "發票開立日期。",
+        "seller_name": "賣方或開立人名稱。",
+        "amount": "發票總金額。",
+        "raw_payload": "連接器回傳的原始或正規化 JSON。",
+        "created_at": "發票首次寫入的時間。",
+        "updated_at": "發票最後更新的時間。"
+      }
+    },
+    "manual_assets": {
+      "description": "使用者手動登錄、無法由銀行或投資連接器同步的資產。",
+      "notes": "資產目前的金額與歷史值存於 net_worth_history，asset_type 對應此表的 id。",
+      "columns": {
+        "id": "手動資產的系統識別碼。",
+        "name": "前端顯示的資產名稱。",
+        "category": "資產分類，例如房產、現金或其他。",
+        "note": "使用者補充的備註。",
+        "created_at": "手動資產建立的時間。"
+      }
+    },
+    "net_worth_history": {
+      "description": "按日期保存的淨資產或資產類別歷史數值，用於圖表與歷史查詢。",
+      "notes": "這是由銀行餘額、投資持倉與手動資產等來源整理出的讀模型，不是單一連接器的原始資料。",
+      "columns": {
+        "id": "歷史點的系統識別碼。",
+        "date": "此數值所代表的日期。",
+        "net_worth": "該日期與資產類型的金額，通常以 TWD 表示。",
+        "asset_type": "資產類型，例如 total、deposit、stock、fund 或手動資產 id。",
+        "source": "數值來源，例如 bank 或 manual。",
+        "snapshotted_at": "此歷史點實際建立或重算的時間。"
+      }
+    },
+    "sync_jobs": {
+      "description": "每個連接器與同步範圍的排程、鎖定狀態與最近執行結果。",
+      "notes": "Worker Cron 會依 next_run_at 找到工作並取得 lease；locked_* 欄位用來避免同一工作重複執行。",
+      "columns": {
+        "id": "同步工作的系統識別碼，通常由 connector_id 與 scope 組成。",
+        "connector_id": "要執行同步的連接器識別碼。",
+        "scope": "同步範圍，例如 all 或特定帳戶範圍。",
+        "enabled": "是否啟用此同步工作。",
+        "interval_minutes": "同步間隔，單位為分鐘。",
+        "next_run_at": "下一次允許執行的時間。",
+        "locked_until": "目前 lease 鎖定到期時間。",
+        "locked_by": "取得 lease 的同步執行識別碼。",
+        "lock_trigger": "取得鎖定的觸發來源，例如 manual 或 scheduled。",
+        "lock_scope": "此次執行實際鎖定的細部範圍。",
+        "last_run_at": "最近一次開始執行的時間。",
+        "last_success_at": "最近一次成功完成的時間。",
+        "last_status": "最近一次結果，例如 success、failed 或 needs_user_action。",
+        "last_error": "最近一次失敗或需要使用者處理的錯誤訊息。",
+        "created_at": "同步工作建立的時間。",
+        "updated_at": "同步工作最後更新的時間。",
+        "schedule_mode": "排程模式；inherit 使用全域設定，custom 使用工作自己的設定。",
+        "preferred_time": "每日或每週排程偏好的台北時間。",
+        "preferred_weekday": "每週排程的星期，0 代表週日、6 代表週六。"
+      }
+    },
+    "sync_schedule_settings": {
+      "description": "所有使用 inherit 模式之同步工作的全域預設排程。",
+      "notes": "id 固定為 default；修改設定時會同步重算繼承此設定的 sync_jobs。",
+      "columns": {
+        "id": "設定識別碼，固定為 default。",
+        "interval_minutes": "預設同步間隔，單位為分鐘。",
+        "preferred_time": "預設每日或每週執行時間，使用台北時間。",
+        "timezone": "排程使用的時區，目前為 Asia/Taipei。",
+        "updated_at": "全域排程最後更新的時間。",
+        "preferred_weekday": "每週排程的預設星期，0 代表週日、6 代表週六。"
+      }
+    },
+    "sync_write_staging": {
+      "description": "同步流程寫入正式資料表前的暫存資料。",
+      "notes": "payload 必須是合法 JSON；同步完成或失敗後會清理，避免部分同步結果直接暴露為正式資料。",
+      "columns": {
+        "run_id": "此次同步執行的識別碼。",
+        "entity_type": "暫存資料的實體類型，例如 bank_transaction。",
+        "record_key": "該實體在此次同步中的去重與覆寫鍵。",
+        "payload": "待寫入正式表的正規化 JSON 資料。",
+        "created_at": "暫存資料建立的時間。"
+      }
+    }
+  }
+}

--- a/scripts/generate-database-schema.mjs
+++ b/scripts/generate-database-schema.mjs
@@ -1,0 +1,448 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const databaseName = process.env.D1_DATABASE ?? "DB";
+const outputPath = join(projectRoot, "docs", "database-schema.md");
+const migrationsPath = join(projectRoot, "packages", "db", "migrations");
+const metadataPath = join(projectRoot, "packages", "db", "schema-metadata.json");
+const persistencePath = mkdtempSync(join(tmpdir(), "taiwan-fin-hub-schema-"));
+
+function getWranglerEntry() {
+  const configuredEntry = process.env.WRANGLER_ENTRY;
+  if (configuredEntry) {
+    return isAbsolute(configuredEntry) ? configuredEntry : resolve(projectRoot, configuredEntry);
+  }
+
+  const candidates = [
+    join(projectRoot, "node_modules", "wrangler", "bin", "wrangler.js"),
+    join(projectRoot, "apps", "worker", "node_modules", "wrangler", "bin", "wrangler.js"),
+  ];
+  const entry = candidates.find((candidate) => existsSync(candidate));
+  if (!entry) {
+    throw new Error(
+      "Cannot find Wrangler. Run npm install, or set WRANGLER_ENTRY to the Wrangler CLI entry point.",
+    );
+  }
+  return entry;
+}
+
+function runWrangler(args) {
+  const env = {
+    ...process.env,
+    // Migrations are applied to the temporary D1 below, so this command never
+    // changes the developer's existing local database.
+    CI: process.env.CI ?? "1",
+    XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME ?? join(projectRoot, ".wrangler-config"),
+  };
+
+  try {
+    return execFileSync(process.execPath, [getWranglerEntry(), ...args], {
+      cwd: projectRoot,
+      env,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    const stderr = error?.stderr?.toString().trim();
+    const stdout = error?.stdout?.toString().trim();
+    const details = [stderr, stdout].filter(Boolean).join("\n");
+    throw new Error(`Wrangler command failed: wrangler ${args.join(" ")}\n${details}`, {
+      cause: error,
+    });
+  }
+}
+
+function runJsonQuery(sql) {
+  const output = runWrangler([
+    "d1",
+    "execute",
+    databaseName,
+    "--local",
+    "--persist-to",
+    persistencePath,
+    "--json",
+    "--command",
+    sql,
+  ]);
+
+  let response;
+  try {
+    response = JSON.parse(output);
+  } catch (error) {
+    throw new Error(`Wrangler returned invalid JSON for query: ${sql}\n${output}`, { cause: error });
+  }
+
+  if (!Array.isArray(response)) {
+    throw new Error(`Unexpected Wrangler response for query: ${sql}`);
+  }
+
+  return response.flatMap((result) => {
+    if (Array.isArray(result)) return result;
+    return Array.isArray(result?.results) ? result.results : [];
+  });
+}
+
+function quoteLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function readSchemaMetadata() {
+  let metadata;
+  try {
+    metadata = JSON.parse(readFileSync(metadataPath, "utf8"));
+  } catch (error) {
+    throw new Error(`Cannot read schema metadata at ${metadataPath}.`, { cause: error });
+  }
+
+  if (!metadata || typeof metadata.tables !== "object" || metadata.tables === null) {
+    throw new Error(`Schema metadata at ${metadataPath} must contain a tables object.`);
+  }
+  return metadata.tables;
+}
+
+function readSchemaObjects() {
+  return runJsonQuery(`
+    SELECT type, name, tbl_name AS table_name, sql
+    FROM sqlite_schema
+    WHERE type IN ('table', 'index', 'trigger', 'view')
+      AND name NOT LIKE 'sqlite_%'
+      AND name NOT GLOB '_cf_*'
+      AND name <> 'd1_migrations'
+    ORDER BY
+      CASE type
+        WHEN 'table' THEN 1
+        WHEN 'index' THEN 2
+        WHEN 'view' THEN 3
+        WHEN 'trigger' THEN 4
+        ELSE 5
+      END,
+      name
+  `);
+}
+
+function readTableDetails(schemaObjects) {
+  const tables = schemaObjects.filter((object) => object.type === "table");
+  const indexes = schemaObjects.filter((object) => object.type === "index");
+  const statements = [];
+
+  for (const table of tables) {
+    const tableLiteral = quoteLiteral(table.name);
+    statements.push(
+      `SELECT ${tableLiteral} AS __schema_table, 'columns' AS __schema_kind, cid, name, type, "notnull" AS not_null, dflt_value, pk, hidden FROM pragma_table_xinfo(${tableLiteral})`,
+      `SELECT ${tableLiteral} AS __schema_table, 'foreign_keys' AS __schema_kind, id, seq, "table" AS referenced_table, "from" AS from_column, "to" AS to_column, on_update, on_delete, match FROM pragma_foreign_key_list(${tableLiteral})`,
+      `SELECT ${tableLiteral} AS __schema_table, 'index_list' AS __schema_kind, seq, name, "unique", origin, partial FROM pragma_index_list(${tableLiteral}) WHERE name NOT GLOB 'sqlite_*'`,
+    );
+
+    // index_info needs the index name as an argument, so generate one query
+    // per explicit index while still executing all metadata queries in one
+    // Wrangler process.
+    for (const index of indexes.filter((candidate) => candidate.table_name === table.name)) {
+      statements.push(
+        `SELECT ${tableLiteral} AS __schema_table, 'index_columns' AS __schema_kind, ${quoteLiteral(
+          index.name,
+        )} AS index_name, seqno, cid, name FROM pragma_index_info(${quoteLiteral(index.name)})`,
+      );
+    }
+  }
+
+  const metadataRows = runJsonQuery(statements.join(";\n"));
+  const detailsByTable = new Map(
+    tables.map((table) => [table.name, { columns: [], foreignKeys: [], indexes: [] }]),
+  );
+
+  for (const row of metadataRows) {
+    const details = detailsByTable.get(row.__schema_table);
+    if (!details) continue;
+
+    if (row.__schema_kind === "columns") {
+      details.columns.push({
+        cid: row.cid,
+        name: row.name,
+        type: row.type,
+        notnull: row.not_null,
+        dflt_value: row.dflt_value,
+        pk: row.pk,
+        hidden: row.hidden,
+      });
+    } else if (row.__schema_kind === "foreign_keys") {
+      details.foreignKeys.push({
+        from: row.from_column,
+        table: row.referenced_table,
+        to: row.to_column,
+        on_update: row.on_update,
+        on_delete: row.on_delete,
+      });
+    } else if (row.__schema_kind === "index_list") {
+      details.indexes.push({
+        name: row.name,
+        unique: row.unique,
+        partial: row.partial,
+        columns: [],
+      });
+    } else if (row.__schema_kind === "index_columns") {
+      const index = details.indexes.find((candidate) => candidate.name === row.index_name);
+      index?.columns.push({ name: row.name, seqno: row.seqno, cid: row.cid });
+    }
+  }
+
+  for (const table of tables) {
+    const details = detailsByTable.get(table.name);
+    for (const index of details.indexes) {
+      const schemaIndex = indexes.find(
+        (candidate) => candidate.table_name === table.name && candidate.name === index.name,
+      );
+      if (schemaIndex) Object.assign(index, { sql: schemaIndex.sql });
+    }
+  }
+
+  return detailsByTable;
+}
+
+function markdownValue(value) {
+  if (value === null || value === undefined || value === "") return "—";
+  return String(value).replaceAll("|", "\\|").replaceAll("\n", "<br>");
+}
+
+function normalizeSql(sql) {
+  return sql
+    .trim()
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n");
+}
+
+function validateMetadata(detailsByTable, metadataTables) {
+  const errors = [];
+  const actualTableNames = [...detailsByTable.keys()];
+  const metadataTableNames = Object.keys(metadataTables);
+
+  for (const tableName of actualTableNames) {
+    const tableMetadata = metadataTables[tableName];
+    if (!tableMetadata || typeof tableMetadata !== "object") {
+      errors.push(`missing table description: ${tableName}`);
+      continue;
+    }
+    if (typeof tableMetadata.description !== "string" || tableMetadata.description.trim() === "") {
+      errors.push(`missing table description: ${tableName}`);
+    }
+
+    const actualColumns = detailsByTable.get(tableName).columns.map((column) => column.name);
+    const describedColumns = Object.keys(tableMetadata.columns ?? {});
+    for (const columnName of actualColumns) {
+      const description = tableMetadata.columns?.[columnName];
+      if (typeof description !== "string" || description.trim() === "") {
+        errors.push(`missing column description: ${tableName}.${columnName}`);
+      }
+    }
+    for (const columnName of describedColumns) {
+      if (!actualColumns.includes(columnName)) {
+        errors.push(`unknown column description: ${tableName}.${columnName}`);
+      }
+    }
+  }
+
+  for (const tableName of metadataTableNames) {
+    if (!actualTableNames.includes(tableName)) {
+      errors.push(`unknown table description: ${tableName}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Schema metadata is incomplete or stale:\n- ${errors.join("\n- ")}`);
+  }
+}
+
+function renderColumns(columns, columnMetadata) {
+  const rows = columns.map((column) => {
+    const generated =
+      column.hidden === 2 ? "virtual" : column.hidden === 3 ? "stored" : "—";
+    return `| ${column.cid + 1} | \`${markdownValue(column.name)}\` | ${markdownValue(
+      columnMetadata[column.name],
+    )} | ${markdownValue(column.type)} | ${column.notnull ? "NO" : "YES"} | ${markdownValue(
+      column.dflt_value,
+    )} | ${column.pk || "—"} | ${generated} |`;
+  });
+
+  return [
+    "| 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |",
+    "| ---: | --- | --- | --- | :---: | --- | ---: | --- |",
+    ...rows,
+  ].join("\n");
+}
+
+function renderForeignKeys(foreignKeys) {
+  if (foreignKeys.length === 0) return "—";
+  return [
+    "| 欄位 | 參照表 | 參照欄位 | ON UPDATE | ON DELETE |",
+    "| --- | --- | --- | --- | --- |",
+    ...foreignKeys.map(
+      (foreignKey) =>
+        `| \`${markdownValue(foreignKey.from)}\` | \`${markdownValue(
+          foreignKey.table,
+        )}\` | \`${markdownValue(foreignKey.to)}\` | ${markdownValue(
+          foreignKey.on_update,
+        )} | ${markdownValue(foreignKey.on_delete)} |`,
+    ),
+  ].join("\n");
+}
+
+function renderIndexes(indexes) {
+  if (indexes.length === 0) return "—";
+  return [
+    "| Index | Unique | Partial | 欄位 | 定義 |",
+    "| --- | :---: | :---: | --- | --- |",
+    ...indexes.map((index) => {
+      const columns = index.columns
+        .filter((column) => column.name !== null && column.name !== undefined)
+        .map((column) => `\`${column.name}\``)
+        .join(", ");
+      return `| \`${markdownValue(index.name)}\` | ${index.unique ? "是" : "否"} | ${
+        index.partial ? "是" : "否"
+      } | ${columns || "—"} | ${index.sql ? `\`${markdownValue(index.sql)}\`` : "—"} |`;
+    }),
+  ].join("\n");
+}
+
+function renderSchema(schemaObjects, migrations, metadataTables) {
+  const tables = schemaObjects.filter((object) => object.type === "table");
+  const detailsByTable = readTableDetails(schemaObjects);
+  validateMetadata(detailsByTable, metadataTables);
+  const otherObjects = schemaObjects.filter(
+    (object) => object.type !== "table" && object.type !== "index",
+  );
+  const totalIndexes = schemaObjects.filter((object) => object.type === "index").length;
+
+  const lines = [
+    "# Database Schema",
+    "",
+    "> 此文件由 `npm run db:schema:docs` 自動產生，請勿直接編輯。",
+    ">",
+    "> Schema 來源是套用 `packages/db/migrations/*.sql` 後的隔離 local D1；不包含任何正式環境資料。",
+    "> Wrangler 管理的 `d1_migrations` metadata table 刻意省略。",
+    "> Table 與欄位的業務語意來自 `packages/db/schema-metadata.json`。",
+    "",
+    "## 目錄",
+    "",
+    `- Tables：${tables.length}`,
+    `- Explicit indexes：${totalIndexes}`,
+    `- Other objects：${otherObjects.length}`,
+    `- Migrations：${migrations.length}`,
+    "",
+    "## Tables",
+    "",
+    "| Table | 用途 | Columns | Foreign keys | Indexes |",
+    "| --- | --- | ---: | ---: | ---: |",
+    ...tables.map((table) => {
+      const details = detailsByTable.get(table.name);
+      return `| [\`${table.name}\`](#${table.name}) | ${markdownValue(
+        metadataTables[table.name].description,
+      )} | ${
+        details.columns.length
+      } | ${details.foreignKeys.length} | ${details.indexes.length} |`;
+    }),
+    "",
+  ];
+
+  for (const table of tables) {
+    const details = detailsByTable.get(table.name);
+    lines.push(
+      `### \`${table.name}\``,
+      "",
+      `> 用途：${markdownValue(metadataTables[table.name].description)}`,
+      ...(metadataTables[table.name].notes
+        ? [`> 注意：${markdownValue(metadataTables[table.name].notes)}`]
+        : []),
+      "",
+      "#### Columns",
+      "",
+      renderColumns(details.columns, metadataTables[table.name].columns),
+      "",
+      "#### Foreign keys",
+      "",
+      renderForeignKeys(details.foreignKeys),
+      "",
+      "#### Indexes",
+      "",
+      renderIndexes(details.indexes),
+      "",
+      "#### DDL",
+      "",
+      "```sql",
+      table.sql ? normalizeSql(table.sql) : "-- DDL unavailable",
+      "```",
+      "",
+    );
+  }
+
+  lines.push("## Other database objects", "");
+  if (otherObjects.length === 0) {
+    lines.push("目前沒有 view 或 trigger。", "");
+  } else {
+    lines.push("| Type | Name | Definition |", "| --- | --- | --- |");
+    for (const object of otherObjects) {
+      lines.push(
+        `| ${object.type} | \`${markdownValue(object.name)}\` | ${markdownValue(object.sql)} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  lines.push("## Migration history", "");
+  lines.push(
+    "Migration 是 schema 演進的 source of truth；若要了解某欄位的變更原因，請從對應 migration 檔案與 Git history 追查。",
+    "",
+    ...migrations.map((migration) => `- [\`${migration}\`](../packages/db/migrations/${migration})`),
+    "",
+    "## 程式碼導覽",
+    "",
+    "- Feature-specific SQL：`apps/worker/src/features/*/repository.ts`",
+    "- 共用 D1 能力：`packages/db/src/`",
+    "- 共用資料契約：`packages/core/`",
+    "",
+  );
+
+  return lines.join("\n");
+}
+
+function listMigrations() {
+  return readdirSync(migrationsPath)
+    .filter((file) => file.endsWith(".sql"))
+    .sort((left, right) => left.localeCompare(right, undefined, { numeric: true }));
+}
+
+try {
+  runWrangler([
+    "d1",
+    "migrations",
+    "apply",
+    databaseName,
+    "--local",
+    "--persist-to",
+    persistencePath,
+  ]);
+
+  const schemaObjects = readSchemaObjects();
+  const migrations = listMigrations();
+  const metadataTables = readSchemaMetadata();
+  writeFileSync(
+    outputPath,
+    `${renderSchema(schemaObjects, migrations, metadataTables).trimEnd()}\n`,
+    "utf8",
+  );
+  console.log(`Generated ${outputPath}`);
+} finally {
+  rmSync(persistencePath, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Description

- 新增 `db:schema:docs` 指令，從隔離的 local D1 產生 schema 文件。
- 新增 `packages/db/schema-metadata.json`，補充 20 個 table 與 204 個欄位的業務用途與注意事項。
- `docs/database-schema.md` 同時呈現 table 用途、欄位意義、型別、約束、index、DDL 與 migration history。
- 產生器會驗證實際 schema 與語意 metadata 完整同步，避免新增欄位後文件缺少說明。

## Architecture

`npm script -> generate-database-schema.mjs -> temporary D1 -> migrations + sqlite_schema/PRAGMA -> metadata validation -> Markdown`

語意描述與結構快照分離：migration 負責結構，`schema-metadata.json` 負責業務語意，Markdown 由產生器統一輸出。產生流程不會修改既有 local D1，也不會連線或寫入 remote D1。

## Breaking Changes

無。

## Test & Risk

- `npm run db:schema:docs`：通過。
- `npm run typecheck`：通過，web、worker、connectors、core、db 均無錯誤。
- `node --check scripts/generate-database-schema.mjs`：通過。
- `git diff --check`：通過。
- 主要 regression scope 是 schema 文件產生與 metadata 完整性驗證；沒有 runtime API 或正式資料庫 migration 變更。
- 未來 schema 新增 table/column 若未同步補 metadata，產生指令會故意失敗，需補齊語意描述後才能更新文件。

## Checklist

- [ ] 代碼符合本專案風格 (Lint / Formatter 通過)
- [x] 自我 Review 並移除無用程式、除錯訊息
- [x] 文件 / Release Note 已更新
- [ ] 無新增 ESLint / Lint 警告
- [x] 無 API、DB migration 或相依套件變更
- [ ] 拼字檢查通過