### PR TITLE
重整設定頁資訊架構與字級

### DIFF
--- a/apps/web/src/app/App.svelte
+++ b/apps/web/src/app/App.svelte
@@ -151,11 +151,7 @@
       </nav>
     </aside>
 
-    <div
-      class:min-w-0={true}
-      class:pb-20={!mobileSetting}
-      class:pb-5={!!mobileSetting}
-    >
+    <div class="min-w-0 pb-20">
       <div
         class="no-scrollbar hidden border-b border-ink/10 bg-white px-4 py-2 md:flex md:gap-1 md:overflow-x-auto xl:hidden"
       >
@@ -186,7 +182,8 @@
                   <h1
                     class="truncate text-2xl font-semibold tracking-tight xl:text-3xl"
                   >
-                    {mobileSetting.label}
+                    <span class="md:hidden">{mobileSetting.label}</span>
+                    <span class="hidden md:inline">設定</span>
                   </h1>
                 </div>
               {:else}
@@ -218,7 +215,9 @@
             </div>
             <div class="flex shrink-0 items-center gap-2">
               <Button
-                class={mobileSetting ? "hidden" : "rounded-full"}
+                class={mobileSetting
+                  ? "hidden rounded-full md:inline-flex"
+                  : "rounded-full"}
                 aria-label={moneyState.hidden ? "顯示金額" : "隱藏金額"}
                 onclick={toggleMoneyVisibility}
                 size="icon"
@@ -271,27 +270,24 @@
       </footer>
     </div>
 
-    {#if !mobileSetting}
-      <nav
-        aria-label="主要導覽"
-        class="fixed inset-x-0 bottom-0 z-50 grid grid-cols-4 gap-1 border-t border-ink/10 bg-ink px-2 pb-[max(env(safe-area-inset-bottom),0.5rem)] pt-2 text-white shadow-[0_-8px_28px_rgba(31,41,51,0.12)] md:hidden"
-      >
-        {#each mobilePrimaryViews as mobileView (mobileView)}
-          {@const item = navItems.find(
-            (candidate) => candidate.view === mobileView,
-          )!}{@const NavIcon = item.icon}
-          <button
-            class={`flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-xl px-1 text-[11px] font-medium transition ${primaryView === item.view ? "bg-white/10 text-white" : "text-white/65"}`}
-            onclick={() => navigate(item.view)}
-            ><NavIcon class="size-5" />{item.shortLabel}</button
-          >
-        {/each}
+    <nav
+      aria-label="主要導覽"
+      class="fixed inset-x-0 bottom-0 z-50 grid grid-cols-4 gap-1 border-t border-ink/10 bg-ink px-2 pb-[max(env(safe-area-inset-bottom),0.5rem)] pt-2 text-white shadow-[0_-8px_28px_rgba(31,41,51,0.12)] md:hidden"
+    >
+      {#each mobilePrimaryViews as mobileView (mobileView)}
+        {@const item = navItems.find(
+          (candidate) => candidate.view === mobileView,
+        )!}{@const NavIcon = item.icon}
         <button
-          class={`flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-xl px-1 text-[11px] font-medium transition ${view === "more" || !mobilePrimaryViews.includes(primaryView) ? "bg-white/10 text-white" : "text-white/65"}`}
-          onclick={() => navigate("more")}
-          ><Ellipsis class="size-5" />更多</button
+          class={`flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-xl px-1 text-[11px] font-medium transition ${primaryView === item.view ? "bg-white/10 text-white" : "text-white/65"}`}
+          onclick={() => navigate(item.view)}
+          ><NavIcon class="size-5" />{item.shortLabel}</button
         >
-      </nav>
-    {/if}
+      {/each}
+      <button
+        class={`flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-xl px-1 text-[11px] font-medium transition ${view === "more" || !mobilePrimaryViews.includes(primaryView) ? "bg-white/10 text-white" : "text-white/65"}`}
+        onclick={() => navigate("more")}><Ellipsis class="size-5" />更多</button
+      >
+    </nav>
   </div>
 </QueryClientProvider>

--- a/apps/web/src/app/navigation-config.ts
+++ b/apps/web/src/app/navigation-config.ts
@@ -75,6 +75,10 @@ export const mobileSettingsLabels: Record<
     label: "資料來源與連接器",
     description: "管理來源狀態、憑證、自動同步與重新驗證。",
   },
+  "sync-notifications": {
+    label: "同步與通知",
+    description: "管理預設同步排程、推播與同步狀態通知。",
+  },
   "exchange-rates": {
     label: "匯率",
     description: "管理資產換算使用的參考匯率。",

--- a/apps/web/src/app/navigation.test.ts
+++ b/apps/web/src/app/navigation.test.ts
@@ -5,6 +5,7 @@ describe("view hash navigation", () => {
   it("parses supported hash routes", () => {
     expect(parseViewHash("#/assets")).toBe("assets");
     expect(parseViewHash("#classification-rules")).toBe("classification-rules");
+    expect(parseViewHash("#/sync-notifications")).toBe("sync-notifications");
   });
 
   it("rejects unknown routes and formats valid views", () => {

--- a/apps/web/src/app/navigation.ts
+++ b/apps/web/src/app/navigation.ts
@@ -11,6 +11,7 @@ const views = new Set<View>([
   "investments",
   "manual-assets",
   "data-sources",
+  "sync-notifications",
   "exchange-rates",
   "classification-rules",
   "more",

--- a/apps/web/src/app/types.ts
+++ b/apps/web/src/app/types.ts
@@ -4,7 +4,10 @@ export type PrimaryView =
 export type DetailView = "bank" | "cards" | "investments" | "manual-assets";
 
 export type MobileSettingsView =
-  "data-sources" | "exchange-rates" | "classification-rules";
+  | "data-sources"
+  | "sync-notifications"
+  | "exchange-rates"
+  | "classification-rules";
 
 export type View = PrimaryView | DetailView | MobileSettingsView | "more";
 

--- a/apps/web/src/features/settings/SettingsPage.svelte
+++ b/apps/web/src/features/settings/SettingsPage.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { createQuery } from "@tanstack/svelte-query";
-  import { ShieldCheck } from "@lucide/svelte";
   import type { ApiClient } from "@/shared/api/client";
   import type { MobileSettingsView, View } from "@/app/types";
+  import { exchangeRatesQuery } from "@/data/assets/queries";
   import { bankQuery } from "@/data/bank/queries";
   import { classificationRulesQuery } from "@/data/classification/queries";
   import {
@@ -10,11 +10,12 @@
     connectorFields,
   } from "@/data/connectors/definitions";
   import { syncJobsQuery } from "@/data/connectors/queries";
+  import { notificationConfigQuery } from "@/data/notifications/queries";
   import type { ConnectorId } from "@/data/connectors/types";
+  import { formatDateTime } from "@/shared/format/financial";
   import ClassificationRulesPanel from "./components/ClassificationRulesPanel.svelte";
   import DefaultSchedulePanel from "./components/DefaultSchedulePanel.svelte";
   import ExchangeRatesPanel from "./components/ExchangeRatesPanel.svelte";
-  import Metric from "./components/Metric.svelte";
   import MobileMore from "./components/MobileMore.svelte";
   import NotificationPanel from "./components/NotificationPanel.svelte";
   import SourceCard from "./components/SourceCard.svelte";
@@ -31,142 +32,567 @@
     navigate: (view: View) => void;
   } = $props();
   const sources = connectorDefinitions;
+  const weekdayLabels = [
+    "週日",
+    "週一",
+    "週二",
+    "週三",
+    "週四",
+    "週五",
+    "週六",
+  ];
+  const settingTabs = [
+    { view: "settings" as const, label: "總覽" },
+    { view: "data-sources" as const, label: "資料來源" },
+    { view: "sync-notifications" as const, label: "同步與通知" },
+    { view: "exchange-rates" as const, label: "匯率" },
+    { view: "classification-rules" as const, label: "分類規則" },
+  ];
   const jobs = createQuery(syncJobsQuery(() => api));
   const rules = createQuery(classificationRulesQuery(() => api));
   const bank = createQuery(bankQuery(() => api));
+  const rates = createQuery(exchangeRatesQuery(() => api));
+  const notifications = createQuery(notificationConfigQuery(() => api));
   let selectedConnector = $state<ConnectorId | null>(null);
-  const enabledJobs = $derived(
-    ($jobs.data ?? []).filter((j) => j.enabled).length,
-  );
   const needsAction = $derived(
     ($jobs.data ?? []).filter(
       (j) => j.lastStatus === "failed" || j.lastStatus === "needs_user_action",
     ).length,
   );
+  const healthySources = $derived(Math.max(sources.length - needsAction, 0));
+  const actionJob = $derived(
+    ($jobs.data ?? []).find(
+      (job) =>
+        job.lastStatus === "failed" || job.lastStatus === "needs_user_action",
+    ),
+  );
+  const actionSource = $derived(
+    sources.find((source) => source.id === actionJob?.connectorId),
+  );
+  const latestSuccessAt = $derived(
+    ($jobs.data ?? []).reduce<string | undefined>((latest, job) => {
+      if (!job.lastSuccessAt) return latest;
+      return !latest || job.lastSuccessAt > latest ? job.lastSuccessAt : latest;
+    }, undefined),
+  );
+  const inheritedJob = $derived(
+    ($jobs.data ?? []).find(
+      (job) => job.scope === "all" && job.scheduleMode === "inherit",
+    ),
+  );
+  const inheritedJobCount = $derived(
+    ($jobs.data ?? []).filter((job) => job.scheduleMode === "inherit").length,
+  );
+  const scheduleSummary = $derived(
+    !inheritedJob
+      ? "尚未設定"
+      : inheritedJob.intervalMinutes === 1440
+        ? `每天 ${inheritedJob.preferredTime}`
+        : inheritedJob.intervalMinutes === 10080
+          ? `每${weekdayLabels[inheritedJob.preferredWeekday] ?? "週一"} ${inheritedJob.preferredTime}`
+          : `每 ${inheritedJob.intervalMinutes / 60} 小時`,
+  );
+  const ratesSummary = $derived(
+    ($rates.data ?? [])
+      .map((rate) => `${rate.currency} ${rate.rateTwd.toFixed(3)}`)
+      .join(" · ") || "尚未設定",
+  );
+  const notificationSummary = $derived(
+    $notifications.isPending
+      ? "載入中…"
+      : $notifications.data?.enabled
+        ? "已開啟"
+        : "未啟用",
+  );
+  const notificationDescription = $derived(
+    $notifications.data?.enabled
+      ? "失敗與重新驗證時通知"
+      : "前往同步與通知開啟",
+  );
+  const rulesSummary = $derived(
+    $rules.isPending ? "載入中…" : `${$rules.data?.length ?? 0} 條銀行交易規則`,
+  );
+  const enabledRuleCount = $derived(
+    ($rules.data ?? []).filter((rule) => rule.enabled).length,
+  );
+  const recentJobs = $derived(
+    ($jobs.data ?? []).filter((job) => job.scope === "all"),
+  );
+  const recentSuccessCount = $derived(
+    recentJobs.filter((job) => job.lastStatus === "success").length,
+  );
+  const nextRunAt = $derived(
+    recentJobs.reduce<string | undefined>((next, job) => {
+      if (!job.nextRunAt) return next;
+      return !next || job.nextRunAt < next ? job.nextRunAt : next;
+    }, undefined),
+  );
   function selectConnector(id: ConnectorId) {
     selectedConnector = selectedConnector === id ? null : id;
   }
+
+  function isActiveTab(tabView: (typeof settingTabs)[number]["view"]) {
+    return tabView === "settings"
+      ? !mobileView || mobileView === "more"
+      : mobileView === tabView;
+  }
 </script>
 
-{#if mobileView === "more"}
-  <MobileMore
-    {demoMode}
-    jobs={$jobs.data ?? []}
-    rules={$rules.data ?? []}
-    bank={$bank.data ?? { accounts: [], transactions: [] }}
-    {navigate}
-    {api}
-  />
-{:else if mobileView === "data-sources"}
-  <div class="grid gap-4">
-    <DefaultSchedulePanel {api} {demoMode} jobs={$jobs.data ?? []} />
-    <NotificationPanel {api} {demoMode} />
-    <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5">
-      {#each sources as source (source.id)}
-        <SourceCard
-          {api}
-          {...source}
-          id={source.id}
-          jobs={$jobs.data ?? []}
-          selected={selectedConnector === source.id}
-          onConfigure={() => selectConnector(source.id)}
-        >
-          {#if selectedConnector === source.id}
-            {#key source.id}<ConnectorPanel
-                {api}
-                connectorId={source.id}
-                {demoMode}
-                title={source.title}
-                fields={connectorFields[source.id]}
-                embedded
-              />{/key}
-          {/if}
-        </SourceCard>
-      {/each}
-    </div>
-  </div>
-{:else if mobileView === "exchange-rates"}<ExchangeRatesPanel {api} />
-{:else if mobileView === "classification-rules"}<ClassificationRulesPanel
-    {api}
-  />
-{:else}
-  <div class="grid gap-5">
-    <section class="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
-      <Metric
-        label="資料來源"
-        value={String(sources.length)}
-        detail="支援的連接器"
-      /><Metric
-        label="同步排程"
-        value={String(enabledJobs)}
-        detail="已啟用"
-        tone={enabledJobs ? "positive" : "neutral"}
-      /><Metric
-        label="分類規則"
-        value={String($rules.data?.length ?? 0)}
-        detail="銀行交易"
-      /><Metric
-        label="需要處理"
-        value={String(needsAction)}
-        detail="同步或驗證狀態"
-        tone={needsAction ? "negative" : "positive"}
-      />
-    </section>
+<div class="grid min-w-0 gap-5">
+  <nav
+    aria-label="設定分類"
+    class="no-scrollbar hidden overflow-x-auto border-b border-border bg-card md:flex md:gap-1 md:px-1"
+  >
+    {#each settingTabs as tab (tab.view)}
+      <button
+        class={`min-h-11 shrink-0 rounded-t-lg px-4 text-sm font-semibold transition ${isActiveTab(tab.view) ? "bg-muted text-steel" : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"}`}
+        aria-current={isActiveTab(tab.view) ? "page" : undefined}
+        onclick={() => navigate(tab.view)}>{tab.label}</button
+      >
+    {/each}
+  </nav>
 
-    <DefaultSchedulePanel {api} {demoMode} jobs={$jobs.data ?? []} />
-    <NotificationPanel {api} {demoMode} />
-
-    <section
-      aria-label="資料來源"
-      class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5"
-    >
-      {#each sources as source (source.id)}
-        <SourceCard
-          {api}
-          {...source}
-          id={source.id}
-          jobs={$jobs.data ?? []}
-          selected={selectedConnector === source.id}
-          onConfigure={() => selectConnector(source.id)}
+  {#if mobileView === "more"}
+    <MobileMore
+      {demoMode}
+      jobs={$jobs.data ?? []}
+      rules={$rules.data ?? []}
+      bank={$bank.data ?? { accounts: [], transactions: [] }}
+      {navigate}
+      {api}
+    />
+  {:else if mobileView === "data-sources"}
+    <div class="grid min-w-0 gap-4">
+      <section
+        aria-label="資料來源頁標題"
+        class="hidden min-w-0 items-center justify-between gap-4 md:flex"
+      >
+        <div>
+          <h2 class="text-2xl font-bold tracking-tight">資料來源與連接器</h2>
+          <p class="mt-1 text-sm text-muted-foreground">
+            管理連線、驗證狀態與最近同步結果。
+          </p>
+        </div>
+        <span
+          class="rounded-lg bg-steel px-4 py-2 text-sm font-bold text-white transition hover:bg-steel/90"
+          >＋ 新增連接器</span
         >
-          {#if selectedConnector === source.id}
-            {#key source.id}<ConnectorPanel
-                {api}
-                connectorId={source.id}
-                {demoMode}
-                title={source.title}
-                fields={connectorFields[source.id]}
-                embedded
-              />{/key}
-          {/if}
-        </SourceCard>
-      {/each}
-    </section>
+      </section>
 
-    <section
-      class="grid items-start gap-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]"
-    >
-      <div class="grid gap-5">
-        <ExchangeRatesPanel {api} />
-        <aside
-          class="rounded-xl border border-border bg-card p-5 text-card-foreground shadow-xs"
+      <div
+        class="hidden gap-4 md:grid lg:grid-cols-[minmax(0,620px)_minmax(0,1fr)]"
+      >
+        <section
+          aria-label="資料來源清單"
+          class="grid min-w-0 content-start gap-3"
         >
-          <div class="flex items-start gap-3">
-            <span
-              class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-moss/10 text-moss"
-            >
-              <ShieldCheck class="size-5" />
-            </span>
-            <div>
-              <h2 class="font-semibold">資料安全</h2>
-              <p class="mt-1 text-sm leading-relaxed text-muted-foreground">
-                連接器憑證僅用於個人資料同步，機密欄位會加密保存，且不會重新顯示在設定頁。
-              </p>
+          {#each sources as source (source.id)}
+            <SourceCard
+              {api}
+              {...source}
+              id={source.id}
+              jobs={$jobs.data ?? []}
+              compact
+              compactCard
+              selected={selectedConnector === source.id}
+              onConfigure={() => selectConnector(source.id)}
+            />
+          {/each}
+        </section>
+
+        <section
+          aria-label="連接器詳情"
+          class="min-h-[520px] min-w-0 rounded-xl border border-border bg-card p-5 shadow-xs"
+        >
+          {#if selectedConnector}
+            {@const selectedSource = sources.find(
+              (source) => source.id === selectedConnector,
+            )}
+            <div class="mb-4 flex items-start justify-between gap-3">
+              <div>
+                <h2 class="text-lg font-bold">{selectedSource?.title}</h2>
+                <p class="mt-1 text-sm text-muted-foreground">
+                  {selectedSource?.description}
+                </p>
+              </div>
+              <button
+                class="text-sm font-semibold text-muted-foreground hover:text-foreground"
+                onclick={() => (selectedConnector = null)}>關閉</button
+              >
             </div>
+            {#key selectedConnector}<ConnectorPanel
+                {api}
+                connectorId={selectedConnector}
+                {demoMode}
+                title={selectedSource?.title ?? "連接器"}
+                fields={connectorFields[selectedConnector]}
+                embedded
+              />{/key}
+          {:else}
+            <div class="grid min-h-[480px] place-items-center text-center">
+              <div>
+                <p class="text-base font-semibold">選擇一個連接器</p>
+                <p class="mt-1 text-sm text-muted-foreground">
+                  查看連線狀態、同步範圍與驗證設定。
+                </p>
+              </div>
+            </div>
+          {/if}
+        </section>
+      </div>
+
+      <section
+        aria-label="資料來源與連接器"
+        class="grid min-w-0 gap-3 sm:grid-cols-2 md:hidden"
+      >
+        {#each sources as source (source.id)}
+          <SourceCard
+            {api}
+            {...source}
+            id={source.id}
+            jobs={$jobs.data ?? []}
+            selected={selectedConnector === source.id}
+            onConfigure={() => selectConnector(source.id)}
+          >
+            {#if selectedConnector === source.id}
+              {#key source.id}<ConnectorPanel
+                  {api}
+                  connectorId={source.id}
+                  {demoMode}
+                  title={source.title}
+                  fields={connectorFields[source.id]}
+                  embedded
+                />{/key}
+            {/if}
+          </SourceCard>
+        {/each}
+      </section>
+    </div>
+  {:else if mobileView === "sync-notifications"}
+    <div class="grid min-w-0 gap-4">
+      <section aria-label="同步通知頁標題" class="hidden min-w-0 md:block">
+        <h2 class="text-2xl font-bold tracking-tight">同步與通知</h2>
+        <p class="mt-1 text-sm text-muted-foreground">
+          設定所有連接器共用的預設排程與通知時機。
+        </p>
+      </section>
+
+      <div
+        class="hidden gap-4 md:grid lg:grid-cols-[minmax(0,560px)_minmax(0,1fr)]"
+      >
+        <DefaultSchedulePanel
+          {api}
+          {demoMode}
+          jobs={$jobs.data ?? []}
+          variant="desktop"
+        />
+        <NotificationPanel {api} {demoMode} variant="desktop" />
+      </div>
+
+      <section
+        aria-label="最近排程"
+        class="hidden min-w-0 rounded-xl border border-border bg-card p-[18px] shadow-xs md:block"
+      >
+        <div class="flex items-center justify-between gap-3">
+          <h2 class="text-base font-bold">最近一次排程</h2>
+          <span class="text-sm text-muted-foreground">
+            {latestSuccessAt ? formatDateTime(latestSuccessAt) : "尚無紀錄"}
+          </span>
+        </div>
+        <div class="mt-3 grid gap-3 sm:grid-cols-3">
+          <div class="rounded-lg bg-muted px-3 py-2.5">
+            <p class="text-sm font-bold text-moss">
+              {recentSuccessCount} 個成功
+            </p>
           </div>
+          <div class="rounded-lg bg-coral/5 px-3 py-2.5">
+            <p class="text-sm font-bold text-coral">{needsAction} 個需要處理</p>
+          </div>
+          <div class="rounded-lg bg-muted px-3 py-2.5">
+            <p class="text-sm font-semibold">
+              下次：{nextRunAt ? formatDateTime(nextRunAt) : "尚未排程"}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <div class="grid min-w-0 gap-4 md:hidden">
+        <DefaultSchedulePanel {api} {demoMode} jobs={$jobs.data ?? []} />
+        <NotificationPanel {api} {demoMode} />
+      </div>
+    </div>
+  {:else if mobileView === "exchange-rates"}
+    <div class="grid min-w-0 gap-4">
+      <div class="hidden items-center justify-between gap-4 md:flex">
+        <div>
+          <h2 class="text-2xl font-bold tracking-tight">匯率</h2>
+          <p class="mt-1 text-sm text-muted-foreground">
+            管理資產與活動使用的換算基準。
+          </p>
+        </div>
+        <span class="rounded-lg bg-steel px-4 py-2 text-sm font-bold text-white"
+          >更新匯率</span
+        >
+      </div>
+
+      <section
+        aria-label="匯率摘要"
+        class="hidden min-w-0 gap-3 md:grid md:grid-cols-3"
+      >
+        <div class="rounded-xl border border-border bg-card p-4 shadow-xs">
+          <p class="text-sm font-semibold text-muted-foreground">基準幣別</p>
+          <p class="mt-2 text-lg font-bold">TWD</p>
+          <p class="mt-1 text-sm text-muted-foreground">新台幣</p>
+        </div>
+        <div class="rounded-xl border border-border bg-card p-4 shadow-xs">
+          <p class="text-sm font-semibold text-muted-foreground">資料來源</p>
+          <p class="mt-2 text-lg font-bold">手動設定</p>
+          <p class="mt-1 text-sm text-muted-foreground">以設定值換算</p>
+        </div>
+        <div class="rounded-xl bg-muted p-4">
+          <p class="text-sm font-semibold text-muted-foreground">自訂匯率</p>
+          <p class="mt-2 text-lg font-bold">{$rates.data?.length ?? 0} 筆</p>
+          <p class="mt-1 text-sm font-semibold text-steel">可在下方編輯</p>
+        </div>
+      </section>
+
+      <div class="hidden md:block">
+        <ExchangeRatesPanel {api} variant="desktop" />
+      </div>
+      <aside
+        class="hidden rounded-lg bg-muted p-3 text-sm text-muted-foreground md:block"
+      >
+        匯率僅用於資產總覽與統計換算，不會變更原始交易幣別或金額。
+      </aside>
+      <div class="md:hidden">
+        <ExchangeRatesPanel {api} />
+      </div>
+    </div>
+  {:else if mobileView === "classification-rules"}
+    <div class="grid min-w-0 gap-4">
+      <div class="hidden items-center justify-between gap-4 md:flex">
+        <div>
+          <h2 class="text-2xl font-bold tracking-tight">分類規則</h2>
+          <p class="mt-1 text-sm text-muted-foreground">
+            依照優先順序，自動為銀行交易套用分類與計算設定。
+          </p>
+        </div>
+        <span class="rounded-lg bg-steel px-4 py-2 text-sm font-bold text-white"
+          >＋ 新增規則</span
+        >
+      </div>
+
+      <section
+        aria-label="分類規則摘要"
+        class="hidden min-w-0 gap-3 md:grid md:grid-cols-3"
+      >
+        <div class="rounded-xl border border-border bg-card p-3.5 shadow-xs">
+          <p class="text-sm font-semibold text-muted-foreground">規則總數</p>
+          <p class="mt-1 text-lg font-bold">{$rules.data?.length ?? 0}</p>
+        </div>
+        <div class="rounded-xl border border-border bg-card p-3.5 shadow-xs">
+          <p class="text-sm font-semibold text-muted-foreground">已啟用</p>
+          <p class="mt-1 text-lg font-bold text-moss">{enabledRuleCount}</p>
+        </div>
+        <div class="rounded-xl bg-muted p-3.5">
+          <p class="text-sm font-semibold text-muted-foreground">最近套用</p>
+          <p class="mt-1 text-lg font-bold">—</p>
+        </div>
+      </section>
+
+      <div
+        class="hidden gap-4 md:grid lg:grid-cols-[minmax(0,690px)_minmax(0,1fr)]"
+      >
+        <ClassificationRulesPanel {api} />
+        <aside
+          class="min-w-0 rounded-xl border border-border bg-card p-5 shadow-xs"
+          aria-label="規則如何運作"
+        >
+          <h2 class="text-base font-bold">規則如何運作</h2>
+          <p class="mt-2 text-sm leading-relaxed text-muted-foreground">
+            同步完成後，系統由上到下檢查規則。第一個符合條件的規則會套用到交易。
+          </p>
+          <div class="mt-5 rounded-lg bg-muted p-3">
+            <p class="text-sm font-bold">優先順序很重要</p>
+            <p class="mt-1 text-sm leading-relaxed text-muted-foreground">
+              將條件較精確的規則放在前面；可在下方調整規則順序。
+            </p>
+          </div>
+          <span
+            class="mt-5 block w-full rounded-lg border border-steel px-3 py-2.5 text-center text-sm font-bold text-steel"
+            >重新套用到既有交易</span
+          >
         </aside>
       </div>
-      <ClassificationRulesPanel {api} />
-    </section>
-  </div>
-{/if}
+      <div class="md:hidden">
+        <ClassificationRulesPanel {api} />
+      </div>
+    </div>
+  {:else}
+    <div class="grid min-w-0 gap-4">
+      <section
+        aria-label="設定總覽介紹"
+        class="flex min-w-0 flex-wrap items-center justify-between gap-3"
+      >
+        <div>
+          <h2 class="text-2xl font-bold tracking-tight">設定總覽</h2>
+          <p class="mt-1 text-sm text-muted-foreground">
+            先處理資料異常，再調整日常偏好。
+          </p>
+        </div>
+        <p class="text-sm text-muted-foreground">
+          狀態更新：{latestSuccessAt
+            ? formatDateTime(latestSuccessAt)
+            : "尚無同步紀錄"}
+        </p>
+      </section>
+
+      <section
+        aria-label="資料狀態"
+        class="grid min-w-0 gap-4 lg:grid-cols-[minmax(0,1fr)_340px]"
+      >
+        <div
+          class={`min-w-0 rounded-xl border bg-card p-5 shadow-xs ${needsAction ? "border-coral/70 border-l-4" : "border-border"}`}
+        >
+          <div class="flex items-center justify-between gap-3">
+            <p
+              class={`text-sm font-semibold ${needsAction ? "text-coral" : "text-moss"}`}
+            >
+              {needsAction ? `需要處理 · ${needsAction}` : "資料同步狀態"}
+            </p>
+            <span class="text-sm font-semibold text-muted-foreground">
+              {needsAction ? "影響資料更新" : "目前正常"}
+            </span>
+          </div>
+          <h2 class="mt-2 text-xl font-bold">
+            {actionSource?.title ??
+              `${healthySources} / ${sources.length} 來源正常`}
+          </h2>
+          <p class="mt-1 text-sm text-muted-foreground">
+            {needsAction
+              ? "完成重新驗證後即可恢復自動同步。"
+              : "所有連接器都能正常同步。"}
+          </p>
+          <button
+            class="mt-4 rounded-lg bg-steel px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-steel/90"
+            onclick={() => navigate("data-sources")}
+            >{needsAction ? "查看連接器" : "管理資料來源"}</button
+          >
+        </div>
+
+        <div
+          class="min-w-0 rounded-xl border border-border bg-card p-5 shadow-xs"
+          aria-label="資料健康度"
+        >
+          <div class="flex items-center justify-between gap-3">
+            <p class="text-sm font-semibold text-muted-foreground">
+              資料健康度
+            </p>
+            <span
+              class={`text-sm font-semibold ${needsAction ? "text-coral" : "text-moss"}`}
+              >{needsAction ? "需要處理" : "大致正常"}</span
+            >
+          </div>
+          <p class="mt-2 text-3xl font-bold">
+            {healthySources} / {sources.length}
+          </p>
+          <p class="mt-1 text-sm text-muted-foreground">
+            {inheritedJobCount} 個排程啟用 · {latestSuccessAt
+              ? `最近成功 ${formatDateTime(latestSuccessAt)}`
+              : "尚無成功紀錄"}
+          </p>
+        </div>
+      </section>
+
+      <section
+        aria-label="資料來源與自動化"
+        class="grid min-w-0 gap-4 lg:grid-cols-[minmax(0,1fr)_340px]"
+      >
+        <div
+          class="min-w-0 rounded-xl border border-border bg-card p-[18px] shadow-xs"
+        >
+          <div class="flex items-center justify-between gap-3">
+            <h2 class="text-lg font-bold">資料來源與連接器</h2>
+            <button
+              class="text-sm font-semibold text-steel transition hover:text-steel/80"
+              onclick={() => navigate("data-sources")}>管理全部 →</button
+            >
+          </div>
+          <div class="mt-2">
+            {#each sources as source (source.id)}
+              <SourceCard
+                {api}
+                {...source}
+                id={source.id}
+                jobs={$jobs.data ?? []}
+                compact
+                selected={false}
+                onConfigure={() => navigate("data-sources")}
+              />
+            {/each}
+          </div>
+        </div>
+
+        <div class="grid min-w-0 gap-3">
+          <button
+            type="button"
+            class="min-w-0 rounded-xl border border-border bg-card p-[17px] text-left shadow-xs transition hover:-translate-y-0.5 hover:border-ink/20 hover:shadow-sm"
+            onclick={() => navigate("sync-notifications")}
+          >
+            <h2 class="text-base font-bold">預設同步排程</h2>
+            <p class="mt-1 text-xl font-bold">{scheduleSummary}</p>
+            <p class="mt-1 text-sm text-muted-foreground">
+              {inheritedJobCount} 個連接器套用
+            </p>
+            <span class="mt-3 block text-sm font-semibold text-steel"
+              >管理 →</span
+            >
+          </button>
+          <button
+            type="button"
+            class="min-w-0 rounded-xl border border-border bg-card p-[17px] text-left shadow-xs transition hover:-translate-y-0.5 hover:border-ink/20 hover:shadow-sm"
+            onclick={() => navigate("sync-notifications")}
+          >
+            <h2 class="text-base font-bold">通知設定</h2>
+            <p class="mt-1 text-xl font-bold">{notificationSummary}</p>
+            <p class="mt-1 text-sm text-muted-foreground">
+              {notificationDescription}
+            </p>
+            <span class="mt-3 block text-sm font-semibold text-steel"
+              >管理 →</span
+            >
+          </button>
+        </div>
+      </section>
+
+      <section aria-label="其他設定" class="grid min-w-0 gap-4 md:grid-cols-2">
+        <button
+          type="button"
+          class="min-w-0 rounded-xl border border-border bg-card p-[18px] text-left shadow-xs transition hover:-translate-y-0.5 hover:border-ink/20 hover:shadow-sm"
+          onclick={() => navigate("exchange-rates")}
+        >
+          <h2 class="text-base font-bold">匯率</h2>
+          <p
+            class="mt-2 break-words text-sm leading-relaxed text-muted-foreground"
+          >
+            {ratesSummary}
+          </p>
+          <span class="mt-4 block text-sm font-semibold text-steel"
+            >開啟設定 →</span
+          >
+        </button>
+        <button
+          type="button"
+          class="min-w-0 rounded-xl border border-border bg-card p-[15px] text-left shadow-xs transition hover:-translate-y-0.5 hover:border-ink/20 hover:shadow-sm"
+          onclick={() => navigate("classification-rules")}
+        >
+          <h2 class="text-base font-bold">分類規則</h2>
+          <p class="mt-1 text-sm text-muted-foreground">{rulesSummary}</p>
+          <span class="mt-3 block text-sm font-semibold text-steel"
+            >開啟設定 →</span
+          >
+        </button>
+      </section>
+    </div>
+  {/if}
+</div>

--- a/apps/web/src/features/settings/components/ClassificationRulesPanel.svelte
+++ b/apps/web/src/features/settings/components/ClassificationRulesPanel.svelte
@@ -132,7 +132,7 @@
   <CardHeader class="gap-4 sm:flex-row sm:items-start sm:justify-between">
     <div>
       <h2 class="text-lg font-semibold">分類規則</h2>
-      <p class="text-xs text-muted-foreground">
+      <p class="text-sm text-muted-foreground">
         讓銀行交易依條件自動分類，也可選擇不計入收支
       </p>
     </div>
@@ -145,7 +145,9 @@
       >
         <Plus class="size-4" />新增分類
       </Button>
-      <Badge variant="secondary">{$rules.data?.length ?? 0} 條</Badge>
+      <Badge class="text-sm" variant="secondary"
+        >{$rules.data?.length ?? 0} 條</Badge
+      >
     </div>
   </CardHeader>
   <CardContent>
@@ -224,7 +226,7 @@
           />
           <div class="min-w-0">
             <p class="text-sm font-semibold">符合時不計入收支</p>
-            <p class="text-xs text-muted-foreground">
+            <p class="text-sm text-muted-foreground">
               仍保留所選分類，只排除圖表與收支加總。
             </p>
           </div>
@@ -295,7 +297,7 @@
                     />
                     <div class="min-w-0">
                       <p class="font-semibold">符合時不計入收支</p>
-                      <p class="text-xs text-muted-foreground">
+                      <p class="text-sm text-muted-foreground">
                         仍保留所選分類，只排除圖表與收支加總。
                       </p>
                     </div>
@@ -333,16 +335,18 @@
                 />
                 <div class="min-w-0 flex-1">
                   <div class="flex flex-wrap items-center gap-1.5">
-                    <Badge variant="outline">
+                    <Badge class="text-sm" variant="outline">
                       {categoryLabels[rule.categoryId] ?? rule.categoryId}
                     </Badge>
                     {#if rule.excludedFromCalculation}
-                      <Badge class="border-transparent bg-coral/10 text-coral">
+                      <Badge
+                        class="border-transparent bg-coral/10 text-coral text-sm"
+                      >
                         不計入收支
                       </Badge>
                     {/if}
                     {#if rule.isSystem}
-                      <Badge variant="secondary">內建</Badge>
+                      <Badge class="text-sm" variant="secondary">內建</Badge>
                     {/if}
                   </div>
                   <p class="mt-1.5 break-words text-foreground/80">

--- a/apps/web/src/features/settings/components/DefaultSchedulePanel.svelte
+++ b/apps/web/src/features/settings/components/DefaultSchedulePanel.svelte
@@ -22,10 +22,12 @@
     api,
     demoMode,
     jobs,
+    variant = "default",
   }: {
     api: ApiClient;
     demoMode: boolean;
     jobs: SyncJobRow[];
+    variant?: "default" | "desktop";
   } = $props();
 
   const queryClient = useQueryClient();
@@ -76,28 +78,37 @@
   });
 </script>
 
-<Card as="section" class="overflow-hidden">
+<Card
+  as="section"
+  class={`overflow-hidden ${variant === "desktop" ? "border-border shadow-xs" : ""}`}
+>
   <div
-    class="flex flex-wrap items-start justify-between gap-4 border-b border-border bg-ink px-5 py-4 text-white"
+    class={`flex flex-wrap items-start justify-between gap-4 border-b px-5 py-4 ${variant === "desktop" ? "border-border bg-card text-foreground" : "border-border bg-ink text-white"}`}
   >
     <div class="flex items-start gap-3">
       <span
-        class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-white/10 text-white"
+        class={`flex size-10 shrink-0 items-center justify-center rounded-xl ${variant === "desktop" ? "bg-steel/10 text-steel" : "bg-white/10 text-white"}`}
       >
         <Clock3 class="size-5" />
       </span>
       <div>
         <h2 class="font-semibold">預設同步排程</h2>
-        <p class="mt-1 text-xs text-white/55">
+        <p
+          class={`mt-1 text-sm ${variant === "desktop" ? "text-muted-foreground" : "text-white/55"}`}
+        >
           選擇跟隨預設的連接器，會從設定時間起依序同步。
         </p>
       </div>
     </div>
-    <div class="flex flex-wrap items-center gap-2 text-xs">
-      <span class="rounded-full bg-white/10 px-3 py-1.5 text-white/70">
+    <div class="flex flex-wrap items-center gap-2 text-sm">
+      <span
+        class={`rounded-full px-3 py-1.5 ${variant === "desktop" ? "bg-muted text-muted-foreground" : "bg-white/10 text-white/70"}`}
+      >
         Asia/Taipei
       </span>
-      <span class="rounded-full bg-white/10 px-3 py-1.5 font-semibold">
+      <span
+        class={`rounded-full px-3 py-1.5 font-semibold ${variant === "desktop" ? "bg-moss/10 text-moss" : "bg-white/10"}`}
+      >
         {inheritedJobs} 個連接器跟隨
       </span>
     </div>
@@ -137,7 +148,7 @@
       </div>
     {/if}
     <p
-      class="text-xs leading-relaxed text-muted-foreground md:min-w-52 md:flex-1 md:pb-2"
+      class="text-sm leading-relaxed text-muted-foreground md:min-w-52 md:flex-1 md:pb-2"
     >
       修改後只會影響「跟隨預設」的來源；自訂排程不會改變。
     </p>
@@ -150,13 +161,13 @@
   </div>
   {#if $save.isSuccess}
     <p
-      class="border-t border-border bg-moss/5 px-5 py-2 text-xs font-medium text-moss"
+      class="border-t border-border bg-moss/5 px-5 py-2 text-sm font-medium text-moss"
     >
       預設同步排程已更新，跟隨此設定的連接器也已重新排程。
     </p>
   {:else if $save.isError}
     <p
-      class="border-t border-border bg-coral/5 px-5 py-2 text-xs font-medium text-coral"
+      class="border-t border-border bg-coral/5 px-5 py-2 text-sm font-medium text-coral"
     >
       預設排程儲存失敗，請稍後再試。
     </p>

--- a/apps/web/src/features/settings/components/ExchangeRatesPanel.svelte
+++ b/apps/web/src/features/settings/components/ExchangeRatesPanel.svelte
@@ -15,16 +15,27 @@
   import { queryKeys } from "@/shared/api/query-keys";
   import { exchangeRatesQuery } from "@/data/assets/queries";
   import { bankQuery } from "@/data/bank/queries";
-  let { api }: { api: ApiClient } = $props();
+  import { formatDateTime } from "@/shared/format/financial";
+  let {
+    api,
+    variant = "default",
+  }: {
+    api: ApiClient;
+    variant?: "default" | "desktop";
+  } = $props();
   const rates = createQuery(exchangeRatesQuery(() => api));
   const bank = createQuery(bankQuery(() => api));
   const qc = useQueryClient();
   let values = $state<Record<string, string>>({});
   const currencies = $derived([
     ...new Set(
-      ($bank.data?.accounts ?? [])
-        .map((a) => a.currency)
-        .filter((c) => c && c !== "TWD"),
+      [
+        ...($bank.data?.accounts ?? []).map((account) => account.currency),
+        ...($rates.data ?? []).map((rate) => rate.currency),
+      ].filter(
+        (currency): currency is string =>
+          Boolean(currency) && currency !== "TWD",
+      ),
     ),
   ]);
   const save = createMutation({
@@ -43,37 +54,102 @@
   );
 </script>
 
-<Card
-  ><CardHeader
-    ><h2 class="text-lg font-semibold">匯率</h2>
-    <p class="text-xs text-muted-foreground">
-      管理外幣換算使用的參考匯率
-    </p></CardHeader
-  ><CardContent
-    ><div class="grid gap-3">
-      {#if currencies.length === 0}<p class="text-sm text-muted-foreground">
-          目前沒有外幣帳戶。
-        </p>{:else}{#each currencies as currency (currency)}<label
-            class="flex items-center justify-between gap-3 text-sm"
-            ><span class="font-semibold">{currency}</span><Input
-              class="w-32 text-right"
+{#if variant === "desktop"}
+  <Card as="section" class="overflow-hidden border-border shadow-xs">
+    <CardHeader class="border-b border-border bg-muted/60">
+      <div>
+        <h2 class="text-base font-bold">匯率表格</h2>
+        <p class="mt-1 text-sm text-muted-foreground">
+          可調整外幣換算使用的參考匯率。
+        </p>
+      </div>
+    </CardHeader>
+    <CardContent class="p-0">
+      {#if currencies.length === 0}
+        <p class="p-5 text-sm text-muted-foreground">目前沒有外幣帳戶。</p>
+      {:else}
+        <div
+          class="hidden grid-cols-[minmax(0,1fr)_180px_220px_220px] bg-muted/60 text-sm font-semibold text-muted-foreground sm:grid"
+        >
+          <span class="px-4 py-3">幣別</span>
+          <span class="px-4 py-3">換算率</span>
+          <span class="px-4 py-3">來源</span>
+          <span class="px-4 py-3">更新時間</span>
+        </div>
+        {#each currencies as currency (currency)}
+          {@const rate = ($rates.data ?? []).find(
+            (item) => item.currency === currency,
+          )}
+          <label
+            class="grid gap-2 border-t border-border px-4 py-3 text-sm sm:grid-cols-[minmax(0,1fr)_180px_220px_220px] sm:items-center"
+          >
+            <span class="font-semibold">{currency}</span>
+            <Input
+              class="w-full text-right sm:w-32"
               type="number"
               step="0.0001"
               bind:value={values[currency]}
-            /></label
-          >{/each}<Button
-          variant="primary"
-          disabled={$save.isPending}
-          onclick={() =>
-            $save.mutate(
-              Object.fromEntries(
-                Object.entries(values).map(([k, v]) => [k, Number(v)]),
-              ),
-            )}
-          ><Save class="size-4" />{$save.isPending
-            ? "儲存中…"
-            : "儲存匯率"}</Button
-        >{/if}
-    </div></CardContent
-  ></Card
->
+              aria-label={`${currency} 匯率`}
+            />
+            <span class="text-sm text-muted-foreground">手動設定</span>
+            <span class="text-sm text-muted-foreground"
+              >{rate?.updatedAt
+                ? formatDateTime(rate.updatedAt)
+                : "尚未更新"}</span
+            >
+          </label>
+        {/each}
+        <div class="border-t border-border p-4">
+          <Button
+            variant="primary"
+            disabled={$save.isPending}
+            onclick={() =>
+              $save.mutate(
+                Object.fromEntries(
+                  Object.entries(values).map(([k, v]) => [k, Number(v)]),
+                ),
+              )}
+            ><Save class="size-4" />{$save.isPending
+              ? "儲存中…"
+              : "儲存匯率"}</Button
+          >
+        </div>
+      {/if}
+    </CardContent>
+  </Card>
+{:else}
+  <Card
+    ><CardHeader
+      ><h2 class="text-lg font-semibold">匯率</h2>
+      <p class="text-sm text-muted-foreground">
+        管理外幣換算使用的參考匯率
+      </p></CardHeader
+    ><CardContent
+      ><div class="grid gap-3">
+        {#if currencies.length === 0}<p class="text-sm text-muted-foreground">
+            目前沒有外幣帳戶。
+          </p>{:else}{#each currencies as currency (currency)}<label
+              class="flex items-center justify-between gap-3 text-sm"
+              ><span class="font-semibold">{currency}</span><Input
+                class="w-32 text-right"
+                type="number"
+                step="0.0001"
+                bind:value={values[currency]}
+              /></label
+            >{/each}<Button
+            variant="primary"
+            disabled={$save.isPending}
+            onclick={() =>
+              $save.mutate(
+                Object.fromEntries(
+                  Object.entries(values).map(([k, v]) => [k, Number(v)]),
+                ),
+              )}
+            ><Save class="size-4" />{$save.isPending
+              ? "儲存中…"
+              : "儲存匯率"}</Button
+          >{/if}
+      </div></CardContent
+    ></Card
+  >
+{/if}

--- a/apps/web/src/features/settings/components/Metric.svelte
+++ b/apps/web/src/features/settings/components/Metric.svelte
@@ -16,12 +16,12 @@
 
 <Card
   ><CardContent class="p-4"
-    ><p class="text-xs font-semibold text-muted-foreground">{label}</p>
+    ><p class="text-sm font-semibold text-muted-foreground">{label}</p>
     <p
       class={`mt-2 text-2xl font-bold ${tone === "positive" ? "text-moss" : tone === "negative" ? "text-coral" : ""}`}
     >
       {value}
     </p>
-    <p class="mt-1 text-xs text-muted-foreground">{detail}</p></CardContent
+    <p class="mt-1 text-sm text-muted-foreground">{detail}</p></CardContent
   ></Card
 >

--- a/apps/web/src/features/settings/components/MobileMore.svelte
+++ b/apps/web/src/features/settings/components/MobileMore.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Database, Settings, WalletCards } from "@lucide/svelte";
+  import { Clock3, Database, Settings, WalletCards } from "@lucide/svelte";
   import Card from "@/shared/ui/Card.svelte";
   import CardContent from "@/shared/ui/CardContent.svelte";
   import type { ApiClient } from "@/shared/api/client";
@@ -33,12 +33,12 @@
 
 <div class="grid gap-4">
   {#if demoMode}<span
-      class="w-fit rounded-full bg-steel/10 px-3 py-1 text-xs font-semibold text-steel"
+      class="w-fit rounded-full bg-steel/10 px-3 py-1 text-sm font-semibold text-steel"
       >Demo 資料</span
     >{/if}
   <Card
     ><CardContent class="pt-5"
-      ><p class="text-xs font-semibold text-ink/45">資料健康度</p>
+      ><p class="text-sm font-semibold text-ink/45">資料健康度</p>
       <p class="mt-2 text-2xl font-bold">
         {Math.max(sources.length - unhealthy.length, 0)} / {sources.length} 來源正常
       </p>
@@ -48,7 +48,7 @@
     ></Card
   >
   <section>
-    <h2 class="mb-2 text-sm font-semibold text-ink/50">設定與資料</h2>
+    <h2 class="mb-2 text-base font-semibold text-ink/50">設定與資料</h2>
     <Card
       ><div class="divide-y divide-ink/8">
         <button
@@ -59,11 +59,23 @@
             ><Database class="size-5" /></span
           ><span class="flex-1"
             ><span class="block font-semibold">資料來源與連接器</span><span
-              class="block text-xs text-ink/45">狀態、憑證、排程與重新驗證</span
+              class="block text-sm text-ink/45">狀態、憑證、排程與重新驗證</span
             ></span
-          ><span class="text-xs font-semibold text-steel"
+          ><span class="text-sm font-semibold text-steel"
             >{sources.length} 個　›</span
           ></button
+        >
+        <button
+          class="flex min-h-16 w-full items-center gap-3 px-4 py-3 text-left"
+          onclick={() => navigate("sync-notifications")}
+          ><span
+            class="flex size-10 items-center justify-center rounded-xl bg-steel/10 text-steel"
+            ><Clock3 class="size-5" /></span
+          ><span class="flex-1"
+            ><span class="block font-semibold">同步與通知</span><span
+              class="block text-sm text-ink/45">預設排程、推播與同步結果</span
+            ></span
+          ><span class="text-sm font-semibold text-steel">›</span></button
         >
         <button
           class="flex min-h-16 w-full items-center gap-3 px-4 py-3 text-left"
@@ -73,9 +85,9 @@
             ><WalletCards class="size-5" /></span
           ><span class="flex-1"
             ><span class="block font-semibold">匯率</span><span
-              class="block text-xs text-ink/45">管理外幣換算</span
+              class="block text-sm text-ink/45">管理外幣換算</span
             ></span
-          ><span class="text-xs font-semibold text-steel">›</span></button
+          ><span class="text-sm font-semibold text-steel">›</span></button
         >
         <button
           class="flex min-h-16 w-full items-center gap-3 px-4 py-3 text-left"
@@ -85,9 +97,9 @@
             ><Settings class="size-5" /></span
           ><span class="flex-1"
             ><span class="block font-semibold">分類規則</span><span
-              class="block text-xs text-ink/45">銀行交易自動分類</span
+              class="block text-sm text-ink/45">銀行交易自動分類</span
             ></span
-          ><span class="text-xs font-semibold text-steel"
+          ><span class="text-sm font-semibold text-steel"
             >{rules.length} 條　›</span
           ></button
         >
@@ -96,9 +108,9 @@
   </section>
   <section>
     <div class="mb-2 flex items-center justify-between">
-      <h2 class="text-sm font-semibold text-ink/50">資料來源</h2>
+      <h2 class="text-base font-semibold text-ink/50">資料來源</h2>
       <button
-        class="min-h-8 px-2 text-xs font-semibold text-steel"
+        class="min-h-8 px-2 text-sm font-semibold text-steel"
         onclick={() => navigate("data-sources")}>管理</button
       >
     </div>

--- a/apps/web/src/features/settings/components/MobileMore.test.ts
+++ b/apps/web/src/features/settings/components/MobileMore.test.ts
@@ -19,6 +19,7 @@ describe("MobileMore", () => {
 
     expect(getByText("6 / 6 來源正常")).toBeInTheDocument();
     expect(getByText(/6 個\s*›/)).toBeInTheDocument();
+    expect(getByText("同步與通知")).toBeInTheDocument();
     expect(getByText("台新銀行")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/settings/components/NotificationPanel.svelte
+++ b/apps/web/src/features/settings/components/NotificationPanel.svelte
@@ -30,9 +30,11 @@
   let {
     api,
     demoMode,
+    variant = "default",
   }: {
     api: ApiClient;
     demoMode: boolean;
+    variant?: "default" | "desktop";
   } = $props();
 
   const queryClient = useQueryClient();
@@ -208,27 +210,43 @@
   }
 </script>
 
-<Card as="section" class="overflow-hidden">
+<Card
+  as="section"
+  class={`overflow-hidden ${variant === "desktop" ? "border-border shadow-xs" : ""}`}
+>
   <div
-    class="flex flex-wrap items-start justify-between gap-4 border-b border-white/10 bg-steel px-5 py-4 text-white"
+    class={`flex flex-wrap items-start justify-between gap-4 border-b px-5 py-4 ${variant === "desktop" ? "border-border bg-card text-foreground" : "border-white/10 bg-steel text-white"}`}
   >
     <div class="flex items-start gap-3">
       <span
-        class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-white/15 text-white"
+        class={`flex size-10 shrink-0 items-center justify-center rounded-xl ${variant === "desktop" ? "bg-steel/10 text-steel" : "bg-white/15 text-white"}`}
       >
         <BellRing class="size-5" />
       </span>
       <div>
-        <h2 class="font-semibold">同步推播</h2>
-        <p class="mt-1 text-xs text-white/65">
-          排程同步完成、失敗或需要驗證時提醒你。
+        <h2 class="font-semibold">
+          {variant === "desktop" ? "通知設定" : "同步推播"}
+        </h2>
+        <p
+          class={`mt-1 text-sm ${variant === "desktop" ? "text-muted-foreground" : "text-white/65"}`}
+        >
+          {variant === "desktop"
+            ? "選擇需要收到推播的同步事件。"
+            : "排程同步完成、失敗或需要驗證時提醒你。"}
         </p>
       </div>
     </div>
     {#if subscribed}
-      <Badge variant="success" class="bg-white/15 text-white">已啟用</Badge>
+      <Badge
+        variant="success"
+        class={variant === "desktop"
+          ? "text-sm"
+          : "bg-white/15 text-white text-sm"}>已啟用</Badge
+      >
     {:else}
-      <span class="rounded-full bg-white/10 px-3 py-1.5 text-xs text-white/70">
+      <span
+        class={`rounded-full px-3 py-1.5 text-sm ${variant === "desktop" ? "bg-muted text-muted-foreground" : "bg-white/10 text-white/70"}`}
+      >
         尚未啟用
       </span>
     {/if}
@@ -279,7 +297,7 @@
           <p class="font-medium">
             {subscribed ? "這個裝置會收到同步狀態" : "在背景同步完成時收到提醒"}
           </p>
-          <p class="mt-1 text-xs text-muted-foreground">
+          <p class="mt-1 text-sm text-muted-foreground">
             可在多個瀏覽器或裝置各自開啟；通知不會包含金額或交易內容。
           </p>
         </div>
@@ -312,7 +330,7 @@
       {#if subscribed}
         <div class="grid gap-2 border-t border-border pt-4">
           <p
-            class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground"
+            class="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground"
           >
             通知內容
           </p>
@@ -327,7 +345,7 @@
             >
               <span>
                 <span class="block text-sm font-medium">{item.label}</span>
-                <span class="mt-0.5 block text-xs text-muted-foreground"
+                <span class="mt-0.5 block text-sm text-muted-foreground"
                   >{item.description}</span
                 >
               </span>
@@ -346,7 +364,7 @@
 
     {#if feedback}
       <p
-        class={`border-t border-border pt-3 text-xs font-medium ${feedback.tone === "success" ? "text-moss" : "text-coral"}`}
+        class={`border-t border-border pt-3 text-sm font-medium ${feedback.tone === "success" ? "text-moss" : "text-coral"}`}
       >
         {#if feedback.tone === "success"}<Check
             class="mr-1 inline size-4"

--- a/apps/web/src/features/settings/components/SourceCard.svelte
+++ b/apps/web/src/features/settings/components/SourceCard.svelte
@@ -19,6 +19,8 @@
     selected,
     onConfigure,
     jobs,
+    compact = false,
+    compactCard = false,
     children,
   }: {
     api: ApiClient;
@@ -28,6 +30,8 @@
     selected: boolean;
     onConfigure: () => void;
     jobs?: SyncJobRow[];
+    compact?: boolean;
+    compactCard?: boolean;
     children?: Snippet;
   } = $props();
   const settings = createQuery(
@@ -62,59 +66,105 @@
   );
 </script>
 
-<Card
-  class={`transition duration-200 ${selected ? "sm:col-span-2 lg:col-span-3 2xl:col-span-5 border-steel/50 shadow-md ring-2 ring-steel/15" : "hover:-translate-y-0.5 hover:border-ink/20 hover:shadow-sm"}`}
-  ><CardContent class="pt-5"
-    ><div class="flex items-start justify-between gap-4">
-      <div class="flex min-w-0 items-start gap-3">
-        <span
-          class={`flex size-10 shrink-0 items-center justify-center rounded-xl ${selected ? "bg-steel text-white" : "bg-steel/10 text-steel"}`}
-        >
-          <SourceIcon class="size-5" />
-        </span>
-        <div class="min-w-0">
-          <h2 class="font-semibold">{title}</h2>
-          <p class="mt-0.5 text-sm text-muted-foreground">{description}</p>
-        </div>
-      </div>
-      <Badge
-        class="shrink-0 whitespace-nowrap"
-        variant={needsAction
-          ? "destructive"
-          : $settings.data?.configured
-            ? "success"
-            : "secondary"}
-        >{needsAction
-          ? "需要處理"
-          : $settings.data?.configured
-            ? "已設定"
-            : "未設定"}</Badge
-      >
-    </div>
-    <div
-      class="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4"
+{#if compact}
+  <button
+    type="button"
+    class={`group flex w-full items-center text-left transition ${compactCard ? "min-h-20 gap-3 rounded-xl border border-border bg-card px-4 py-3 hover:-translate-y-0.5 hover:border-ink/20 hover:shadow-sm" : "min-h-12 gap-3 border-t border-border py-2.5 hover:bg-muted/40"} ${selected && compactCard ? "border-steel/50 ring-2 ring-steel/15" : ""}`}
+    aria-label={`管理${title}`}
+    onclick={onConfigure}
+  >
+    <span
+      class={`flex shrink-0 items-center justify-center rounded-lg bg-steel/10 text-steel ${compactCard ? "size-10" : "size-8"}`}
     >
-      <div class="text-xs text-muted-foreground">
-        <p>
-          上次成功：{job?.lastSuccessAt
-            ? formatDateTime(job.lastSuccessAt)
-            : "尚無紀錄"}
-        </p>
-        <p class="mt-1">
-          排程：{scheduleLabel}
-        </p>
-      </div>
-      <Button
-        size="sm"
-        variant={selected ? "default" : "outline"}
-        aria-expanded={selected}
-        onclick={onConfigure}>{selected ? "收合" : "管理設定"}</Button
+      <SourceIcon class={compactCard ? "size-5" : "size-4.5"} />
+    </span>
+    <span class="min-w-0 flex-1">
+      <span class="block truncate text-sm font-semibold text-foreground"
+        >{title}</span
       >
-    </div>
-    {#if selected && children}
-      <div class="mt-5 border-t border-border pt-5">
-        {@render children()}
+      <span class="block truncate text-sm text-muted-foreground">
+        {job?.lastSuccessAt
+          ? `最近同步 ${formatDateTime(job.lastSuccessAt)}`
+          : $settings.data?.configured
+            ? "尚未成功同步"
+            : "尚未設定"}
+      </span>
+    </span>
+    <Badge
+      class="shrink-0 whitespace-nowrap text-sm"
+      variant={needsAction
+        ? "destructive"
+        : $settings.data?.configured && job?.lastSuccessAt
+          ? "success"
+          : "secondary"}
+      >{needsAction
+        ? "需要處理"
+        : $settings.data?.configured && job?.lastSuccessAt
+          ? "正常"
+          : $settings.data?.configured
+            ? "尚未同步"
+            : "未設定"}</Badge
+    >
+    {#if compactCard}<span
+        aria-hidden="true"
+        class="text-xl leading-none text-muted-foreground">›</span
+      >{/if}
+  </button>
+{:else}
+  <Card
+    class={`transition duration-200 ${selected ? "sm:col-span-2 lg:col-span-3 2xl:col-span-5 border-steel/50 shadow-md ring-2 ring-steel/15" : "hover:-translate-y-0.5 hover:border-ink/20 hover:shadow-sm"}`}
+    ><CardContent class="pt-5"
+      ><div class="flex items-start justify-between gap-4">
+        <div class="flex min-w-0 items-start gap-3">
+          <span
+            class={`flex size-10 shrink-0 items-center justify-center rounded-xl ${selected ? "bg-steel text-white" : "bg-steel/10 text-steel"}`}
+          >
+            <SourceIcon class="size-5" />
+          </span>
+          <div class="min-w-0">
+            <h2 class="font-semibold">{title}</h2>
+            <p class="mt-0.5 text-sm text-muted-foreground">{description}</p>
+          </div>
+        </div>
+        <Badge
+          class="shrink-0 whitespace-nowrap text-sm"
+          variant={needsAction
+            ? "destructive"
+            : $settings.data?.configured
+              ? "success"
+              : "secondary"}
+          >{needsAction
+            ? "需要處理"
+            : $settings.data?.configured
+              ? "已設定"
+              : "未設定"}</Badge
+        >
       </div>
-    {/if}</CardContent
-  ></Card
->
+      <div
+        class="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4"
+      >
+        <div class="text-sm text-muted-foreground">
+          <p>
+            上次成功：{job?.lastSuccessAt
+              ? formatDateTime(job.lastSuccessAt)
+              : "尚無紀錄"}
+          </p>
+          <p class="mt-1">
+            排程：{scheduleLabel}
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant={selected ? "default" : "outline"}
+          aria-expanded={selected}
+          onclick={onConfigure}>{selected ? "收合" : "管理設定"}</Button
+        >
+      </div>
+      {#if selected && children}
+        <div class="mt-5 border-t border-border pt-5">
+          {@render children()}
+        </div>
+      {/if}</CardContent
+    ></Card
+  >
+{/if}

--- a/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
+++ b/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
@@ -386,7 +386,7 @@
         >
       {:else if connectorId === "tdcc"}
         <span
-          class="inline-flex items-center gap-1.5 rounded-full border border-steel/20 bg-steel/[0.06] px-3 py-1.5 text-xs font-semibold text-steel"
+          class="inline-flex items-center gap-1.5 rounded-full border border-steel/20 bg-steel/[0.06] px-3 py-1.5 text-sm font-semibold text-steel"
         >
           <ShieldCheck class="size-3.5" />等待完成身分驗證
         </span>
@@ -512,7 +512,7 @@
             >{/if}
         </div>
         {#if job?.lastRunAt}
-          <p class="mt-1 text-xs text-muted-foreground">
+          <p class="mt-1 text-sm text-muted-foreground">
             上次同步：{formatDateTime(job.lastRunAt)}
           </p>
         {/if}
@@ -528,7 +528,7 @@
 
     {#if job?.enabled}
       <div class="mt-3 grid gap-3 border-t border-ink/10 pt-3 md:grid-cols-4">
-        <label class="grid gap-1 text-xs font-semibold text-ink/70">
+        <label class="grid gap-1 text-sm font-semibold text-ink/70">
           排程方式
           <Select
             value={job.scheduleMode ?? "custom"}
@@ -564,7 +564,7 @@
             {/if}
           </div>
         {:else}
-          <label class="grid gap-1 text-xs font-semibold text-ink/70">
+          <label class="grid gap-1 text-sm font-semibold text-ink/70">
             同步頻率
             <Select
               value={job.intervalMinutes}
@@ -582,7 +582,7 @@
             </Select>
           </label>
           {#if job.intervalMinutes === 10080}
-            <label class="grid gap-1 text-xs font-semibold text-ink/70">
+            <label class="grid gap-1 text-sm font-semibold text-ink/70">
               執行日
               <Select
                 value={job.preferredWeekday}
@@ -601,7 +601,7 @@
             </label>
           {/if}
           {#if job.intervalMinutes >= 1440}
-            <label class="grid gap-1 text-xs font-semibold text-ink/70">
+            <label class="grid gap-1 text-sm font-semibold text-ink/70">
               開始時間
               <TimePicker
                 value={job.preferredTime}
@@ -611,7 +611,7 @@
             </label>
           {:else}
             <div
-              class="flex items-end pb-2 text-xs leading-relaxed text-muted-foreground"
+              class="flex items-end pb-2 text-sm leading-relaxed text-muted-foreground"
             >
               從上次同步完成後重新計時。
             </div>
@@ -620,7 +620,7 @@
       </div>
     {/if}
     {#if error || (job?.lastError && !bankCaptchaImage)}<p
-        class="mt-2 text-xs text-coral"
+        class="mt-2 text-sm text-coral"
       >
         {error ? `本次同步：${error}` : `上次同步：${job?.lastError}`}
       </p>{/if}
@@ -633,14 +633,14 @@
         <h3 class="text-sm font-semibold">
           {connectorId === "tdcc" ? "集保 App 身分驗證" : "連線憑證"}
         </h3>
-        <p class="mt-0.5 text-xs text-muted-foreground">
+        <p class="mt-0.5 text-sm text-muted-foreground">
           {connectorId === "tdcc"
             ? "請使用集保 e 存摺 App 的登入資料；不是券商網路下單密碼。"
             : "已儲存的機密欄位不會顯示內容；留白會維持原值。"}
         </p>
       </div>
       {#if $save.isSuccess}<span
-          class="rounded-full bg-moss/10 px-2.5 py-1 text-xs font-semibold text-moss"
+          class="rounded-full bg-moss/10 px-2.5 py-1 text-sm font-semibold text-moss"
           >已安全儲存</span
         >{/if}
     </div>
@@ -668,7 +668,7 @@
               <span>{field.label}</span>
               {#if storedCredential}
                 <span
-                  class={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${hasReplacement ? "bg-steel/10 text-steel" : "bg-moss/10 text-moss"}`}
+                  class={`rounded-full px-2 py-0.5 text-sm font-semibold ${hasReplacement ? "bg-steel/10 text-steel" : "bg-moss/10 text-moss"}`}
                 >
                   {hasReplacement ? "將更新" : "已儲存"}
                 </span>
@@ -695,7 +695,7 @@
     <div
       class="flex flex-wrap items-center justify-between gap-3 border-t border-border bg-paper/70 px-4 py-3"
     >
-      <p class="text-xs text-muted-foreground">
+      <p class="text-sm text-muted-foreground">
         {connectorId === "tdcc"
           ? tdccConnectionReady
             ? "重新填寫任一欄位會清除舊的登入狀態並重新驗證。"
@@ -733,7 +733,7 @@
       {/if}
     </div>
   </section>
-  {#if $save.isError}<p class="mt-2 text-xs font-medium text-coral">
+  {#if $save.isError}<p class="mt-2 text-sm font-medium text-coral">
       儲存失敗：{error}
     </p>{/if}
   {#if connectorId === "tdcc" && (tdccSetupStep === "email" || tdccSetupStep === "sms")}<div
@@ -753,7 +753,7 @@
               ? "簡訊驗證碼已寄出"
               : "Email 驗證碼已寄出"}
           </p>
-          <p class="mt-0.5 text-xs leading-relaxed text-ink/60">
+          <p class="mt-0.5 text-sm leading-relaxed text-ink/60">
             {tdccSetupStep === "sms"
               ? "Email 驗證已通過；請輸入集保寄到手機的驗證碼。"
               : "請查看集保帳號登記的電子信箱，也別忘了檢查垃圾郵件匣。"}
@@ -789,7 +789,7 @@
       >
         <button
           type="button"
-          class="text-xs font-semibold text-ink/55 underline-offset-4 hover:text-ink hover:underline"
+          class="text-sm font-semibold text-ink/55 underline-offset-4 hover:text-ink hover:underline"
           onclick={() => {
             otp = "";
             tdccSetupStep = "credentials";
@@ -810,11 +810,11 @@
       </div>
     </div>{/if}
   {#if connectorId === "tdcc" && error}<p
-      class="mt-3 rounded-lg border border-coral/20 bg-coral/[0.06] px-3 py-2 text-xs font-medium text-coral"
+      class="mt-3 rounded-lg border border-coral/20 bg-coral/[0.06] px-3 py-2 text-sm font-medium text-coral"
     >
       {error}
     </p>{/if}
-  <p class="mt-3 text-xs text-ink/50">
+  <p class="mt-3 text-sm text-ink/50">
     {connectorId === "sinopac"
       ? "永豐 session 失效時會由 Gemma 4 自動辨識並登入，連續三次失敗後才需人工驗證。"
       : connectorId === "tdcc"

--- a/apps/web/src/features/settings/connectors/TdccConnectionProgress.svelte
+++ b/apps/web/src/features/settings/connectors/TdccConnectionProgress.svelte
@@ -18,30 +18,30 @@
     class={`flex items-center gap-3 px-3 py-3 ${step === "credentials" && !connectionReady ? "bg-steel/[0.07] text-steel" : "text-ink/55"}`}
   >
     <span
-      class="grid size-7 shrink-0 place-items-center rounded-full border border-current/20 text-xs font-bold"
+      class="grid size-7 shrink-0 place-items-center rounded-full border border-current/20 text-sm font-bold"
       >1</span
     >
-    <span class="text-xs font-semibold">確認集保帳密</span>
+    <span class="text-sm font-semibold">確認集保帳密</span>
   </div>
   <div
     class={`flex items-center gap-3 border-t border-ink/10 px-3 py-3 sm:border-l sm:border-t-0 ${step === "email" || step === "sms" ? "bg-steel/[0.07] text-steel" : "text-ink/55"}`}
   >
     <span
-      class="grid size-7 shrink-0 place-items-center rounded-full border border-current/20 text-xs font-bold"
+      class="grid size-7 shrink-0 place-items-center rounded-full border border-current/20 text-sm font-bold"
       >2</span
     >
-    <span class="text-xs font-semibold">驗證這台裝置</span>
+    <span class="text-sm font-semibold">驗證這台裝置</span>
   </div>
   <div
     class={`flex items-center gap-3 border-t border-ink/10 px-3 py-3 sm:border-l sm:border-t-0 ${connectionReady || step === "complete" ? "bg-moss/[0.07] text-moss" : "text-ink/55"}`}
   >
     <span
-      class="grid size-7 shrink-0 place-items-center rounded-full border border-current/20 text-xs font-bold"
+      class="grid size-7 shrink-0 place-items-center rounded-full border border-current/20 text-sm font-bold"
       >{#if connectionReady || step === "complete"}<CircleCheckBig
           class="size-4"
         />{:else}3{/if}</span
     >
-    <span class="text-xs font-semibold">完成首次同步</span>
+    <span class="text-sm font-semibold">完成首次同步</span>
   </div>
 </div>
 

--- a/design/settings-redesign.pen
+++ b/design/settings-redesign.pen
@@ -1,0 +1,9930 @@
+{
+  "version": "2.14",
+  "children": [
+    {
+      "type": "frame",
+      "id": "axdMG",
+      "x": 0,
+      "y": 0,
+      "name": "Desktop｜設定總覽",
+      "clip": true,
+      "width": 1440,
+      "height": 1024,
+      "fill": "$bg",
+      "children": [
+        {
+          "type": "frame",
+          "id": "J3F2v5",
+          "name": "Desktop 全域導覽",
+          "width": 240,
+          "height": "fill_container",
+          "fill": "$text",
+          "layout": "vertical",
+          "gap": 22,
+          "padding": [
+            28,
+            24
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "r8zBM",
+              "name": "Taiwan Fin Hub 品牌",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 7,
+              "padding": [
+                0,
+                8
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "hW9oB",
+                  "name": "Taiwan Fin Hub 標題",
+                  "fill": "#FFFFFF",
+                  "content": "Taiwan Fin Hub",
+                  "fontFamily": "$font",
+                  "fontSize": 19,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "gGgao",
+                  "name": "Wealth OS 標籤",
+                  "fill": "$accent",
+                  "content": "WEALTH OS",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1.6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "pfpTw",
+              "name": "Desktop 主要導覽清單",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 6,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Q2TcRF",
+                  "name": "全域導覽｜總覽",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "QNUQB",
+                      "name": "全域導覽圖示｜總覽",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "Ko8Il",
+                      "name": "全域導覽文字｜總覽",
+                      "fill": "#FFFFFFA6",
+                      "content": "總覽",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "u3Pk5q",
+                  "name": "全域導覽｜資產",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "Nr44G",
+                      "name": "全域導覽圖示｜資產",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "YbVeX",
+                      "name": "全域導覽文字｜資產",
+                      "fill": "#FFFFFFA6",
+                      "content": "資產",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "KdOra",
+                  "name": "全域導覽｜活動",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "L0n7V",
+                      "name": "全域導覽圖示｜活動",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "YOvq8",
+                      "name": "全域導覽文字｜活動",
+                      "fill": "#FFFFFFA6",
+                      "content": "活動",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MxBIn",
+                  "name": "全域導覽｜發票",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "h54s8A",
+                      "name": "全域導覽圖示｜發票",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "tJ5y7",
+                      "name": "全域導覽文字｜發票",
+                      "fill": "#FFFFFFA6",
+                      "content": "發票",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "fcju9",
+                  "name": "全域導覽｜設定",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF1A",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "CLWcJ",
+                      "name": "全域導覽圖示｜設定",
+                      "fill": "#FFFFFF",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "ciBhC",
+                      "name": "全域導覽文字｜設定",
+                      "fill": "#FFFFFF",
+                      "content": "設定",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "hXMYv",
+          "name": "Desktop 設定應用內容",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$bg",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "N2x9AO",
+              "name": "Desktop 設定頁首",
+              "width": "fill_container",
+              "height": 116,
+              "padding": [
+                0,
+                32
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "nltu3",
+                  "name": "Desktop 設定標題組",
+                  "layout": "vertical",
+                  "gap": 7,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "OtI3m",
+                      "name": "Desktop 設定標題",
+                      "fill": "$text",
+                      "content": "設定",
+                      "fontFamily": "$font",
+                      "fontSize": 30,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "wB7gx",
+                      "name": "Desktop 設定描述",
+                      "fill": "$text-muted",
+                      "content": "管理資料來源、同步排程、匯率與交易分類。",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ua8s3",
+                  "name": "Desktop 頁首動作",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "OfMFq",
+                      "name": "隱藏金額按鈕",
+                      "width": 40,
+                      "height": 40,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 20,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 6,
+                          "id": "CLm7M",
+                          "name": "隱藏金額圖示",
+                          "width": 17,
+                          "height": 12,
+                          "stroke": "$text-muted",
+                          "strokeWidth": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "DMCdr",
+                      "name": "重新整理按鈕",
+                      "height": 40,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 20,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        15
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 7,
+                          "id": "iXbbv",
+                          "name": "重新整理圖示",
+                          "width": 14,
+                          "height": 14,
+                          "stroke": "$text-muted",
+                          "strokeWidth": 1
+                        },
+                        {
+                          "type": "text",
+                          "id": "HqBdq",
+                          "name": "重新整理文字",
+                          "fill": "$text",
+                          "content": "重新整理",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ub3o7",
+              "name": "Desktop 設定水平次導覽",
+              "width": "fill_container",
+              "height": 54,
+              "fill": "$surface",
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1,
+                "bottom": 1
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                32
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "hGftk",
+                  "name": "設定分頁｜總覽",
+                  "height": 36,
+                  "fill": "$surface-muted",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "pHNOL",
+                      "name": "設定分頁文字｜總覽",
+                      "fill": "$accent",
+                      "content": "總覽",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "M6Ok7",
+                  "name": "設定分頁｜資料來源",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "bOJYV",
+                      "name": "設定分頁文字｜資料來源",
+                      "fill": "$text-muted",
+                      "content": "資料來源",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BtT7O",
+                  "name": "設定分頁｜同步與通知",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "r8rWzc",
+                      "name": "設定分頁文字｜同步與通知",
+                      "fill": "$text-muted",
+                      "content": "同步與通知",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Z1VRv",
+                  "name": "設定分頁｜匯率",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "g6ocZ",
+                      "name": "設定分頁文字｜匯率",
+                      "fill": "$text-muted",
+                      "content": "匯率",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "V4ygf",
+                  "name": "設定分頁｜分類規則",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "r8CPq",
+                      "name": "設定分頁文字｜分類規則",
+                      "fill": "$text-muted",
+                      "content": "分類規則",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "pD0cb",
+              "name": "Desktop 設定總覽內容",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "padding": [
+                24,
+                32
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "qX4zm",
+                  "name": "Desktop 總覽介紹",
+                  "width": "fill_container",
+                  "height": 58,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "LjsLb",
+                      "name": "Desktop 總覽介紹文字",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ootLm",
+                          "name": "Desktop 總覽區標題",
+                          "fill": "$text",
+                          "content": "設定總覽",
+                          "fontFamily": "$font",
+                          "fontSize": 23,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "pcvXL",
+                          "name": "Desktop 總覽區描述",
+                          "fill": "$text-muted",
+                          "content": "先處理資料異常，再調整日常偏好。",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "qymGc",
+                      "name": "Desktop 狀態更新時間",
+                      "fill": "$text-muted",
+                      "content": "狀態更新：剛剛",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jQzP5",
+                  "name": "Desktop 狀態優先區",
+                  "width": "fill_container",
+                  "height": 176,
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "BaC7z",
+                      "name": "Desktop 需要處理主卡",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "fill": "$surface",
+                      "cornerRadius": "$radius",
+                      "stroke": "$negative",
+                      "strokeWidth": {
+                        "top": 1,
+                        "right": 1,
+                        "bottom": 1,
+                        "left": 4
+                      },
+                      "layout": "vertical",
+                      "gap": 10,
+                      "padding": 20,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "iW9is",
+                          "name": "Desktop 問題標題列",
+                          "width": "fill_container",
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "VTGHO",
+                              "name": "Desktop 問題標籤",
+                              "fill": "$negative",
+                              "content": "需要處理 · 1",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "vtnnW",
+                              "name": "Desktop 問題影響",
+                              "fill": "$text-muted",
+                              "content": "影響資料更新",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "xxbKx",
+                          "name": "Desktop 問題名稱",
+                          "fill": "$text",
+                          "content": "台新銀行連接器需要重新驗證",
+                          "fontFamily": "$font",
+                          "fontSize": 19,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "fMLqC",
+                          "name": "Desktop 問題描述",
+                          "fill": "$text-muted",
+                          "content": "完成驗證後即可恢復每天 07:30 的自動同步。",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "XfEnG",
+                          "name": "Desktop 問題動作",
+                          "gap": 12,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "lXMTW",
+                              "name": "Desktop 重新驗證按鈕",
+                              "fill": "$accent",
+                              "cornerRadius": 8,
+                              "padding": [
+                                9,
+                                14
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "zNqfw",
+                                  "name": "Desktop 重新驗證文字",
+                                  "fill": "#FFFFFF",
+                                  "content": "重新驗證",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "Rh1e4",
+                              "name": "Desktop 問題詳情",
+                              "fill": "$accent",
+                              "content": "查看連接器詳情 →",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "eW7MP",
+                      "name": "Desktop 資料健康度卡",
+                      "width": 340,
+                      "height": "fill_container",
+                      "fill": "$surface",
+                      "cornerRadius": "$radius",
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "layout": "vertical",
+                      "gap": 12,
+                      "padding": 20,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "mqxoL",
+                          "name": "Desktop 健康度標題列",
+                          "width": "fill_container",
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Fd9FS",
+                              "name": "Desktop 健康度標題",
+                              "fill": "$text-muted",
+                              "content": "資料健康度",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "yNgDM",
+                              "name": "Desktop 健康度狀態",
+                              "fill": "$positive",
+                              "content": "大致正常",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "mibR4",
+                          "name": "Desktop 健康度數值",
+                          "fill": "$text",
+                          "content": "5 / 6",
+                          "fontFamily": "$font",
+                          "fontSize": 34,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "wc4jE",
+                          "name": "Desktop 健康度說明",
+                          "fill": "$text-muted",
+                          "content": "4 個排程啟用 · 最近成功 07:31",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "TA7Dp",
+                  "name": "Desktop 來源與自動化區",
+                  "width": "fill_container",
+                  "height": 300,
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "cFrYo",
+                      "name": "Desktop 資料來源狀態",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "fill": "$surface",
+                      "cornerRadius": "$radius",
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "layout": "vertical",
+                      "gap": 10,
+                      "padding": 18,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Lv9Rx",
+                          "name": "Desktop 資料來源標題列",
+                          "width": "fill_container",
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "D1sfiG",
+                              "name": "Desktop 資料來源標題",
+                              "fill": "$text",
+                              "content": "資料來源與連接器",
+                              "fontFamily": "$font",
+                              "fontSize": 15,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Wecwe",
+                              "name": "Desktop 資料來源動作",
+                              "fill": "$accent",
+                              "content": "管理全部 →",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "I5ikX",
+                          "name": "Desktop 來源列｜永豐銀行",
+                          "width": "fill_container",
+                          "height": 52,
+                          "stroke": "$border",
+                          "strokeWidth": {
+                            "top": 1
+                          },
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 8,
+                              "id": "Gai39",
+                              "name": "Desktop 來源圖示｜永豐銀行",
+                              "fill": "$surface-muted",
+                              "width": 32,
+                              "height": 32
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Lg27D",
+                              "name": "Desktop 來源文字｜永豐銀行",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 2,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "UclWw",
+                                  "name": "Desktop 來源名稱｜永豐銀行",
+                                  "fill": "$text",
+                                  "content": "永豐銀行",
+                                  "fontFamily": "$font",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "CGt8s",
+                                  "name": "Desktop 來源時間｜永豐銀行",
+                                  "fill": "$text-muted",
+                                  "content": "最近同步 07:31",
+                                  "fontFamily": "$font",
+                                  "fontSize": 9,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "tskk2",
+                              "name": "Desktop 來源狀態｜永豐銀行",
+                              "fill": "$positive",
+                              "content": "正常",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "XZVpg",
+                          "name": "Desktop 來源列｜台新銀行",
+                          "width": "fill_container",
+                          "height": 52,
+                          "stroke": "$border",
+                          "strokeWidth": {
+                            "top": 1
+                          },
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 8,
+                              "id": "DqpA2",
+                              "name": "Desktop 來源圖示｜台新銀行",
+                              "fill": "$surface-muted",
+                              "width": 32,
+                              "height": 32
+                            },
+                            {
+                              "type": "frame",
+                              "id": "U2ywd",
+                              "name": "Desktop 來源文字｜台新銀行",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 2,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "TH7nj",
+                                  "name": "Desktop 來源名稱｜台新銀行",
+                                  "fill": "$text",
+                                  "content": "台新銀行",
+                                  "fontFamily": "$font",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "E7gUFy",
+                                  "name": "Desktop 來源時間｜台新銀行",
+                                  "fill": "$text-muted",
+                                  "content": "最近同步 昨天",
+                                  "fontFamily": "$font",
+                                  "fontSize": 9,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "MnHbI",
+                              "name": "Desktop 來源狀態｜台新銀行",
+                              "fill": "$negative",
+                              "content": "需要處理",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Y1LnN",
+                          "name": "Desktop 來源列｜電子發票",
+                          "width": "fill_container",
+                          "height": 52,
+                          "stroke": "$border",
+                          "strokeWidth": {
+                            "top": 1
+                          },
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 8,
+                              "id": "b8saS",
+                              "name": "Desktop 來源圖示｜電子發票",
+                              "fill": "$surface-muted",
+                              "width": 32,
+                              "height": 32
+                            },
+                            {
+                              "type": "frame",
+                              "id": "UWhN7",
+                              "name": "Desktop 來源文字｜電子發票",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 2,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "ekW7L",
+                                  "name": "Desktop 來源名稱｜電子發票",
+                                  "fill": "$text",
+                                  "content": "電子發票",
+                                  "fontFamily": "$font",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "C3VmpP",
+                                  "name": "Desktop 來源時間｜電子發票",
+                                  "fill": "$text-muted",
+                                  "content": "最近同步 07:18",
+                                  "fontFamily": "$font",
+                                  "fontSize": 9,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "EEl4W",
+                              "name": "Desktop 來源狀態｜電子發票",
+                              "fill": "$positive",
+                              "content": "正常",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "UkC5B",
+                          "name": "Desktop 來源列｜集保 e 存摺",
+                          "width": "fill_container",
+                          "height": 52,
+                          "stroke": "$border",
+                          "strokeWidth": {
+                            "top": 1
+                          },
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 8,
+                              "id": "M3RP2H",
+                              "name": "Desktop 來源圖示｜集保 e 存摺",
+                              "fill": "$surface-muted",
+                              "width": 32,
+                              "height": 32
+                            },
+                            {
+                              "type": "frame",
+                              "id": "xyMDI",
+                              "name": "Desktop 來源文字｜集保 e 存摺",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 2,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "PhUnl",
+                                  "name": "Desktop 來源名稱｜集保 e 存摺",
+                                  "fill": "$text",
+                                  "content": "集保 e 存摺",
+                                  "fontFamily": "$font",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "r2jNF",
+                                  "name": "Desktop 來源時間｜集保 e 存摺",
+                                  "fill": "$text-muted",
+                                  "content": "最近同步 —",
+                                  "fontFamily": "$font",
+                                  "fontSize": 9,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "spgGU",
+                              "name": "Desktop 來源狀態｜集保 e 存摺",
+                              "fill": "$text-muted",
+                              "content": "尚未同步",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "pF1Lv",
+                      "name": "Desktop 同步與通知摘要",
+                      "width": 340,
+                      "height": "fill_container",
+                      "layout": "vertical",
+                      "gap": 14,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Udb4T",
+                          "name": "Desktop 摘要卡｜預設同步排程",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "fill": "$surface",
+                          "cornerRadius": "$radius",
+                          "stroke": "$border",
+                          "strokeWidth": 1,
+                          "layout": "vertical",
+                          "gap": 8,
+                          "padding": 17,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "QmQBW",
+                              "name": "Desktop 摘要標題｜預設同步排程",
+                              "fill": "$text",
+                              "content": "預設同步排程",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "L2R76",
+                              "name": "Desktop 摘要值｜預設同步排程",
+                              "fill": "$text",
+                              "content": "每天 07:30",
+                              "fontFamily": "$font",
+                              "fontSize": 21,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "BBlKM",
+                              "name": "Desktop 摘要說明｜預設同步排程",
+                              "fill": "$text-muted",
+                              "content": "4 個連接器套用",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "AS8Bj",
+                              "name": "Desktop 摘要動作｜預設同步排程",
+                              "fill": "$accent",
+                              "content": "管理 →",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "bpslQ",
+                          "name": "Desktop 摘要卡｜通知設定",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "fill": "$surface",
+                          "cornerRadius": "$radius",
+                          "stroke": "$border",
+                          "strokeWidth": 1,
+                          "layout": "vertical",
+                          "gap": 8,
+                          "padding": 17,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "F9Np5",
+                              "name": "Desktop 摘要標題｜通知設定",
+                              "fill": "$text",
+                              "content": "通知設定",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "cDj7D",
+                              "name": "Desktop 摘要值｜通知設定",
+                              "fill": "$text",
+                              "content": "已開啟",
+                              "fontFamily": "$font",
+                              "fontSize": 21,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "R4nxFT",
+                              "name": "Desktop 摘要說明｜通知設定",
+                              "fill": "$text-muted",
+                              "content": "失敗與重新驗證時通知",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "WYSB9",
+                              "name": "Desktop 摘要動作｜通知設定",
+                              "fill": "$accent",
+                              "content": "管理 →",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "KLuDW",
+                  "name": "Desktop 其他設定摘要",
+                  "width": "fill_container",
+                  "height": 104,
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "QEsc7",
+                      "name": "Desktop 其他設定｜匯率",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "fill": "$surface",
+                      "cornerRadius": "$radius",
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "layout": "vertical",
+                      "gap": 7,
+                      "padding": 15,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XAGeJ",
+                          "name": "Desktop 其他標題｜匯率",
+                          "fill": "$text",
+                          "content": "匯率",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ES5E2",
+                          "name": "Desktop 其他描述｜匯率",
+                          "fill": "$text-muted",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "USD 31.42 · JPY 0.207",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ivPrE",
+                          "name": "Desktop 其他動作｜匯率",
+                          "fill": "$accent",
+                          "content": "開啟設定 →",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dGQRa",
+                      "name": "Desktop 其他設定｜分類規則",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "fill": "$surface",
+                      "cornerRadius": "$radius",
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "layout": "vertical",
+                      "gap": 7,
+                      "padding": 15,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Ch6yz",
+                          "name": "Desktop 其他標題｜分類規則",
+                          "fill": "$text",
+                          "content": "分類規則",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "wlhDb",
+                          "name": "Desktop 其他描述｜分類規則",
+                          "fill": "$text-muted",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "12 條銀行交易規則",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "K8d7tu",
+                          "name": "Desktop 其他動作｜分類規則",
+                          "fill": "$accent",
+                          "content": "開啟設定 →",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "k0OZCH",
+      "x": 1560,
+      "y": 0,
+      "name": "Mobile｜更多與設定總覽",
+      "clip": true,
+      "width": 390,
+      "height": 844,
+      "fill": "$bg",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "dICXm",
+          "name": "Mobile 更多頁首",
+          "width": "fill_container",
+          "height": 72,
+          "fill": "$surface",
+          "stroke": "$border",
+          "strokeWidth": {
+            "bottom": 1
+          },
+          "padding": [
+            0,
+            18
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "BMlU0",
+              "name": "Mobile 更多標題",
+              "fill": "$text",
+              "content": "更多",
+              "fontFamily": "$font",
+              "fontSize": 24,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "xGEDj",
+              "name": "Mobile 隱藏金額按鈕",
+              "width": 40,
+              "height": 40,
+              "fill": "$surface-muted",
+              "cornerRadius": 20,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 6,
+                  "id": "kLhno",
+                  "name": "Mobile 隱藏金額圖示",
+                  "width": 17,
+                  "height": 12,
+                  "stroke": "$text-muted",
+                  "strokeWidth": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "bZSOQ",
+          "name": "Mobile 更多內容",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 11,
+          "padding": [
+            14,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "AJsn8",
+              "name": "Mobile 資料健康度",
+              "width": "fill_container",
+              "height": 98,
+              "fill": "$surface",
+              "cornerRadius": "$radius",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 14,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "GCokc",
+                  "name": "Mobile 健康度標題列",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "k9rpv6",
+                      "name": "Mobile 健康度標題",
+                      "fill": "$text-muted",
+                      "content": "資料健康度",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "THpdb",
+                      "name": "Mobile 健康度待處理",
+                      "fill": "$negative",
+                      "content": "需要處理",
+                      "fontFamily": "$font",
+                      "fontSize": 10,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Gg9sh",
+                  "name": "Mobile 健康度數值",
+                  "fill": "$text",
+                  "content": "5 / 6 來源正常",
+                  "fontFamily": "$font",
+                  "fontSize": 20,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "tahfQ",
+                  "name": "Mobile 健康度動作",
+                  "fill": "$accent",
+                  "content": "台新銀行需要重新驗證  →",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "Y5VpPN",
+              "name": "Mobile 設定與資料標題",
+              "fill": "$text-muted",
+              "content": "設定與資料",
+              "fontFamily": "$font",
+              "fontSize": 11,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "T3YZk6",
+              "name": "Mobile 設定分類清單",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "H6rI1",
+                  "name": "Mobile 設定分類｜資料來源與連接器",
+                  "width": "fill_container",
+                  "height": 62,
+                  "stroke": "$border",
+                  "gap": 11,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 9,
+                      "id": "qNE3S",
+                      "name": "Mobile 設定分類圖示｜資料來源與連接器",
+                      "fill": "$surface-muted",
+                      "width": 34,
+                      "height": 34
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZZdKo",
+                      "name": "Mobile 設定分類文字｜資料來源與連接器",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "eAiDi",
+                          "name": "Mobile 設定分類名稱｜資料來源與連接器",
+                          "fill": "$text",
+                          "content": "資料來源與連接器",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "J7SKbX",
+                          "name": "Mobile 設定分類描述｜資料來源與連接器",
+                          "fill": "$text-muted",
+                          "content": "狀態、憑證、排程與通知",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "toSXT",
+                      "name": "Mobile 設定分類箭頭｜資料來源與連接器",
+                      "fill": "$text-muted",
+                      "content": "›",
+                      "fontFamily": "$font",
+                      "fontSize": 19,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "SU99b",
+                  "name": "Mobile 設定分類｜同步與通知",
+                  "width": "fill_container",
+                  "height": 62,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "gap": 11,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 9,
+                      "id": "q75ags",
+                      "name": "Mobile 設定分類圖示｜匯率",
+                      "fill": "$surface-muted",
+                      "width": 34,
+                      "height": 34
+                    },
+                    {
+                      "type": "frame",
+                      "id": "eBu4m",
+                      "name": "Mobile 設定分類文字｜匯率",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "nJoyK",
+                          "name": "Mobile 設定分類名稱｜匯率",
+                          "fill": "$text",
+                          "content": "同步與通知",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "tOE0u",
+                          "name": "Mobile 設定分類描述｜匯率",
+                          "fill": "$text-muted",
+                          "content": "排程、推播與同步結果",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "QM4Ru",
+                      "name": "Mobile 設定分類箭頭｜匯率",
+                      "fill": "$text-muted",
+                      "content": "›",
+                      "fontFamily": "$font",
+                      "fontSize": 19,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "PpJ5M",
+                  "name": "Mobile 設定分類｜匯率",
+                  "width": "fill_container",
+                  "height": 62,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "gap": 11,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 9,
+                      "id": "dVz94",
+                      "name": "Mobile 設定分類圖示｜匯率",
+                      "fill": "$surface-muted",
+                      "width": 34,
+                      "height": 34
+                    },
+                    {
+                      "type": "frame",
+                      "id": "f4Nm2E",
+                      "name": "Mobile 設定分類文字｜匯率",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "qDBqa",
+                          "name": "Mobile 設定分類名稱｜匯率",
+                          "fill": "$text",
+                          "content": "匯率",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "nKIV6",
+                          "name": "Mobile 設定分類描述｜匯率",
+                          "fill": "$text-muted",
+                          "content": "管理外幣換算",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "G8yYO",
+                      "name": "Mobile 設定分類箭頭｜匯率",
+                      "fill": "$text-muted",
+                      "content": "›",
+                      "fontFamily": "$font",
+                      "fontSize": 19,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "toHAP",
+                  "name": "Mobile 設定分類｜分類規則",
+                  "width": "fill_container",
+                  "height": 62,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "gap": 11,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 9,
+                      "id": "TqBb6",
+                      "name": "Mobile 設定分類圖示｜分類規則",
+                      "fill": "$surface-muted",
+                      "width": 34,
+                      "height": 34
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qjh23",
+                      "name": "Mobile 設定分類文字｜分類規則",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "W0ZTIo",
+                          "name": "Mobile 設定分類名稱｜分類規則",
+                          "fill": "$text",
+                          "content": "分類規則",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "O0Xja",
+                          "name": "Mobile 設定分類描述｜分類規則",
+                          "fill": "$text-muted",
+                          "content": "銀行交易自動分類",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "rN5kD",
+                      "name": "Mobile 設定分類箭頭｜分類規則",
+                      "fill": "$text-muted",
+                      "content": "›",
+                      "fontFamily": "$font",
+                      "fontSize": 19,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "o0sAGd",
+              "name": "Mobile 資料來源區標題",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "nDfRN",
+                  "name": "Mobile 資料來源區名稱",
+                  "fill": "$text-muted",
+                  "content": "資料來源",
+                  "fontFamily": "$font",
+                  "fontSize": 11,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "NOBrA",
+                  "name": "Mobile 資料來源管理",
+                  "fill": "$accent",
+                  "content": "管理 →",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "n1wuU",
+              "name": "Mobile 資料來源狀態清單",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "RXiaX",
+                  "name": "Mobile 來源狀態｜永豐銀行",
+                  "width": "fill_container",
+                  "height": 40,
+                  "stroke": "$border",
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "w1XDu",
+                      "name": "Mobile 來源名稱｜永豐銀行",
+                      "fill": "$text",
+                      "content": "永豐銀行",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ZLTbq",
+                      "name": "Mobile 來源狀態文字｜永豐銀行",
+                      "fill": "$positive",
+                      "content": "正常",
+                      "fontFamily": "$font",
+                      "fontSize": 9,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "FcGS9",
+                  "name": "Mobile 來源狀態｜台新銀行",
+                  "width": "fill_container",
+                  "height": 40,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "vS8In",
+                      "name": "Mobile 來源名稱｜台新銀行",
+                      "fill": "$text",
+                      "content": "台新銀行",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xI71v",
+                      "name": "Mobile 來源狀態文字｜台新銀行",
+                      "fill": "$negative",
+                      "content": "需要處理",
+                      "fontFamily": "$font",
+                      "fontSize": 9,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "l4tVx",
+                  "name": "Mobile 來源狀態｜電子發票",
+                  "width": "fill_container",
+                  "height": 40,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "nHFXu",
+                      "name": "Mobile 來源名稱｜電子發票",
+                      "fill": "$text",
+                      "content": "電子發票",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "PM90L",
+                      "name": "Mobile 來源狀態文字｜電子發票",
+                      "fill": "$positive",
+                      "content": "正常",
+                      "fontFamily": "$font",
+                      "fontSize": 9,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "J095Pw",
+                  "name": "Mobile 來源狀態｜集保 e 存摺",
+                  "width": "fill_container",
+                  "height": 40,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "yf6o3",
+                      "name": "Mobile 來源名稱｜集保 e 存摺",
+                      "fill": "$text",
+                      "content": "集保 e 存摺",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "PXayF",
+                      "name": "Mobile 來源狀態文字｜集保 e 存摺",
+                      "fill": "$text-muted",
+                      "content": "尚未同步",
+                      "fontFamily": "$font",
+                      "fontSize": 9,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "MKXyx",
+          "name": "Mobile 主要底部導覽",
+          "width": "fill_container",
+          "height": 76,
+          "fill": "$text",
+          "stroke": "#FFFFFF1A",
+          "strokeWidth": {
+            "top": 1
+          },
+          "gap": 4,
+          "padding": [
+            7,
+            8,
+            10,
+            8
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "gnb9U",
+              "name": "Mobile 底部導覽｜總覽",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "p7Hh10",
+                  "name": "Mobile 底部圖示｜總覽",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "gEGEf",
+                  "name": "Mobile 底部文字｜總覽",
+                  "fill": "#FFFFFFA6",
+                  "content": "總覽",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "X6XT6",
+              "name": "Mobile 底部導覽｜資產",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "ZsH5I",
+                  "name": "Mobile 底部圖示｜資產",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "A3TyD0",
+                  "name": "Mobile 底部文字｜資產",
+                  "fill": "#FFFFFFA6",
+                  "content": "資產",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "IqRHy",
+              "name": "Mobile 底部導覽｜活動",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "VHxKf",
+                  "name": "Mobile 底部圖示｜活動",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "QYPP8",
+                  "name": "Mobile 底部文字｜活動",
+                  "fill": "#FFFFFFA6",
+                  "content": "活動",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "DVCac",
+              "name": "Mobile 底部導覽｜更多",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF1A",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "U4gKp",
+                  "name": "Mobile 底部圖示｜更多",
+                  "fill": "#FFFFFF",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "xacQA",
+                  "name": "Mobile 底部文字｜更多",
+                  "fill": "#FFFFFF",
+                  "content": "更多",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "I3eSah",
+      "x": 0,
+      "y": 1144,
+      "name": "Desktop｜資料來源與連接器",
+      "clip": true,
+      "width": 1440,
+      "height": 1024,
+      "fill": "$bg",
+      "children": [
+        {
+          "type": "frame",
+          "id": "S9tzXG",
+          "name": "Desktop 全域導覽",
+          "width": 240,
+          "height": "fill_container",
+          "fill": "$text",
+          "layout": "vertical",
+          "gap": 22,
+          "padding": [
+            28,
+            24
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "SxY0R",
+              "name": "Taiwan Fin Hub 品牌",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 7,
+              "padding": [
+                0,
+                8
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "fbeTh",
+                  "name": "Taiwan Fin Hub 標題",
+                  "fill": "#FFFFFF",
+                  "content": "Taiwan Fin Hub",
+                  "fontFamily": "$font",
+                  "fontSize": 19,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "BMTt7",
+                  "name": "Wealth OS 標籤",
+                  "fill": "$accent",
+                  "content": "WEALTH OS",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1.6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "eKhII",
+              "name": "Desktop 主要導覽清單",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 6,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "b6Kep",
+                  "name": "全域導覽｜總覽",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "HN6f5",
+                      "name": "全域導覽圖示｜總覽",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "SEnQo",
+                      "name": "全域導覽文字｜總覽",
+                      "fill": "#FFFFFFA6",
+                      "content": "總覽",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "b7fDi9",
+                  "name": "全域導覽｜資產",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "wQwb3",
+                      "name": "全域導覽圖示｜資產",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "QJ5VB",
+                      "name": "全域導覽文字｜資產",
+                      "fill": "#FFFFFFA6",
+                      "content": "資產",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "yoPqk",
+                  "name": "全域導覽｜活動",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "S4IxJa",
+                      "name": "全域導覽圖示｜活動",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "C51IVo",
+                      "name": "全域導覽文字｜活動",
+                      "fill": "#FFFFFFA6",
+                      "content": "活動",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "cSmlb",
+                  "name": "全域導覽｜發票",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "u6DIk",
+                      "name": "全域導覽圖示｜發票",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "F4UjCd",
+                      "name": "全域導覽文字｜發票",
+                      "fill": "#FFFFFFA6",
+                      "content": "發票",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Zhxoq",
+                  "name": "全域導覽｜設定",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF1A",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "dRk2j",
+                      "name": "全域導覽圖示｜設定",
+                      "fill": "#FFFFFF",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "UEzmX",
+                      "name": "全域導覽文字｜設定",
+                      "fill": "#FFFFFF",
+                      "content": "設定",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "wEH9j",
+          "name": "Desktop 設定應用內容",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$bg",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "w3cTiw",
+              "name": "Desktop 設定頁首",
+              "width": "fill_container",
+              "height": 116,
+              "padding": [
+                0,
+                32
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "myln8",
+                  "name": "Desktop 設定標題組",
+                  "layout": "vertical",
+                  "gap": 7,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "C590tI",
+                      "name": "Desktop 設定標題",
+                      "fill": "$text",
+                      "content": "設定",
+                      "fontFamily": "$font",
+                      "fontSize": 30,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "cCKnv",
+                      "name": "Desktop 設定描述",
+                      "fill": "$text-muted",
+                      "content": "管理資料來源、同步排程、匯率與交易分類。",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "NGLUq",
+                  "name": "Desktop 頁首動作",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "U6O8sX",
+                      "name": "隱藏金額按鈕",
+                      "width": 40,
+                      "height": 40,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 20,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 6,
+                          "id": "b2WojW",
+                          "name": "隱藏金額圖示",
+                          "width": 17,
+                          "height": 12,
+                          "stroke": "$text-muted",
+                          "strokeWidth": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vMjSV",
+                      "name": "重新整理按鈕",
+                      "height": 40,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 20,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        15
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 7,
+                          "id": "WJklm",
+                          "name": "重新整理圖示",
+                          "width": 14,
+                          "height": 14,
+                          "stroke": "$text-muted",
+                          "strokeWidth": 1
+                        },
+                        {
+                          "type": "text",
+                          "id": "n9HmYt",
+                          "name": "重新整理文字",
+                          "fill": "$text",
+                          "content": "重新整理",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "p8aVX",
+              "name": "Desktop 設定水平次導覽",
+              "width": "fill_container",
+              "height": 54,
+              "fill": "$surface",
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1,
+                "bottom": 1
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                32
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Q40Ec",
+                  "name": "設定分頁｜總覽",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "t1BfU",
+                      "name": "設定分頁文字｜總覽",
+                      "fill": "$text-muted",
+                      "content": "總覽",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "b8ABxI",
+                  "name": "設定分頁｜資料來源",
+                  "height": 36,
+                  "fill": "$surface-muted",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "c7agWz",
+                      "name": "設定分頁文字｜資料來源",
+                      "fill": "$accent",
+                      "content": "資料來源",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "QrmBd",
+                  "name": "設定分頁｜同步與通知",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "EjofF",
+                      "name": "設定分頁文字｜同步與通知",
+                      "fill": "$text-muted",
+                      "content": "同步與通知",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "plZWy",
+                  "name": "設定分頁｜匯率",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "PdwLi",
+                      "name": "設定分頁文字｜匯率",
+                      "fill": "$text-muted",
+                      "content": "匯率",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "KlbYJ",
+                  "name": "設定分頁｜分類規則",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "e5XWE9",
+                      "name": "設定分頁文字｜分類規則",
+                      "fill": "$text-muted",
+                      "content": "分類規則",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "TvV6d",
+              "name": "Desktop 資料來源內容",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 18,
+              "padding": [
+                24,
+                32
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "T9M8lp",
+                  "name": "資料來源頁標題列",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "hnp1c",
+                      "name": "資料來源標題文字",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "IUd7t",
+                          "name": "資料來源標題",
+                          "fill": "$text",
+                          "content": "資料來源與連接器",
+                          "fontFamily": "$font",
+                          "fontSize": 23,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "KnEla",
+                          "name": "資料來源說明",
+                          "fill": "$text-muted",
+                          "content": "管理連線、驗證狀態與最近同步結果。",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jVMP8",
+                      "name": "新增連接器按鈕",
+                      "height": 38,
+                      "fill": "$accent",
+                      "cornerRadius": 9,
+                      "padding": [
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Nqvsp",
+                          "name": "新增連接器文字",
+                          "fill": "#FFFFFF",
+                          "content": "＋ 新增連接器",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Hj772",
+                  "name": "資料來源雙欄",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 18,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "lcXoU",
+                      "name": "資料來源清單",
+                      "width": 620,
+                      "height": "fill_container",
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "L9M0a",
+                          "name": "資料來源列｜永豐銀行",
+                          "width": "fill_container",
+                          "height": 82,
+                          "fill": "$surface",
+                          "cornerRadius": "$radius",
+                          "stroke": "$border",
+                          "strokeWidth": 1,
+                          "gap": 14,
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 9,
+                              "id": "avLUE",
+                              "name": "來源圖示｜永豐銀行",
+                              "fill": "$surface-muted",
+                              "width": 38,
+                              "height": 38
+                            },
+                            {
+                              "type": "frame",
+                              "id": "HblvW",
+                              "name": "來源文字｜永豐銀行",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 5,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "TuuEH",
+                                  "name": "來源名稱｜永豐銀行",
+                                  "fill": "$text",
+                                  "content": "永豐銀行",
+                                  "fontFamily": "$font",
+                                  "fontSize": 14,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "T56GTK",
+                                  "name": "來源描述｜永豐銀行",
+                                  "fill": "$text-muted",
+                                  "content": "最近同步：今天 07:31",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "uGtgi",
+                              "name": "來源狀態｜永豐銀行",
+                              "fill": "$positive",
+                              "content": "正常",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Z6H2e",
+                              "name": "來源箭頭｜永豐銀行",
+                              "fill": "$text-muted",
+                              "content": "›",
+                              "fontFamily": "$font",
+                              "fontSize": 20,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "J1D7P",
+                          "name": "資料來源列｜台新銀行",
+                          "width": "fill_container",
+                          "height": 82,
+                          "fill": "$surface",
+                          "cornerRadius": "$radius",
+                          "stroke": "$border",
+                          "strokeWidth": 1,
+                          "gap": 14,
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 9,
+                              "id": "Bibg9",
+                              "name": "來源圖示｜台新銀行",
+                              "fill": "$surface-muted",
+                              "width": 38,
+                              "height": 38
+                            },
+                            {
+                              "type": "frame",
+                              "id": "yobJX",
+                              "name": "來源文字｜台新銀行",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 5,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "PDQ6d",
+                                  "name": "來源名稱｜台新銀行",
+                                  "fill": "$text",
+                                  "content": "台新銀行",
+                                  "fontFamily": "$font",
+                                  "fontSize": 14,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "o3RFq",
+                                  "name": "來源描述｜台新銀行",
+                                  "fill": "$text-muted",
+                                  "content": "驗證已失效，資料停在 7 月 23 日",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "X1vaGy",
+                              "name": "來源狀態｜台新銀行",
+                              "fill": "$negative",
+                              "content": "需要處理",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "jx2Jd",
+                              "name": "來源箭頭｜台新銀行",
+                              "fill": "$text-muted",
+                              "content": "›",
+                              "fontFamily": "$font",
+                              "fontSize": 20,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "jtMRh",
+                          "name": "資料來源列｜電子發票",
+                          "width": "fill_container",
+                          "height": 82,
+                          "fill": "$surface",
+                          "cornerRadius": "$radius",
+                          "stroke": "$border",
+                          "strokeWidth": 1,
+                          "gap": 14,
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 9,
+                              "id": "dLg9m",
+                              "name": "來源圖示｜電子發票",
+                              "fill": "$surface-muted",
+                              "width": 38,
+                              "height": 38
+                            },
+                            {
+                              "type": "frame",
+                              "id": "S8iRhP",
+                              "name": "來源文字｜電子發票",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 5,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "NehiH",
+                                  "name": "來源名稱｜電子發票",
+                                  "fill": "$text",
+                                  "content": "電子發票",
+                                  "fontFamily": "$font",
+                                  "fontSize": 14,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "QCfOJ",
+                                  "name": "來源描述｜電子發票",
+                                  "fill": "$text-muted",
+                                  "content": "最近同步：今天 06:10",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "F5ruyH",
+                              "name": "來源狀態｜電子發票",
+                              "fill": "$positive",
+                              "content": "正常",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "tnxD9",
+                              "name": "來源箭頭｜電子發票",
+                              "fill": "$text-muted",
+                              "content": "›",
+                              "fontFamily": "$font",
+                              "fontSize": 20,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Zzge9",
+                          "name": "資料來源列｜集保 e 存摺",
+                          "width": "fill_container",
+                          "height": 82,
+                          "fill": "$surface",
+                          "cornerRadius": "$radius",
+                          "stroke": "$border",
+                          "strokeWidth": 1,
+                          "gap": 14,
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 9,
+                              "id": "Aekhr",
+                              "name": "來源圖示｜集保 e 存摺",
+                              "fill": "$surface-muted",
+                              "width": 38,
+                              "height": 38
+                            },
+                            {
+                              "type": "frame",
+                              "id": "a1FQzv",
+                              "name": "來源文字｜集保 e 存摺",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 5,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Uj74h",
+                                  "name": "來源名稱｜集保 e 存摺",
+                                  "fill": "$text",
+                                  "content": "集保 e 存摺",
+                                  "fontFamily": "$font",
+                                  "fontSize": 14,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "KWwy2",
+                                  "name": "來源描述｜集保 e 存摺",
+                                  "fill": "$text-muted",
+                                  "content": "完成授權後即可匯入部位",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "QDusv",
+                              "name": "來源狀態｜集保 e 存摺",
+                              "fill": "$text-muted",
+                              "content": "尚未同步",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "p7JtNh",
+                              "name": "來源箭頭｜集保 e 存摺",
+                              "fill": "$text-muted",
+                              "content": "›",
+                              "fontFamily": "$font",
+                              "fontSize": 20,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "wOSrC",
+                      "name": "台新銀行連接器詳情",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "fill": "$surface",
+                      "cornerRadius": "$radius",
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "layout": "vertical",
+                      "gap": 18,
+                      "padding": 22,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "J3VDPo",
+                          "name": "連接器詳情標題列",
+                          "width": "fill_container",
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ueyoY",
+                              "name": "連接器名稱組",
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "zShOk",
+                                  "name": "連接器詳情名稱",
+                                  "fill": "$text",
+                                  "content": "台新銀行",
+                                  "fontFamily": "$font",
+                                  "fontSize": 18,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "G6NIoj",
+                                  "name": "連接器詳情類型",
+                                  "fill": "$text-muted",
+                                  "content": "信用卡資料",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "lS9rA",
+                              "name": "需要處理標籤",
+                              "fill": "#FBE9E4",
+                              "cornerRadius": 8,
+                              "padding": [
+                                7,
+                                10
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "y8NSuO",
+                                  "name": "需要處理文字",
+                                  "fill": "$negative",
+                                  "content": "需要處理",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "700"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Djbc9",
+                          "name": "驗證問題說明",
+                          "width": "fill_container",
+                          "fill": "#FFF8F5",
+                          "cornerRadius": 10,
+                          "stroke": "$negative",
+                          "strokeWidth": 1,
+                          "layout": "vertical",
+                          "gap": 6,
+                          "padding": 14,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "BnngO",
+                              "name": "驗證問題標題",
+                              "fill": "$text",
+                              "content": "需要重新驗證",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "KN9UN",
+                              "name": "驗證問題內容",
+                              "fill": "$text-muted",
+                              "content": "登入狀態已失效。重新驗證後會從上次進度繼續同步，不會刪除既有資料。",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "k8I8cm",
+                          "name": "連接器資訊",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 11,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "J518p",
+                              "name": "最後成功同步列",
+                              "width": "fill_container",
+                              "justifyContent": "space_between",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "U4fJh8",
+                                  "name": "最後成功同步標籤",
+                                  "fill": "$text-muted",
+                                  "content": "最後成功同步",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "zVudZ",
+                                  "name": "最後成功同步值",
+                                  "fill": "$text",
+                                  "content": "2026/07/23 07:30",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "lQOFE",
+                              "name": "同步範圍列",
+                              "width": "fill_container",
+                              "justifyContent": "space_between",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "LU4K2",
+                                  "name": "同步範圍標籤",
+                                  "fill": "$text-muted",
+                                  "content": "同步範圍",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "wGWZL",
+                                  "name": "同步範圍值",
+                                  "fill": "$text",
+                                  "content": "信用卡交易",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "A5bjo",
+                              "name": "排程繼承列",
+                              "width": "fill_container",
+                              "justifyContent": "space_between",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "tc0Qj",
+                                  "name": "排程繼承標籤",
+                                  "fill": "$text-muted",
+                                  "content": "同步排程",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "FnS5N",
+                                  "name": "排程繼承值",
+                                  "fill": "$text",
+                                  "content": "使用預設排程",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ByPdm",
+                          "name": "連接器主要動作",
+                          "width": "fill_container",
+                          "height": 42,
+                          "fill": "$accent",
+                          "cornerRadius": 9,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "K3hp0",
+                              "name": "連接器主要動作文字",
+                              "fill": "#FFFFFF",
+                              "content": "重新驗證",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "r050G6",
+                          "name": "移除連接器動作",
+                          "fill": "$negative",
+                          "content": "移除連接器",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "jKkSG",
+      "x": 1560,
+      "y": 1144,
+      "name": "Mobile｜資料來源與連接器",
+      "clip": true,
+      "width": 390,
+      "height": 844,
+      "fill": "$bg",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "jjYft",
+          "name": "Mobile 資料來源頁首",
+          "width": "fill_container",
+          "height": 72,
+          "fill": "$surface",
+          "stroke": "$border",
+          "strokeWidth": {
+            "bottom": 1
+          },
+          "gap": 12,
+          "padding": [
+            0,
+            18
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "GabD0",
+              "name": "Mobile 返回箭頭｜資料來源",
+              "fill": "$text",
+              "content": "‹",
+              "fontFamily": "$font",
+              "fontSize": 27,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "Sqx32",
+              "name": "Mobile 頁面標題｜資料來源",
+              "fill": "$text",
+              "content": "資料來源與連接器",
+              "fontFamily": "$font",
+              "fontSize": 19,
+              "fontWeight": "700"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "RT8dH",
+          "name": "Mobile 資料來源內容",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 11,
+          "padding": [
+            14,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "Q9ntRR",
+              "name": "Mobile 資料來源摘要",
+              "width": "fill_container",
+              "height": 68,
+              "fill": "$surface-muted",
+              "cornerRadius": 10,
+              "padding": 14,
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "cYRmn",
+                  "name": "Mobile 來源摘要文字",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "N9rR0O",
+                      "name": "Mobile 來源摘要標題",
+                      "fill": "$text",
+                      "content": "4 個連接器",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "v16kE",
+                      "name": "Mobile 來源摘要說明",
+                      "fill": "$text-muted",
+                      "content": "3 個可正常同步",
+                      "fontFamily": "$font",
+                      "fontSize": 10,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "NwrGm",
+                  "name": "Mobile 來源摘要異常",
+                  "fill": "$negative",
+                  "content": "1 個需要處理",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "700"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "quK4R",
+              "name": "Mobile 來源卡｜永豐銀行",
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "gap": 10,
+              "padding": 14,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "sekYi",
+                  "name": "Mobile 來源標題列｜永豐銀行",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "tkmNN",
+                      "name": "Mobile 來源名稱組｜永豐銀行",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "AAylq",
+                          "name": "Mobile 來源名稱｜永豐銀行",
+                          "fill": "$text",
+                          "content": "永豐銀行",
+                          "fontFamily": "$font",
+                          "fontSize": 14,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Jq0m4",
+                          "name": "Mobile 來源描述｜永豐銀行",
+                          "fill": "$text-muted",
+                          "content": "今天 07:31",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "UrfOQ",
+                      "name": "Mobile 來源狀態｜永豐銀行",
+                      "fill": "$positive",
+                      "content": "正常",
+                      "fontFamily": "$font",
+                      "fontSize": 10,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "g1XAx",
+              "name": "Mobile 來源卡｜台新銀行",
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius",
+              "stroke": "$negative",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "gap": 10,
+              "padding": 14,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "EWjXm",
+                  "name": "Mobile 來源標題列｜台新銀行",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "mHYyU",
+                      "name": "Mobile 來源名稱組｜台新銀行",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "a8WbG",
+                          "name": "Mobile 來源名稱｜台新銀行",
+                          "fill": "$text",
+                          "content": "台新銀行",
+                          "fontFamily": "$font",
+                          "fontSize": 14,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "y03kSa",
+                          "name": "Mobile 來源描述｜台新銀行",
+                          "fill": "$text-muted",
+                          "content": "驗證已失效",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "tUaH2",
+                      "name": "Mobile 來源狀態｜台新銀行",
+                      "fill": "$negative",
+                      "content": "需要處理",
+                      "fontFamily": "$font",
+                      "fontSize": 10,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "m45h1N",
+                  "name": "Mobile 重新驗證按鈕｜台新銀行",
+                  "width": "fill_container",
+                  "height": 38,
+                  "fill": "$accent",
+                  "cornerRadius": 9,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "F8oit",
+                      "name": "Mobile 重新驗證文字｜台新銀行",
+                      "fill": "#FFFFFF",
+                      "content": "重新驗證",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "M7q6v3",
+              "name": "Mobile 來源卡｜電子發票",
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "gap": 10,
+              "padding": 14,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "rTf7J",
+                  "name": "Mobile 來源標題列｜電子發票",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "GsQ9j",
+                      "name": "Mobile 來源名稱組｜電子發票",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "pjexl",
+                          "name": "Mobile 來源名稱｜電子發票",
+                          "fill": "$text",
+                          "content": "電子發票",
+                          "fontFamily": "$font",
+                          "fontSize": 14,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "WZDcQ",
+                          "name": "Mobile 來源描述｜電子發票",
+                          "fill": "$text-muted",
+                          "content": "今天 06:10",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "b9Ft5T",
+                      "name": "Mobile 來源狀態｜電子發票",
+                      "fill": "$positive",
+                      "content": "正常",
+                      "fontFamily": "$font",
+                      "fontSize": 10,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Gu2Vk",
+              "name": "Mobile 來源卡｜集保 e 存摺",
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "gap": 10,
+              "padding": 14,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NaFTa",
+                  "name": "Mobile 來源標題列｜集保 e 存摺",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "JL5zO",
+                      "name": "Mobile 來源名稱組｜集保 e 存摺",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "esFTY",
+                          "name": "Mobile 來源名稱｜集保 e 存摺",
+                          "fill": "$text",
+                          "content": "集保 e 存摺",
+                          "fontFamily": "$font",
+                          "fontSize": 14,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "yG5QE",
+                          "name": "Mobile 來源描述｜集保 e 存摺",
+                          "fill": "$text-muted",
+                          "content": "等待首次授權",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "V7PGPW",
+                      "name": "Mobile 來源狀態｜集保 e 存摺",
+                      "fill": "$text-muted",
+                      "content": "尚未同步",
+                      "fontFamily": "$font",
+                      "fontSize": 10,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "G3rbpj",
+              "name": "Mobile 新增連接器按鈕",
+              "width": "fill_container",
+              "height": 42,
+              "cornerRadius": 9,
+              "stroke": "$accent",
+              "strokeWidth": 1,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "HgQUS",
+                  "name": "Mobile 新增連接器文字",
+                  "fill": "$accent",
+                  "content": "＋ 新增連接器",
+                  "fontFamily": "$font",
+                  "fontSize": 12,
+                  "fontWeight": "700"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "IjjqF",
+          "name": "Mobile 主要底部導覽",
+          "width": "fill_container",
+          "height": 76,
+          "fill": "$text",
+          "stroke": "#FFFFFF1A",
+          "strokeWidth": {
+            "top": 1
+          },
+          "gap": 4,
+          "padding": [
+            7,
+            8,
+            10,
+            8
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "kwEnJ",
+              "name": "Mobile 底部導覽｜總覽",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "p77CYK",
+                  "name": "Mobile 底部圖示｜總覽",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "D5Jwo",
+                  "name": "Mobile 底部文字｜總覽",
+                  "fill": "#FFFFFFA6",
+                  "content": "總覽",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "V2RtLq",
+              "name": "Mobile 底部導覽｜資產",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "bHKvu",
+                  "name": "Mobile 底部圖示｜資產",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "C8G4M",
+                  "name": "Mobile 底部文字｜資產",
+                  "fill": "#FFFFFFA6",
+                  "content": "資產",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Gasxc",
+              "name": "Mobile 底部導覽｜活動",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "XQeHh",
+                  "name": "Mobile 底部圖示｜活動",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "MUi8A",
+                  "name": "Mobile 底部文字｜活動",
+                  "fill": "#FFFFFFA6",
+                  "content": "活動",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rd9HL",
+              "name": "Mobile 底部導覽｜更多",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF1A",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "EGt1q",
+                  "name": "Mobile 底部圖示｜更多",
+                  "fill": "#FFFFFF",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "lWzZO",
+                  "name": "Mobile 底部文字｜更多",
+                  "fill": "#FFFFFF",
+                  "content": "更多",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "f6a5x",
+      "x": 0,
+      "y": 2288,
+      "name": "Desktop｜同步與通知",
+      "clip": true,
+      "width": 1440,
+      "height": 1024,
+      "fill": "$bg",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Ohzgo",
+          "name": "Desktop 全域導覽",
+          "width": 240,
+          "height": "fill_container",
+          "fill": "$text",
+          "layout": "vertical",
+          "gap": 22,
+          "padding": [
+            28,
+            24
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "NuGsN",
+              "name": "Taiwan Fin Hub 品牌",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 7,
+              "padding": [
+                0,
+                8
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "B3Zw3U",
+                  "name": "Taiwan Fin Hub 標題",
+                  "fill": "#FFFFFF",
+                  "content": "Taiwan Fin Hub",
+                  "fontFamily": "$font",
+                  "fontSize": 19,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "U44gxX",
+                  "name": "Wealth OS 標籤",
+                  "fill": "$accent",
+                  "content": "WEALTH OS",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1.6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "NBDPM",
+              "name": "Desktop 主要導覽清單",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 6,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "e7J8up",
+                  "name": "全域導覽｜總覽",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "mUf4b",
+                      "name": "全域導覽圖示｜總覽",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "j1aBXq",
+                      "name": "全域導覽文字｜總覽",
+                      "fill": "#FFFFFFA6",
+                      "content": "總覽",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "sxF1I",
+                  "name": "全域導覽｜資產",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "NGGQt",
+                      "name": "全域導覽圖示｜資產",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "QawkV",
+                      "name": "全域導覽文字｜資產",
+                      "fill": "#FFFFFFA6",
+                      "content": "資產",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "j1zgY",
+                  "name": "全域導覽｜活動",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "QxCLs",
+                      "name": "全域導覽圖示｜活動",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "uVCW8",
+                      "name": "全域導覽文字｜活動",
+                      "fill": "#FFFFFFA6",
+                      "content": "活動",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ruFUP",
+                  "name": "全域導覽｜發票",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "oPaBi",
+                      "name": "全域導覽圖示｜發票",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "qlOrN",
+                      "name": "全域導覽文字｜發票",
+                      "fill": "#FFFFFFA6",
+                      "content": "發票",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "gn2Sd",
+                  "name": "全域導覽｜設定",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF1A",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "KFv8B",
+                      "name": "全域導覽圖示｜設定",
+                      "fill": "#FFFFFF",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "KaSQH",
+                      "name": "全域導覽文字｜設定",
+                      "fill": "#FFFFFF",
+                      "content": "設定",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "DZ6WQ",
+          "name": "Desktop 設定應用內容",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$bg",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "IRBGy",
+              "name": "Desktop 設定頁首",
+              "width": "fill_container",
+              "height": 116,
+              "padding": [
+                0,
+                32
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "z2705F",
+                  "name": "Desktop 設定標題組",
+                  "layout": "vertical",
+                  "gap": 7,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "jQTUA",
+                      "name": "Desktop 設定標題",
+                      "fill": "$text",
+                      "content": "設定",
+                      "fontFamily": "$font",
+                      "fontSize": 30,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "YJajj",
+                      "name": "Desktop 設定描述",
+                      "fill": "$text-muted",
+                      "content": "管理資料來源、同步排程、匯率與交易分類。",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "u4Ihm",
+                  "name": "Desktop 頁首動作",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "E30Oi",
+                      "name": "隱藏金額按鈕",
+                      "width": 40,
+                      "height": 40,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 20,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 6,
+                          "id": "XE5ff",
+                          "name": "隱藏金額圖示",
+                          "width": 17,
+                          "height": 12,
+                          "stroke": "$text-muted",
+                          "strokeWidth": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "pN8ZI",
+                      "name": "重新整理按鈕",
+                      "height": 40,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 20,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        15
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 7,
+                          "id": "ocEN2",
+                          "name": "重新整理圖示",
+                          "width": 14,
+                          "height": 14,
+                          "stroke": "$text-muted",
+                          "strokeWidth": 1
+                        },
+                        {
+                          "type": "text",
+                          "id": "Q4Uxmo",
+                          "name": "重新整理文字",
+                          "fill": "$text",
+                          "content": "重新整理",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "cyzS1",
+              "name": "Desktop 設定水平次導覽",
+              "width": "fill_container",
+              "height": 54,
+              "fill": "$surface",
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1,
+                "bottom": 1
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                32
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "b6sKgF",
+                  "name": "設定分頁｜總覽",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ICcHP",
+                      "name": "設定分頁文字｜總覽",
+                      "fill": "$text-muted",
+                      "content": "總覽",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "D4bvP6",
+                  "name": "設定分頁｜資料來源",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "L91GOE",
+                      "name": "設定分頁文字｜資料來源",
+                      "fill": "$text-muted",
+                      "content": "資料來源",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ZkIxW",
+                  "name": "設定分頁｜同步與通知",
+                  "height": 36,
+                  "fill": "$surface-muted",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "owglk",
+                      "name": "設定分頁文字｜同步與通知",
+                      "fill": "$accent",
+                      "content": "同步與通知",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "lS9vO",
+                  "name": "設定分頁｜匯率",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "d9z8Us",
+                      "name": "設定分頁文字｜匯率",
+                      "fill": "$text-muted",
+                      "content": "匯率",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "CaQWu",
+                  "name": "設定分頁｜分類規則",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "p8OawQ",
+                      "name": "設定分頁文字｜分類規則",
+                      "fill": "$text-muted",
+                      "content": "分類規則",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "t11rJs",
+              "name": "Desktop 同步與通知內容",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 18,
+              "padding": [
+                24,
+                32
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "q3qZE",
+                  "name": "同步通知頁標題",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 5,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "hFRrW",
+                      "name": "同步通知標題",
+                      "fill": "$text",
+                      "content": "同步與通知",
+                      "fontFamily": "$font",
+                      "fontSize": 23,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "OITF2",
+                      "name": "同步通知說明",
+                      "fill": "$text-muted",
+                      "content": "設定所有連接器共用的預設排程與通知時機。",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BDsJI",
+                  "name": "同步通知雙欄",
+                  "width": "fill_container",
+                  "gap": 18,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "D8Zxf0",
+                      "name": "預設同步排程卡",
+                      "width": 560,
+                      "fill": "$surface",
+                      "cornerRadius": "$radius",
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "layout": "vertical",
+                      "gap": 16,
+                      "padding": 20,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "i7wGSv",
+                          "name": "排程卡標題列",
+                          "width": "fill_container",
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "roBKJ",
+                              "name": "排程卡文字",
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "zNHPk",
+                                  "name": "排程卡標題",
+                                  "fill": "$text",
+                                  "content": "預設同步排程",
+                                  "fontFamily": "$font",
+                                  "fontSize": 17,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "UQ0N8",
+                                  "name": "排程卡說明",
+                                  "fill": "$text-muted",
+                                  "content": "新連接器預設沿用此排程",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "MhWbG",
+                              "name": "排程啟用標籤",
+                              "fill": "#EDF2E5",
+                              "cornerRadius": 8,
+                              "padding": [
+                                6,
+                                9
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "O0U1LQ",
+                                  "name": "排程啟用文字",
+                                  "fill": "$positive",
+                                  "content": "已啟用",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "700"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "HBQ7k",
+                          "name": "排程欄位列",
+                          "width": "fill_container",
+                          "gap": 12,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "xvEIz",
+                              "name": "同步頻率",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 6,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "I2LDdv",
+                                  "name": "同步頻率標籤",
+                                  "fill": "$text-muted",
+                                  "content": "頻率",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "R6SGP",
+                                  "name": "同步頻率欄位",
+                                  "width": "fill_container",
+                                  "height": 42,
+                                  "fill": "$surface-muted",
+                                  "cornerRadius": 8,
+                                  "padding": [
+                                    0,
+                                    12
+                                  ],
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "E8debg",
+                                      "name": "同步頻率值",
+                                      "fill": "$text",
+                                      "content": "每天",
+                                      "fontFamily": "$font",
+                                      "fontSize": 12,
+                                      "fontWeight": "600"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "yp6UJ",
+                                      "name": "同步頻率箭頭",
+                                      "fill": "$text-muted",
+                                      "content": "⌄",
+                                      "fontFamily": "$font",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "FN0qM",
+                              "name": "同步時間",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 6,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "bDC78",
+                                  "name": "同步時間標籤",
+                                  "fill": "$text-muted",
+                                  "content": "時間",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "XS6EQ",
+                                  "name": "同步時間欄位",
+                                  "width": "fill_container",
+                                  "height": 42,
+                                  "fill": "$surface-muted",
+                                  "cornerRadius": 8,
+                                  "padding": [
+                                    0,
+                                    12
+                                  ],
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "ucr06",
+                                      "name": "同步時間值",
+                                      "fill": "$text",
+                                      "content": "07:30",
+                                      "fontFamily": "$font",
+                                      "fontSize": 12,
+                                      "fontWeight": "600"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "M0HyMw",
+                                      "name": "同步時間箭頭",
+                                      "fill": "$text-muted",
+                                      "content": "⌄",
+                                      "fontFamily": "$font",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "B4qDk4",
+                          "name": "排程時區",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 6,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "lvMzq",
+                              "name": "排程時區標籤",
+                              "fill": "$text-muted",
+                              "content": "時區",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "x7Y7R",
+                              "name": "排程時區欄位",
+                              "width": "fill_container",
+                              "height": 42,
+                              "fill": "$surface-muted",
+                              "cornerRadius": 8,
+                              "padding": [
+                                0,
+                                12
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "jaDvY",
+                                  "name": "排程時區值",
+                                  "fill": "$text",
+                                  "content": "Asia / Taipei",
+                                  "fontFamily": "$font",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "d0EDI",
+                                  "name": "排程時區箭頭",
+                                  "fill": "$text-muted",
+                                  "content": "⌄",
+                                  "fontFamily": "$font",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "JdYYk",
+                          "name": "排程套用說明",
+                          "width": "fill_container",
+                          "fill": "$surface-muted",
+                          "cornerRadius": 9,
+                          "padding": 12,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "gMcB0",
+                              "name": "排程套用文字",
+                              "fill": "$text-muted",
+                              "content": "4 個連接器使用預設排程；個別連接器可另外調整。",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "jj3li",
+                          "name": "儲存排程按鈕",
+                          "width": 118,
+                          "height": 38,
+                          "fill": "$accent",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "oBRdT",
+                              "name": "儲存排程文字",
+                              "fill": "#FFFFFF",
+                              "content": "儲存排程",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "RVHRE",
+                      "name": "通知設定卡",
+                      "width": "fill_container",
+                      "fill": "$surface",
+                      "cornerRadius": "$radius",
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "layout": "vertical",
+                      "padding": 20,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "f0HsT",
+                          "name": "通知設定標題",
+                          "fill": "$text",
+                          "content": "通知設定",
+                          "fontFamily": "$font",
+                          "fontSize": 17,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "B06yxW",
+                          "name": "通知設定說明",
+                          "fill": "$text-muted",
+                          "content": "選擇需要收到推播的同步事件。",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "X3csp",
+                          "name": "通知列｜同步失敗",
+                          "width": "fill_container",
+                          "height": 64,
+                          "stroke": "$border",
+                          "strokeWidth": {
+                            "top": 1
+                          },
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Qi1ay",
+                              "name": "通知文字｜同步失敗",
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Z7QpOc",
+                                  "name": "通知名稱｜同步失敗",
+                                  "fill": "$text",
+                                  "content": "同步失敗",
+                                  "fontFamily": "$font",
+                                  "fontSize": 13,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "KjYur",
+                                  "name": "通知說明｜同步失敗",
+                                  "fill": "$text-muted",
+                                  "content": "連接器無法登入或同步中斷",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "uXmnq",
+                              "name": "通知開關｜同步失敗",
+                              "width": 42,
+                              "height": 24,
+                              "fill": "$accent",
+                              "cornerRadius": 12,
+                              "padding": 3,
+                              "justifyContent": "end",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "ZzfR9",
+                                  "name": "通知開關圓點｜同步失敗",
+                                  "fill": "$surface",
+                                  "width": 18,
+                                  "height": 18
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "F6vi0",
+                          "name": "通知列｜需要重新驗證",
+                          "width": "fill_container",
+                          "height": 64,
+                          "stroke": "$border",
+                          "strokeWidth": {
+                            "top": 1
+                          },
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Cv4pe",
+                              "name": "通知文字｜需要重新驗證",
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Fk7S0",
+                                  "name": "通知名稱｜需要重新驗證",
+                                  "fill": "$text",
+                                  "content": "需要重新驗證",
+                                  "fontFamily": "$font",
+                                  "fontSize": 13,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "mdoqe",
+                                  "name": "通知說明｜需要重新驗證",
+                                  "fill": "$text-muted",
+                                  "content": "登入狀態失效時通知",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "SMHyF",
+                              "name": "通知開關｜需要重新驗證",
+                              "width": 42,
+                              "height": 24,
+                              "fill": "$accent",
+                              "cornerRadius": 12,
+                              "padding": 3,
+                              "justifyContent": "end",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "UroGL",
+                                  "name": "通知開關圓點｜需要重新驗證",
+                                  "fill": "$surface",
+                                  "width": 18,
+                                  "height": 18
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "AMeRJ",
+                          "name": "通知列｜同步完成",
+                          "width": "fill_container",
+                          "height": 64,
+                          "stroke": "$border",
+                          "strokeWidth": {
+                            "top": 1
+                          },
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "yHItu",
+                              "name": "通知文字｜同步完成",
+                              "layout": "vertical",
+                              "gap": 4,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "s0am0",
+                                  "name": "通知名稱｜同步完成",
+                                  "fill": "$text",
+                                  "content": "同步完成",
+                                  "fontFamily": "$font",
+                                  "fontSize": 13,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "y5pU3y",
+                                  "name": "通知說明｜同步完成",
+                                  "fill": "$text-muted",
+                                  "content": "每次成功同步後通知",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "dvNnq",
+                              "name": "通知開關｜同步完成",
+                              "width": 42,
+                              "height": 24,
+                              "fill": "$border",
+                              "cornerRadius": 12,
+                              "padding": 3,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "JrSUa",
+                                  "name": "通知開關圓點｜同步完成",
+                                  "fill": "$surface",
+                                  "width": 18,
+                                  "height": 18
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "NPGpB",
+                  "name": "最近排程狀態",
+                  "width": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": "$radius",
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": 18,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "g8BMSz",
+                      "name": "最近排程標題列",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Zx82c",
+                          "name": "最近排程標題",
+                          "fill": "$text",
+                          "content": "最近一次排程",
+                          "fontFamily": "$font",
+                          "fontSize": 14,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "X5vrJ",
+                          "name": "最近排程時間",
+                          "fill": "$text-muted",
+                          "content": "今天 07:31",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "K7XIZe",
+                      "name": "最近排程摘要列",
+                      "width": "fill_container",
+                      "height": 42,
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "DX5kh",
+                          "name": "排程結果成功",
+                          "width": 358,
+                          "height": "fill_container",
+                          "fill": "$surface-muted",
+                          "cornerRadius": 8,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "DAhay",
+                              "name": "排程成功文字",
+                              "fill": "$positive",
+                              "content": "3 個成功",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "wFJ8X",
+                          "name": "排程結果異常",
+                          "width": 358,
+                          "height": "fill_container",
+                          "fill": "#FFF8F5",
+                          "cornerRadius": 8,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "xFrtk",
+                              "name": "排程異常文字",
+                              "fill": "$negative",
+                              "content": "1 個需要處理",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "W8IKPo",
+                          "name": "排程下次執行",
+                          "width": 360,
+                          "height": "fill_container",
+                          "fill": "$surface-muted",
+                          "cornerRadius": 8,
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "B7QGs",
+                              "name": "排程下次文字",
+                              "fill": "$text",
+                              "content": "下次：明天 07:30",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "oZD1t",
+      "x": 1560,
+      "y": 2288,
+      "name": "Mobile｜同步與通知",
+      "clip": true,
+      "width": 390,
+      "height": 844,
+      "fill": "$bg",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "H8vvld",
+          "name": "Mobile 同步與通知頁首",
+          "width": "fill_container",
+          "height": 72,
+          "fill": "$surface",
+          "stroke": "$border",
+          "strokeWidth": {
+            "bottom": 1
+          },
+          "gap": 12,
+          "padding": [
+            0,
+            18
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "ycUab",
+              "name": "Mobile 返回箭頭｜同步通知",
+              "fill": "$text",
+              "content": "‹",
+              "fontFamily": "$font",
+              "fontSize": 27,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "Yacf3",
+              "name": "Mobile 頁面標題｜同步通知",
+              "fill": "$text",
+              "content": "同步與通知",
+              "fontFamily": "$font",
+              "fontSize": 19,
+              "fontWeight": "700"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "wC7FM",
+          "name": "Mobile 同步與通知內容",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 11,
+          "padding": [
+            14,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "olnrB",
+              "name": "Mobile 預設同步排程卡",
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 14,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "jVnSH",
+                  "name": "Mobile 排程標題列",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "n04sa",
+                      "name": "Mobile 排程標題",
+                      "fill": "$text",
+                      "content": "預設同步排程",
+                      "fontFamily": "$font",
+                      "fontSize": 15,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "N43B2W",
+                      "name": "Mobile 排程狀態",
+                      "fill": "$positive",
+                      "content": "已啟用",
+                      "fontFamily": "$font",
+                      "fontSize": 10,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "nPHMi",
+                  "name": "Mobile 排程欄位列",
+                  "width": "fill_container",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "YTXtc",
+                      "name": "Mobile 同步頻率",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "cplEQ",
+                          "name": "Mobile 同步頻率標籤",
+                          "fill": "$text-muted",
+                          "content": "頻率",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "nBOx1",
+                          "name": "Mobile 同步頻率欄位",
+                          "width": "fill_container",
+                          "height": 38,
+                          "fill": "$surface-muted",
+                          "cornerRadius": 8,
+                          "padding": [
+                            0,
+                            11
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "dKCOW",
+                              "name": "Mobile 同步頻率值",
+                              "fill": "$text",
+                              "content": "每天",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "rXx2K",
+                              "name": "Mobile 同步頻率箭頭",
+                              "fill": "$text-muted",
+                              "content": "⌄",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xG3ND",
+                      "name": "Mobile 同步時間",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "fIsrY",
+                          "name": "Mobile 同步時間標籤",
+                          "fill": "$text-muted",
+                          "content": "時間",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "E3igb6",
+                          "name": "Mobile 同步時間欄位",
+                          "width": "fill_container",
+                          "height": 38,
+                          "fill": "$surface-muted",
+                          "cornerRadius": 8,
+                          "padding": [
+                            0,
+                            11
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "uVlqj",
+                              "name": "Mobile 同步時間值",
+                              "fill": "$text",
+                              "content": "07:30",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "d2RhX",
+                              "name": "Mobile 同步時間箭頭",
+                              "fill": "$text-muted",
+                              "content": "⌄",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "k4UwiP",
+                  "name": "Mobile 排程時區",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 5,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "RT3SD",
+                      "name": "Mobile 排程時區標籤",
+                      "fill": "$text-muted",
+                      "content": "時區",
+                      "fontFamily": "$font",
+                      "fontSize": 10,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "sW0vr",
+                      "name": "Mobile 排程時區欄位",
+                      "width": "fill_container",
+                      "height": 38,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 8,
+                      "padding": [
+                        0,
+                        11
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "k7aEQ",
+                          "name": "Mobile 排程時區值",
+                          "fill": "$text",
+                          "content": "Asia / Taipei",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "jI2at",
+                          "name": "Mobile 排程時區箭頭",
+                          "fill": "$text-muted",
+                          "content": "⌄",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "OgFgq",
+                  "name": "Mobile 儲存排程按鈕",
+                  "width": "fill_container",
+                  "height": 38,
+                  "fill": "$accent",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "qXy95",
+                      "name": "Mobile 儲存排程文字",
+                      "fill": "#FFFFFF",
+                      "content": "儲存排程",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "UQYKn",
+              "name": "Mobile 通知設定卡",
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "padding": [
+                12,
+                14
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "hNBP4",
+                  "name": "Mobile 通知設定標題",
+                  "fill": "$text",
+                  "content": "通知設定",
+                  "fontFamily": "$font",
+                  "fontSize": 15,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "frame",
+                  "id": "zDfP0",
+                  "name": "Mobile 通知列｜同步失敗",
+                  "width": "fill_container",
+                  "height": 48,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "EW3gl",
+                      "name": "Mobile 通知名稱｜同步失敗",
+                      "fill": "$text",
+                      "content": "同步失敗",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FS83L",
+                      "name": "Mobile 通知開關｜同步失敗",
+                      "width": 40,
+                      "height": 23,
+                      "fill": "$accent",
+                      "cornerRadius": 12,
+                      "padding": 3,
+                      "justifyContent": "end",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "vJrBs",
+                          "name": "Mobile 通知圓點｜同步失敗",
+                          "fill": "$surface",
+                          "width": 17,
+                          "height": 17
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "LSVN3",
+                  "name": "Mobile 通知列｜需要重新驗證",
+                  "width": "fill_container",
+                  "height": 48,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "mlJvm",
+                      "name": "Mobile 通知名稱｜需要重新驗證",
+                      "fill": "$text",
+                      "content": "需要重新驗證",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lv9a7",
+                      "name": "Mobile 通知開關｜需要重新驗證",
+                      "width": 40,
+                      "height": 23,
+                      "fill": "$accent",
+                      "cornerRadius": 12,
+                      "padding": 3,
+                      "justifyContent": "end",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "ASznH",
+                          "name": "Mobile 通知圓點｜需要重新驗證",
+                          "fill": "$surface",
+                          "width": 17,
+                          "height": 17
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "B4j5pt",
+                  "name": "Mobile 通知列｜同步完成",
+                  "width": "fill_container",
+                  "height": 48,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "PnpLU",
+                      "name": "Mobile 通知名稱｜同步完成",
+                      "fill": "$text",
+                      "content": "同步完成",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "m6dEU",
+                      "name": "Mobile 通知開關｜同步完成",
+                      "width": 40,
+                      "height": 23,
+                      "fill": "$border",
+                      "cornerRadius": 12,
+                      "padding": 3,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "cJlPA",
+                          "name": "Mobile 通知圓點｜同步完成",
+                          "fill": "$surface",
+                          "width": 17,
+                          "height": 17
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Udbhi",
+              "name": "Mobile 最近排程狀態",
+              "width": "fill_container",
+              "fill": "$surface-muted",
+              "cornerRadius": 10,
+              "padding": 13,
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "vN0fe",
+                  "name": "Mobile 最近排程文字",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "S4T0E",
+                      "name": "Mobile 最近排程標題",
+                      "fill": "$text-muted",
+                      "content": "最近一次排程",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "BB83e",
+                      "name": "Mobile 最近排程結果",
+                      "fill": "$text",
+                      "content": "3 成功 · 1 需要處理",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "V8d9K1",
+                  "name": "Mobile 最近排程時間",
+                  "fill": "$text-muted",
+                  "content": "今天 07:31",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "j6hAvl",
+          "name": "Mobile 主要底部導覽",
+          "width": "fill_container",
+          "height": 76,
+          "fill": "$text",
+          "stroke": "#FFFFFF1A",
+          "strokeWidth": {
+            "top": 1
+          },
+          "gap": 4,
+          "padding": [
+            7,
+            8,
+            10,
+            8
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "wx4Ey",
+              "name": "Mobile 底部導覽｜總覽",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "lLYjr",
+                  "name": "Mobile 底部圖示｜總覽",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "oQBKt",
+                  "name": "Mobile 底部文字｜總覽",
+                  "fill": "#FFFFFFA6",
+                  "content": "總覽",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "wq4Zz",
+              "name": "Mobile 底部導覽｜資產",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "Y9l7xI",
+                  "name": "Mobile 底部圖示｜資產",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "lhZ67",
+                  "name": "Mobile 底部文字｜資產",
+                  "fill": "#FFFFFFA6",
+                  "content": "資產",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "G2jP8g",
+              "name": "Mobile 底部導覽｜活動",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "J69ML",
+                  "name": "Mobile 底部圖示｜活動",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "KXott",
+                  "name": "Mobile 底部文字｜活動",
+                  "fill": "#FFFFFFA6",
+                  "content": "活動",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "J71sL",
+              "name": "Mobile 底部導覽｜更多",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF1A",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "eEErs",
+                  "name": "Mobile 底部圖示｜更多",
+                  "fill": "#FFFFFF",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "SAl42",
+                  "name": "Mobile 底部文字｜更多",
+                  "fill": "#FFFFFF",
+                  "content": "更多",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "H7ddi",
+      "x": 0,
+      "y": 3432,
+      "name": "Desktop｜匯率",
+      "clip": true,
+      "width": 1440,
+      "height": 1024,
+      "fill": "$bg",
+      "children": [
+        {
+          "type": "frame",
+          "id": "PRapD",
+          "name": "Desktop 全域導覽",
+          "width": 240,
+          "height": "fill_container",
+          "fill": "$text",
+          "layout": "vertical",
+          "gap": 22,
+          "padding": [
+            28,
+            24
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "bbUeZ",
+              "name": "Taiwan Fin Hub 品牌",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 7,
+              "padding": [
+                0,
+                8
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "e8e8ez",
+                  "name": "Taiwan Fin Hub 標題",
+                  "fill": "#FFFFFF",
+                  "content": "Taiwan Fin Hub",
+                  "fontFamily": "$font",
+                  "fontSize": 19,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "ql0TX",
+                  "name": "Wealth OS 標籤",
+                  "fill": "$accent",
+                  "content": "WEALTH OS",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1.6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "X5ntD",
+              "name": "Desktop 主要導覽清單",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 6,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "v2aShB",
+                  "name": "全域導覽｜總覽",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "EeTXU",
+                      "name": "全域導覽圖示｜總覽",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "t0LDTc",
+                      "name": "全域導覽文字｜總覽",
+                      "fill": "#FFFFFFA6",
+                      "content": "總覽",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "hrfoE",
+                  "name": "全域導覽｜資產",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "AXeWV",
+                      "name": "全域導覽圖示｜資產",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "rkA0A",
+                      "name": "全域導覽文字｜資產",
+                      "fill": "#FFFFFFA6",
+                      "content": "資產",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rNZQO",
+                  "name": "全域導覽｜活動",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "NWG7r",
+                      "name": "全域導覽圖示｜活動",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "c9vao",
+                      "name": "全域導覽文字｜活動",
+                      "fill": "#FFFFFFA6",
+                      "content": "活動",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xlvmG",
+                  "name": "全域導覽｜發票",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "oI1FD",
+                      "name": "全域導覽圖示｜發票",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "y1rPE",
+                      "name": "全域導覽文字｜發票",
+                      "fill": "#FFFFFFA6",
+                      "content": "發票",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "zQAZp",
+                  "name": "全域導覽｜設定",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF1A",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "jlo6F",
+                      "name": "全域導覽圖示｜設定",
+                      "fill": "#FFFFFF",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "Ytxqh",
+                      "name": "全域導覽文字｜設定",
+                      "fill": "#FFFFFF",
+                      "content": "設定",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "fP4h5",
+          "name": "Desktop 設定應用內容",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$bg",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "CZtWP",
+              "name": "Desktop 設定頁首",
+              "width": "fill_container",
+              "height": 116,
+              "padding": [
+                0,
+                32
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Q9Q339",
+                  "name": "Desktop 設定標題組",
+                  "layout": "vertical",
+                  "gap": 7,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "m75fv",
+                      "name": "Desktop 設定標題",
+                      "fill": "$text",
+                      "content": "設定",
+                      "fontFamily": "$font",
+                      "fontSize": 30,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "PRFDY",
+                      "name": "Desktop 設定描述",
+                      "fill": "$text-muted",
+                      "content": "管理資料來源、同步排程、匯率與交易分類。",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "uFvJ8",
+                  "name": "Desktop 頁首動作",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "u1kEd3",
+                      "name": "隱藏金額按鈕",
+                      "width": 40,
+                      "height": 40,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 20,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 6,
+                          "id": "mMlLv",
+                          "name": "隱藏金額圖示",
+                          "width": 17,
+                          "height": 12,
+                          "stroke": "$text-muted",
+                          "strokeWidth": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HKZZX",
+                      "name": "重新整理按鈕",
+                      "height": 40,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 20,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        15
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 7,
+                          "id": "zq7pI",
+                          "name": "重新整理圖示",
+                          "width": 14,
+                          "height": 14,
+                          "stroke": "$text-muted",
+                          "strokeWidth": 1
+                        },
+                        {
+                          "type": "text",
+                          "id": "OduuY",
+                          "name": "重新整理文字",
+                          "fill": "$text",
+                          "content": "重新整理",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Rc79r",
+              "name": "Desktop 設定水平次導覽",
+              "width": "fill_container",
+              "height": 54,
+              "fill": "$surface",
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1,
+                "bottom": 1
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                32
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "yptku",
+                  "name": "設定分頁｜總覽",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "SGTey",
+                      "name": "設定分頁文字｜總覽",
+                      "fill": "$text-muted",
+                      "content": "總覽",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "XESPc",
+                  "name": "設定分頁｜資料來源",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "d8USXo",
+                      "name": "設定分頁文字｜資料來源",
+                      "fill": "$text-muted",
+                      "content": "資料來源",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "umXdm",
+                  "name": "設定分頁｜同步與通知",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "z7NiT",
+                      "name": "設定分頁文字｜同步與通知",
+                      "fill": "$text-muted",
+                      "content": "同步與通知",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "mWH60",
+                  "name": "設定分頁｜匯率",
+                  "height": 36,
+                  "fill": "$surface-muted",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "UQKxt",
+                      "name": "設定分頁文字｜匯率",
+                      "fill": "$accent",
+                      "content": "匯率",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "hlNe4",
+                  "name": "設定分頁｜分類規則",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "HL6fn",
+                      "name": "設定分頁文字｜分類規則",
+                      "fill": "$text-muted",
+                      "content": "分類規則",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "r83U0",
+              "name": "Desktop 匯率內容",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 18,
+              "padding": [
+                24,
+                32
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "o8GSq",
+                  "name": "匯率頁標題列",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dtQHR",
+                      "name": "匯率標題文字",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "s668YE",
+                          "name": "匯率頁標題",
+                          "fill": "$text",
+                          "content": "匯率",
+                          "fontFamily": "$font",
+                          "fontSize": 23,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Cav1a",
+                          "name": "匯率頁說明",
+                          "fill": "$text-muted",
+                          "content": "管理資產與活動使用的換算基準。",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "e8ara",
+                      "name": "更新匯率按鈕",
+                      "height": 38,
+                      "fill": "$accent",
+                      "cornerRadius": 9,
+                      "padding": [
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "j8mLNc",
+                          "name": "更新匯率文字",
+                          "fill": "#FFFFFF",
+                          "content": "更新匯率",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "N6DCbL",
+                  "name": "匯率摘要列",
+                  "width": "fill_container",
+                  "gap": 14,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "GK0Ws",
+                      "name": "基準幣別卡",
+                      "width": "fill_container",
+                      "height": 94,
+                      "fill": "$surface",
+                      "cornerRadius": "$radius",
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "layout": "vertical",
+                      "gap": 8,
+                      "padding": 16,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "nWhJS",
+                          "name": "基準幣別標籤",
+                          "fill": "$text-muted",
+                          "content": "基準幣別",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "yW9ue",
+                          "name": "基準幣別欄位",
+                          "width": "fill_container",
+                          "justifyContent": "space_between",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "f49ax",
+                              "name": "基準幣別值",
+                              "fill": "$text",
+                              "content": "TWD · 新台幣",
+                              "fontFamily": "$font",
+                              "fontSize": 17,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "YLqjJ",
+                              "name": "基準幣別箭頭",
+                              "fill": "$text-muted",
+                              "content": "⌄",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "SdJHL",
+                      "name": "匯率來源卡",
+                      "width": "fill_container",
+                      "height": 94,
+                      "fill": "$surface",
+                      "cornerRadius": "$radius",
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "layout": "vertical",
+                      "gap": 8,
+                      "padding": 16,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Oco1Z",
+                          "name": "匯率來源標籤",
+                          "fill": "$text-muted",
+                          "content": "資料來源",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "t1tE6",
+                          "name": "匯率來源值",
+                          "fill": "$text",
+                          "content": "系統每日參考匯率",
+                          "fontFamily": "$font",
+                          "fontSize": 17,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "cNdTi",
+                          "name": "匯率來源時間",
+                          "fill": "$text-muted",
+                          "content": "最後更新：2026/07/25 06:00",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gt8aV",
+                      "name": "自訂匯率摘要卡",
+                      "width": "fill_container",
+                      "height": 94,
+                      "fill": "$surface-muted",
+                      "cornerRadius": "$radius",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "padding": 16,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "MCaux",
+                          "name": "自訂匯率標籤",
+                          "fill": "$text-muted",
+                          "content": "自訂匯率",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "TnjGV",
+                          "name": "自訂匯率數值",
+                          "fill": "$text",
+                          "content": "1 筆",
+                          "fontFamily": "$font",
+                          "fontSize": 17,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "BQxhC",
+                          "name": "自訂匯率說明",
+                          "fill": "$accent",
+                          "content": "JPY 使用手動設定",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "S775T",
+                  "name": "匯率表格",
+                  "clip": true,
+                  "width": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": "$radius",
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "BsIgN",
+                      "name": "匯率表頭",
+                      "width": "fill_container",
+                      "height": 46,
+                      "fill": "$surface-muted",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "iSui3",
+                          "name": "表頭幣別",
+                          "width": 250,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "GhcrR",
+                              "name": "表頭幣別文字",
+                              "fill": "$text-muted",
+                              "content": "幣別",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ItWYV",
+                          "name": "表頭換算率",
+                          "width": 210,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "SyTQN",
+                              "name": "表頭換算率文字",
+                              "fill": "$text-muted",
+                              "content": "1 單位等於 TWD",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "YKAwd",
+                          "name": "表頭來源",
+                          "width": 250,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "msxKf",
+                              "name": "表頭來源文字",
+                              "fill": "$text-muted",
+                              "content": "來源",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ROny9",
+                          "name": "表頭更新",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "cHYZ5",
+                              "name": "表頭更新文字",
+                              "fill": "$text-muted",
+                              "content": "更新時間",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "B712b",
+                      "name": "匯率表列｜USD",
+                      "width": "fill_container",
+                      "height": 58,
+                      "stroke": "$border",
+                      "strokeWidth": {
+                        "top": 1
+                      },
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "YaaY5",
+                          "name": "幣別｜USD",
+                          "width": 250,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "y2PEW3",
+                              "name": "幣別｜USD文字",
+                              "fill": "$text",
+                              "content": "USD  美元",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "t1xyRe",
+                          "name": "換算率｜USD",
+                          "width": 210,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "caT80",
+                              "name": "換算率｜USD文字",
+                              "fill": "$text",
+                              "content": "31.42",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "GL0qd",
+                          "name": "來源｜USD",
+                          "width": 250,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "b669ds",
+                              "name": "來源｜USD文字",
+                              "fill": "$text-muted",
+                              "content": "系統參考匯率",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Ygk9U",
+                          "name": "更新時間｜USD",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Xeavp",
+                              "name": "更新時間｜USD文字",
+                              "fill": "$text-muted",
+                              "content": "今天 06:00",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "pZp6j",
+                      "name": "匯率表列｜EUR",
+                      "width": "fill_container",
+                      "height": 58,
+                      "stroke": "$border",
+                      "strokeWidth": {
+                        "top": 1
+                      },
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ZJbDy",
+                          "name": "幣別｜EUR",
+                          "width": 250,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "uJCUj",
+                              "name": "幣別｜EUR文字",
+                              "fill": "$text",
+                              "content": "EUR  歐元",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "iqH2s",
+                          "name": "換算率｜EUR",
+                          "width": 210,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "P5BQFO",
+                              "name": "換算率｜EUR文字",
+                              "fill": "$text",
+                              "content": "36.84",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "W6slIL",
+                          "name": "來源｜EUR",
+                          "width": 250,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "kv1bi",
+                              "name": "來源｜EUR文字",
+                              "fill": "$text-muted",
+                              "content": "系統參考匯率",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "mFczB",
+                          "name": "更新時間｜EUR",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "E7UKm6",
+                              "name": "更新時間｜EUR文字",
+                              "fill": "$text-muted",
+                              "content": "今天 06:00",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "P3nNHG",
+                      "name": "匯率表列｜JPY",
+                      "width": "fill_container",
+                      "height": 58,
+                      "stroke": "$border",
+                      "strokeWidth": {
+                        "top": 1
+                      },
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Ovygb",
+                          "name": "幣別｜JPY",
+                          "width": 250,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "r94kOG",
+                              "name": "幣別｜JPY文字",
+                              "fill": "$text",
+                              "content": "JPY  日圓",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Znbgc",
+                          "name": "換算率｜JPY",
+                          "width": 210,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "XWQkV",
+                              "name": "換算率｜JPY文字",
+                              "fill": "$text",
+                              "content": "0.207",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "uxWGv",
+                          "name": "來源｜JPY",
+                          "width": 250,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "M8s7UG",
+                              "name": "來源｜JPY文字",
+                              "fill": "$text-muted",
+                              "content": "手動設定",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "SSCHs",
+                          "name": "更新時間｜JPY",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "O8phRo",
+                              "name": "更新時間｜JPY文字",
+                              "fill": "$text-muted",
+                              "content": "昨天 21:15",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "s7UqGt",
+                      "name": "匯率表列｜CNY",
+                      "width": "fill_container",
+                      "height": 58,
+                      "stroke": "$border",
+                      "strokeWidth": {
+                        "top": 1
+                      },
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "i4C5z",
+                          "name": "幣別｜CNY",
+                          "width": 250,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "PYXpe",
+                              "name": "幣別｜CNY文字",
+                              "fill": "$text",
+                              "content": "CNY  人民幣",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "S4ECp",
+                          "name": "換算率｜CNY",
+                          "width": 210,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "u8MOA",
+                              "name": "換算率｜CNY文字",
+                              "fill": "$text",
+                              "content": "4.38",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "uR1DD",
+                          "name": "來源｜CNY",
+                          "width": 250,
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "LthNz",
+                              "name": "來源｜CNY文字",
+                              "fill": "$text-muted",
+                              "content": "系統參考匯率",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "o6l1N",
+                          "name": "更新時間｜CNY",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "padding": [
+                            0,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "SvJKR",
+                              "name": "更新時間｜CNY文字",
+                              "fill": "$text-muted",
+                              "content": "今天 06:00",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "khPUu",
+                  "name": "匯率注意事項",
+                  "width": "fill_container",
+                  "fill": "$surface-muted",
+                  "cornerRadius": 10,
+                  "padding": 14,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "p1zyZQ",
+                      "name": "匯率注意事項文字",
+                      "fill": "$text-muted",
+                      "content": "匯率僅用於資產總覽與統計換算，不會變更原始交易幣別或金額。",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "cxIn4",
+      "x": 1560,
+      "y": 3432,
+      "name": "Mobile｜匯率",
+      "clip": true,
+      "width": 390,
+      "height": 844,
+      "fill": "$bg",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Mn4cY",
+          "name": "Mobile 匯率頁首",
+          "width": "fill_container",
+          "height": 72,
+          "fill": "$surface",
+          "stroke": "$border",
+          "strokeWidth": {
+            "bottom": 1
+          },
+          "gap": 12,
+          "padding": [
+            0,
+            18
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "Vvwk8",
+              "name": "Mobile 返回箭頭｜匯率",
+              "fill": "$text",
+              "content": "‹",
+              "fontFamily": "$font",
+              "fontSize": 27,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "pK9q9",
+              "name": "Mobile 頁面標題｜匯率",
+              "fill": "$text",
+              "content": "匯率",
+              "fontFamily": "$font",
+              "fontSize": 19,
+              "fontWeight": "700"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "d5NKf",
+          "name": "Mobile 匯率內容",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 11,
+          "padding": [
+            14,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "Vmvsc",
+              "name": "Mobile 基準幣別卡",
+              "width": "fill_container",
+              "height": 74,
+              "fill": "$surface",
+              "cornerRadius": "$radius",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "padding": 14,
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "DMtT9",
+                  "name": "Mobile 基準幣別文字",
+                  "layout": "vertical",
+                  "gap": 5,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "UoOU3",
+                      "name": "Mobile 基準幣別標籤",
+                      "fill": "$text-muted",
+                      "content": "基準幣別",
+                      "fontFamily": "$font",
+                      "fontSize": 10,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "c7oA5b",
+                      "name": "Mobile 基準幣別值",
+                      "fill": "$text",
+                      "content": "TWD · 新台幣",
+                      "fontFamily": "$font",
+                      "fontSize": 15,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "AgRws",
+                  "name": "Mobile 基準幣別箭頭",
+                  "fill": "$text-muted",
+                  "content": "⌄",
+                  "fontFamily": "$font",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "aCIcC",
+              "name": "Mobile 匯率更新摘要",
+              "width": "fill_container",
+              "fill": "$surface-muted",
+              "cornerRadius": 10,
+              "padding": 12,
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "LSYXI",
+                  "name": "Mobile 匯率更新文字",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "eUYm4",
+                      "name": "Mobile 匯率更新來源",
+                      "fill": "$text",
+                      "content": "系統每日參考匯率",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "I4HiEU",
+                      "name": "Mobile 匯率更新時間",
+                      "fill": "$text-muted",
+                      "content": "今天 06:00 更新",
+                      "fontFamily": "$font",
+                      "fontSize": 9,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "smqNa",
+                  "name": "Mobile 更新匯率動作",
+                  "fill": "$accent",
+                  "content": "更新",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "700"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "CNR3H",
+              "name": "Mobile 匯率清單",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Wjt1S",
+                  "name": "Mobile 匯率列｜USD",
+                  "width": "fill_container",
+                  "height": 64,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "yd3pa",
+                      "name": "Mobile 幣別文字｜USD",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SIRmQ",
+                          "name": "Mobile 幣別代碼｜USD",
+                          "fill": "$text",
+                          "content": "USD · 美元",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "W9g9V0",
+                          "name": "Mobile 匯率來源｜USD",
+                          "fill": "$text-muted",
+                          "content": "系統參考",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "e12nYw",
+                      "name": "Mobile 匯率值組｜USD",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "xpBiz",
+                          "name": "Mobile 匯率值｜USD",
+                          "fill": "$text",
+                          "content": "31.42",
+                          "fontFamily": "$font",
+                          "fontSize": 14,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Z4z03",
+                          "name": "Mobile 匯率單位｜USD",
+                          "fill": "$text-muted",
+                          "content": "TWD",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ZKKv4",
+                  "name": "Mobile 匯率列｜EUR",
+                  "width": "fill_container",
+                  "height": 64,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dnscx",
+                      "name": "Mobile 幣別文字｜EUR",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "zzAkD",
+                          "name": "Mobile 幣別代碼｜EUR",
+                          "fill": "$text",
+                          "content": "EUR · 歐元",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "dt3eF",
+                          "name": "Mobile 匯率來源｜EUR",
+                          "fill": "$text-muted",
+                          "content": "系統參考",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FNgEj",
+                      "name": "Mobile 匯率值組｜EUR",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "NLDjf",
+                          "name": "Mobile 匯率值｜EUR",
+                          "fill": "$text",
+                          "content": "36.84",
+                          "fontFamily": "$font",
+                          "fontSize": 14,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "XvAHQ",
+                          "name": "Mobile 匯率單位｜EUR",
+                          "fill": "$text-muted",
+                          "content": "TWD",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "e7mFBK",
+                  "name": "Mobile 匯率列｜JPY",
+                  "width": "fill_container",
+                  "height": 64,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "yxj2e",
+                      "name": "Mobile 幣別文字｜JPY",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Vc3Dj",
+                          "name": "Mobile 幣別代碼｜JPY",
+                          "fill": "$text",
+                          "content": "JPY · 日圓",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ql859",
+                          "name": "Mobile 匯率來源｜JPY",
+                          "fill": "$accent",
+                          "content": "手動設定",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "G7MkiO",
+                      "name": "Mobile 匯率值組｜JPY",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ewCdR",
+                          "name": "Mobile 匯率值｜JPY",
+                          "fill": "$text",
+                          "content": "0.207",
+                          "fontFamily": "$font",
+                          "fontSize": 14,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "OM8hN",
+                          "name": "Mobile 匯率單位｜JPY",
+                          "fill": "$text-muted",
+                          "content": "TWD",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BHq2J",
+                  "name": "Mobile 匯率列｜CNY",
+                  "width": "fill_container",
+                  "height": 64,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Z7cSOS",
+                      "name": "Mobile 幣別文字｜CNY",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "sM5gI",
+                          "name": "Mobile 幣別代碼｜CNY",
+                          "fill": "$text",
+                          "content": "CNY · 人民幣",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ppOkH",
+                          "name": "Mobile 匯率來源｜CNY",
+                          "fill": "$text-muted",
+                          "content": "系統參考",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "i131O",
+                      "name": "Mobile 匯率值組｜CNY",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "g7M8H",
+                          "name": "Mobile 匯率值｜CNY",
+                          "fill": "$text",
+                          "content": "4.38",
+                          "fontFamily": "$font",
+                          "fontSize": 14,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ld45u",
+                          "name": "Mobile 匯率單位｜CNY",
+                          "fill": "$text-muted",
+                          "content": "TWD",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "jqNSV",
+              "name": "Mobile 自訂匯率按鈕",
+              "width": "fill_container",
+              "height": 42,
+              "cornerRadius": 9,
+              "stroke": "$accent",
+              "strokeWidth": 1,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "OPSR4",
+                  "name": "Mobile 自訂匯率文字",
+                  "fill": "$accent",
+                  "content": "設定自訂匯率",
+                  "fontFamily": "$font",
+                  "fontSize": 12,
+                  "fontWeight": "700"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "jIDJl",
+              "name": "Mobile 匯率說明",
+              "width": "fill_container",
+              "fill": "$surface-muted",
+              "cornerRadius": 10,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "y6Uie",
+                  "name": "Mobile 匯率說明文字",
+                  "fill": "$text-muted",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "只影響顯示與統計換算，不會變更原始交易金額。",
+                  "lineHeight": 1.4,
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "iJuAK",
+          "name": "Mobile 主要底部導覽",
+          "width": "fill_container",
+          "height": 76,
+          "fill": "$text",
+          "stroke": "#FFFFFF1A",
+          "strokeWidth": {
+            "top": 1
+          },
+          "gap": 4,
+          "padding": [
+            7,
+            8,
+            10,
+            8
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "KKH2x",
+              "name": "Mobile 底部導覽｜總覽",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "PN2DC",
+                  "name": "Mobile 底部圖示｜總覽",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "RsUzI",
+                  "name": "Mobile 底部文字｜總覽",
+                  "fill": "#FFFFFFA6",
+                  "content": "總覽",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "wgzKN",
+              "name": "Mobile 底部導覽｜資產",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "d7nTra",
+                  "name": "Mobile 底部圖示｜資產",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "mgAGU",
+                  "name": "Mobile 底部文字｜資產",
+                  "fill": "#FFFFFFA6",
+                  "content": "資產",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "BGbD7",
+              "name": "Mobile 底部導覽｜活動",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "GH5HB",
+                  "name": "Mobile 底部圖示｜活動",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "SVinj",
+                  "name": "Mobile 底部文字｜活動",
+                  "fill": "#FFFFFFA6",
+                  "content": "活動",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "c2gSQ",
+              "name": "Mobile 底部導覽｜更多",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF1A",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "T7V1Qv",
+                  "name": "Mobile 底部圖示｜更多",
+                  "fill": "#FFFFFF",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "i6IdgK",
+                  "name": "Mobile 底部文字｜更多",
+                  "fill": "#FFFFFF",
+                  "content": "更多",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "g84tnu",
+      "x": 0,
+      "y": 4576,
+      "name": "Desktop｜分類規則",
+      "clip": true,
+      "width": 1440,
+      "height": 1024,
+      "fill": "$bg",
+      "children": [
+        {
+          "type": "frame",
+          "id": "uIkl2",
+          "name": "Desktop 全域導覽",
+          "width": 240,
+          "height": "fill_container",
+          "fill": "$text",
+          "layout": "vertical",
+          "gap": 22,
+          "padding": [
+            28,
+            24
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "g6JUT",
+              "name": "Taiwan Fin Hub 品牌",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 7,
+              "padding": [
+                0,
+                8
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "PlST9",
+                  "name": "Taiwan Fin Hub 標題",
+                  "fill": "#FFFFFF",
+                  "content": "Taiwan Fin Hub",
+                  "fontFamily": "$font",
+                  "fontSize": 19,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "MSDCZ",
+                  "name": "Wealth OS 標籤",
+                  "fill": "$accent",
+                  "content": "WEALTH OS",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1.6
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "BAl7r",
+              "name": "Desktop 主要導覽清單",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 6,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "jQYOi",
+                  "name": "全域導覽｜總覽",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "mfFkh",
+                      "name": "全域導覽圖示｜總覽",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "Ro3U8",
+                      "name": "全域導覽文字｜總覽",
+                      "fill": "#FFFFFFA6",
+                      "content": "總覽",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "XV9LA",
+                  "name": "全域導覽｜資產",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "zEhYa",
+                      "name": "全域導覽圖示｜資產",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "G2Hzhw",
+                      "name": "全域導覽文字｜資產",
+                      "fill": "#FFFFFFA6",
+                      "content": "資產",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "y65Ui",
+                  "name": "全域導覽｜活動",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "E8udAV",
+                      "name": "全域導覽圖示｜活動",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "SO8JZ",
+                      "name": "全域導覽文字｜活動",
+                      "fill": "#FFFFFFA6",
+                      "content": "活動",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HVlji",
+                  "name": "全域導覽｜發票",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "DG2lF",
+                      "name": "全域導覽圖示｜發票",
+                      "fill": "#FFFFFF66",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "H9rD7",
+                      "name": "全域導覽文字｜發票",
+                      "fill": "#FFFFFFA6",
+                      "content": "發票",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "PUnD4",
+                  "name": "全域導覽｜設定",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#FFFFFF1A",
+                  "cornerRadius": 8,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 5,
+                      "id": "Y6xQWS",
+                      "name": "全域導覽圖示｜設定",
+                      "fill": "#FFFFFF",
+                      "width": 20,
+                      "height": 20
+                    },
+                    {
+                      "type": "text",
+                      "id": "kNws3",
+                      "name": "全域導覽文字｜設定",
+                      "fill": "#FFFFFF",
+                      "content": "設定",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Racyq",
+          "name": "Desktop 設定應用內容",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$bg",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "h2oOq",
+              "name": "Desktop 設定頁首",
+              "width": "fill_container",
+              "height": 116,
+              "padding": [
+                0,
+                32
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "mMh6E",
+                  "name": "Desktop 設定標題組",
+                  "layout": "vertical",
+                  "gap": 7,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "V2NCV",
+                      "name": "Desktop 設定標題",
+                      "fill": "$text",
+                      "content": "設定",
+                      "fontFamily": "$font",
+                      "fontSize": 30,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "M6OXno",
+                      "name": "Desktop 設定描述",
+                      "fill": "$text-muted",
+                      "content": "管理資料來源、同步排程、匯率與交易分類。",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "SY5di",
+                  "name": "Desktop 頁首動作",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "gI2Ip",
+                      "name": "隱藏金額按鈕",
+                      "width": 40,
+                      "height": 40,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 20,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 6,
+                          "id": "CEd0Z",
+                          "name": "隱藏金額圖示",
+                          "width": 17,
+                          "height": 12,
+                          "stroke": "$text-muted",
+                          "strokeWidth": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Enz9v",
+                      "name": "重新整理按鈕",
+                      "height": 40,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 20,
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        15
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 7,
+                          "id": "WPDOA",
+                          "name": "重新整理圖示",
+                          "width": 14,
+                          "height": 14,
+                          "stroke": "$text-muted",
+                          "strokeWidth": 1
+                        },
+                        {
+                          "type": "text",
+                          "id": "AJtLA",
+                          "name": "重新整理文字",
+                          "fill": "$text",
+                          "content": "重新整理",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sFFHB",
+              "name": "Desktop 設定水平次導覽",
+              "width": "fill_container",
+              "height": 54,
+              "fill": "$surface",
+              "stroke": "$border",
+              "strokeWidth": {
+                "top": 1,
+                "bottom": 1
+              },
+              "gap": 6,
+              "padding": [
+                0,
+                32
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "B9YP0U",
+                  "name": "設定分頁｜總覽",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "z4URF",
+                      "name": "設定分頁文字｜總覽",
+                      "fill": "$text-muted",
+                      "content": "總覽",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "eI41w",
+                  "name": "設定分頁｜資料來源",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "bLBTn",
+                      "name": "設定分頁文字｜資料來源",
+                      "fill": "$text-muted",
+                      "content": "資料來源",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "bnXC7",
+                  "name": "設定分頁｜同步與通知",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "moTFT",
+                      "name": "設定分頁文字｜同步與通知",
+                      "fill": "$text-muted",
+                      "content": "同步與通知",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "tWiVT",
+                  "name": "設定分頁｜匯率",
+                  "height": 36,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "S7XF4b",
+                      "name": "設定分頁文字｜匯率",
+                      "fill": "$text-muted",
+                      "content": "匯率",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "j018u",
+                  "name": "設定分頁｜分類規則",
+                  "height": 36,
+                  "fill": "$surface-muted",
+                  "cornerRadius": 8,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "lXhas",
+                      "name": "設定分頁文字｜分類規則",
+                      "fill": "$accent",
+                      "content": "分類規則",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "s9wSyM",
+              "name": "Desktop 分類規則內容",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 18,
+              "padding": [
+                24,
+                32
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "n1G7z",
+                  "name": "分類規則頁標題列",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "JUDAo",
+                      "name": "分類規則標題文字",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "pdZt6",
+                          "name": "分類規則標題",
+                          "fill": "$text",
+                          "content": "分類規則",
+                          "fontFamily": "$font",
+                          "fontSize": 23,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "x0BAs",
+                          "name": "分類規則說明",
+                          "fill": "$text-muted",
+                          "content": "依照優先順序，自動為銀行交易套用分類與計算設定。",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "LFwfU",
+                      "name": "新增分類規則按鈕",
+                      "height": 38,
+                      "fill": "$accent",
+                      "cornerRadius": 9,
+                      "padding": [
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "bAV7f",
+                          "name": "新增分類規則文字",
+                          "fill": "#FFFFFF",
+                          "content": "＋ 新增規則",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "t0GVB",
+                  "name": "分類規則摘要列",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "YBDFY",
+                      "name": "分類規則總數",
+                      "width": 370,
+                      "height": 72,
+                      "fill": "$surface",
+                      "cornerRadius": "$radius",
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "layout": "vertical",
+                      "gap": 5,
+                      "padding": 14,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "cRWqi",
+                          "name": "分類規則總數標籤",
+                          "fill": "$text-muted",
+                          "content": "規則總數",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Fzpvt",
+                          "name": "分類規則總數值",
+                          "fill": "$text",
+                          "content": "12",
+                          "fontFamily": "$font",
+                          "fontSize": 18,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kKG79",
+                      "name": "分類規則啟用數",
+                      "width": 370,
+                      "height": 72,
+                      "fill": "$surface",
+                      "cornerRadius": "$radius",
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "layout": "vertical",
+                      "gap": 5,
+                      "padding": 14,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "I6VDP",
+                          "name": "分類規則啟用標籤",
+                          "fill": "$text-muted",
+                          "content": "已啟用",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ZUO2t",
+                          "name": "分類規則啟用值",
+                          "fill": "$positive",
+                          "content": "10",
+                          "fontFamily": "$font",
+                          "fontSize": 18,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "iO5RT",
+                      "name": "分類規則最近命中",
+                      "width": 372,
+                      "height": 72,
+                      "fill": "$surface-muted",
+                      "cornerRadius": "$radius",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "padding": 14,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XUduG",
+                          "name": "分類規則命中標籤",
+                          "fill": "$text-muted",
+                          "content": "最近套用",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Qqm7O",
+                          "name": "分類規則命中值",
+                          "fill": "$text",
+                          "content": "今天 24 筆",
+                          "fontFamily": "$font",
+                          "fontSize": 18,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "my8AS",
+                  "name": "分類規則雙欄",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 18,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "c8K4H",
+                      "name": "分類規則清單",
+                      "width": 690,
+                      "height": "fill_container",
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Whzyb",
+                          "name": "分類規則列｜薪資入帳",
+                          "width": "fill_container",
+                          "height": 86,
+                          "fill": "$surface",
+                          "cornerRadius": "$radius",
+                          "stroke": "$border",
+                          "strokeWidth": 1,
+                          "gap": 14,
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "kMF1s",
+                              "name": "規則順序｜薪資入帳",
+                              "width": 28,
+                              "height": 28,
+                              "fill": "$surface-muted",
+                              "cornerRadius": 8,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "NWNFF",
+                                  "name": "規則順序文字｜薪資入帳",
+                                  "fill": "$text-muted",
+                                  "content": "1",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "sr8Zw",
+                              "name": "規則主內容｜薪資入帳",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 5,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "BgRfz",
+                                  "name": "規則名稱｜薪資入帳",
+                                  "fill": "$text",
+                                  "content": "薪資入帳",
+                                  "fontFamily": "$font",
+                                  "fontSize": 14,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "z1Cn1",
+                                  "name": "規則條件｜薪資入帳",
+                                  "fill": "$text-muted",
+                                  "content": "說明包含「薪資」或「SALARY」",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "wQMZy",
+                                  "name": "規則結果｜薪資入帳",
+                                  "fill": "$accent",
+                                  "content": "→ 分類：收入／薪資",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "nsRqR",
+                              "name": "規則狀態｜薪資入帳",
+                              "width": 42,
+                              "height": 24,
+                              "fill": "$accent",
+                              "cornerRadius": 12,
+                              "padding": 3,
+                              "justifyContent": "end",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "atyty",
+                                  "name": "規則狀態圓點｜薪資入帳",
+                                  "fill": "$surface",
+                                  "width": 18,
+                                  "height": 18
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "U5Rsqn",
+                              "name": "規則更多｜薪資入帳",
+                              "fill": "$text-muted",
+                              "content": "•••",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "t1Bsi",
+                          "name": "分類規則列｜超商消費",
+                          "width": "fill_container",
+                          "height": 86,
+                          "fill": "$surface",
+                          "cornerRadius": "$radius",
+                          "stroke": "$border",
+                          "strokeWidth": 1,
+                          "gap": 14,
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "c5FbS",
+                              "name": "規則順序｜超商消費",
+                              "width": 28,
+                              "height": 28,
+                              "fill": "$surface-muted",
+                              "cornerRadius": 8,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "e1yiit",
+                                  "name": "規則順序文字｜超商消費",
+                                  "fill": "$text-muted",
+                                  "content": "2",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "c0chXI",
+                              "name": "規則主內容｜超商消費",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 5,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "grBkm",
+                                  "name": "規則名稱｜超商消費",
+                                  "fill": "$text",
+                                  "content": "超商消費",
+                                  "fontFamily": "$font",
+                                  "fontSize": 14,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "FB1Pq",
+                                  "name": "規則條件｜超商消費",
+                                  "fill": "$text-muted",
+                                  "content": "商戶包含 7-ELEVEN、全家、萊爾富",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "s89k6g",
+                                  "name": "規則結果｜超商消費",
+                                  "fill": "$accent",
+                                  "content": "→ 分類：日常／餐飲",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "OzJVO",
+                              "name": "規則狀態｜超商消費",
+                              "width": 42,
+                              "height": 24,
+                              "fill": "$accent",
+                              "cornerRadius": 12,
+                              "padding": 3,
+                              "justifyContent": "end",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "jnBOj",
+                                  "name": "規則狀態圓點｜超商消費",
+                                  "fill": "$surface",
+                                  "width": 18,
+                                  "height": 18
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "Xkvc7",
+                              "name": "規則更多｜超商消費",
+                              "fill": "$text-muted",
+                              "content": "•••",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "iT7fv",
+                          "name": "分類規則列｜轉帳排除計算",
+                          "width": "fill_container",
+                          "height": 86,
+                          "fill": "$surface",
+                          "cornerRadius": "$radius",
+                          "stroke": "$border",
+                          "strokeWidth": 1,
+                          "gap": 14,
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "nHXq6",
+                              "name": "規則順序｜轉帳排除計算",
+                              "width": 28,
+                              "height": 28,
+                              "fill": "$surface-muted",
+                              "cornerRadius": 8,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "MTSng",
+                                  "name": "規則順序文字｜轉帳排除計算",
+                                  "fill": "$text-muted",
+                                  "content": "3",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "kFQHl",
+                              "name": "規則主內容｜轉帳排除計算",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 5,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "jklK7",
+                                  "name": "規則名稱｜轉帳排除計算",
+                                  "fill": "$text",
+                                  "content": "轉帳排除計算",
+                                  "fontFamily": "$font",
+                                  "fontSize": 14,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "fM1Sm",
+                                  "name": "規則條件｜轉帳排除計算",
+                                  "fill": "$text-muted",
+                                  "content": "說明包含「轉帳」",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Ulbh5",
+                                  "name": "規則結果｜轉帳排除計算",
+                                  "fill": "$accent",
+                                  "content": "→ 排除收支統計",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "jJ92L",
+                              "name": "規則狀態｜轉帳排除計算",
+                              "width": 42,
+                              "height": 24,
+                              "fill": "$accent",
+                              "cornerRadius": 12,
+                              "padding": 3,
+                              "justifyContent": "end",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "arIfP",
+                                  "name": "規則狀態圓點｜轉帳排除計算",
+                                  "fill": "$surface",
+                                  "width": 18,
+                                  "height": 18
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "IeXdE",
+                              "name": "規則更多｜轉帳排除計算",
+                              "fill": "$text-muted",
+                              "content": "•••",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "TNVJo",
+                          "name": "分類規則列｜交通費",
+                          "width": "fill_container",
+                          "height": 86,
+                          "fill": "$surface",
+                          "cornerRadius": "$radius",
+                          "stroke": "$border",
+                          "strokeWidth": 1,
+                          "gap": 14,
+                          "padding": [
+                            0,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "GnTUB",
+                              "name": "規則順序｜交通費",
+                              "width": 28,
+                              "height": 28,
+                              "fill": "$surface-muted",
+                              "cornerRadius": 8,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "f3dWx",
+                                  "name": "規則順序文字｜交通費",
+                                  "fill": "$text-muted",
+                                  "content": "4",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "UBO85",
+                              "name": "規則主內容｜交通費",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 5,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "pKtM4",
+                                  "name": "規則名稱｜交通費",
+                                  "fill": "$text",
+                                  "content": "交通費",
+                                  "fontFamily": "$font",
+                                  "fontSize": 14,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "aqUMF",
+                                  "name": "規則條件｜交通費",
+                                  "fill": "$text-muted",
+                                  "content": "商戶包含 UBER、台灣大車隊",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "NfTqd",
+                                  "name": "規則結果｜交通費",
+                                  "fill": "$accent",
+                                  "content": "→ 分類：交通",
+                                  "fontFamily": "$font",
+                                  "fontSize": 10,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "WhC2k",
+                              "name": "規則狀態｜交通費",
+                              "width": 42,
+                              "height": 24,
+                              "fill": "$border",
+                              "cornerRadius": 12,
+                              "padding": 3,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "J9ubpU",
+                                  "name": "規則狀態圓點｜交通費",
+                                  "fill": "$surface",
+                                  "width": 18,
+                                  "height": 18
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "Imrl4",
+                              "name": "規則更多｜交通費",
+                              "fill": "$text-muted",
+                              "content": "•••",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UfvXh",
+                      "name": "分類規則說明面板",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "fill": "$surface",
+                      "cornerRadius": "$radius",
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "layout": "vertical",
+                      "gap": 16,
+                      "padding": 20,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Z79Rv",
+                          "name": "規則運作標題",
+                          "fill": "$text",
+                          "content": "規則如何運作",
+                          "fontFamily": "$font",
+                          "fontSize": 16,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "K7rsZz",
+                          "name": "規則運作說明",
+                          "fill": "$text-muted",
+                          "content": "同步完成後，系統由上到下檢查規則。第一個符合條件的規則會套用到交易。",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qFUWO",
+                          "name": "規則優先順序說明",
+                          "width": "fill_container",
+                          "fill": "$surface-muted",
+                          "cornerRadius": 9,
+                          "layout": "vertical",
+                          "gap": 6,
+                          "padding": 13,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "gstgx",
+                              "name": "規則優先標題",
+                              "fill": "$text",
+                              "content": "優先順序很重要",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "qU8Xa",
+                              "name": "規則優先內容",
+                              "fill": "$text-muted",
+                              "content": "將條件較精確的規則放在前面；可拖曳調整順序。",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "XC0Zq",
+                          "name": "重新套用規則按鈕",
+                          "width": "fill_container",
+                          "height": 40,
+                          "cornerRadius": 8,
+                          "stroke": "$accent",
+                          "strokeWidth": 1,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "gef1r",
+                              "name": "重新套用規則文字",
+                              "fill": "$accent",
+                              "content": "重新套用到既有交易",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "AmVvA",
+      "x": 1560,
+      "y": 4576,
+      "name": "Mobile｜分類規則",
+      "clip": true,
+      "width": 390,
+      "height": 844,
+      "fill": "$bg",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "gU3xt",
+          "name": "Mobile 分類規則頁首",
+          "width": "fill_container",
+          "height": 72,
+          "fill": "$surface",
+          "stroke": "$border",
+          "strokeWidth": {
+            "bottom": 1
+          },
+          "gap": 12,
+          "padding": [
+            0,
+            18
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "P9RzG",
+              "name": "Mobile 返回箭頭｜分類規則",
+              "fill": "$text",
+              "content": "‹",
+              "fontFamily": "$font",
+              "fontSize": 27,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "Bcjhw",
+              "name": "Mobile 頁面標題｜分類規則",
+              "fill": "$text",
+              "content": "分類規則",
+              "fontFamily": "$font",
+              "fontSize": 19,
+              "fontWeight": "700"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "zaUFr",
+          "name": "Mobile 分類規則內容",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 11,
+          "padding": [
+            14,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "tCtWh",
+              "name": "Mobile 分類規則摘要",
+              "width": "fill_container",
+              "height": 72,
+              "fill": "$surface",
+              "cornerRadius": "$radius",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "padding": 14,
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "jifTj",
+                  "name": "Mobile 分類規則摘要文字",
+                  "layout": "vertical",
+                  "gap": 5,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "oXFUX",
+                      "name": "Mobile 規則摘要標題",
+                      "fill": "$text",
+                      "content": "12 個分類規則",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xVkmV",
+                      "name": "Mobile 規則摘要說明",
+                      "fill": "$text-muted",
+                      "content": "依照順序自動套用",
+                      "fontFamily": "$font",
+                      "fontSize": 10,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "yDfuV",
+                  "name": "Mobile 規則摘要狀態",
+                  "fill": "$positive",
+                  "content": "10 個啟用",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "700"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "GHXk0",
+              "name": "Mobile 分類規則清單",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "p4HLUA",
+                  "name": "Mobile 分類規則列｜薪資入帳",
+                  "width": "fill_container",
+                  "height": 76,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "gap": 11,
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "E6Dvo",
+                      "name": "Mobile 規則順序｜薪資入帳",
+                      "width": 26,
+                      "height": 26,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 7,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "apKop",
+                          "name": "Mobile 規則順序文字｜薪資入帳",
+                          "fill": "$text-muted",
+                          "content": "1",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "NXt5u",
+                      "name": "Mobile 規則文字｜薪資入帳",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "AaMq3",
+                          "name": "Mobile 規則名稱｜薪資入帳",
+                          "fill": "$text",
+                          "content": "薪資入帳",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "sEgRX",
+                          "name": "Mobile 規則結果｜薪資入帳",
+                          "fill": "$accent",
+                          "content": "收入／薪資",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "RYOKT",
+                      "name": "Mobile 規則開關｜薪資入帳",
+                      "width": 38,
+                      "height": 22,
+                      "fill": "$accent",
+                      "cornerRadius": 11,
+                      "padding": 3,
+                      "justifyContent": "end",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "gnOJl",
+                          "name": "Mobile 規則圓點｜薪資入帳",
+                          "fill": "$surface",
+                          "width": 16,
+                          "height": 16
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "buygN",
+                  "name": "Mobile 分類規則列｜超商消費",
+                  "width": "fill_container",
+                  "height": 76,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "gap": 11,
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "NV4l7",
+                      "name": "Mobile 規則順序｜超商消費",
+                      "width": 26,
+                      "height": 26,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 7,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "T5hji",
+                          "name": "Mobile 規則順序文字｜超商消費",
+                          "fill": "$text-muted",
+                          "content": "2",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BwqKS",
+                      "name": "Mobile 規則文字｜超商消費",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "K4YEBx",
+                          "name": "Mobile 規則名稱｜超商消費",
+                          "fill": "$text",
+                          "content": "超商消費",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "gJlyH",
+                          "name": "Mobile 規則結果｜超商消費",
+                          "fill": "$accent",
+                          "content": "日常／餐飲",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FCntu",
+                      "name": "Mobile 規則開關｜超商消費",
+                      "width": 38,
+                      "height": 22,
+                      "fill": "$accent",
+                      "cornerRadius": 11,
+                      "padding": 3,
+                      "justifyContent": "end",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "J8zbmI",
+                          "name": "Mobile 規則圓點｜超商消費",
+                          "fill": "$surface",
+                          "width": 16,
+                          "height": 16
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jQny2",
+                  "name": "Mobile 分類規則列｜轉帳排除計算",
+                  "width": "fill_container",
+                  "height": 76,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "gap": 11,
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "F87GLF",
+                      "name": "Mobile 規則順序｜轉帳排除計算",
+                      "width": 26,
+                      "height": 26,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 7,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "axBHS",
+                          "name": "Mobile 規則順序文字｜轉帳排除計算",
+                          "fill": "$text-muted",
+                          "content": "3",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "m1bNJG",
+                      "name": "Mobile 規則文字｜轉帳排除計算",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "lHomv",
+                          "name": "Mobile 規則名稱｜轉帳排除計算",
+                          "fill": "$text",
+                          "content": "轉帳排除計算",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "F7H0U",
+                          "name": "Mobile 規則結果｜轉帳排除計算",
+                          "fill": "$accent",
+                          "content": "排除收支統計",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "fglUl",
+                      "name": "Mobile 規則開關｜轉帳排除計算",
+                      "width": 38,
+                      "height": 22,
+                      "fill": "$accent",
+                      "cornerRadius": 11,
+                      "padding": 3,
+                      "justifyContent": "end",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "EOTin",
+                          "name": "Mobile 規則圓點｜轉帳排除計算",
+                          "fill": "$surface",
+                          "width": 16,
+                          "height": 16
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "n4tv5",
+                  "name": "Mobile 分類規則列｜交通費",
+                  "width": "fill_container",
+                  "height": 76,
+                  "stroke": "$border",
+                  "strokeWidth": {
+                    "top": 1
+                  },
+                  "gap": 11,
+                  "padding": [
+                    0,
+                    13
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "LTfGz",
+                      "name": "Mobile 規則順序｜交通費",
+                      "width": 26,
+                      "height": 26,
+                      "fill": "$surface-muted",
+                      "cornerRadius": 7,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "cLfuR",
+                          "name": "Mobile 規則順序文字｜交通費",
+                          "fill": "$text-muted",
+                          "content": "4",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Aj9Zm",
+                      "name": "Mobile 規則文字｜交通費",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "gonWO",
+                          "name": "Mobile 規則名稱｜交通費",
+                          "fill": "$text",
+                          "content": "交通費",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "dQoIf",
+                          "name": "Mobile 規則結果｜交通費",
+                          "fill": "$accent",
+                          "content": "交通",
+                          "fontFamily": "$font",
+                          "fontSize": 9,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QF5CA",
+                      "name": "Mobile 規則開關｜交通費",
+                      "width": 38,
+                      "height": 22,
+                      "fill": "$border",
+                      "cornerRadius": 11,
+                      "padding": 3,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "eMjnx",
+                          "name": "Mobile 規則圓點｜交通費",
+                          "fill": "$surface",
+                          "width": 16,
+                          "height": 16
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "GGRkS",
+              "name": "Mobile 新增分類規則按鈕",
+              "width": "fill_container",
+              "height": 42,
+              "fill": "$accent",
+              "cornerRadius": 9,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "A0UIaH",
+                  "name": "Mobile 新增分類規則文字",
+                  "fill": "#FFFFFF",
+                  "content": "＋ 新增規則",
+                  "fontFamily": "$font",
+                  "fontSize": 12,
+                  "fontWeight": "700"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dVHat",
+              "name": "Mobile 規則排序提示",
+              "width": "fill_container",
+              "fill": "$surface-muted",
+              "cornerRadius": 10,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "E2exf",
+                  "name": "Mobile 規則排序提示文字",
+                  "fill": "$text-muted",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "規則會由上到下檢查；拖曳即可調整優先順序。",
+                  "lineHeight": 1.4,
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "yrMJ4",
+              "name": "Mobile 重新套用規則動作",
+              "width": "fill_container",
+              "height": 40,
+              "cornerRadius": 8,
+              "stroke": "$accent",
+              "strokeWidth": 1,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "sj3wP",
+                  "name": "Mobile 重新套用規則文字",
+                  "fill": "$accent",
+                  "content": "重新套用到既有交易",
+                  "fontFamily": "$font",
+                  "fontSize": 11,
+                  "fontWeight": "700"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "TMy39",
+          "name": "Mobile 主要底部導覽",
+          "width": "fill_container",
+          "height": 76,
+          "fill": "$text",
+          "stroke": "#FFFFFF1A",
+          "strokeWidth": {
+            "top": 1
+          },
+          "gap": 4,
+          "padding": [
+            7,
+            8,
+            10,
+            8
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "lG8US",
+              "name": "Mobile 底部導覽｜總覽",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "MFQIe",
+                  "name": "Mobile 底部圖示｜總覽",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "W6WBi8",
+                  "name": "Mobile 底部文字｜總覽",
+                  "fill": "#FFFFFFA6",
+                  "content": "總覽",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "cU5KZ",
+              "name": "Mobile 底部導覽｜資產",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "gGAsf",
+                  "name": "Mobile 底部圖示｜資產",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "vzzHb",
+                  "name": "Mobile 底部文字｜資產",
+                  "fill": "#FFFFFFA6",
+                  "content": "資產",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "xTqff",
+              "name": "Mobile 底部導覽｜活動",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "svNyK",
+                  "name": "Mobile 底部圖示｜活動",
+                  "fill": "#FFFFFF99",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "ZuXw5",
+                  "name": "Mobile 底部文字｜活動",
+                  "fill": "#FFFFFFA6",
+                  "content": "活動",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "BezKi",
+              "name": "Mobile 底部導覽｜更多",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF1A",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 5,
+                  "id": "reQnn",
+                  "name": "Mobile 底部圖示｜更多",
+                  "fill": "#FFFFFF",
+                  "width": 19,
+                  "height": 19
+                },
+                {
+                  "type": "text",
+                  "id": "i389u",
+                  "name": "Mobile 底部文字｜更多",
+                  "fill": "#FFFFFF",
+                  "content": "更多",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "bg": {
+      "type": "color",
+      "value": "#F7F7F2"
+    },
+    "surface": {
+      "type": "color",
+      "value": "#FFFFFF"
+    },
+    "surface-muted": {
+      "type": "color",
+      "value": "#ECEEEA"
+    },
+    "text": {
+      "type": "color",
+      "value": "#1F2933"
+    },
+    "text-muted": {
+      "type": "color",
+      "value": "#66727C"
+    },
+    "border": {
+      "type": "color",
+      "value": "#D8DDDF"
+    },
+    "accent": {
+      "type": "color",
+      "value": "#3E6F7C"
+    },
+    "positive": {
+      "type": "color",
+      "value": "#556B2F"
+    },
+    "negative": {
+      "type": "color",
+      "value": "#B75B45"
+    },
+    "font": {
+      "type": "string",
+      "value": "Inter"
+    },
+    "radius": {
+      "type": "number",
+      "value": 12
+    },
+    "space": {
+      "type": "number",
+      "value": 16
+    }
+  },
+  "fileToken": "5d3ef864-7b10-44a8-9994-b54db2b26fee"
+}


### PR DESCRIPTION
## 變更內容

- 以設定總覽＋分類子頁整理設定功能，新增桌面資料來源左右欄與同步／匯率／分類子頁呈現。
- 保留資料健康度、資料來源與連接器、預設同步排程、通知、匯率、分類規則等既有功能，並加入 `design/settings-redesign.pen`。
- 放大設定區主要文字與狀態資訊，讓來源同步時間、匯率、分類規則摘要更易讀；匯率摘要顯示所有 API 可用幣別。
- 手機版保留 More 導覽，並修正放大字級造成的 390px 橫向溢位。

## 背景

原設定總覽在桌面上使用過多 10／11px 輔助文字，來源清單及分類規則摘要不易閱讀；桌面／手機資訊架構也需要對齊已確認的設計方向。

## 驗證

- `npm run typecheck`
- `npm run test:unit -w @taiwan-fin-hub/web`
- `npm run build -w @taiwan-fin-hub/web`
- `npm run format:check`
- `git diff --check`
- `npm run test:e2e -w @taiwan-fin-hub/web -- --grep "responsive shell|mobile bottom navigation"`（2 passed）
- Svelte autofixer：此次修改的 Svelte 元件皆無 issues／suggestions