### PR TITLE
修正台新同步流程與信用卡交易金額方向

### DIFF
--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -53,6 +53,7 @@
     buildActivityCategorySlices,
     activityCashAmountTwd,
     activityCashFlow,
+    activityDisplayAmount,
   } from "./model/chart";
   import {
     deduplicateBankTransactions,
@@ -519,11 +520,6 @@
     if (item.invoiceAmount == null || item.amount == null) return 0;
     return Math.abs(item.invoiceAmount - Math.abs(item.amount));
   }
-  function renderedAmount(item: ActivityItem) {
-    return item.source === "card" || item.source === "invoice"
-      ? -Math.abs(item.amount ?? 0)
-      : item.amount;
-  }
   function countMatches() {
     if (!pending) return 0;
     return activityBankTransactions.filter((t) =>
@@ -733,7 +729,7 @@
             >
               沒有符合條件的活動。
             </p>{:else}{#each filtered.slice(0, 100) as item (item.source + "-" + item.id)}{@const amount =
-                renderedAmount(item)}
+                activityDisplayAmount(item)}
               <button
                 aria-label={`查看 ${item.title} 活動詳情`}
                 class={`flex w-full min-w-0 items-center gap-3 px-4 py-3 text-left transition hover:bg-paper ${item.excludedFromCalculation ? "bg-ink/[0.025]" : ""}`}
@@ -785,7 +781,7 @@
                     >沒有符合條件的活動。</td
                   ></tr
                 >{:else}{#each filtered.slice(0, 100) as item (item.source + "-" + item.id)}{@const amount =
-                    renderedAmount(item)}<tr
+                    activityDisplayAmount(item)}<tr
                     aria-label={`查看 ${item.title} 活動詳情`}
                     class={`cursor-pointer transition hover:bg-paper focus-visible:outline-2 focus-visible:outline-steel ${item.excludedFromCalculation ? "bg-ink/[0.025]" : ""}`}
                     onclick={() => openDetail(item)}
@@ -836,7 +832,7 @@
       >
     </div>
     {#if detailItem}
-      {@const amount = renderedAmount(detailItem)}
+      {@const amount = activityDisplayAmount(detailItem)}
       {@const transaction = transactionForItem(detailItem)}
       {@const invoice = invoiceForItem(detailItem)}
       <div class="fixed inset-0 z-[60] bg-ink/40 md:flex md:justify-end">

--- a/apps/web/src/features/activity/model/chart.test.ts
+++ b/apps/web/src/features/activity/model/chart.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   activityCashAmountTwd,
   activityCashFlow,
+  activityDisplayAmount,
   buildActivityCategorySlices,
 } from "./chart";
 import type { ActivityItem } from "./types";
@@ -22,12 +23,12 @@ function item(overrides: Partial<ActivityItem>): ActivityItem {
 }
 
 describe("activity category chart", () => {
-  it("converts cash flow to TWD and treats cards and invoices as expenses", () => {
+  it("converts cash flow to TWD and keeps invoices as expenses", () => {
     expect(
       activityCashAmountTwd(item({ amount: 10, currency: "USD" }), { USD: 32 }),
     ).toBe(320);
     expect(
-      activityCashAmountTwd(item({ source: "card", amount: 500 }), {}),
+      activityCashAmountTwd(item({ source: "card", amount: -500 }), {}),
     ).toBe(-500);
     expect(
       activityCashAmountTwd(item({ source: "invoice", amount: 500 }), {}),
@@ -35,6 +36,28 @@ describe("activity category chart", () => {
     expect(activityCashFlow(item({ source: "invoice", amount: 500 }))).toBe(
       "expense",
     );
+  });
+
+  it("treats a positive card discount as income in display and totals", () => {
+    const discount = item({
+      source: "card",
+      amount: 63,
+      category: "購物",
+      title: "信用卡消費折抵_樂購蝦皮－daniel0329",
+    });
+
+    expect(activityDisplayAmount(discount)).toBe(63);
+    expect(activityCashAmountTwd(discount, {})).toBe(63);
+    expect(activityCashFlow(discount)).toBe("income");
+    expect(buildActivityCategorySlices([discount], "expense", {})).toEqual([]);
+    expect(buildActivityCategorySlices([discount], "income", {})).toEqual([
+      {
+        category: "購物",
+        amount: 63,
+        percentage: 100,
+        color: "#3e6f7c",
+      },
+    ]);
   });
 
   it("groups categories and sorts them by amount descending", () => {

--- a/apps/web/src/features/activity/model/chart.ts
+++ b/apps/web/src/features/activity/model/chart.ts
@@ -20,6 +20,11 @@ export const ACTIVITY_CATEGORY_COLORS = [
   "#68747b",
 ];
 
+export function activityDisplayAmount(item: ActivityItem) {
+  if (item.amount == null) return undefined;
+  return item.source === "invoice" ? -Math.abs(item.amount) : item.amount;
+}
+
 export function activityCashFlow(item: ActivityItem): ActivityFlow | null {
   if (
     item.amount == null ||
@@ -28,9 +33,10 @@ export function activityCashFlow(item: ActivityItem): ActivityFlow | null {
       item.source !== "invoice")
   )
     return null;
-  if (item.source === "card" || item.source === "invoice") return "expense";
-  if (item.amount > 0) return "income";
-  if (item.amount < 0) return "expense";
+  const amount = activityDisplayAmount(item);
+  if (amount == null) return null;
+  if (amount > 0) return "income";
+  if (amount < 0) return "expense";
   return null;
 }
 
@@ -47,10 +53,7 @@ export function activityCashAmountTwd(
   )
     return 0;
   const rate = item.currency === "TWD" ? 1 : (rates[item.currency] ?? 0);
-  const converted = item.amount * rate;
-  return item.source === "card" || item.source === "invoice"
-    ? -Math.abs(converted)
-    : converted;
+  return (activityDisplayAmount(item) ?? 0) * rate;
 }
 
 export function buildActivityCategorySlices(

--- a/apps/worker/src/connectors/esun.ts
+++ b/apps/worker/src/connectors/esun.ts
@@ -457,15 +457,16 @@ export function normalizeEsunTimelineTransactions(
         const postedDate = lifecycle === "未入帳"
           ? undefined
           : normalizeEsunMonthDay(year, txn.postingDt ?? txn.consumerDt ?? "");
-        const amount = parseTwd(txn.payAmt ?? txn.consumerAmt ?? "0");
+        const rawAmount = parseTwd(txn.payAmt ?? txn.consumerAmt ?? "0");
         const currency = txn.payCur?.trim() || txn.consumerCur?.trim() || "TWD";
         const description = txn.storeName?.trim() || "玉山信用卡交易";
+        const amount = signedCreditCardAmount(rawAmount, description);
         const accountId = creditCardSourceId(txn.cardNo);
         const sourceKey = [
           authorizedAt,
           accountId,
           description,
-          amount,
+          rawAmount,
           currency,
         ].join(":");
         candidates.push({
@@ -817,6 +818,15 @@ function normalizeEsunTxDateTime(txDate: string | null | undefined, txTime: stri
 function parseTwd(text: string): number {
   const n = Number(text.replace(/[^0-9.-]/g, ""));
   return Number.isFinite(n) ? Math.round(n) : 0;
+}
+
+function signedCreditCardAmount(rawAmount: number, description: string) {
+  const isCredit =
+    rawAmount < 0 ||
+    /退款|退貨|折抵|折讓|回饋|沖銷|貸方|繳款|自動轉帳扣繳|refund|credit|payment/i.test(
+      description,
+    );
+  return isCredit ? Math.abs(rawAmount) : -Math.abs(rawAmount);
 }
 
 // Format "0YYYMMDD" where YYY = 民國 year (e.g. "01150629" → "2026/06/29")

--- a/apps/worker/src/connectors/taishin.ts
+++ b/apps/worker/src/connectors/taishin.ts
@@ -18,6 +18,11 @@ const REALTIME_PATH = `${API_ROOT}/web4/rb0708rwd/qryRealTime`;
 export const TAISHIN_AUTO_LOGIN_ATTEMPTS = 3;
 const CAPTCHA_KEEP_ALIVE_MS = 150_000;
 const CAPTCHA_VALIDITY_MS = 120_000;
+const LOGIN_RESULT_ATTEMPTS = 10;
+const LOGIN_RESULT_POLL_MS = 500;
+const REQUIRED_API_TIMEOUT_MS = 8_000;
+const OPTIONAL_API_TIMEOUT_MS = 4_000;
+const REALTIME_BUSY_RETRY_ATTEMPTS = 3;
 const USER_AGENT =
   "Mozilla/5.0 (Linux; Android 14; Pixel 7 Build/UP1A.231105.003) " +
   "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36";
@@ -46,8 +51,19 @@ export class TaishinCaptchaRejectedError extends TaishinVerificationRequiredErro
   }
 }
 
-export class TaishinConnectionError extends Error {
+class TaishinLoginOutcomeUnknownError extends TaishinVerificationRequiredError {
   constructor(message: string) {
+    super(message);
+    this.name = "TaishinLoginOutcomeUnknownError";
+  }
+}
+
+export class TaishinConnectionError extends Error {
+  constructor(
+    message: string,
+    readonly sessionCookies?: string,
+    readonly sessionCreatedAt?: string,
+  ) {
     super(message);
     this.name = "TaishinConnectionError";
   }
@@ -87,6 +103,7 @@ export function createTaishinConnector(
       );
       const pages = await browserInstance.pages();
       const page = pages[0] ?? (await browserInstance.newPage());
+      let authenticated = false;
       try {
         await configurePage(page);
         let loggedIn = false;
@@ -123,15 +140,40 @@ export function createTaishinConnector(
           }
           pageContext = await loginWithOcr(page, config, recognizeCaptcha);
         }
+        authenticated = true;
 
-        const payloads = await fetchCreditCardPayloads(
-          pageContext,
-          config.lookbackMonths,
-        );
-        const data = parseTaishinCreditCardData(
-          payloads,
-          config.lookbackMonths,
-        );
+        let payloads;
+        try {
+          payloads = await fetchCreditCardPayloads(
+            pageContext,
+            config.lookbackMonths,
+          );
+        } catch (error) {
+          if (
+            !(error instanceof TaishinVerificationRequiredError) ||
+            !recognizeCaptcha
+          ) {
+            throw error;
+          }
+          pageContext = await loginWithOcr(page, config, recognizeCaptcha);
+          authenticated = true;
+          payloads = await fetchCreditCardPayloads(
+            pageContext,
+            config.lookbackMonths,
+          );
+        }
+        let data;
+        try {
+          data = parseTaishinCreditCardData(payloads, config.lookbackMonths);
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message.startsWith("台新信用卡 API")
+          ) {
+            throw new TaishinConnectionError(error.message);
+          }
+          throw error;
+        }
         const now = new Date();
         return {
           records: [],
@@ -142,6 +184,21 @@ export function createTaishinConnector(
             syncedAt: now.toISOString(),
           }),
         };
+      } catch (error) {
+        if (authenticated && error instanceof TaishinConnectionError) {
+          const sessionCookies = await page
+            .cookies()
+            .then((cookies) => JSON.stringify(cookies))
+            .catch(() => undefined);
+          if (sessionCookies) {
+            throw new TaishinConnectionError(
+              error.message,
+              sessionCookies,
+              new Date().toISOString(),
+            );
+          }
+        }
+        throw error;
       } finally {
         await browserInstance.close();
       }
@@ -204,7 +261,12 @@ async function loginWithOcr(
       return frame;
     } catch (error) {
       if (error instanceof TaishinCredentialRejectedError) throw error;
-      if (!(error instanceof TaishinCaptchaRejectedError)) throw error;
+      if (
+        !(error instanceof TaishinCaptchaRejectedError) &&
+        !(error instanceof TaishinLoginOutcomeUnknownError)
+      ) {
+        throw error;
+      }
     }
   }
   throw new TaishinVerificationRequiredError(
@@ -216,28 +278,77 @@ async function fetchCreditCardPayloads(
   page: BrowserPage,
   lookbackMonths: number,
 ) {
-  if (!(await hasValidSession(page))) {
-    throw new TaishinVerificationRequiredError(
-      "台新銀行 session 已失效，需要重新登入。",
+  const realtime = await fetchRealtimeTransactions(page);
+  let summary: unknown = { value: {}, error: null };
+  try {
+    summary = await postJson(page, SUMMARY_PATH, {}, OPTIONAL_API_TIMEOUT_MS);
+    const billingContext = taishinBillingContext(summary);
+    const months = recentMonths(
+      Math.max(1, Math.min(6, lookbackMonths)),
+      billingContext.anchor,
     );
+    const fetchBill = ({ year, month }: (typeof months)[number]) =>
+      postJson(
+        page,
+        BILL_PATH,
+        {
+          org: billingContext.org,
+          byear: String(year),
+          bmonth: String(month).padStart(2, "0"),
+          cardHolderFlagSelected: "1",
+          cardNo: "",
+        },
+        OPTIONAL_API_TIMEOUT_MS,
+      );
+    const currentBill = await fetchBill(months[0]!);
+    if (!hasBillPayload(currentBill)) {
+      return { summary, bills: [], realtime };
+    }
+    const historicalBills = (
+      await Promise.all(
+        months.slice(1).map((month) => fetchBill(month).catch(() => undefined)),
+      )
+    ).filter((bill) => bill !== undefined);
+    return {
+      summary,
+      bills: [currentBill, ...historicalBills],
+      realtime,
+    };
+  } catch (error) {
+    if (error instanceof TaishinVerificationRequiredError) throw error;
+    if (!(error instanceof TaishinConnectionError)) throw error;
+    console.warn(`[taishin] optional bill sync skipped: ${error.message}`);
+    return { summary, bills: [], realtime };
   }
+}
 
-  const summary = await postJson(page, SUMMARY_PATH);
-  const realtime = await postJson(page, REALTIME_PATH);
-  const months = recentMonths(Math.max(1, Math.min(6, lookbackMonths)));
-  const bills = [];
-  for (const { year, month } of months) {
-    bills.push(
-      await postJson(page, BILL_PATH, {
-        org: "001",
-        byear: String(year),
-        bmonth: String(month).padStart(2, "0"),
-        cardHolderFlagSelected: "1",
-        cardNo: "",
-      }),
-    );
+async function fetchRealtimeTransactions(page: BrowserPage) {
+  for (let attempt = 1; attempt <= REALTIME_BUSY_RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      return await postJson(page, REALTIME_PATH, "", REQUIRED_API_TIMEOUT_MS);
+    } catch (error) {
+      const isBusy =
+        error instanceof TaishinConnectionError &&
+        /系統忙碌|無法取得資料/.test(error.message);
+      if (!isBusy) throw error;
+      if (attempt < REALTIME_BUSY_RETRY_ATTEMPTS) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 250));
+      } else {
+        console.warn(
+          `[taishin] realtime sync skipped after ${attempt} busy responses`,
+        );
+      }
+    }
   }
-  return { summary, bills, realtime };
+  return { value: { fmtRealTxListMap: [] }, error: null };
+}
+
+function hasBillPayload(payload: unknown) {
+  if (!isRecord(payload) || !isRecord(payload.value)) return false;
+  return (
+    typeof payload.value.showAccoutnYM === "string" &&
+    payload.value.showAccoutnYM.trim().length > 0
+  );
 }
 
 async function hasValidSession(page: BrowserPage) {
@@ -254,30 +365,68 @@ async function hasValidSession(page: BrowserPage) {
   }
 }
 
-async function postJson(page: BrowserPage, path: string, body?: JsonRecord) {
+async function postJson(
+  page: BrowserPage,
+  path: string,
+  body?: JsonRecord | string,
+  timeoutMs = REQUIRED_API_TIMEOUT_MS,
+) {
   const response = await page.evaluate(
-    async (input: { path: string; body?: JsonRecord }) => {
-      const response = await fetch(input.path, {
-        method: "POST",
-        headers: {
-          Accept: "application/json, text/plain, */*",
-          "Content-Type": "application/json",
-        },
-        body: input.body ? JSON.stringify(input.body) : undefined,
-        credentials: "same-origin",
-      });
-      return {
-        ok: response.ok,
-        status: response.status,
-        contentType: response.headers.get("content-type") ?? "",
-        text: await response.text(),
-      };
+    async (input: {
+      path: string;
+      body?: JsonRecord | string;
+      timeoutMs: number;
+    }) => {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), input.timeoutMs);
+      try {
+        const response = await fetch(input.path, {
+          method: "POST",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "Content-Type":
+              typeof input.body === "string"
+                ? "application/x-www-form-urlencoded"
+                : "application/json",
+          },
+          body:
+            typeof input.body === "string"
+              ? input.body
+              : input.body
+                ? JSON.stringify(input.body)
+                : undefined,
+          credentials: "same-origin",
+          signal: controller.signal,
+        });
+        return {
+          ok: response.ok,
+          status: response.status,
+          contentType: response.headers.get("content-type") ?? "",
+          text: await response.text(),
+          timedOut: false,
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          status: 0,
+          contentType: "",
+          text: "",
+          timedOut:
+            error instanceof DOMException && error.name === "AbortError",
+        };
+      } finally {
+        clearTimeout(timeout);
+      }
     },
-    { path, body },
+    { path, body, timeoutMs },
   );
+  const endpoint = path.split("/").at(-1) ?? path;
+  if (response.timedOut) {
+    throw new TaishinConnectionError(`台新信用卡 API ${endpoint} 請求逾時。`);
+  }
   if (!response.ok) {
     throw new TaishinConnectionError(
-      `台新信用卡 API 回應 HTTP ${response.status}。`,
+      `台新信用卡 API ${endpoint} 回應 HTTP ${response.status}。`,
     );
   }
   if (!response.contentType.includes("application/json")) {
@@ -290,12 +439,12 @@ async function postJson(page: BrowserPage, path: string, body?: JsonRecord) {
   }
   try {
     const payload = JSON.parse(response.text) as unknown;
-    if (
-      isRecord(payload) &&
-      payload.error != null &&
-      !isEmptyObject(payload.error)
-    ) {
-      throw new TaishinConnectionError("台新信用卡 API 回傳錯誤。");
+    if (isRecord(payload) && Boolean(payload.error)) {
+      const endpoint = path.split("/").at(-1) ?? path;
+      const detail = summarizeApiError(payload.error);
+      throw new TaishinConnectionError(
+        `台新信用卡 API ${endpoint} 回傳錯誤${detail ? `：${detail}` : ""}。`,
+      );
     }
     return payload;
   } catch (error) {
@@ -407,18 +556,13 @@ async function openLoginAndFill(page: Page, config: TaishinConfig) {
   ) {
     throw new TaishinConnectionError("台新登入頁欄位結構已變更。");
   }
-  await replaceInput(frame, selectors.userId, config.userId!);
-  await replaceInput(frame, selectors.account, config.account!);
-  await replaceInput(frame, selectors.password, config.password!);
+  await typeInput(frame, selectors.userId, config.userId!);
+  await typeInput(frame, selectors.account, config.account!);
+  await typeInput(frame, selectors.password, config.password!);
   return frame;
 }
 
-async function replaceInput(
-  page: BrowserPage,
-  selector: string,
-  value: string,
-) {
-  await page.click(selector, { clickCount: 3 });
+async function typeInput(page: BrowserPage, selector: string, value: string) {
   await page.type(selector, value);
 }
 
@@ -472,7 +616,7 @@ async function captureCaptcha(page: BrowserPage) {
 async function submitLogin(page: BrowserPage, captcha: string) {
   const captchaInput =
     'input[data-taishin-field="captcha"], input[placeholder*="驗證碼"]';
-  await replaceInput(page, captchaInput, captcha);
+  await typeInput(page, captchaInput, captcha);
   const loginButton = await page.evaluate(() => {
     const normalize = (value: string | null | undefined) =>
       value?.replace(/\s+/g, "").trim() ?? "";
@@ -503,46 +647,64 @@ async function submitLogin(page: BrowserPage, captcha: string) {
       ) ?? candidates.at(-1);
     if (!target) return false;
     target.dataset.taishinLogin = "submit";
+    target.click();
     return true;
   });
   if (!loginButton) {
     throw new TaishinConnectionError("台新登入按鈕結構已變更。");
   }
-  await page.click('[data-taishin-login="submit"]');
 
-  await page
-    .waitForFunction(
-      () =>
-        document.body.innerText.includes("帳戶總覽") ||
-        /驗證碼.*(?:錯誤|有誤)|密碼.*(?:錯誤|有誤)|登入失敗|使用者代(?:號|碼).*(?:錯誤|有誤)/.test(
-          document.body.innerText,
-        ),
-      { timeout: 30_000 },
-    )
-    .catch(() => undefined);
-
-  if (!(await isLoggedIn(page))) {
-    const detail = await page
-      .evaluate(() =>
-        document.body.innerText.replace(/\s+/g, " ").trim().slice(0, 500),
-      )
-      .catch(() => "");
-    if (/驗證碼.*(?:錯誤|有誤)/.test(detail)) {
+  for (let attempt = 0; attempt < LOGIN_RESULT_ATTEMPTS; attempt += 1) {
+    const detail = await readLoginDetail(page);
+    if (isCaptchaRejected(detail)) {
       throw new TaishinCaptchaRejectedError("台新圖形驗證碼錯誤。");
     }
-    if (
-      /密碼.*(?:錯誤|有誤)|使用者代(?:號|碼).*(?:錯誤|有誤)|身分證.*(?:錯誤|有誤)/.test(
-        detail,
-      )
-    ) {
+    if (isCredentialRejected(detail)) {
       throw new TaishinCredentialRejectedError(
         "台新登入資料遭銀行拒絕，請確認設定。",
       );
     }
-    throw new TaishinVerificationRequiredError(
-      "台新銀行登入失敗，請改用人工驗證。",
-    );
+    if (/USER\s*正在線上.*無法登入/i.test(detail)) {
+      throw new TaishinVerificationRequiredError(
+        "台新網銀已有使用中連線，請先登出後再試。",
+      );
+    }
+    if (await hasValidSession(page)) return;
+    if (attempt < LOGIN_RESULT_ATTEMPTS - 1) {
+      await new Promise((resolve) => setTimeout(resolve, LOGIN_RESULT_POLL_MS));
+    }
   }
+
+  throw new TaishinLoginOutcomeUnknownError(
+    "台新銀行登入失敗，請改用人工驗證。",
+  );
+}
+
+async function readLoginDetail(page: BrowserPage) {
+  return page
+    .evaluate(() =>
+      (document.body?.innerText ?? "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 1_000),
+    )
+    .catch(() => "");
+}
+
+function isCaptchaRejected(detail: string) {
+  return (
+    /驗證碼.{0,30}(?:錯誤|有誤|不正確|無效)/.test(detail) ||
+    /(?:錯誤|有誤|不正確|無效).{0,30}驗證碼/.test(detail)
+  );
+}
+
+function isCredentialRejected(detail: string) {
+  const field = "(?:密碼|使用者代(?:號|碼)|身分證(?:字號)?|統一編號)";
+  const failure = "(?:錯誤|有誤|不正確|無效)";
+  return (
+    new RegExp(`${field}.{0,30}${failure}`).test(detail) ||
+    new RegExp(`${failure}.{0,30}${field}`).test(detail)
+  );
 }
 
 async function isLoggedIn(page: BrowserPage) {
@@ -575,14 +737,35 @@ async function findLoginFrame(page: Page): Promise<BrowserPage> {
   return page.mainFrame();
 }
 
-function recentMonths(count: number) {
-  const now = new Date();
+function recentMonths(count: number, anchor = new Date()) {
   return Array.from({ length: count }, (_, index) => {
     const date = new Date(
-      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - index, 1),
+      Date.UTC(anchor.getUTCFullYear(), anchor.getUTCMonth() - index, 1),
     );
     return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1 };
   });
+}
+
+function taishinBillingContext(summary: unknown) {
+  const value =
+    isRecord(summary) && isRecord(summary.value) ? summary.value : undefined;
+  const knownOrganizations = ["001", "055", "100"];
+  const org =
+    knownOrganizations.find((candidate) => isRecord(value?.[candidate])) ??
+    "001";
+  const account = isRecord(value?.[org]) ? value[org] : undefined;
+  const statementDate =
+    typeof account?.["OUT-DTE-LST-STMT"] === "string"
+      ? account["OUT-DTE-LST-STMT"]
+      : "";
+  const match = /^(\d{4})(\d{2})\d{2}$/.exec(statementDate);
+  const year = Number(match?.[1]);
+  const month = Number(match?.[2]);
+  const anchor =
+    year >= 2000 && month >= 1 && month <= 12
+      ? new Date(Date.UTC(year, month - 1, 1))
+      : new Date();
+  return { org, anchor };
 }
 
 async function importCookies(page: Page, serialized: string) {
@@ -721,6 +904,20 @@ function isRecord(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function isEmptyObject(value: unknown) {
-  return isRecord(value) && Object.keys(value).length === 0;
+function summarizeApiError(value: unknown) {
+  const serialized =
+    typeof value === "string"
+      ? value
+      : (() => {
+          try {
+            return JSON.stringify(value);
+          } catch {
+            return String(value);
+          }
+        })();
+  return serialized
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[。.!！]+$/, "")
+    .slice(0, 300);
 }

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -17,6 +17,7 @@ import { createEsunConnector } from "../../connectors/esun";
 import {
   createTaishinConnector,
   prepareTaishinCaptcha,
+  TaishinConnectionError,
   TaishinVerificationRequiredError,
 } from "../../connectors/taishin";
 import {
@@ -686,6 +687,11 @@ export async function syncTaishin(
     delete cleaned.browserSessionId;
     delete cleaned.browserSessionExpiresAt;
     delete cleaned.captchaDigitCount;
+    if (error instanceof TaishinConnectionError && error.sessionCookies) {
+      cleaned.sessionCookies = error.sessionCookies;
+      cleaned.sessionCreatedAt =
+        error.sessionCreatedAt ?? new Date().toISOString();
+    }
     if (error instanceof TaishinVerificationRequiredError) {
       delete cleaned.sessionCookies;
       delete cleaned.sessionCreatedAt;

--- a/apps/worker/tests/connectors/esun.test.ts
+++ b/apps/worker/tests/connectors/esun.test.ts
@@ -43,6 +43,7 @@ describe("E.SUN credit card timeline normalization", () => {
       "2026-07-05T00:00:00.000Z:credit:esun:1204:全支付﹘全聯:252:TWD:1",
     );
     expect(rows[0]).toMatchObject({
+      amount: -252,
       status: "posted",
       authorizedAt: "2026-07-05T00:00:00.000Z",
       postedDate: "2026-07-05T00:00:00.000Z",
@@ -79,6 +80,32 @@ describe("E.SUN credit card timeline normalization", () => {
     expect(rows).toEqual([
       expect.objectContaining({ status: "pending", postedDate: undefined }),
       expect.objectContaining({ status: "pending", postedDate: undefined }),
+    ]);
+  });
+
+  it("records purchases as expenses and discounts as positive credits", () => {
+    const rows = normalizeEsunTimelineTransactions([
+      page([
+        transaction("已入帳", {
+          payAmt: "350",
+          storeName: "樂購蝦皮－daniel0329TAIPEI",
+        }),
+        transaction("已入帳", {
+          payAmt: "-63",
+          storeName: "信用卡消費折抵_樂購蝦皮－daniel0329",
+        }),
+      ]),
+    ]);
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        description: "樂購蝦皮－daniel0329TAIPEI",
+        amount: -350,
+      }),
+      expect.objectContaining({
+        description: "信用卡消費折抵_樂購蝦皮－daniel0329",
+        amount: 63,
+      }),
     ]);
   });
 

--- a/apps/worker/tests/connectors/taishin-session.test.ts
+++ b/apps/worker/tests/connectors/taishin-session.test.ts
@@ -13,6 +13,7 @@ import {
   createTaishinConnector,
   prepareTaishinCaptcha,
   TaishinBrowserCapacityError,
+  TaishinConnectionError,
   TaishinCredentialRejectedError,
 } from "../../src/connectors/taishin";
 
@@ -75,7 +76,6 @@ function rejectLoginSequence(
     .mockResolvedValueOnce(selectors)
     .mockResolvedValueOnce(captchaTarget)
     .mockResolvedValueOnce(true)
-    .mockResolvedValueOnce(false)
     .mockResolvedValueOnce(detail);
 }
 
@@ -93,11 +93,11 @@ beforeEach(() => {
 describe("Taishin browser session lifecycle", () => {
   it("reuses valid encrypted cookies without running OCR", async () => {
     const browserPage = page();
-    const response = (value: unknown) => ({
+    const response = (value: unknown, error: unknown = null) => ({
       ok: true,
       status: 200,
       contentType: "application/json",
-      text: JSON.stringify({ value, error: null }),
+      text: JSON.stringify({ value, error }),
     });
     const activeSession = {
       ok: true,
@@ -110,17 +110,20 @@ describe("Taishin browser session lifecycle", () => {
     };
     browserPage.evaluate
       .mockResolvedValueOnce(activeSession)
-      .mockResolvedValueOnce(activeSession)
-      .mockResolvedValueOnce(
-        response({
-          "001": {
-            "OUT-AVAIL-CREDIT": "100000",
-            "OUT-STMT-BALANCE": "1200",
-            "OUT-CRLIMIT-PERM": "200000",
-          },
-        }),
-      )
       .mockResolvedValueOnce(response({ fmtRealTxListMap: [] }))
+      .mockResolvedValueOnce(
+        response(
+          {
+            "001": {
+              "OUT-AVAIL-CREDIT": "100000",
+              "OUT-STMT-BALANCE": "1200",
+              "OUT-CRLIMIT-PERM": "200000",
+              "OUT-DTE-LST-STMT": "20260720",
+            },
+          },
+          "",
+        ),
+      )
       .mockResolvedValueOnce(
         response({
           showAccoutnYM: "2026/07",
@@ -148,6 +151,231 @@ describe("Taishin browser session lifecycle", () => {
     expect(browserPage.setCookie).toHaveBeenCalledOnce();
     expect(recognize).not.toHaveBeenCalled();
     expect(result.bankAccounts).toHaveLength(1);
+    expect(browserPage.evaluate).toHaveBeenCalledWith(expect.any(Function), {
+      path: "/TIBNetBank/svc/web4/rb0708rwd/qryRealTime",
+      body: "",
+      timeoutMs: 8_000,
+    });
+    expect(browserPage.evaluate).toHaveBeenCalledWith(expect.any(Function), {
+      path: "/TIBNetBank/svc/web4/rb0708rwd/doXTPA",
+      body: {},
+      timeoutMs: 4_000,
+    });
+    expect(browserPage.evaluate).toHaveBeenCalledWith(expect.any(Function), {
+      path: "/TIBNetBank/svc/web4/rb0708rwd/init",
+      body: {
+        org: "001",
+        byear: "2026",
+        bmonth: "07",
+        cardHolderFlagSelected: "1",
+        cardNo: "",
+      },
+      timeoutMs: 4_000,
+    });
+    expect(browserInstance.close).toHaveBeenCalledOnce();
+  });
+
+  it("re-authenticates once and skips history when no current bill exists", async () => {
+    const browserPage = page();
+    const response = (value: unknown) => ({
+      ok: true,
+      status: 200,
+      contentType: "application/json",
+      text: JSON.stringify({ value, error: null }),
+    });
+    const activeSession = {
+      ok: true,
+      status: 200,
+      contentType: "application/json",
+      text: JSON.stringify({
+        RESULT: "SUCCESS",
+        DBSESSIONID: "database-session",
+      }),
+    };
+    browserPage.evaluate
+      .mockResolvedValueOnce(activeSession)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        contentType: "text/html",
+        text: "登入",
+      })
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(selectors)
+      .mockResolvedValueOnce(captchaTarget)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce("登入成功")
+      .mockResolvedValueOnce(activeSession)
+      .mockResolvedValueOnce(response({ fmtRealTxListMap: [] }))
+      .mockResolvedValueOnce(
+        response({
+          "001": { "OUT-DTE-LST-STMT": "20260720" },
+        }),
+      )
+      .mockResolvedValueOnce(response({}));
+    const browserInstance = browser(browserPage);
+    puppeteerMock.launch.mockResolvedValue(browserInstance);
+    const recognize = vi.fn().mockResolvedValue("123456");
+
+    const result = await createTaishinConnector({} as Fetcher, recognize).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "expired-during-fetch",
+          domain: "my.taishinbank.com.tw",
+        },
+      ]),
+    });
+
+    const billCalls = browserPage.evaluate.mock.calls.filter(
+      ([, input]) =>
+        typeof input === "object" &&
+        input !== null &&
+        "path" in input &&
+        input.path === "/TIBNetBank/svc/web4/rb0708rwd/init",
+    );
+    expect(recognize).toHaveBeenCalledOnce();
+    expect(billCalls).toHaveLength(1);
+    expect(result.bankBalanceSnapshots).toEqual([]);
+    expect(result.creditCardBills).toEqual([]);
+    expect(browserInstance.close).toHaveBeenCalledOnce();
+  });
+
+  it("keeps realtime transactions when the optional bill API fails", async () => {
+    const browserPage = page();
+    const response = (value: unknown, error: unknown = null) => ({
+      ok: true,
+      status: 200,
+      contentType: "application/json",
+      text: JSON.stringify({ value, error }),
+    });
+    browserPage.evaluate
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        contentType: "application/json",
+        text: JSON.stringify({
+          RESULT: "SUCCESS",
+          DBSESSIONID: "database-session",
+        }),
+      })
+      .mockResolvedValueOnce(response({}, "系統忙碌中，無法取得資料。"))
+      .mockResolvedValueOnce(response({}, "系統忙碌中，無法取得資料。"))
+      .mockResolvedValueOnce(
+        response({
+          fmtRealTxListMap: [
+            {
+              cardname: "信用卡 (卡號末四碼:3108)",
+              txlist: [
+                ["2026/07/24", "12:30:00", "即時消費", "350", "TW", "成功"],
+              ],
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        response({
+          "001": { "OUT-DTE-LST-STMT": "20260720" },
+        }),
+      )
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 504,
+        contentType: "application/json",
+        text: "{}",
+      });
+    const browserInstance = browser(browserPage);
+    puppeteerMock.launch.mockResolvedValue(browserInstance);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const result = await createTaishinConnector({} as Fetcher).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "valid",
+          domain: "my.taishinbank.com.tw",
+        },
+      ]),
+    });
+
+    const transactions = result.bankTransactions ?? [];
+    const realtimeCalls = browserPage.evaluate.mock.calls.filter(
+      ([, input]) =>
+        typeof input === "object" &&
+        input !== null &&
+        "path" in input &&
+        input.path === "/TIBNetBank/svc/web4/rb0708rwd/qryRealTime",
+    );
+    expect(realtimeCalls).toHaveLength(3);
+    expect(realtimeCalls.map(([, input]) => input)).toEqual(
+      Array.from({ length: 3 }, () => ({
+        path: "/TIBNetBank/svc/web4/rb0708rwd/qryRealTime",
+        body: "",
+        timeoutMs: 8_000,
+      })),
+    );
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0]).toMatchObject({
+      description: "即時消費",
+      status: "pending",
+    });
+    expect(result.creditCardBills).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("optional bill sync skipped"),
+    );
+    warn.mockRestore();
+  });
+
+  it("returns fresh session cookies when an API fails after login", async () => {
+    const browserPage = page();
+    const activeSession = {
+      ok: true,
+      status: 200,
+      contentType: "application/json",
+      text: JSON.stringify({
+        RESULT: "SUCCESS",
+        DBSESSIONID: "database-session",
+      }),
+    };
+    browserPage.evaluate
+      .mockResolvedValueOnce(activeSession)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        contentType: "application/json",
+        text: "{}",
+      });
+    const browserInstance = browser(browserPage);
+    puppeteerMock.launch.mockResolvedValue(browserInstance);
+
+    const error = await createTaishinConnector({} as Fetcher)
+      .sync({
+        ...credentials,
+        lookbackMonths: 1,
+        sessionCookies: JSON.stringify([
+          {
+            name: "SESSION",
+            value: "expired",
+            domain: "my.taishinbank.com.tw",
+          },
+        ]),
+      })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(TaishinConnectionError);
+    expect(error).toMatchObject({
+      message: "台新信用卡 API qryRealTime 回應 HTTP 502。",
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "fresh",
+          domain: "my.taishinbank.com.tw",
+        },
+      ]),
+      sessionCreatedAt: expect.any(String),
+    });
     expect(browserInstance.close).toHaveBeenCalledOnce();
   });
 
@@ -182,7 +410,6 @@ describe("Taishin browser session lifecycle", () => {
     const browserPage = page();
     browserPage.evaluate
       .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(false)
       .mockResolvedValueOnce("驗證碼錯誤");
     const browserInstance = browser(browserPage);
     puppeteerMock.sessions.mockResolvedValue([
@@ -217,6 +444,7 @@ describe("Taishin browser session lifecycle", () => {
         .fn()
         .mockReturnValue({ width: 300, height: 50 }),
       matches: vi.fn().mockReturnValue(false),
+      click: vi.fn(),
     };
     browserPage.evaluate
       .mockImplementationOnce(async (callback: () => unknown) => {
@@ -229,7 +457,6 @@ describe("Taishin browser session lifecycle", () => {
           vi.unstubAllGlobals();
         }
       })
-      .mockResolvedValueOnce(false)
       .mockResolvedValueOnce("驗證碼錯誤");
     const browserInstance = browser(browserPage);
     puppeteerMock.sessions.mockResolvedValue([
@@ -248,9 +475,65 @@ describe("Taishin browser session lifecycle", () => {
     ).rejects.toThrow("圖形驗證碼錯誤");
 
     expect(loginButton.dataset.taishinLogin).toBe("submit");
-    expect(browserPage.click).toHaveBeenCalledWith(
-      '[data-taishin-login="submit"]',
-    );
+    expect(loginButton.click).toHaveBeenCalledOnce();
+    expect(browserPage.click).not.toHaveBeenCalled();
+  });
+
+  it("accepts a valid bank session without relying on account overview text", async () => {
+    const browserPage = page();
+    const activeSession = {
+      ok: true,
+      status: 200,
+      contentType: "application/json",
+      text: JSON.stringify({
+        RESULT: "SUCCESS",
+        DBSESSIONID: "database-session",
+      }),
+    };
+    const response = (value: unknown) => ({
+      ok: true,
+      status: 200,
+      contentType: "application/json",
+      text: JSON.stringify({ value, error: null }),
+    });
+    browserPage.evaluate
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(selectors)
+      .mockResolvedValueOnce(captchaTarget)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce("登入成功")
+      .mockResolvedValueOnce(activeSession)
+      .mockResolvedValueOnce(response({ fmtRealTxListMap: [] }))
+      .mockResolvedValueOnce(
+        response({
+          "001": {
+            "OUT-AVAIL-CREDIT": "100000",
+            "OUT-STMT-BALANCE": "1200",
+            "OUT-CRLIMIT-PERM": "200000",
+            "OUT-DTE-LST-STMT": "20260720",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        response({
+          showAccoutnYM: "2026/07",
+          showCbalance: "1200",
+          showCdue: "1200",
+          newAcctDetailList: [],
+        }),
+      );
+    const browserInstance = browser(browserPage);
+    puppeteerMock.launch.mockResolvedValue(browserInstance);
+    const recognize = vi.fn().mockResolvedValue("123456");
+
+    const result = await createTaishinConnector({} as Fetcher, recognize).sync({
+      ...credentials,
+      lookbackMonths: 1,
+    });
+
+    expect(result.bankAccounts).toHaveLength(1);
+    expect(recognize).toHaveBeenCalledOnce();
+    expect(browserInstance.close).toHaveBeenCalledOnce();
   });
 
   it("stops automatic login immediately when credentials are rejected", async () => {

--- a/apps/worker/tests/connectors/taishin.test.ts
+++ b/apps/worker/tests/connectors/taishin.test.ts
@@ -149,6 +149,25 @@ describe("Taishin credit-card parser", () => {
     ).toEqual(["2026-06"]);
   });
 
+  it("keeps a valid bill when the bank leaves the remaining due blank", () => {
+    const noPaymentBill = bill();
+    Object.assign(noPaymentBill.value, {
+      showCdue: "",
+      showCbalance: "",
+    });
+
+    const result = parseTaishinCreditCardData({
+      summary: { value: {}, error: null },
+      bills: [noPaymentBill],
+    });
+
+    expect(result.creditCardBills).toHaveLength(1);
+    expect(result.bankBalanceSnapshots[0]).toMatchObject({
+      balance: 0,
+      noPaymentNeeded: undefined,
+    });
+  });
+
   it("upgrades merchant-matched pending occurrences and keeps the rest pending", () => {
     const result = parseTaishinCreditCardData({
       summary,
@@ -328,6 +347,31 @@ describe("Taishin credit-card parser", () => {
     ).toHaveLength(2);
   });
 
+  it("records a negative consumption discount as a positive credit", () => {
+    const result = parseTaishinCreditCardData({
+      summary,
+      bills: [
+        bill("2026/07", [
+          transaction("樂購蝦皮－daniel0329TAIPEI", "350"),
+          transaction("信用卡消費折抵_樂購蝦皮－daniel0329", "-63"),
+        ]),
+      ],
+    });
+
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          description: "樂購蝦皮－daniel0329TAIPEI",
+          amount: -350,
+        }),
+        expect.objectContaining({
+          description: "信用卡消費折抵_樂購蝦皮－daniel0329",
+          amount: 63,
+        }),
+      ]),
+    );
+  });
+
   it("persists only masked, whitelisted raw fields", () => {
     const payload = bill();
     Object.assign(payload.value, {
@@ -349,19 +393,22 @@ describe("Taishin credit-card parser", () => {
     expect(serialized).toContain("3108");
   });
 
-  it("fails explicitly on empty or error payloads", () => {
-    expect(() =>
-      parseTaishinCreditCardData({
-        summary: { value: {}, error: null },
-        bills: [],
-      }),
-    ).toThrow("缺少額度或帳單資料");
-    expect(() =>
-      parseTaishinCreditCardData({
-        summary,
-        bills: [{ value: {}, error: null }],
-      }),
-    ).toThrow("缺少額度或帳單資料");
+  it("returns a partial result when no statement is available", () => {
+    const result = parseTaishinCreditCardData({
+      summary: { value: {}, error: null },
+      bills: [],
+      realtime: realtime([
+        ["2026/07/08", "12:30:00", "尚未入帳", "350", "TW", "成功"],
+      ]),
+    });
+
+    expect(result.bankAccounts).toHaveLength(1);
+    expect(result.bankBalanceSnapshots).toEqual([]);
+    expect(result.creditCardBills).toEqual([]);
+    expect(result.bankTransactions).toHaveLength(1);
+  });
+
+  it("fails explicitly on error payloads", () => {
     expect(() =>
       parseTaishinCreditCardData({
         summary: { value: {}, error: { code: "DRIFT" } },

--- a/packages/connectors/src/taishin.ts
+++ b/packages/connectors/src/taishin.ts
@@ -59,7 +59,7 @@ export function parseTaishinCreditCardData(
   now = new Date(),
 ): TaishinCreditCardData {
   const summary = responseValue(payloads.summary);
-  const summaryTwd = firstRecordValue(summary);
+  const summaryTwd = firstRecordValue(summary) ?? {};
   const billValues = payloads.bills
     .map(responseValue)
     .filter((value): value is JsonRecord => Boolean(value));
@@ -71,14 +71,10 @@ export function parseTaishinCreditCardData(
     .sort((left, right) =>
       right.bill.billingPeriod.localeCompare(left.bill.billingPeriod),
     );
-  const currentBillEntry = billEntries.find(
-    ({ value }) => optionalNumber(value.showCdue) != null,
-  );
-  if (!summaryTwd || !currentBillEntry) {
-    throw new Error("台新信用卡 API 缺少額度或帳單資料。");
-  }
-
-  const currentBill = currentBillEntry.value;
+  const currentBillEntry =
+    billEntries.find(({ value }) => optionalNumber(value.showCdue) != null) ??
+    billEntries[0];
+  const currentBill = currentBillEntry?.value;
   const postedCandidates = billValues.flatMap(postedTransactions);
   const pendingCandidates = realtimeTransactions(
     responseValue(payloads.realtime),
@@ -96,13 +92,14 @@ export function parseTaishinCreditCardData(
   ).sort();
 
   const statementAmount = optionalAbsoluteNumber(
-    currentBill.showCbalance ?? summaryTwd["OUT-STMT-BALANCE"],
+    currentBill?.showCbalance ?? summaryTwd["OUT-STMT-BALANCE"],
   );
   const availableCredit = optionalNumber(summaryTwd["OUT-AVAIL-CREDIT"]);
   const creditLimit = optionalNumber(summaryTwd["OUT-CRLIMIT-PERM"]);
-  const paymentDueDate = normalizeDate(currentBill.showDueDate);
-  const statementClosingDate = normalizeDate(currentBill.showStmtDate);
-  const remainingDue = Math.abs(optionalNumber(currentBill.showCdue)!);
+  const paymentDueDate = normalizeDate(currentBill?.showDueDate);
+  const statementClosingDate = normalizeDate(currentBill?.showStmtDate);
+  const parsedRemainingDue = optionalAbsoluteNumber(currentBill?.showCdue);
+  const remainingDue = parsedRemainingDue ?? 0;
   const asOfAt = now.toISOString();
 
   const bills = billEntries
@@ -121,26 +118,29 @@ export function parseTaishinCreditCardData(
         raw: { cardLast4s },
       },
     ],
-    bankBalanceSnapshots: [
-      {
-        accountId: ACCOUNT_SOURCE_ID,
-        sourceId: `${ACCOUNT_SOURCE_ID}:${asOfAt.slice(0, 10)}`,
-        balance: remainingDue > 0 ? -remainingDue : 0,
-        availableBalance: availableCredit,
-        statementBalance: statementAmount,
-        paymentDueDate,
-        statementClosingDate,
-        noPaymentNeeded: remainingDue === 0,
-        currency: "TWD",
-        asOfAt,
-        raw: {
-          statementAmount,
-          availableCredit,
-          paymentDueDate,
-          statementClosingDate,
-        },
-      },
-    ],
+    bankBalanceSnapshots: currentBill
+      ? [
+          {
+            accountId: ACCOUNT_SOURCE_ID,
+            sourceId: `${ACCOUNT_SOURCE_ID}:${asOfAt.slice(0, 10)}`,
+            balance: remainingDue > 0 ? -remainingDue : 0,
+            availableBalance: availableCredit,
+            statementBalance: statementAmount,
+            paymentDueDate,
+            statementClosingDate,
+            noPaymentNeeded:
+              parsedRemainingDue == null ? undefined : parsedRemainingDue === 0,
+            currency: "TWD",
+            asOfAt,
+            raw: {
+              statementAmount,
+              availableCredit,
+              paymentDueDate,
+              statementClosingDate,
+            },
+          },
+        ]
+      : [],
     bankTransactions: transactions.map((transaction) => ({
       ...transaction,
       accountId: ACCOUNT_SOURCE_ID,
@@ -422,10 +422,7 @@ function normalizeMerchantName(value: string | undefined) {
 
 function responseValue(value: unknown): JsonRecord | undefined {
   if (!isRecord(value)) return undefined;
-  if (
-    value.error != null &&
-    (!isRecord(value.error) || Object.keys(value.error).length > 0)
-  ) {
+  if (Boolean(value.error)) {
     throw new Error("台新信用卡 API 回傳錯誤。");
   }
   return isRecord(value.value) ? value.value : undefined;

--- a/packages/connectors/tests/selfcheck/taishin.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/taishin.selfcheck.ts
@@ -9,7 +9,7 @@ const summary = {
       "OUT-CRLIMIT-PERM": "200,000",
     },
   },
-  error: null,
+  error: "",
 };
 
 function bill(period: string) {

--- a/packages/db/migrations/0018_esun_credit_transaction_signs.sql
+++ b/packages/db/migrations/0018_esun_credit_transaction_signs.sql
@@ -1,0 +1,23 @@
+UPDATE bank_transactions
+SET amount = CASE
+  WHEN amount < 0
+    OR description LIKE '%退款%'
+    OR description LIKE '%退貨%'
+    OR description LIKE '%折抵%'
+    OR description LIKE '%折讓%'
+    OR description LIKE '%回饋%'
+    OR description LIKE '%沖銷%'
+    OR description LIKE '%貸方%'
+    OR description LIKE '%繳款%'
+    OR lower(COALESCE(description, '')) LIKE '%refund%'
+    OR lower(COALESCE(description, '')) LIKE '%credit%'
+    OR lower(COALESCE(description, '')) LIKE '%payment%'
+  THEN ABS(amount)
+  ELSE -ABS(amount)
+END
+WHERE account_id IN (
+  SELECT id
+  FROM bank_accounts
+  WHERE connector_id = 'esun'
+    AND account_type = 'credit'
+);


### PR DESCRIPTION
## 變更內容

- 配合台新版網銀登入頁，改用可見 DOM 元素觸發登入並強化輸入欄位、session 驗證與 OCR 重試流程。
- 優先同步即時消費；帳單 API 失敗時允許部分成功，並保留可續用的 session。
- 修正台新信用卡消費、退款與折抵的正負號，讓消費為負數、折抵為正數。
- 修正玉山信用卡交易的入庫方向，並新增 migration 校正既有遠端 D1 資料。
- 活動頁改為依信用卡交易的實際正負號計算收入／支出；電子發票仍維持負數支出。

## 問題原因

台新版網銀調整了登入按鈕與頁面互動結構，舊 Puppeteer 操作會遇到元素不可點擊、session 誤判及下游 API 部分失敗。另一方面，各信用卡連接器的金額方向不一致：玉山一般消費以正數入庫，而台新折抵雖已轉為正數，活動頁仍將所有信用卡交易強制視為支出。

## 架構與資料流程

- `apps/worker/src/connectors/taishin.ts`：負責 Browser Rendering 登入、session 驗證、API 呼叫與部分成功策略。
- `packages/connectors/src/taishin.ts`：負責台新回應解析與標準交易金額正規化。
- `apps/worker/src/connectors/esun.ts`：統一玉山信用卡交易方向，來源 ID 仍保留原始金額以避免重複交易。
- `packages/db/migrations/0018_esun_credit_transaction_signs.sql`：一次校正既有玉山信用卡交易。
- `apps/web/src/features/activity/model/chart.ts`：以前後端一致的 signed amount 計算顯示與圖表。

## Breaking Changes

無 API contract 破壞性變更。資料行為調整：玉山既有信用卡消費會由正數校正為負數；退款、折抵及繳款維持正數。

## 驗證

- `npm run typecheck`：通過（Web、Worker、Connectors、Core、DB）。
- Worker 測試：22 files、141 tests 通過。
- DB 測試：1 file、4 tests 通過。
- 受影響回歸測試：5 files、42 tests 通過。
- Connector self-check：TDCC、電子發票 v1/v2、台新皆通過。
- `npm run build -w @taiwan-fin-hub/web`：通過；僅有既有的 bundle 大小警告。
- Web 完整 Vitest runner 在此環境停於啟動畫面，未產生 assertion failure；受影響的活動圖表測試已單獨通過。
- 遠端 D1 migration 已實際套用並抽查：玉山一般消費已為負數，台新 `信用卡消費折抵_樂購蝦皮－daniel0329` 維持 `+63`。

## 風險與人工驗證重點

- 台新銀行上游頁面與 API 仍可能受系統忙碌或介面再次改版影響。
- 請確認活動頁的一般信用卡消費列入支出、退款／折抵列入收入，且電子發票仍列入支出。
- 請確認玉山 pending／posted lifecycle 去重後不會產生重複交易。