### PR TITLE
修正 iPhone 推播失敗診斷與裝置提示

### DIFF
--- a/apps/web/src/features/settings/components/NotificationPanel.svelte
+++ b/apps/web/src/features/settings/components/NotificationPanel.svelte
@@ -170,15 +170,23 @@
     try {
       const result = await api.post<{
         delivered: number;
+        failed: number;
         attempted: number;
         removed: number;
       }>("/api/notifications/test");
+      const text =
+        result.delivered > 0
+          ? "測試通知已送出，請查看你的裝置。"
+          : result.attempted === 0
+            ? "目前沒有已登錄的推播裝置。"
+            : result.removed === result.attempted
+              ? "推播訂閱已失效，請重新開啟此裝置的推播。"
+              : result.failed > 0
+                ? "推播裝置已登錄，但測試通知送出失敗；請重新開啟此裝置的推播後再試。"
+                : "測試通知未送達，請稍後再試。";
       feedback = {
         tone: result.delivered > 0 ? "success" : "error",
-        text:
-          result.delivered > 0
-            ? "測試通知已送出，請查看你的裝置。"
-            : "目前沒有可用的推播裝置。",
+        text,
       };
     } catch (error) {
       feedback = {

--- a/apps/worker/src/features/notifications/service.ts
+++ b/apps/worker/src/features/notifications/service.ts
@@ -223,7 +223,7 @@ function pushDeliveryFailureDetails(error: unknown, endpoint?: string) {
         "reason" in parsed &&
         typeof parsed.reason === "string"
       ) {
-        reason = parsed.reason;
+        reason = parsed.reason.slice(0, 128);
       }
     } catch {
       // Keep the truncated response body below for non-JSON push service errors.

--- a/apps/worker/src/features/notifications/service.ts
+++ b/apps/worker/src/features/notifications/service.ts
@@ -163,11 +163,13 @@ async function deliverPushPayload(env: Env, payload: PushNotificationPayload) {
   const encryptionKey = configEncryptionKey(env);
   let delivered = 0;
   let removed = 0;
+  let failed = 0;
 
   await Promise.all(
     subscriptions.map(async (row) => {
+      let subscription: PushSubscriptionInput | undefined;
       try {
-        const subscription = await decryptJson<PushSubscriptionInput>(
+        subscription = await decryptJson<PushSubscriptionInput>(
           row.encrypted_subscription,
           encryptionKey,
         );
@@ -185,19 +187,66 @@ async function deliverPushPayload(env: Env, payload: PushNotificationPayload) {
           removed += 1;
           return;
         }
+        failed += 1;
         await markPushFailure(env.DB, row.id, new Date().toISOString());
+        const details = pushDeliveryFailureDetails(
+          error,
+          subscription?.endpoint,
+        );
         console.warn(
           JSON.stringify({
             event: "push_subscription_delivery_failed",
             subscriptionId: row.id,
-            statusCode,
+            ...details,
           }),
         );
       }
     }),
   );
 
-  return { delivered, removed, attempted: subscriptions.length };
+  return { delivered, failed, removed, attempted: subscriptions.length };
+}
+
+function pushDeliveryFailureDetails(error: unknown, endpoint?: string) {
+  if (!(error instanceof WebPushError)) {
+    return { statusCode: 0 };
+  }
+
+  const responseBody = error.body?.trim();
+  let reason: string | undefined;
+  if (responseBody) {
+    try {
+      const parsed: unknown = JSON.parse(responseBody);
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        "reason" in parsed &&
+        typeof parsed.reason === "string"
+      ) {
+        reason = parsed.reason;
+      }
+    } catch {
+      // Keep the truncated response body below for non-JSON push service errors.
+    }
+  }
+
+  return {
+    statusCode: error.statusCode,
+    ...(reason ? { reason } : {}),
+    ...(responseBody ? { responseBody: responseBody.slice(0, 512) } : {}),
+    ...(error.headers["apns-id"]
+      ? { pushServiceRequestId: error.headers["apns-id"] }
+      : {}),
+    ...(endpoint ? { endpointHost: safeEndpointHostname(endpoint) } : {}),
+  };
+}
+
+function safeEndpointHostname(endpoint: string) {
+  try {
+    return new URL(endpoint).hostname;
+  } catch {
+    return "invalid";
+  }
 }
 
 function validatePushEndpoint(value: string) {

--- a/apps/worker/tests/features/notifications/route.test.ts
+++ b/apps/worker/tests/features/notifications/route.test.ts
@@ -42,6 +42,14 @@ function env(): Env {
   };
 }
 
+function configuredPushEnv() {
+  const testEnv = env();
+  testEnv.VAPID_PUBLIC_KEY =
+    "BGtkbcjrO12YMoDuq2sCQeHlu47uPx3SHTgFKZFYiBW8Qr0D9vgyZSZPdw6_4ZFEI9Snk1VEAj2qTYI1I1YxBXE";
+  testEnv.VAPID_PRIVATE_KEY = "I0_d0vnesxbBSUmlDdOKibGo6vEXRO-Vu88QlSlm5j0";
+  return testEnv;
+}
+
 describe("notification routes", () => {
   it("reports the configured shared push state", async () => {
     const response = await notificationRoutes.request(
@@ -73,6 +81,22 @@ describe("notification routes", () => {
     await expect(response.json()).resolves.toMatchObject({
       enabled: true,
       publicKey: "public-key",
+    });
+  });
+
+  it("distinguishes an empty device list from delivery failures", async () => {
+    const response = await notificationRoutes.request(
+      "/notifications/test",
+      { method: "POST" },
+      configuredPushEnv(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      delivered: 0,
+      failed: 0,
+      removed: 0,
+      attempted: 0,
     });
   });
 


### PR DESCRIPTION
## 變更內容

- 記錄 Web Push 服務回傳的 HTTP status、reason、截短 response body、push service request id 與 endpoint hostname。
- 測試通知 API 新增 failed 計數，讓前端能區分沒有裝置、訂閱失效與已登錄但送達失敗。
- 修正設定頁錯誤提示，不再把 Apple Push HTTP 400 顯示成「沒有可用的推播裝置」。
- 新增空裝置清單的 route 測試。

## 根因

iPhone subscription 已成功登錄，但 Apple Push Service 回傳 HTTP 400。原本 Worker 只記錄 statusCode，未保留 Apple 回應的 reason，因此無法判斷是 VAPID key mismatch、JWT、加密格式或其他 Web Push 請求錯誤。

## 驗證

- `npm run typecheck`
- `npm run test:backend`
- `npm run test:unit`
- `npm run build -w @taiwan-fin-hub/web`
- `npm run format:check`
- Svelte autofixer：無 issues 或 suggestions