### PR TITLE
feat(部署): 部署時自動產生並保留 VAPID 金鑰

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -4,7 +4,9 @@ POLICY_AUD=replace-with-cloudflare-access-application-audience-tag
 # Optional: comma- or whitespace-separated additional audience tags.
 POLICY_AUDS=
 DEMO_MODE=false
-VAPID_PUBLIC_KEY=replace-with-web-push-public-key
-VAPID_PRIVATE_KEY=replace-with-web-push-private-key
+# Production deploys generate and persist the VAPID key pair automatically.
+# For local push testing, uncomment and provide a matching key pair.
+# VAPID_PUBLIC_KEY=replace-with-web-push-public-key
+# VAPID_PRIVATE_KEY=replace-with-web-push-private-key
 # Optional; defaults to mailto:admin@example.com
 # VAPID_SUBJECT=mailto:admin@example.com

--- a/README.md
+++ b/README.md
@@ -115,16 +115,6 @@
 
 > 進階用法：若同一個 Worker 需要接受多個 Access Application，可另外設定 `POLICY_AUDS`，以逗號或空白分隔多個 Audience。
 
-若要啟用同步完成推播，請另外產生一組固定的 VAPID 金鑰，並在同一個 Worker 的 **Variables and secrets** 設定：
-
-```bash
-npx web-push generate-vapid-keys
-wrangler secret put VAPID_PUBLIC_KEY
-wrangler secret put VAPID_PRIVATE_KEY
-```
-
-`VAPID_SUBJECT` 可省略，程式會使用內建的 `mailto:admin@example.com` 預設值；若要提供實際聯絡方式，可自行設定為 `mailto:` 或 `https:` URI。VAPID public/private key 必須在同一個部署中保持不變；若更換金鑰，既有瀏覽器訂閱需要重新開啟推播。
-
 ### 步驟三：確認部署
 
 1. 開啟 Worker 的 `workers.dev` 網址，確認會先要求 Cloudflare Access 登入

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -19,6 +19,8 @@ self.addEventListener("push", (event) => {
       icon: "/icon-192x192.png",
       badge: "/icon-192x192.png",
       tag: data.tag,
+      // iOS PWA notifications remain visible, but do not play a sound or vibrate.
+      silent: true,
       data: { url: data.url },
     }),
   );

--- a/apps/worker/.dev.vars.example
+++ b/apps/worker/.dev.vars.example
@@ -4,7 +4,9 @@ POLICY_AUD=replace-with-cloudflare-access-application-audience-tag
 # Optional: comma- or whitespace-separated additional audience tags.
 POLICY_AUDS=
 DEMO_MODE=false
-VAPID_PUBLIC_KEY=replace-with-web-push-public-key
-VAPID_PRIVATE_KEY=replace-with-web-push-private-key
+# Production deploys generate and persist the VAPID key pair automatically.
+# For local push testing, uncomment and provide a matching key pair.
+# VAPID_PUBLIC_KEY=replace-with-web-push-public-key
+# VAPID_PRIVATE_KEY=replace-with-web-push-private-key
 # Optional; defaults to mailto:admin@example.com
 # VAPID_SUBJECT=mailto:admin@example.com

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -9,7 +9,7 @@
     "test": "vitest run tests",
     "dev": "npm run db:migrate:local && XDG_CONFIG_HOME=../../.wrangler-config wrangler dev -c wrangler.local.toml",
     "dev:remote": "XDG_CONFIG_HOME=../../.wrangler-config wrangler dev -c ../../wrangler.toml --remote",
-    "deploy": "npm run build -w @taiwan-fin-hub/web && npm run db:migrate:remote && XDG_CONFIG_HOME=../../.wrangler-config wrangler deploy -c ../../wrangler.toml",
+    "deploy": "npm run build -w @taiwan-fin-hub/web && npm run db:migrate:remote && XDG_CONFIG_HOME=../../.wrangler-config node ../../scripts/deploy-with-vapid.mjs -c ../../wrangler.toml",
     "db:migrate:local": "XDG_CONFIG_HOME=../../.wrangler-config wrangler d1 migrations apply DB --local -c wrangler.local.toml",
     "db:migrate:remote": "XDG_CONFIG_HOME=../../.wrangler-config wrangler d1 migrations apply DB --remote -c ../../wrangler.toml"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:e2e": "npm run test:e2e -w @taiwan-fin-hub/web",
     "verify:web": "npm run typecheck -w @taiwan-fin-hub/web && npm run test:unit -w @taiwan-fin-hub/web && npm run test:e2e -w @taiwan-fin-hub/web && npm run build -w @taiwan-fin-hub/web",
     "dev": "npm run dev -w @taiwan-fin-hub/worker",
-    "deploy": "npm run db:migrate:remote && XDG_CONFIG_HOME=.wrangler-config wrangler deploy",
+    "deploy": "npm run db:migrate:remote && XDG_CONFIG_HOME=.wrangler-config node scripts/deploy-with-vapid.mjs",
     "db:migrate:local": "XDG_CONFIG_HOME=.wrangler-config wrangler d1 migrations apply DB --local",
     "db:migrate:remote": "XDG_CONFIG_HOME=.wrangler-config wrangler d1 migrations apply DB --remote",
     "db:schema:docs": "node scripts/generate-database-schema.mjs"
@@ -47,15 +47,6 @@
       },
       "AI": {
         "description": "Cloudflare Workers AI binding，供 Gemma 4 辨識永豐登入驗證碼。"
-      },
-      "VAPID_PUBLIC_KEY": {
-        "description": "Web Push 的 VAPID public key；可與 private key 一起用 wrangler secret put 設定。"
-      },
-      "VAPID_PRIVATE_KEY": {
-        "description": "Web Push 的 VAPID private key；請使用 wrangler secret put 設定並保持機密。"
-      },
-      "VAPID_SUBJECT": {
-        "description": "Web Push VAPID 聯絡資訊，可省略；省略時使用 mailto:admin@example.com。"
       }
     }
   },

--- a/scripts/deploy-with-vapid.mjs
+++ b/scripts/deploy-with-vapid.mjs
@@ -1,5 +1,5 @@
 import { createECDH } from "node:crypto";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
@@ -40,6 +40,42 @@ function optionArguments(argumentsToInspect, optionNames) {
   return selected;
 }
 
+function removeSingleOption(argumentsToInspect, optionName) {
+  const remaining = [];
+  const values = [];
+
+  for (let index = 0; index < argumentsToInspect.length; index += 1) {
+    const argument = argumentsToInspect[index];
+
+    if (argument === optionName) {
+      const value = argumentsToInspect[index + 1];
+      if (!value || value.startsWith("-")) {
+        throw new Error(`${optionName} requires a file path.`);
+      }
+      values.push(value);
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith(`${optionName}=`)) {
+      const value = argument.slice(optionName.length + 1);
+      if (!value) throw new Error(`${optionName} requires a file path.`);
+      values.push(value);
+      continue;
+    }
+
+    remaining.push(argument);
+  }
+
+  if (values.length > 1) {
+    throw new Error(
+      `${optionName} can only be provided once; pass one file containing all deployment secrets.`,
+    );
+  }
+
+  return { remaining, value: values[0] ?? null };
+}
+
 function runWrangler(argumentsToRun, options = {}) {
   const { captureOutput = false } = options;
   const child = spawn(process.execPath, [wranglerScript, ...argumentsToRun], {
@@ -47,7 +83,8 @@ function runWrangler(argumentsToRun, options = {}) {
     env: {
       ...process.env,
       XDG_CONFIG_HOME:
-        process.env.XDG_CONFIG_HOME ?? join(invocationDirectory, ".wrangler-config"),
+        process.env.XDG_CONFIG_HOME ??
+        join(invocationDirectory, ".wrangler-config"),
     },
     stdio: captureOutput ? ["ignore", "pipe", "pipe"] : "inherit",
     windowsHide: true,
@@ -117,6 +154,7 @@ async function existingSecretNames() {
     "-c",
     "--env",
     "-e",
+    "--env-file",
     "--name",
   ]);
   const result = await runWrangler(
@@ -150,11 +188,76 @@ async function existingSecretNames() {
   return new Set(secrets.map((secret) => secret?.name).filter(Boolean));
 }
 
+function parseJsonSecrets(content, filePath) {
+  let secrets;
+  try {
+    secrets = JSON.parse(content);
+  } catch {
+    return null;
+  }
+
+  if (!secrets || typeof secrets !== "object" || Array.isArray(secrets)) {
+    throw new Error(
+      `Secrets file ${filePath} must contain a JSON object or dotenv values.`,
+    );
+  }
+
+  for (const [key, value] of Object.entries(secrets)) {
+    if (value !== null && typeof value !== "string") {
+      throw new Error(
+        `Secret ${key} in ${filePath} must be a string or null value.`,
+      );
+    }
+  }
+
+  return secrets;
+}
+
+async function createInitialSecretsFile(
+  temporaryDirectory,
+  sourceFile,
+  vapidKeys,
+) {
+  if (!sourceFile) {
+    const secretsFile = join(temporaryDirectory, "secrets.json");
+    await writeFile(secretsFile, `${JSON.stringify(vapidKeys)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    return secretsFile;
+  }
+
+  const sourcePath = resolve(invocationDirectory, sourceFile);
+  const sourceContent = await readFile(sourcePath, "utf8");
+  const parsedJson = parseJsonSecrets(sourceContent, sourceFile);
+  const secretsFile = join(
+    temporaryDirectory,
+    parsedJson ? "secrets.json" : "secrets.env",
+  );
+
+  if (parsedJson) {
+    await writeFile(
+      secretsFile,
+      `${JSON.stringify({ ...parsedJson, ...vapidKeys })}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
+    return secretsFile;
+  }
+
+  await writeFile(
+    secretsFile,
+    `${sourceContent.trimEnd()}\nVAPID_PUBLIC_KEY=${vapidKeys.publicKey}\nVAPID_PRIVATE_KEY=${vapidKeys.privateKey}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+  return secretsFile;
+}
+
 async function deploy() {
   const secrets = await existingSecretNames();
   const hasPublicKey = secrets?.has("VAPID_PUBLIC_KEY") ?? false;
   const hasPrivateKey = secrets?.has("VAPID_PRIVATE_KEY") ?? false;
-  const needsInitialKeys = secrets === null || (!hasPublicKey && !hasPrivateKey);
+  const needsInitialKeys =
+    secrets === null || (!hasPublicKey && !hasPrivateKey);
 
   if (hasPublicKey !== hasPrivateKey && !needsInitialKeys) {
     throw new Error(
@@ -168,20 +271,21 @@ async function deploy() {
     return;
   }
 
+  const { remaining: deployArgumentsWithoutSecretsFile, value: sourceFile } =
+    removeSingleOption(deployArguments, "--secrets-file");
   const vapidKeys = generateVapidKeys();
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "taiwan-fin-hub-vapid-"),
   );
-  const secretsFile = join(temporaryDirectory, "secrets.json");
 
   try {
-    await writeFile(
-      secretsFile,
-      `${JSON.stringify({
+    const secretsFile = await createInitialSecretsFile(
+      temporaryDirectory,
+      sourceFile,
+      {
         VAPID_PUBLIC_KEY: vapidKeys.publicKey,
         VAPID_PRIVATE_KEY: vapidKeys.privateKey,
-      })}\n`,
-      { encoding: "utf8", mode: 0o600 },
+      },
     );
     console.log(
       "[deploy] No VAPID key pair found; generating one for this Worker.",
@@ -189,7 +293,7 @@ async function deploy() {
 
     const result = await runWrangler([
       "deploy",
-      ...deployArguments,
+      ...deployArgumentsWithoutSecretsFile,
       "--secrets-file",
       secretsFile,
     ]);

--- a/scripts/deploy-with-vapid.mjs
+++ b/scripts/deploy-with-vapid.mjs
@@ -40,6 +40,12 @@ function optionArguments(argumentsToInspect, optionNames) {
   return selected;
 }
 
+function booleanOptionEnabled(argumentsToInspect, optionName) {
+  return argumentsToInspect.some(
+    (argument) => argument === optionName || argument === `${optionName}=true`,
+  );
+}
+
 function removeSingleOption(argumentsToInspect, optionName) {
   const remaining = [];
   const values = [];
@@ -267,12 +273,8 @@ function generateVapidSecrets() {
   };
 }
 
-async function createInitialSecretsFile(
-  temporaryDirectory,
-  sourceFile,
-  effectiveDirectory,
-) {
-  if (!sourceFile) {
+async function createInitialSecretsFile(temporaryDirectory, suppliedSecrets) {
+  if (!suppliedSecrets) {
     const vapidKeys = generateVapidSecrets();
     const secretsFile = join(temporaryDirectory, "secrets.json");
     await writeFile(secretsFile, `${JSON.stringify(vapidKeys)}\n`, {
@@ -282,11 +284,7 @@ async function createInitialSecretsFile(
     return { secretsFile, generated: true };
   }
 
-  const sourcePath = resolve(effectiveDirectory, sourceFile);
-  const sourceContent = await readFile(sourcePath, "utf8");
-  const parsedJson = parseJsonSecrets(sourceContent, sourceFile);
-  const sourceSecrets = parsedJson ?? parseDotenvVapidSecrets(sourceContent);
-  const existingVapidKeys = providedVapidKeys(sourceSecrets, sourceFile);
+  const { content, parsedJson, vapidKeys: existingVapidKeys } = suppliedSecrets;
   const vapidKeys = existingVapidKeys ?? generateVapidSecrets();
   const secretsFile = join(
     temporaryDirectory,
@@ -305,14 +303,42 @@ async function createInitialSecretsFile(
   const vapidLines = existingVapidKeys
     ? ""
     : `VAPID_PUBLIC_KEY=${vapidKeys.VAPID_PUBLIC_KEY}\nVAPID_PRIVATE_KEY=${vapidKeys.VAPID_PRIVATE_KEY}\n`;
-  await writeFile(secretsFile, `${sourceContent.trimEnd()}\n${vapidLines}`, {
+  await writeFile(secretsFile, `${content.trimEnd()}\n${vapidLines}`, {
     encoding: "utf8",
     mode: 0o600,
   });
   return { secretsFile, generated: existingVapidKeys === null };
 }
 
+async function readSuppliedSecretsFile(sourceFile, effectiveDirectory) {
+  if (!sourceFile) return null;
+
+  const sourcePath = resolve(effectiveDirectory, sourceFile);
+  const content = await readFile(sourcePath, "utf8");
+  const parsedJson = parseJsonSecrets(content, sourceFile);
+  const secrets = parsedJson ?? parseDotenvVapidSecrets(content);
+
+  return {
+    content,
+    parsedJson,
+    vapidKeys: providedVapidKeys(secrets, sourceFile),
+  };
+}
+
 async function deploy() {
+  if (booleanOptionEnabled(deployArguments, "--dry-run")) {
+    const result = await runWrangler(["deploy", ...deployArguments]);
+    if (result.exitCode !== 0) process.exitCode = result.exitCode ?? 1;
+    return;
+  }
+
+  const { remaining: deployArgumentsWithoutSecretsFile, value: sourceFile } =
+    removeSingleOption(deployArguments, "--secrets-file");
+  const effectiveDirectory = deploymentDirectory();
+  const suppliedSecrets = await readSuppliedSecretsFile(
+    sourceFile,
+    effectiveDirectory,
+  );
   const secrets = await existingSecretNames();
   const hasPublicKey = secrets?.has("VAPID_PUBLIC_KEY") ?? false;
   const hasPrivateKey = secrets?.has("VAPID_PRIVATE_KEY") ?? false;
@@ -331,9 +357,6 @@ async function deploy() {
     return;
   }
 
-  const { remaining: deployArgumentsWithoutSecretsFile, value: sourceFile } =
-    removeSingleOption(deployArguments, "--secrets-file");
-  const effectiveDirectory = deploymentDirectory();
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "taiwan-fin-hub-vapid-"),
   );
@@ -341,8 +364,7 @@ async function deploy() {
   try {
     const { secretsFile, generated } = await createInitialSecretsFile(
       temporaryDirectory,
-      sourceFile,
-      effectiveDirectory,
+      suppliedSecrets,
     );
     console.log(
       generated

--- a/scripts/deploy-with-vapid.mjs
+++ b/scripts/deploy-with-vapid.mjs
@@ -1,0 +1,202 @@
+import { createECDH } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import { spawn } from "node:child_process";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const repositoryDirectory = resolve(scriptDirectory, "..");
+const invocationDirectory = process.cwd();
+const wranglerScript = join(
+  repositoryDirectory,
+  "node_modules",
+  "wrangler",
+  "bin",
+  "wrangler.js",
+);
+
+const deployArguments = process.argv.slice(2);
+
+function optionArguments(argumentsToInspect, optionNames) {
+  const selected = [];
+
+  for (let index = 0; index < argumentsToInspect.length; index += 1) {
+    const argument = argumentsToInspect[index];
+    const matchingName = optionNames.find(
+      (optionName) =>
+        argument === optionName || argument.startsWith(`${optionName}=`),
+    );
+
+    if (!matchingName) continue;
+
+    selected.push(argument);
+    if (argument === matchingName && argumentsToInspect[index + 1]) {
+      selected.push(argumentsToInspect[index + 1]);
+      index += 1;
+    }
+  }
+
+  return selected;
+}
+
+function runWrangler(argumentsToRun, options = {}) {
+  const { captureOutput = false } = options;
+  const child = spawn(process.execPath, [wranglerScript, ...argumentsToRun], {
+    cwd: invocationDirectory,
+    env: {
+      ...process.env,
+      XDG_CONFIG_HOME:
+        process.env.XDG_CONFIG_HOME ?? join(invocationDirectory, ".wrangler-config"),
+    },
+    stdio: captureOutput ? ["ignore", "pipe", "pipe"] : "inherit",
+    windowsHide: true,
+  });
+
+  if (!captureOutput) {
+    return new Promise((resolvePromise, rejectPromise) => {
+      child.once("error", rejectPromise);
+      child.once("close", (exitCode) => resolvePromise({ exitCode }));
+    });
+  }
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.once("error", rejectPromise);
+    child.once("close", (exitCode) =>
+      resolvePromise({ exitCode, stdout, stderr }),
+    );
+  });
+}
+
+function generateVapidKeys() {
+  const curve = createECDH("prime256v1");
+  curve.generateKeys();
+
+  let publicKey = curve.getPublicKey();
+  let privateKey = curve.getPrivateKey();
+
+  // Keep the exact fixed-width representation expected by web-push.
+  if (privateKey.length < 32) {
+    privateKey = Buffer.concat([
+      Buffer.alloc(32 - privateKey.length),
+      privateKey,
+    ]);
+  }
+  if (publicKey.length < 65) {
+    publicKey = Buffer.concat([Buffer.alloc(65 - publicKey.length), publicKey]);
+  }
+
+  return {
+    publicKey: publicKey.toString("base64url"),
+    privateKey: privateKey.toString("base64url"),
+  };
+}
+
+function isMissingWorkerResult(result) {
+  const output = `${result.stdout}\n${result.stderr}`;
+  return (
+    result.exitCode !== 0 &&
+    /worker .* not found|if this is a new worker, run .*wrangler deploy/i.test(
+      output,
+    )
+  );
+}
+
+async function existingSecretNames() {
+  const contextArguments = optionArguments(deployArguments, [
+    "--config",
+    "-c",
+    "--env",
+    "-e",
+    "--name",
+  ]);
+  const result = await runWrangler(
+    ["secret", "list", "--format", "json", ...contextArguments],
+    { captureOutput: true },
+  );
+
+  if (isMissingWorkerResult(result)) {
+    return null;
+  }
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Unable to inspect Worker secrets before deployment.\n${result.stderr.trim()}`,
+    );
+  }
+
+  let secrets;
+  try {
+    secrets = JSON.parse(result.stdout);
+  } catch {
+    throw new Error(
+      `Wrangler returned an unexpected secret list response.\n${result.stdout.trim()}`,
+    );
+  }
+
+  if (!Array.isArray(secrets)) {
+    throw new Error("Wrangler returned an invalid Worker secret list.");
+  }
+
+  return new Set(secrets.map((secret) => secret?.name).filter(Boolean));
+}
+
+async function deploy() {
+  const secrets = await existingSecretNames();
+  const hasPublicKey = secrets?.has("VAPID_PUBLIC_KEY") ?? false;
+  const hasPrivateKey = secrets?.has("VAPID_PRIVATE_KEY") ?? false;
+  const needsInitialKeys = secrets === null || (!hasPublicKey && !hasPrivateKey);
+
+  if (hasPublicKey !== hasPrivateKey && !needsInitialKeys) {
+    throw new Error(
+      "Worker has only one VAPID secret configured. Refusing to rotate the existing key; restore both VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY manually.",
+    );
+  }
+
+  if (!needsInitialKeys) {
+    const result = await runWrangler(["deploy", ...deployArguments]);
+    if (result.exitCode !== 0) process.exitCode = result.exitCode ?? 1;
+    return;
+  }
+
+  const vapidKeys = generateVapidKeys();
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "taiwan-fin-hub-vapid-"),
+  );
+  const secretsFile = join(temporaryDirectory, "secrets.json");
+
+  try {
+    await writeFile(
+      secretsFile,
+      `${JSON.stringify({
+        VAPID_PUBLIC_KEY: vapidKeys.publicKey,
+        VAPID_PRIVATE_KEY: vapidKeys.privateKey,
+      })}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
+    console.log(
+      "[deploy] No VAPID key pair found; generating one for this Worker.",
+    );
+
+    const result = await runWrangler([
+      "deploy",
+      ...deployArguments,
+      "--secrets-file",
+      secretsFile,
+    ]);
+    if (result.exitCode !== 0) process.exitCode = result.exitCode ?? 1;
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+await deploy();

--- a/scripts/deploy-with-vapid.mjs
+++ b/scripts/deploy-with-vapid.mjs
@@ -68,9 +68,7 @@ function removeSingleOption(argumentsToInspect, optionName) {
   }
 
   if (values.length > 1) {
-    throw new Error(
-      `${optionName} can only be provided once; pass one file containing all deployment secrets.`,
-    );
+    throw new Error(`${optionName} can only be provided once.`);
   }
 
   return { remaining, value: values[0] ?? null };
@@ -150,6 +148,7 @@ function isMissingWorkerResult(result) {
 
 async function existingSecretNames() {
   const contextArguments = optionArguments(deployArguments, [
+    "--cwd",
     "--config",
     "-c",
     "--env",
@@ -188,6 +187,16 @@ async function existingSecretNames() {
   return new Set(secrets.map((secret) => secret?.name).filter(Boolean));
 }
 
+function deploymentDirectory() {
+  const { value: requestedDirectory } = removeSingleOption(
+    deployArguments,
+    "--cwd",
+  );
+  return requestedDirectory
+    ? resolve(invocationDirectory, requestedDirectory)
+    : invocationDirectory;
+}
+
 function parseJsonSecrets(content, filePath) {
   let secrets;
   try {
@@ -213,23 +222,72 @@ function parseJsonSecrets(content, filePath) {
   return secrets;
 }
 
+function parseDotenvVapidSecrets(content) {
+  const secrets = {};
+
+  for (const line of content.split(/\r?\n/)) {
+    const match = line.match(
+      /^\s*(?:export\s+)?(VAPID_PUBLIC_KEY|VAPID_PRIVATE_KEY)\s*=\s*(.*)\s*$/,
+    );
+    if (!match) continue;
+
+    const value = match[2].trim();
+    const quotedValue = value.match(/^(['"])(.*?)\1(?:\s*#.*)?$/);
+    secrets[match[1]] = quotedValue
+      ? quotedValue[2]
+      : value.replace(/\s*#.*$/, "").trim();
+  }
+
+  return secrets;
+}
+
+function providedVapidKeys(secrets, filePath) {
+  const publicKey = secrets.VAPID_PUBLIC_KEY?.trim() ?? "";
+  const privateKey = secrets.VAPID_PRIVATE_KEY?.trim() ?? "";
+
+  if (Boolean(publicKey) !== Boolean(privateKey)) {
+    throw new Error(
+      `Secrets file ${filePath} must provide both VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY, or neither.`,
+    );
+  }
+
+  if (!publicKey) return null;
+
+  return {
+    VAPID_PUBLIC_KEY: publicKey,
+    VAPID_PRIVATE_KEY: privateKey,
+  };
+}
+
+function generateVapidSecrets() {
+  const keys = generateVapidKeys();
+  return {
+    VAPID_PUBLIC_KEY: keys.publicKey,
+    VAPID_PRIVATE_KEY: keys.privateKey,
+  };
+}
+
 async function createInitialSecretsFile(
   temporaryDirectory,
   sourceFile,
-  vapidKeys,
+  effectiveDirectory,
 ) {
   if (!sourceFile) {
+    const vapidKeys = generateVapidSecrets();
     const secretsFile = join(temporaryDirectory, "secrets.json");
     await writeFile(secretsFile, `${JSON.stringify(vapidKeys)}\n`, {
       encoding: "utf8",
       mode: 0o600,
     });
-    return secretsFile;
+    return { secretsFile, generated: true };
   }
 
-  const sourcePath = resolve(invocationDirectory, sourceFile);
+  const sourcePath = resolve(effectiveDirectory, sourceFile);
   const sourceContent = await readFile(sourcePath, "utf8");
   const parsedJson = parseJsonSecrets(sourceContent, sourceFile);
+  const sourceSecrets = parsedJson ?? parseDotenvVapidSecrets(sourceContent);
+  const existingVapidKeys = providedVapidKeys(sourceSecrets, sourceFile);
+  const vapidKeys = existingVapidKeys ?? generateVapidSecrets();
   const secretsFile = join(
     temporaryDirectory,
     parsedJson ? "secrets.json" : "secrets.env",
@@ -241,15 +299,17 @@ async function createInitialSecretsFile(
       `${JSON.stringify({ ...parsedJson, ...vapidKeys })}\n`,
       { encoding: "utf8", mode: 0o600 },
     );
-    return secretsFile;
+    return { secretsFile, generated: existingVapidKeys === null };
   }
 
-  await writeFile(
-    secretsFile,
-    `${sourceContent.trimEnd()}\nVAPID_PUBLIC_KEY=${vapidKeys.publicKey}\nVAPID_PRIVATE_KEY=${vapidKeys.privateKey}\n`,
-    { encoding: "utf8", mode: 0o600 },
-  );
-  return secretsFile;
+  const vapidLines = existingVapidKeys
+    ? ""
+    : `VAPID_PUBLIC_KEY=${vapidKeys.VAPID_PUBLIC_KEY}\nVAPID_PRIVATE_KEY=${vapidKeys.VAPID_PRIVATE_KEY}\n`;
+  await writeFile(secretsFile, `${sourceContent.trimEnd()}\n${vapidLines}`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  return { secretsFile, generated: existingVapidKeys === null };
 }
 
 async function deploy() {
@@ -273,22 +333,21 @@ async function deploy() {
 
   const { remaining: deployArgumentsWithoutSecretsFile, value: sourceFile } =
     removeSingleOption(deployArguments, "--secrets-file");
-  const vapidKeys = generateVapidKeys();
+  const effectiveDirectory = deploymentDirectory();
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "taiwan-fin-hub-vapid-"),
   );
 
   try {
-    const secretsFile = await createInitialSecretsFile(
+    const { secretsFile, generated } = await createInitialSecretsFile(
       temporaryDirectory,
       sourceFile,
-      {
-        VAPID_PUBLIC_KEY: vapidKeys.publicKey,
-        VAPID_PRIVATE_KEY: vapidKeys.privateKey,
-      },
+      effectiveDirectory,
     );
     console.log(
-      "[deploy] No VAPID key pair found; generating one for this Worker.",
+      generated
+        ? "[deploy] No VAPID key pair found; generating one for this Worker."
+        : "[deploy] Using the VAPID key pair from the supplied secrets file.",
     );
 
     const result = await runWrangler([


### PR DESCRIPTION
## Summary

- 首次部署時自動產生 VAPID 公私鑰，並透過 Worker Secret 儲存。
- 後續部署沿用既有金鑰；若只存在其中一把，部署會停止以避免意外輪替。
- 部署前置檢查會轉傳所有 `--env-file`，並將 caller 提供的 `--secrets-file` 與 VAPID keys 合併成單一檔案。
- 移除 Deploy Button 與 README 中要求使用者手動設定 VAPID 的內容，降低部署負擔。

## Validation

- `node --check scripts/deploy-with-vapid.mjs`
- `node node_modules/typescript/bin/tsc -p apps/worker/tsconfig.json --noEmit`
- `node node_modules/typescript/bin/tsc -p apps/web/tsconfig.json --noEmit`
- Prettier、JSON parsing 與 `git diff --check` 通過。

## Notes

- 完整 Vitest 尚未執行；目前執行環境為 Node 18，而專案 Wrangler 需要 Node 22。