### PR TITLE
修正 Apple Web Push Topic 導致 iPhone 推播失敗

### DIFF
--- a/apps/worker/src/features/notifications/service.ts
+++ b/apps/worker/src/features/notifications/service.ts
@@ -176,7 +176,7 @@ async function deliverPushPayload(env: Env, payload: PushNotificationPayload) {
         await webpush.sendNotification(subscription, JSON.stringify(payload), {
           TTL: 60 * 60,
           urgency: payload.tag.includes("needs-action") ? "high" : "normal",
-          topic: payload.tag,
+          // Keep the semantic tag in the encrypted payload; Apple rejects it as a raw Web Push Topic.
         });
         delivered += 1;
         await markPushSuccess(env.DB, row.id, new Date().toISOString());

--- a/apps/worker/tests/features/notifications/service.test.ts
+++ b/apps/worker/tests/features/notifications/service.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import webpush from "web-push";
+import type { Env } from "../../../src/platform/env";
+import { encryptJson } from "../../../src/platform/crypto";
+import { sendTestNotification } from "../../../src/features/notifications/service";
+
+const vapidPublicKey =
+  "BGtkbcjrO12YMoDuq2sCQeHlu47uPx3SHTgFKZFYiBW8Qr0D9vgyZSZPdw6_4ZFEI9Snk1VEAj2qTYI1I1YxBXE";
+const vapidPrivateKey = "I0_d0vnesxbBSUmlDdOKibGo6vEXRO-Vu88QlSlm5j0";
+
+function createDb(encryptedSubscription: string) {
+  const row = {
+    id: "subscription-id",
+    encrypted_subscription: encryptedSubscription,
+    created_at: "2026-07-22T00:00:00.000Z",
+    updated_at: "2026-07-22T00:00:00.000Z",
+    last_success_at: null,
+    consecutive_failures: 0,
+  };
+  const db = {
+    prepare() {
+      const statement = {
+        bind() {
+          return statement;
+        },
+        async all() {
+          return { results: [row] };
+        },
+        async run() {
+          return { meta: { changes: 1 } };
+        },
+      };
+      return statement;
+    },
+  } as unknown as D1Database;
+  return db;
+}
+
+function env(DB: D1Database): Env {
+  return {
+    DB,
+    ASSETS: {} as Fetcher,
+    BROWSER: {} as Fetcher,
+    AI: {} as Ai,
+    VAPID_PUBLIC_KEY: vapidPublicKey,
+    VAPID_PRIVATE_KEY: vapidPrivateKey,
+    VAPID_SUBJECT: "mailto:test@example.com",
+    CONFIG_ENCRYPTION_KEY: "test-encryption-key",
+  };
+}
+
+describe("push notification delivery options", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not send the semantic notification tag as a Web Push Topic", async () => {
+    const encryptedSubscription = await encryptJson(
+      {
+        endpoint: "https://push.example.com/subscription",
+        expirationTime: null,
+        keys: { p256dh: "p256dh", auth: "auth" },
+      },
+      "test-encryption-key",
+    );
+    const sendNotification = vi
+      .spyOn(webpush, "sendNotification")
+      .mockResolvedValue({ statusCode: 201, body: "", headers: {} });
+
+    await expect(
+      sendTestNotification(env(createDb(encryptedSubscription))),
+    ).resolves.toEqual({ delivered: 1, failed: 0, removed: 0, attempted: 1 });
+
+    const options = sendNotification.mock.calls[0]?.[2];
+    expect(options).toMatchObject({ TTL: 60 * 60, urgency: "normal" });
+    expect(options?.topic).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 變更內容

- 移除送往 Web Push service 的 `Topic` header。
- 保留 payload 內的 notification `tag`，Service Worker 的通知顯示與合併行為不變。
- 新增 Worker 回歸測試，確認測試通知不會再傳送 semantic tag 作為 Web Push Topic。

## 根因

iPhone 的 Apple Push endpoint 回傳 `400 BadWebPushTopic`。原本將 `notification-test` 等語意 tag 直接傳給 `web-push` 的 `topic` 選項；Apple 對 Topic 格式驗證較嚴格，導致 API 外層雖回傳 200，實際裝置送達仍失敗。

Topic 是選用的推播佇列合併功能，移除後不影響加密 payload 或 Service Worker notification tag。

## 驗證

- `npm run typecheck`
- `npm run test:backend`（Worker 91 tests、DB 4 tests、connector self-check）
- `npm run format:check`