### PR TITLE
fix(台新): 支援新版登入按鈕結構

### DIFF
--- a/apps/worker/src/connectors/taishin.ts
+++ b/apps/worker/src/connectors/taishin.ts
@@ -473,14 +473,42 @@ async function submitLogin(page: BrowserPage, captcha: string) {
   const captchaInput =
     'input[data-taishin-field="captcha"], input[placeholder*="驗證碼"]';
   await replaceInput(page, captchaInput, captcha);
-  const clicked = await page.evaluate(() => {
-    const target = Array.from(
-      document.querySelectorAll<HTMLElement>("button, a"),
-    ).find((element) => element.innerText.trim() === "登入網銀");
-    target?.click();
-    return Boolean(target);
+  const loginButton = await page.evaluate(() => {
+    const normalize = (value: string | null | undefined) =>
+      value?.replace(/\s+/g, "").trim() ?? "";
+    const candidates = Array.from(
+      document.querySelectorAll<HTMLElement>("body *"),
+    ).filter((element) => {
+      const rect = element.getBoundingClientRect();
+      const label =
+        element.tagName === "INPUT"
+          ? (element as HTMLInputElement).value
+          : element.innerText;
+      return (
+        !element.hidden &&
+        !("disabled" in element && Boolean(element.disabled)) &&
+        element.getAttribute("aria-disabled") !== "true" &&
+        rect.width > 0 &&
+        rect.height > 0 &&
+        [label, element.getAttribute("aria-label"), element.title].some(
+          (value) => normalize(value) === "登入網銀",
+        )
+      );
+    });
+    const target =
+      candidates.find((element) =>
+        element.matches(
+          'button, a, input[type="button"], input[type="submit"], [role="button"], [class*="btn"], [class*="button"]',
+        ),
+      ) ?? candidates.at(-1);
+    if (!target) return false;
+    target.dataset.taishinLogin = "submit";
+    return true;
   });
-  if (!clicked) throw new TaishinConnectionError("台新登入按鈕結構已變更。");
+  if (!loginButton) {
+    throw new TaishinConnectionError("台新登入按鈕結構已變更。");
+  }
+  await page.click('[data-taishin-login="submit"]');
 
   await page
     .waitForFunction(

--- a/apps/worker/tests/connectors/taishin-session.test.ts
+++ b/apps/worker/tests/connectors/taishin-session.test.ts
@@ -204,6 +204,55 @@ describe("Taishin browser session lifecycle", () => {
     expect(browserInstance.disconnect).not.toHaveBeenCalled();
   });
 
+  it("clicks a visible div used as the login button", async () => {
+    const browserPage = page();
+    const loginButton = {
+      tagName: "DIV",
+      innerText: "登入網銀",
+      hidden: false,
+      title: "",
+      dataset: {} as Record<string, string>,
+      getAttribute: vi.fn().mockReturnValue(null),
+      getBoundingClientRect: vi
+        .fn()
+        .mockReturnValue({ width: 300, height: 50 }),
+      matches: vi.fn().mockReturnValue(false),
+    };
+    browserPage.evaluate
+      .mockImplementationOnce(async (callback: () => unknown) => {
+        vi.stubGlobal("document", {
+          querySelectorAll: vi.fn().mockReturnValue([loginButton]),
+        });
+        try {
+          return callback();
+        } finally {
+          vi.unstubAllGlobals();
+        }
+      })
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce("驗證碼錯誤");
+    const browserInstance = browser(browserPage);
+    puppeteerMock.sessions.mockResolvedValue([
+      { sessionId: "taishin-session", startTime: Date.now() },
+    ]);
+    puppeteerMock.connect.mockResolvedValue(browserInstance);
+
+    await expect(
+      createTaishinConnector({} as Fetcher).sync({
+        ...credentials,
+        browserSessionId: "taishin-session",
+        browserSessionExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+        captchaDigitCount: 6,
+        captcha: "123456",
+      }),
+    ).rejects.toThrow("圖形驗證碼錯誤");
+
+    expect(loginButton.dataset.taishinLogin).toBe("submit");
+    expect(browserPage.click).toHaveBeenCalledWith(
+      '[data-taishin-login="submit"]',
+    );
+  });
+
   it("stops automatic login immediately when credentials are rejected", async () => {
     const browserPage = page();
     rejectLoginSequence(browserPage, "使用者密碼錯誤");


### PR DESCRIPTION
## 摘要

修正台新銀行新版登入頁將「登入網銀」改為自訂可點擊元素後，自動同步無法找到登入按鈕的問題。

## 主要變更

- 登入按鈕偵測不再限定 `button`／`a`，改為比對所有可見、可用且標籤為「登入網銀」的元素。
- 優先選擇具有按鈕語意或按鈕樣式的節點，標記後交由 Puppeteer 實際點擊。
- 新增以 `div` 呈現登入按鈕的回歸測試。

## 根本原因

台新登入頁按鈕的可點擊節點結構已變更，但連接器仍硬編碼只搜尋 `button, a`，即使畫面文案仍為「登入網銀」也會回報「台新登入按鈕結構已變更」。

## 驗證

- `source ~/.nvm/nvm.sh && nvm use 22`
- `npm test -w @taiwan-fin-hub/worker -- --run tests/connectors/taishin-session.test.ts`（Worker 22 個 test files、133 tests 全數通過）
- `npm run typecheck -w @taiwan-fin-hub/worker`（通過）
- `git diff --check`（通過）

## 風險

變更僅影響台新登入送出按鈕的定位方式；身分證字號、使用者代號、密碼、驗證碼與後續信用卡資料同步流程皆未變更。