### PR TITLE
完善分類規則並新增活動月份範圍查詢

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -104,7 +104,7 @@ test("keeps long recent activity inside the overview card", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
-  await page.route("**/api/bank", async (route) => {
+  await page.route("**/api/bank**", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -200,7 +200,7 @@ test("excludes a bank transaction from activity calculations and restores it", a
   let excludedFromCalculation = false;
   const month = new Date().toISOString().slice(0, 7);
 
-  await page.route("**/api/bank", async (route) => {
+  await page.route("**/api/bank**", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -390,7 +390,7 @@ test("merges a matching invoice and counts an unmatched invoice as expense", asy
   page,
 }) => {
   const month = new Date().toISOString().slice(0, 7);
-  await page.route("**/api/bank", async (route) => {
+  await page.route("**/api/bank**", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -414,7 +414,7 @@ test("merges a matching invoice and counts an unmatched invoice as expense", asy
             sourceId: "transaction-source-1",
             postedDate: `${month}-10`,
             authorizedAt: `${month}-10T12:00:00.000Z`,
-            amount: 860,
+            amount: -860,
             currency: "TWD",
             description: "信用卡消費",
             counterparty: "好食餐飲",
@@ -430,7 +430,7 @@ test("merges a matching invoice and counts an unmatched invoice as expense", asy
       }),
     });
   });
-  await page.route("**/api/invoices", async (route) => {
+  await page.route("**/api/invoices**", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -526,7 +526,7 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
     }
     await route.fulfill({ json: mappings });
   });
-  await page.route("**/api/bank", async (route) => {
+  await page.route("**/api/bank**", async (route) => {
     await route.fulfill({
       json: {
         accounts: [
@@ -581,7 +581,7 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
       },
     });
   });
-  await page.route("**/api/invoices", async (route) => {
+  await page.route("**/api/invoices**", async (route) => {
     await route.fulfill({
       json: [
         {

--- a/apps/web/src/app/App.svelte
+++ b/apps/web/src/app/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { Ellipsis, Eye, EyeOff, RefreshCw } from "@lucide/svelte";
+  import { Ellipsis, Eye, EyeOff } from "@lucide/svelte";
   import { QueryClientProvider } from "@tanstack/svelte-query";
   import Activity from "@/features/activity/ActivityPage.svelte";
   import Assets from "@/features/assets/AssetsPage.svelte";
@@ -227,12 +227,6 @@
                   size="lg"
                 /></Button
               >
-              {#if primaryView === "settings"}<Button
-                  class="hidden md:inline-flex"
-                  onclick={() => queryClient.invalidateQueries()}
-                  variant="secondary"
-                  ><Icon icon={RefreshCw} size="sm" />重新整理</Button
-                >{/if}
             </div>
           </div>
         </div>

--- a/apps/web/src/data/bank/queries.ts
+++ b/apps/web/src/data/bank/queries.ts
@@ -1,18 +1,57 @@
 import { queryOptions } from "@tanstack/svelte-query";
+import type { CreateQueryOptions } from "@tanstack/svelte-query";
 import type { ApiClient } from "@/shared/api/client";
 import { queryKeys } from "@/shared/api/query-keys";
+import type { MonthRange } from "@/shared/date-range";
 import type { BankData, CreditCardBillRow } from "./types";
 
 type ApiProvider = () => ApiClient;
 
-export const bankQuery = (getApi: ApiProvider) =>
+export const bankRangeQuery = (getApi: ApiProvider, range: MonthRange) =>
   queryOptions({
-    queryKey: queryKeys.bank,
-    queryFn: () => getApi().get<BankData>("/api/bank"),
+    queryKey: queryKeys.bankRange(range.from, range.to),
+    queryFn: () =>
+      getApi().get<BankData>(
+        `/api/bank?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}`,
+      ),
   });
 
-export const creditCardBillsQuery = (getApi: ApiProvider) =>
+export const bankQuery = (
+  getApi: ApiProvider,
+  range?: MonthRange,
+): CreateQueryOptions<BankData> => ({
+  queryKey: range ? queryKeys.bankRange(range.from, range.to) : queryKeys.bank,
+  queryFn: () =>
+    getApi().get<BankData>(
+      range
+        ? `/api/bank?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}`
+        : "/api/bank",
+    ),
+});
+
+export const creditCardBillsRangeQuery = (
+  getApi: ApiProvider,
+  range: MonthRange,
+) =>
   queryOptions({
-    queryKey: queryKeys.bills,
-    queryFn: () => getApi().get<CreditCardBillRow[]>("/api/bank/bills"),
+    queryKey: queryKeys.billsRange(range.from, range.to),
+    queryFn: () =>
+      getApi().get<CreditCardBillRow[]>(
+        `/api/bank/bills?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}`,
+      ),
   });
+
+export const creditCardBillsQuery = (
+  getApi: ApiProvider,
+  range?: MonthRange,
+): CreateQueryOptions<CreditCardBillRow[]> => ({
+  queryKey: range
+    ? queryKeys.billsRange(range.from, range.to)
+    : queryKeys.bills,
+  queryFn: () =>
+    getApi().get<CreditCardBillRow[]>(
+      range
+        ? `/api/bank/bills?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}`
+        : "/api/bank/bills",
+    ),
+});

--- a/apps/web/src/data/investments/queries.ts
+++ b/apps/web/src/data/investments/queries.ts
@@ -1,6 +1,8 @@
 import { queryOptions } from "@tanstack/svelte-query";
+import type { CreateQueryOptions } from "@tanstack/svelte-query";
 import type { ApiClient } from "@/shared/api/client";
 import { queryKeys } from "@/shared/api/query-keys";
+import type { MonthRange } from "@/shared/date-range";
 import type { InvestmentRow, InvestmentTransactionRow } from "./types";
 
 type ApiProvider = () => ApiClient;
@@ -11,9 +13,29 @@ export const investmentsQuery = (getApi: ApiProvider) =>
     queryFn: () => getApi().get<InvestmentRow[]>("/api/investments"),
   });
 
-export const investmentTransactionsQuery = (getApi: ApiProvider) =>
+export const investmentTransactionsRangeQuery = (
+  getApi: ApiProvider,
+  range: MonthRange,
+) =>
   queryOptions({
-    queryKey: queryKeys.investmentTransactions,
+    queryKey: queryKeys.investmentTransactionsRange(range.from, range.to),
     queryFn: () =>
-      getApi().get<InvestmentTransactionRow[]>("/api/investment-transactions"),
+      getApi().get<InvestmentTransactionRow[]>(
+        `/api/investment-transactions?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}`,
+      ),
   });
+
+export const investmentTransactionsQuery = (
+  getApi: ApiProvider,
+  range?: MonthRange,
+): CreateQueryOptions<InvestmentTransactionRow[]> => ({
+  queryKey: range
+    ? queryKeys.investmentTransactionsRange(range.from, range.to)
+    : queryKeys.investmentTransactions,
+  queryFn: () =>
+    getApi().get<InvestmentTransactionRow[]>(
+      range
+        ? `/api/investment-transactions?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}`
+        : "/api/investment-transactions",
+    ),
+});

--- a/apps/web/src/data/invoices/queries.ts
+++ b/apps/web/src/data/invoices/queries.ts
@@ -1,15 +1,35 @@
 import { queryOptions } from "@tanstack/svelte-query";
+import type { CreateQueryOptions } from "@tanstack/svelte-query";
 import type { ApiClient } from "@/shared/api/client";
 import { queryKeys } from "@/shared/api/query-keys";
+import type { MonthRange } from "@/shared/date-range";
 import type { InvoiceRow, InvoiceTransactionPreference } from "./types";
 
 type ApiProvider = () => ApiClient;
 
-export const invoicesQuery = (getApi: ApiProvider) =>
+export const invoicesRangeQuery = (getApi: ApiProvider, range: MonthRange) =>
   queryOptions({
-    queryKey: queryKeys.invoices,
-    queryFn: () => getApi().get<InvoiceRow[]>("/api/invoices"),
+    queryKey: queryKeys.invoicesRange(range.from, range.to),
+    queryFn: () =>
+      getApi().get<InvoiceRow[]>(
+        `/api/invoices?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}`,
+      ),
   });
+
+export const invoicesQuery = (
+  getApi: ApiProvider,
+  range?: MonthRange,
+): CreateQueryOptions<InvoiceRow[]> => ({
+  queryKey: range
+    ? queryKeys.invoicesRange(range.from, range.to)
+    : queryKeys.invoices,
+  queryFn: () =>
+    getApi().get<InvoiceRow[]>(
+      range
+        ? `/api/invoices?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}`
+        : "/api/invoices",
+    ),
+});
 
 export const invoiceTransactionMappingsQuery = (getApi: ApiProvider) =>
   queryOptions({

--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { SvelteDate } from "svelte/reactivity";
   import {
     createMutation,
     createQuery,
@@ -36,13 +35,13 @@
   import { queryKeys } from "@/shared/api/query-keys";
   import type { View } from "@/app/types";
   import { exchangeRatesQuery } from "@/data/assets/queries";
-  import { bankQuery } from "@/data/bank/queries";
+  import { bankRangeQuery } from "@/data/bank/queries";
   import type { BankData, BankTransactionRow } from "@/data/bank/types";
   import { classificationCategoriesQuery } from "@/data/classification/queries";
-  import { investmentTransactionsQuery } from "@/data/investments/queries";
+  import { investmentTransactionsRangeQuery } from "@/data/investments/queries";
   import {
     invoiceTransactionMappingsQuery,
-    invoicesQuery,
+    invoicesRangeQuery,
   } from "@/data/invoices/queries";
   import type {
     InvoiceRow,
@@ -68,21 +67,26 @@
     normalizeFinancialDate,
     rateMap,
   } from "@/shared/format/financial";
+  import { recentMonthRange, recentMonthKeys } from "@/shared/date-range";
   import { swipeBack } from "@/shared/actions/swipe-back";
   let { api, navigate }: { api: ApiClient; navigate: (view: View) => void } =
     $props();
-  const bank = createQuery(bankQuery(() => api));
-  const invoices = createQuery(invoicesQuery(() => api));
+  const initialSelectedMonth = new Date().toISOString().slice(0, 7);
+  let selectedMonth = $state(initialSelectedMonth);
+  const activityRange = recentMonthRange(6);
+  const bank = createQuery(bankRangeQuery(() => api, activityRange));
+  const invoices = createQuery(invoicesRangeQuery(() => api, activityRange));
   const invoiceMappings = createQuery(
     invoiceTransactionMappingsQuery(() => api),
   );
-  const trades = createQuery(investmentTransactionsQuery(() => api));
+  const trades = createQuery(
+    investmentTransactionsRangeQuery(() => api, activityRange),
+  );
   const rates = createQuery(exchangeRatesQuery(() => api));
   const categoryRows = createQuery(classificationCategoriesQuery(() => api));
   const qc = useQueryClient();
   let source = $state<"all" | "bank" | "card" | "invoice">("all");
   let search = $state("");
-  let selectedMonth = $state(new Date().toISOString().slice(0, 7));
   let selectedCategory = $state<{
     flow: "income" | "expense";
     category: string;
@@ -219,18 +223,8 @@
   const detailItem = $derived(
     rawItems.find((item) => activityKey(item) === detailKey),
   );
-  const months = $derived(
-    [
-      ...new Set(
-        rawItems
-          .map((i) => i.date.slice(0, 7))
-          .filter(Boolean)
-          .concat([new Date().toISOString().slice(0, 7)]),
-      ),
-    ]
-      .sort((a, b) => b.localeCompare(a))
-      .slice(0, 12),
-  );
+  const cashFlowMonths = recentMonthKeys(6);
+  const months = [...cashFlowMonths].reverse();
   const monthlyCalculatedItems = $derived(
     rawItems.filter(
       (item) =>
@@ -261,11 +255,6 @@
         (item.status === "pending" || item.categoryId === "other"),
     ).length,
   );
-  const cashFlowMonths = Array.from({ length: 6 }, (_, index) => {
-    const date = new SvelteDate();
-    date.setMonth(date.getMonth() - (5 - index));
-    return date.toISOString().slice(0, 7);
-  });
   const cashFlow = $derived(
     cashFlowMonths.map((month) => {
       const items = rawItems.filter(

--- a/apps/web/src/features/settings/SettingsPage.svelte
+++ b/apps/web/src/features/settings/SettingsPage.svelte
@@ -384,7 +384,7 @@
 
       <section
         aria-label="分類規則摘要"
-        class="hidden min-w-0 gap-3 md:grid md:grid-cols-3"
+        class="hidden min-w-0 gap-3 md:grid md:grid-cols-2"
       >
         <div class="rounded-xl border border-border bg-card p-3.5 shadow-xs">
           <p class="text-sm font-semibold text-muted-foreground">規則總數</p>
@@ -393,10 +393,6 @@
         <div class="rounded-xl border border-border bg-card p-3.5 shadow-xs">
           <p class="text-sm font-semibold text-muted-foreground">已啟用</p>
           <p class="mt-1 text-lg font-bold text-moss">{enabledRuleCount}</p>
-        </div>
-        <div class="rounded-xl bg-muted p-3.5">
-          <p class="text-sm font-semibold text-muted-foreground">最近套用</p>
-          <p class="mt-1 text-lg font-bold">—</p>
         </div>
       </section>
 
@@ -418,13 +414,12 @@
               將條件較精確的規則放在前面；可在下方調整規則順序。
             </p>
           </div>
-          <span
-            class="mt-5 block w-full rounded-lg border border-steel px-3 py-2.5 text-center text-sm font-bold text-steel"
-            >重新套用到既有交易</span
-          >
+          <p class="mt-5 text-sm leading-relaxed text-muted-foreground">
+            儲存規則後，交易資料重新載入時會依目前順序重新判定；已手動分類的交易仍以手動覆寫為準。
+          </p>
         </aside>
       </div>
-      <div class="md:hidden">
+      <div class="w-full min-w-0 md:hidden">
         <ClassificationRulesPanel {api} />
       </div>
     </div>

--- a/apps/web/src/features/settings/components/ClassificationRulesPanel.svelte
+++ b/apps/web/src/features/settings/components/ClassificationRulesPanel.svelte
@@ -4,7 +4,7 @@
     createQuery,
     useQueryClient,
   } from "@tanstack/svelte-query";
-  import { Pencil, Plus } from "@lucide/svelte";
+  import { ChevronDown, ChevronUp, Pencil, Plus } from "@lucide/svelte";
   import Card from "@/shared/ui/Card.svelte";
   import CardHeader from "@/shared/ui/CardHeader.svelte";
   import CardContent from "@/shared/ui/CardContent.svelte";
@@ -76,6 +76,16 @@
     qc.invalidateQueries({ queryKey: queryKeys.bank });
   }
 
+  function editableRuleIndex(ruleId: string) {
+    return ($rules.data ?? [])
+      .filter((rule) => !rule.isSystem)
+      .findIndex((rule) => rule.id === ruleId);
+  }
+
+  const editableRuleCount = $derived(
+    ($rules.data ?? []).filter((rule) => !rule.isSystem).length,
+  );
+
   const addCategory = createMutation({
     mutationFn: () =>
       api.post<ClassificationCategoryRow>("/api/classification/categories", {
@@ -126,9 +136,35 @@
     mutationFn: (id: string) => api.delete(`/api/classification/rules/${id}`),
     onSuccess: invalidateRuleResults,
   });
+  const reorder = createMutation({
+    mutationFn: (ruleIds: string[]) =>
+      api.put("/api/classification/rules/order", { ruleIds }),
+    onSuccess: invalidateRuleResults,
+  });
+
+  function moveRule(ruleId: string, direction: -1 | 1) {
+    const editableRules = ($rules.data ?? []).filter((rule) => !rule.isSystem);
+    const currentIndex = editableRules.findIndex(({ id }) => id === ruleId);
+    const nextIndex = currentIndex + direction;
+    if (
+      currentIndex < 0 ||
+      nextIndex < 0 ||
+      nextIndex >= editableRules.length
+    ) {
+      return;
+    }
+
+    const nextOrder = editableRules.map(({ id }) => id);
+    const currentId = nextOrder[currentIndex];
+    const nextId = nextOrder[nextIndex];
+    if (!currentId || !nextId) return;
+    nextOrder[currentIndex] = nextId;
+    nextOrder[nextIndex] = currentId;
+    $reorder.mutate(nextOrder);
+  }
 </script>
 
-<Card>
+<Card class="w-full min-w-0">
   <CardHeader class="gap-4 sm:flex-row sm:items-start sm:justify-between">
     <div>
       <h2 class="text-lg font-semibold">分類規則</h2>
@@ -320,7 +356,7 @@
                 </div>
               </form>
             {:else}
-              <div class="flex items-start gap-3">
+              <div class="flex min-w-0 flex-wrap items-start gap-3">
                 <Checkbox
                   aria-label={`${rule.enabled ? "停用" : "啟用"}${categoryLabels[rule.categoryId] ?? rule.categoryId}規則`}
                   class="mt-1"
@@ -355,11 +391,37 @@
                   </p>
                 </div>
                 {#if !rule.isSystem}
-                  <div class="flex items-center gap-1">
+                  {@const ruleIndex = editableRuleIndex(rule.id)}
+                  <div
+                    class="flex w-full shrink-0 items-center justify-end gap-1 sm:w-auto"
+                  >
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      aria-label={`將${categoryLabels[rule.categoryId] ?? rule.categoryId}規則上移`}
+                      title="上移"
+                      disabled={$reorder.isPending || ruleIndex <= 0}
+                      onclick={() => moveRule(rule.id, -1)}
+                    >
+                      <ChevronUp />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      aria-label={`將${categoryLabels[rule.categoryId] ?? rule.categoryId}規則下移`}
+                      title="下移"
+                      disabled={$reorder.isPending ||
+                        ruleIndex >= editableRuleCount - 1}
+                      onclick={() => moveRule(rule.id, 1)}
+                    >
+                      <ChevronDown />
+                    </Button>
                     <Button
                       size="sm"
                       variant="ghost"
-                      disabled={$update.isPending || $remove.isPending}
+                      disabled={$update.isPending ||
+                        $remove.isPending ||
+                        $reorder.isPending}
                       onclick={() => startEditing(rule)}
                     >
                       <Pencil class="size-4" />編輯
@@ -381,10 +443,14 @@
       </div>
     {/if}
 
-    {#if $add.isError || $toggle.isError || $update.isError || $remove.isError}
+    {#if $add.isError || $toggle.isError || $update.isError || $remove.isError || $reorder.isError}
       <p class="mt-3 text-sm text-destructive" role="alert">
         {messageFromError(
-          $add.error ?? $toggle.error ?? $update.error ?? $remove.error,
+          $add.error ??
+            $toggle.error ??
+            $update.error ??
+            $remove.error ??
+            $reorder.error,
         )}
       </p>
     {/if}

--- a/apps/web/src/shared/api/query-keys.ts
+++ b/apps/web/src/shared/api/query-keys.ts
@@ -2,10 +2,17 @@ export const queryKeys = {
   runtime: ["runtime"] as const,
   summary: ["summary"] as const,
   bank: ["bank"] as const,
+  bankRange: (from: string, to: string) => ["bank", "range", from, to] as const,
   bills: ["creditCardBills"] as const,
+  billsRange: (from: string, to: string) =>
+    ["creditCardBills", "range", from, to] as const,
   investments: ["investments"] as const,
   investmentTransactions: ["investment-transactions"] as const,
+  investmentTransactionsRange: (from: string, to: string) =>
+    ["investment-transactions", "range", from, to] as const,
   invoices: ["invoices"] as const,
+  invoicesRange: (from: string, to: string) =>
+    ["invoices", "range", from, to] as const,
   invoiceTransactionMappings: ["invoice-transaction-mappings"] as const,
   manualAssets: ["manualAssets"] as const,
   exchangeRates: ["exchange-rates"] as const,

--- a/apps/web/src/shared/date-range.test.ts
+++ b/apps/web/src/shared/date-range.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { recentMonthRange } from "./date-range";
+
+describe("recentMonthRange", () => {
+  it("includes the ending month and uses the following month as the exclusive end", () => {
+    expect(recentMonthRange(6, new Date(2026, 6, 25))).toEqual({
+      from: "2026-02",
+      to: "2026-08",
+    });
+  });
+
+  it("handles a year boundary", () => {
+    expect(recentMonthRange(6, new Date(2026, 0, 25))).toEqual({
+      from: "2025-08",
+      to: "2026-02",
+    });
+  });
+});

--- a/apps/web/src/shared/date-range.ts
+++ b/apps/web/src/shared/date-range.ts
@@ -1,0 +1,33 @@
+export interface MonthRange {
+  from: string;
+  to: string;
+}
+
+export function recentMonthRange(count: number, now = new Date()): MonthRange {
+  return monthRangeEndingAt(monthKey(now), count);
+}
+
+export function monthRangeEndingAt(month: string, count: number): MonthRange {
+  const [year, monthNumber] = month.split("-").map(Number);
+  const start = new Date(year, monthNumber - count, 1);
+  const end = new Date(year, monthNumber, 1);
+  return {
+    from: monthKey(start),
+    to: monthKey(end),
+  };
+}
+
+export function recentMonthKeys(count: number, now = new Date()) {
+  return Array.from({ length: count }, (_, index) => {
+    const date = new Date(
+      now.getFullYear(),
+      now.getMonth() - count + 1 + index,
+      1,
+    );
+    return monthKey(date);
+  });
+}
+
+function monthKey(date: Date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+}

--- a/apps/worker/src/features/bank/repository.ts
+++ b/apps/worker/src/features/bank/repository.ts
@@ -1,4 +1,5 @@
 import type { TransactionPageCursor } from "../investments/repository";
+import type { MonthDateRange } from "../../platform/month-range";
 
 export type BankTransactionPageRow = {
   id: string;
@@ -28,6 +29,32 @@ export type CreditCardBillPageCursor = {
   accountId: string;
   id: string;
 };
+
+const BANK_TRANSACTION_SELECT = `SELECT
+      txn.id,
+      txn.connector_id AS connectorId,
+      txn.account_id AS accountId,
+      account.source_id AS accountSourceId,
+      account.account_name AS accountName,
+      account.institution_name AS institutionName,
+      account.account_type AS accountType,
+      account.bank_code AS bankCode,
+      account.account_last4 AS accountLast4,
+      txn.source_id AS sourceId,
+      txn.posted_date AS postedDate,
+      txn.authorized_at AS authorizedAt,
+      txn.amount,
+      txn.currency,
+      txn.description,
+      txn.counterparty,
+      txn.status,
+      txn.effective_date AS effectiveDate,
+      txn.updated_at AS updatedAt,
+      preference.excluded_from_calculation AS calculationPreference
+    FROM bank_transactions txn
+    JOIN bank_accounts account ON account.id = txn.account_id
+    LEFT JOIN bank_transaction_preferences preference
+      ON preference.transaction_id = txn.id`;
 
 export async function listBankAccounts(db: D1Database) {
   const rows = await db
@@ -72,31 +99,7 @@ export async function listBankTransactions(
     ? "AND (txn.effective_date, txn.updated_at, txn.id) < (?, ?, ?)"
     : "";
   const statement = db.prepare(
-    `SELECT
-      txn.id,
-      txn.connector_id AS connectorId,
-      txn.account_id AS accountId,
-      account.source_id AS accountSourceId,
-      account.account_name AS accountName,
-      account.institution_name AS institutionName,
-      account.account_type AS accountType,
-      account.bank_code AS bankCode,
-      account.account_last4 AS accountLast4,
-      txn.source_id AS sourceId,
-      txn.posted_date AS postedDate,
-      txn.authorized_at AS authorizedAt,
-      txn.amount,
-      txn.currency,
-      txn.description,
-      txn.counterparty,
-      txn.status,
-      txn.effective_date AS effectiveDate,
-      txn.updated_at AS updatedAt,
-      preference.excluded_from_calculation AS calculationPreference
-    FROM bank_transactions txn
-    JOIN bank_accounts account ON account.id = txn.account_id
-    LEFT JOIN bank_transaction_preferences preference
-      ON preference.transaction_id = txn.id
+    `${BANK_TRANSACTION_SELECT}
     WHERE account.canonical_account_id IS NULL
     ${cursorClause}
     ORDER BY txn.effective_date DESC, txn.updated_at DESC, txn.id DESC
@@ -107,6 +110,23 @@ export async function listBankTransactions(
       ? statement.bind(cursor.effectiveDate, cursor.updatedAt, cursor.id, limit)
       : statement.bind(limit)
   ).all<BankTransactionPageRow>();
+  return rows.results;
+}
+
+export async function listBankTransactionsInRange(
+  db: D1Database,
+  range: MonthDateRange,
+) {
+  const rows = await db
+    .prepare(
+      `${BANK_TRANSACTION_SELECT}
+       WHERE account.canonical_account_id IS NULL
+         AND COALESCE(txn.authorized_at, txn.posted_date) >= ?
+         AND COALESCE(txn.authorized_at, txn.posted_date) < ?
+       ORDER BY txn.effective_date DESC, txn.updated_at DESC, txn.id DESC`,
+    )
+    .bind(range.from, range.to)
+    .all<BankTransactionPageRow>();
   return rows.results;
 }
 
@@ -162,5 +182,42 @@ export async function listCreditCardBills(
       billingPeriod: string;
     }
   >();
+  return rows.results;
+}
+
+export async function listCreditCardBillsInRange(
+  db: D1Database,
+  range: MonthDateRange,
+) {
+  const rows = await db
+    .prepare(
+      `SELECT
+      b.id,
+      b.connector_id AS connectorId,
+      b.account_id AS accountId,
+      a.source_id AS accountSourceId,
+      b.source_id AS sourceId,
+      b.billing_period AS billingPeriod,
+      b.statement_amount AS statementAmount,
+      b.minimum_payment AS minimumPayment,
+      b.paid_amount AS paidAmount,
+      b.is_paid AS isPaid,
+      b.payment_due_date AS paymentDueDate,
+      b.statement_closing_date AS statementClosingDate,
+      b.currency
+    FROM credit_card_bills b
+    JOIN bank_accounts a ON a.id = b.account_id
+    WHERE b.billing_period >= substr(?, 1, 7)
+      AND b.billing_period < substr(?, 1, 7)
+    ORDER BY b.billing_period DESC, b.account_id ASC, b.id ASC`,
+    )
+    .bind(range.from, range.to)
+    .all<
+      Record<string, unknown> & {
+        id: string;
+        accountId: string;
+        billingPeriod: string;
+      }
+    >();
   return rows.results;
 }

--- a/apps/worker/src/features/bank/route.ts
+++ b/apps/worker/src/features/bank/route.ts
@@ -1,4 +1,5 @@
 import type { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import type { AppBindings } from "../../platform/env";
 import { honoFactory } from "../../platform/hono";
@@ -7,7 +8,17 @@ import {
   parseKeysetPagination,
   setKeysetPaginationHeaders,
 } from "../../platform/http";
-import { getBankPage, getCreditCardBillPage } from "./service";
+import {
+  monthRangeQuerySchema,
+  resolveMonthDateRange,
+} from "../../platform/month-range";
+import { validationHook } from "../../platform/validation";
+import {
+  getBankPage,
+  getBankRange,
+  getCreditCardBillPage,
+  getCreditCardBillsRange,
+} from "./service";
 
 const transactionPageCursorSchema = z.object({
   effectiveDate: z.string(),
@@ -25,45 +36,70 @@ export const bankRoutes = honoFactory.createApp();
 registerBankRoutes(bankRoutes);
 
 function registerBankRoutes(api: Hono<AppBindings>) {
-  api.get("/bank", async (c) => {
-    const { limit, cursor } = parseKeysetPagination(
-      c.req.query(),
-      transactionPageCursorSchema,
-      100,
-    );
-    const page = await getBankPage(c.env.DB, limit, cursor);
-    setKeysetPaginationHeaders((name, value) => c.header(name, value), {
-      hasMore: page.hasMore,
-      nextCursor:
-        page.hasMore && page.last
-          ? encodePageCursor({
-              effectiveDate: page.last.effectiveDate,
-              updatedAt: page.last.updatedAt,
-              id: page.last.id,
-            })
-          : undefined,
-    });
-    return c.json({ accounts: page.accounts, transactions: page.transactions });
-  });
+  api.get(
+    "/bank",
+    zValidator(
+      "query",
+      monthRangeQuerySchema,
+      validationHook("INVALID_REQUEST", "Invalid month range."),
+    ),
+    async (c) => {
+      const range = resolveMonthDateRange(c.req.valid("query"));
+      if (range) return c.json(await getBankRange(c.env.DB, range));
 
-  api.get("/bank/bills", async (c) => {
-    const { limit, cursor } = parseKeysetPagination(
-      c.req.query(),
-      creditCardBillPageCursorSchema,
-      50,
-    );
-    const page = await getCreditCardBillPage(c.env.DB, limit, cursor);
-    setKeysetPaginationHeaders((name, value) => c.header(name, value), {
-      hasMore: page.hasMore,
-      nextCursor:
-        page.hasMore && page.last
-          ? encodePageCursor({
-              billingPeriod: page.last.billingPeriod,
-              accountId: page.last.accountId,
-              id: page.last.id,
-            })
-          : undefined,
-    });
-    return c.json(page.bills);
-  });
+      const { limit, cursor } = parseKeysetPagination(
+        c.req.query(),
+        transactionPageCursorSchema,
+        100,
+      );
+      const page = await getBankPage(c.env.DB, limit, cursor);
+      setKeysetPaginationHeaders((name, value) => c.header(name, value), {
+        hasMore: page.hasMore,
+        nextCursor:
+          page.hasMore && page.last
+            ? encodePageCursor({
+                effectiveDate: page.last.effectiveDate,
+                updatedAt: page.last.updatedAt,
+                id: page.last.id,
+              })
+            : undefined,
+      });
+      return c.json({
+        accounts: page.accounts,
+        transactions: page.transactions,
+      });
+    },
+  );
+
+  api.get(
+    "/bank/bills",
+    zValidator(
+      "query",
+      monthRangeQuerySchema,
+      validationHook("INVALID_REQUEST", "Invalid month range."),
+    ),
+    async (c) => {
+      const range = resolveMonthDateRange(c.req.valid("query"));
+      if (range) return c.json(await getCreditCardBillsRange(c.env.DB, range));
+
+      const { limit, cursor } = parseKeysetPagination(
+        c.req.query(),
+        creditCardBillPageCursorSchema,
+        50,
+      );
+      const page = await getCreditCardBillPage(c.env.DB, limit, cursor);
+      setKeysetPaginationHeaders((name, value) => c.header(name, value), {
+        hasMore: page.hasMore,
+        nextCursor:
+          page.hasMore && page.last
+            ? encodePageCursor({
+                billingPeriod: page.last.billingPeriod,
+                accountId: page.last.accountId,
+                id: page.last.id,
+              })
+            : undefined,
+      });
+      return c.json(page.bills);
+    },
+  );
 }

--- a/apps/worker/src/features/bank/service.ts
+++ b/apps/worker/src/features/bank/service.ts
@@ -1,10 +1,14 @@
 import {
   listBankAccounts,
   listBankTransactions,
+  listBankTransactionsInRange,
   listCreditCardBills,
+  listCreditCardBillsInRange,
+  type BankTransactionPageRow,
   type CreditCardBillPageCursor,
 } from "./repository";
 import type { TransactionPageCursor } from "../investments/repository";
+import type { MonthDateRange } from "../../platform/month-range";
 import {
   normalizeBankAccountDisplay,
   normalizeBankTransactionDisplay,
@@ -26,11 +30,34 @@ export async function getBankPage(
   ]);
   const hasMore = transactions.length > limit;
   const page = transactions.slice(0, limit);
+  return {
+    hasMore,
+    last: page.at(-1),
+    accounts: accounts.map(normalizeBankAccountDisplay),
+    transactions: await presentBankTransactions(db, page),
+  };
+}
+
+export async function getBankRange(db: D1Database, range: MonthDateRange) {
+  const [accounts, transactions] = await Promise.all([
+    listBankAccounts(db),
+    listBankTransactionsInRange(db, range),
+  ]);
+  return {
+    accounts: accounts.map(normalizeBankAccountDisplay),
+    transactions: await presentBankTransactions(db, transactions),
+  };
+}
+
+async function presentBankTransactions(
+  db: D1Database,
+  transactions: BankTransactionPageRow[],
+) {
   let classificationMap: Map<string, ClassificationResult>;
   try {
     classificationMap = await resolveClassifications(
       db,
-      page.map((transaction) => ({
+      transactions.map((transaction) => ({
         id: transaction.id,
         description: transaction.description,
         counterparty: transaction.counterparty,
@@ -41,30 +68,25 @@ export async function getBankPage(
     console.error("[classify] resolveClassifications failed:", error);
     classificationMap = new Map();
   }
-  return {
-    hasMore,
-    last: page.at(-1),
-    accounts: accounts.map(normalizeBankAccountDisplay),
-    transactions: page.map(
-      ({
-        effectiveDate: _effectiveDate,
-        updatedAt: _updatedAt,
-        ...transaction
-      }) => ({
-        ...normalizeBankTransactionDisplay(transaction),
-        excludedFromCalculation: resolveCalculationExclusion({
-          accountType: transaction.accountType,
-          description: transaction.description,
-          counterparty: transaction.counterparty,
-          calculationPreference: transaction.calculationPreference,
-          classificationExcludedFromCalculation: classificationMap.get(
-            transaction.id,
-          )?.excludedFromCalculation,
-        }),
-        classification: classificationMap.get(transaction.id),
+  return transactions.map(
+    ({
+      effectiveDate: _effectiveDate,
+      updatedAt: _updatedAt,
+      ...transaction
+    }) => ({
+      ...normalizeBankTransactionDisplay(transaction),
+      excludedFromCalculation: resolveCalculationExclusion({
+        accountType: transaction.accountType,
+        description: transaction.description,
+        counterparty: transaction.counterparty,
+        calculationPreference: transaction.calculationPreference,
+        classificationExcludedFromCalculation: classificationMap.get(
+          transaction.id,
+        )?.excludedFromCalculation,
       }),
-    ),
-  };
+      classification: classificationMap.get(transaction.id),
+    }),
+  );
 }
 
 export async function getCreditCardBillPage(
@@ -76,4 +98,11 @@ export async function getCreditCardBillPage(
   const hasMore = rows.length > limit;
   const bills = rows.slice(0, limit);
   return { hasMore, bills, last: bills.at(-1) };
+}
+
+export async function getCreditCardBillsRange(
+  db: D1Database,
+  range: MonthDateRange,
+) {
+  return listCreditCardBillsInRange(db, range);
 }

--- a/apps/worker/src/features/classification/repository.ts
+++ b/apps/worker/src/features/classification/repository.ts
@@ -111,6 +111,39 @@ export async function listClassificationRules(db: D1Database) {
   return rows.results;
 }
 
+export async function listEditableClassificationRuleIds(db: D1Database) {
+  const rows = await db
+    .prepare(
+      `SELECT id
+       FROM classification_rules
+       WHERE is_system = 0
+       ORDER BY priority DESC, updated_at DESC, id ASC`,
+    )
+    .all<{ id: string }>();
+  return rows.results.map((row) => row.id);
+}
+
+export async function updateClassificationRuleOrder(
+  db: D1Database,
+  ruleIds: string[],
+  now: string,
+) {
+  if (ruleIds.length === 0) return;
+
+  const topPriority = 1000 + ruleIds.length;
+  await db.batch(
+    ruleIds.map((ruleId, index) =>
+      db
+        .prepare(
+          `UPDATE classification_rules
+           SET priority = ?, updated_at = ?
+           WHERE id = ? AND is_system = 0`,
+        )
+        .bind(topPriority - index, now, ruleId),
+    ),
+  );
+}
+
 export async function upsertClassificationOverride(
   db: D1Database,
   input: {

--- a/apps/worker/src/features/classification/route.ts
+++ b/apps/worker/src/features/classification/route.ts
@@ -8,6 +8,7 @@ import { validationHook } from "../../platform/validation";
 import {
   ClassificationCategoryExistsError,
   ClassificationCategoryNotFoundError,
+  ClassificationRuleOrderError,
   ClassificationRuleNotFoundError,
   createClassificationCategory,
   createClassificationRule,
@@ -16,6 +17,7 @@ import {
   getClassificationRules,
   removeClassificationOverride,
   removeClassificationRule,
+  reorderClassificationRules,
   setClassificationOverride,
 } from "./service";
 
@@ -46,6 +48,12 @@ const updateRuleSchema = z
     excludedFromCalculation: z.boolean().optional(),
   })
   .refine((body) => Object.keys(body).length > 0);
+const reorderRulesSchema = z.object({
+  ruleIds: z
+    .array(z.string().min(1).max(128))
+    .max(9_000)
+    .refine((ruleIds) => new Set(ruleIds).size === ruleIds.length),
+});
 
 function extractOverrideTargetId(requestPath: string, targetType: string) {
   const prefix = `/classification/overrides/${targetType}/`;
@@ -92,6 +100,26 @@ function registerClassificationRoutes(api: Hono<AppBindings>) {
 
   api.get("/classification/rules", async (c) =>
     c.json(await getClassificationRules(c.env.DB)),
+  );
+
+  api.put(
+    "/classification/rules/order",
+    zValidator(
+      "json",
+      reorderRulesSchema,
+      validationHook(
+        "INVALID_REQUEST",
+        "Classification rule order is invalid.",
+      ),
+    ),
+    async (c) => {
+      try {
+        await reorderClassificationRules(c.env.DB, c.req.valid("json").ruleIds);
+        return c.json({ success: true });
+      } catch (error) {
+        return classificationServiceError(error);
+      }
+    },
   );
 
   api.put(
@@ -202,6 +230,13 @@ function classificationServiceError(error: unknown) {
   }
   if (error instanceof ClassificationRuleNotFoundError) {
     return jsonError("RULE_NOT_FOUND", "Editable rule was not found.", 404);
+  }
+  if (error instanceof ClassificationRuleOrderError) {
+    return jsonError(
+      "INVALID_REQUEST",
+      "Classification rule order is out of date. Reload and try again.",
+      400,
+    );
   }
   throw error;
 }

--- a/apps/worker/src/features/classification/service.ts
+++ b/apps/worker/src/features/classification/service.ts
@@ -111,6 +111,7 @@ export async function resolveClassifications(
 export class ClassificationCategoryExistsError extends Error {}
 export class ClassificationCategoryNotFoundError extends Error {}
 export class ClassificationRuleNotFoundError extends Error {}
+export class ClassificationRuleOrderError extends Error {}
 
 export async function getClassificationCategories(db: D1Database) {
   const rows = await listClassificationCategories(db);
@@ -142,6 +143,27 @@ export async function getClassificationRules(db: D1Database) {
     isSystem: Boolean(row.isSystem),
     excludedFromCalculation: Boolean(row.excludedFromCalculation),
   }));
+}
+
+export async function reorderClassificationRules(
+  db: D1Database,
+  ruleIds: string[],
+) {
+  const editableRuleIds = await listEditableClassificationRuleIds(db);
+  const editableRuleIdSet = new Set(editableRuleIds);
+  if (
+    ruleIds.length !== editableRuleIds.length ||
+    new Set(ruleIds).size !== ruleIds.length ||
+    ruleIds.some((ruleId) => !editableRuleIdSet.has(ruleId))
+  ) {
+    throw new ClassificationRuleOrderError();
+  }
+
+  await updateClassificationRuleOrder(
+    db,
+    ruleIds,
+    new Date().toISOString(),
+  );
 }
 
 export function setClassificationOverride(
@@ -236,10 +258,12 @@ import {
   insertClassificationCategory,
   insertClassificationRule,
   listClassificationCategories,
+  listEditableClassificationRuleIds,
   listClassificationOverrides,
   listClassificationRules,
   listEnabledClassificationRules,
   nextCategorySortOrder,
   updateClassificationRule,
+  updateClassificationRuleOrder,
   upsertClassificationOverride,
 } from "./repository";

--- a/apps/worker/src/features/investments/repository.ts
+++ b/apps/worker/src/features/investments/repository.ts
@@ -1,3 +1,5 @@
+import type { MonthDateRange } from "../../platform/month-range";
+
 export type InvestmentPageCursor = {
   asOfDate: string;
   assetType: string;
@@ -119,5 +121,47 @@ export async function listInvestmentTransactions(
       updatedAt: string;
     }
   >();
+  return rows.results;
+}
+
+export async function listInvestmentTransactionsInRange(
+  db: D1Database,
+  range: MonthDateRange,
+) {
+  const rows = await db
+    .prepare(
+      `SELECT
+      id,
+      connector_id AS connectorId,
+      account_id AS accountId,
+      source_id AS sourceId,
+      broker_no AS brokerNo,
+      broker_account AS brokerAccount,
+      broker_name AS brokerName,
+      symbol,
+      name,
+      asset_type AS assetType,
+      trade_date AS tradeDate,
+      posted_date AS postedDate,
+      transaction_code AS transactionCode,
+      transaction_name AS transactionName,
+      quantity,
+      price,
+      amount,
+      currency,
+      effective_date AS effectiveDate,
+      updated_at AS updatedAt
+    FROM investment_transactions
+    WHERE effective_date >= ? AND effective_date < ?
+    ORDER BY effective_date DESC, updated_at DESC, id DESC`,
+    )
+    .bind(range.from, range.to)
+    .all<
+      Record<string, unknown> & {
+        id: string;
+        effectiveDate: string;
+        updatedAt: string;
+      }
+    >();
   return rows.results;
 }

--- a/apps/worker/src/features/investments/route.ts
+++ b/apps/worker/src/features/investments/route.ts
@@ -1,4 +1,5 @@
 import type { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import type { AppBindings } from "../../platform/env";
 import { honoFactory } from "../../platform/hono";
@@ -7,7 +8,16 @@ import {
   parseKeysetPagination,
   setKeysetPaginationHeaders,
 } from "../../platform/http";
-import { getInvestmentPage, getInvestmentTransactionPage } from "./service";
+import {
+  monthRangeQuerySchema,
+  resolveMonthDateRange,
+} from "../../platform/month-range";
+import { validationHook } from "../../platform/validation";
+import {
+  getInvestmentPage,
+  getInvestmentTransactionPage,
+  getInvestmentTransactionsRange,
+} from "./service";
 
 const investmentPageCursorSchema = z.object({
   asOfDate: z.string(),
@@ -48,24 +58,36 @@ function registerInvestmentRoutes(api: Hono<AppBindings>) {
     return c.json(page.positions);
   });
 
-  api.get("/investment-transactions", async (c) => {
-    const { limit, cursor } = parseKeysetPagination(
-      c.req.query(),
-      transactionPageCursorSchema,
-      100,
-    );
-    const page = await getInvestmentTransactionPage(c.env.DB, limit, cursor);
-    setKeysetPaginationHeaders((name, value) => c.header(name, value), {
-      hasMore: page.hasMore,
-      nextCursor:
-        page.hasMore && page.last
-          ? encodePageCursor({
-              effectiveDate: page.last.effectiveDate,
-              updatedAt: page.last.updatedAt,
-              id: page.last.id,
-            })
-          : undefined,
-    });
-    return c.json(page.transactions);
-  });
+  api.get(
+    "/investment-transactions",
+    zValidator(
+      "query",
+      monthRangeQuerySchema,
+      validationHook("INVALID_REQUEST", "Invalid month range."),
+    ),
+    async (c) => {
+      const range = resolveMonthDateRange(c.req.valid("query"));
+      if (range)
+        return c.json(await getInvestmentTransactionsRange(c.env.DB, range));
+
+      const { limit, cursor } = parseKeysetPagination(
+        c.req.query(),
+        transactionPageCursorSchema,
+        100,
+      );
+      const page = await getInvestmentTransactionPage(c.env.DB, limit, cursor);
+      setKeysetPaginationHeaders((name, value) => c.header(name, value), {
+        hasMore: page.hasMore,
+        nextCursor:
+          page.hasMore && page.last
+            ? encodePageCursor({
+                effectiveDate: page.last.effectiveDate,
+                updatedAt: page.last.updatedAt,
+                id: page.last.id,
+              })
+            : undefined,
+      });
+      return c.json(page.transactions);
+    },
+  );
 }

--- a/apps/worker/src/features/investments/service.ts
+++ b/apps/worker/src/features/investments/service.ts
@@ -1,9 +1,11 @@
 import {
   listInvestmentTransactions,
+  listInvestmentTransactionsInRange,
   listLatestInvestmentPositions,
   type InvestmentPageCursor,
   type TransactionPageCursor,
 } from "./repository";
+import type { MonthDateRange } from "../../platform/month-range";
 
 export async function getInvestmentPage(
   db: D1Database,
@@ -36,4 +38,18 @@ export async function getInvestmentTransactionPage(
       }) => transaction,
     ),
   };
+}
+
+export async function getInvestmentTransactionsRange(
+  db: D1Database,
+  range: MonthDateRange,
+) {
+  const rows = await listInvestmentTransactionsInRange(db, range);
+  return rows.map(
+    ({
+      effectiveDate: _effectiveDate,
+      updatedAt: _updatedAt,
+      ...transaction
+    }) => transaction,
+  );
 }

--- a/apps/worker/src/features/invoices/repository.ts
+++ b/apps/worker/src/features/invoices/repository.ts
@@ -1,4 +1,5 @@
 import type { ConnectorId } from "@taiwan-fin-hub/core";
+import type { MonthDateRange } from "../../platform/month-range";
 
 export type InvoicePageCursor = {
   invoiceDate: string;
@@ -56,6 +57,30 @@ export async function listInvoices(
       ? statement.bind(cursor.invoiceDate, cursor.updatedAt, cursor.id, limit)
       : statement.bind(limit)
   ).all<InvoiceRow>();
+  return rows.results;
+}
+
+export async function listInvoicesInRange(
+  db: D1Database,
+  range: MonthDateRange,
+) {
+  const rows = await db
+    .prepare(
+      `SELECT
+      id,
+      connector_id AS connectorId,
+      source_id AS sourceId,
+      invoice_number AS invoiceNumber,
+      invoice_date AS invoiceDate,
+      seller_name AS sellerName,
+      amount,
+      updated_at AS updatedAt
+    FROM invoices
+    WHERE invoice_date >= ? AND invoice_date < ?
+    ORDER BY invoice_date DESC, updated_at DESC, id DESC`,
+    )
+    .bind(range.from, range.to)
+    .all<InvoiceRow>();
   return rows.results;
 }
 

--- a/apps/worker/src/features/invoices/route.ts
+++ b/apps/worker/src/features/invoices/route.ts
@@ -1,4 +1,5 @@
 import type { Context, Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import type { AppBindings } from "../../platform/env";
 import { honoFactory } from "../../platform/hono";
@@ -9,8 +10,14 @@ import {
   setKeysetPaginationHeaders,
 } from "../../platform/http";
 import {
+  monthRangeQuerySchema,
+  resolveMonthDateRange,
+} from "../../platform/month-range";
+import { validationHook } from "../../platform/validation";
+import {
   getInvoiceDetail,
   getInvoicePage,
+  getInvoicesRange,
   InvoiceNotFoundError,
 } from "./service";
 
@@ -24,26 +31,37 @@ export const invoiceRoutes = honoFactory.createApp();
 registerInvoiceRoutes(invoiceRoutes);
 
 function registerInvoiceRoutes(api: Hono<AppBindings>) {
-  api.get("/invoices", async (c) => {
-    const { limit, cursor } = parseKeysetPagination(
-      c.req.query(),
-      invoicePageCursorSchema,
-      50,
-    );
-    const page = await getInvoicePage(c.env.DB, limit, cursor);
-    setKeysetPaginationHeaders((name, value) => c.header(name, value), {
-      hasMore: page.hasMore,
-      nextCursor:
-        page.hasMore && page.last
-          ? encodePageCursor({
-              invoiceDate: page.last.invoiceDate,
-              updatedAt: page.last.updatedAt,
-              id: page.last.id,
-            })
-          : undefined,
-    });
-    return c.json(page.invoices);
-  });
+  api.get(
+    "/invoices",
+    zValidator(
+      "query",
+      monthRangeQuerySchema,
+      validationHook("INVALID_REQUEST", "Invalid month range."),
+    ),
+    async (c) => {
+      const range = resolveMonthDateRange(c.req.valid("query"));
+      if (range) return c.json(await getInvoicesRange(c.env.DB, range));
+
+      const { limit, cursor } = parseKeysetPagination(
+        c.req.query(),
+        invoicePageCursorSchema,
+        50,
+      );
+      const page = await getInvoicePage(c.env.DB, limit, cursor);
+      setKeysetPaginationHeaders((name, value) => c.header(name, value), {
+        hasMore: page.hasMore,
+        nextCursor:
+          page.hasMore && page.last
+            ? encodePageCursor({
+                invoiceDate: page.last.invoiceDate,
+                updatedAt: page.last.updatedAt,
+                id: page.last.id,
+              })
+            : undefined,
+      });
+      return c.json(page.invoices);
+    },
+  );
 
   api.get("/invoice-detail", async (c) => {
     const invoiceId = c.req.query("invoiceId");

--- a/apps/worker/src/features/invoices/service.ts
+++ b/apps/worker/src/features/invoices/service.ts
@@ -2,9 +2,11 @@ import {
   findInvoice,
   listInvoiceItems,
   listInvoices,
+  listInvoicesInRange,
   type InvoicePageCursor,
   type InvoiceRow,
 } from "./repository";
+import type { MonthDateRange } from "../../platform/month-range";
 
 export class InvoiceNotFoundError extends Error {}
 
@@ -35,6 +37,11 @@ export async function getInvoicePage(
   };
 }
 
+export async function getInvoicesRange(db: D1Database, range: MonthDateRange) {
+  const rows = await listInvoicesInRange(db, range);
+  return presentInvoices(db, rows);
+}
+
 export async function getInvoiceDetail(db: D1Database, invoiceId: string) {
   const invoice = await findInvoice(db, invoiceId);
   if (!invoice) throw new InvoiceNotFoundError();
@@ -56,4 +63,20 @@ function presentInvoice<T extends Omit<InvoiceRow, "updatedAt"> | InvoiceRow>(
     sellerName: invoice.sellerName ?? undefined,
     items,
   };
+}
+
+async function presentInvoices(db: D1Database, rows: InvoiceRow[]) {
+  const items = await listInvoiceItems(
+    db,
+    rows.map((invoice) => invoice.id),
+  );
+  const itemsByInvoiceId = new Map<string, typeof items>();
+  for (const item of items) {
+    const current = itemsByInvoiceId.get(item.invoiceId) ?? [];
+    current.push(item);
+    itemsByInvoiceId.set(item.invoiceId, current);
+  }
+  return rows.map((invoice) =>
+    presentInvoice(invoice, itemsByInvoiceId.get(invoice.id) ?? []),
+  );
 }

--- a/apps/worker/src/platform/month-range.ts
+++ b/apps/worker/src/platform/month-range.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+
+const monthPattern = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+export const monthRangeQuerySchema = z
+  .object({
+    month: z.string().regex(monthPattern).optional(),
+    from: z.string().regex(monthPattern).optional(),
+    to: z.string().regex(monthPattern).optional(),
+  })
+  .superRefine((value, context) => {
+    const hasFrom = value.from !== undefined;
+    const hasTo = value.to !== undefined;
+    if (value.month !== undefined && (hasFrom || hasTo)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["month"],
+        message: "month cannot be combined with from/to.",
+      });
+    }
+    if (hasFrom !== hasTo) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [hasFrom ? "to" : "from"],
+        message: "from and to must be provided together.",
+      });
+    }
+    if (value.from && value.to) {
+      const fromIndex = monthIndex(value.from);
+      const toIndex = monthIndex(value.to);
+      if (toIndex < fromIndex) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["to"],
+          message: "to must not be earlier than from.",
+        });
+      } else if (toIndex - fromIndex > 11) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["to"],
+          message: "The requested range cannot exceed 12 months.",
+        });
+      }
+    }
+  });
+
+export type MonthRangeQuery = z.infer<typeof monthRangeQuerySchema>;
+
+export type MonthDateRange = {
+  from: string;
+  to: string;
+};
+
+export function resolveMonthDateRange(
+  query: MonthRangeQuery,
+): MonthDateRange | undefined {
+  if (query.month) return monthToDateRange(query.month);
+  if (!query.from || !query.to) return undefined;
+  return {
+    from: `${query.from}-01`,
+    to: nextMonthStart(query.to),
+  };
+}
+
+function monthToDateRange(month: string): MonthDateRange {
+  return { from: `${month}-01`, to: nextMonthStart(month) };
+}
+
+function nextMonthStart(month: string) {
+  const [year, monthNumber] = month.split("-").map(Number);
+  const nextYear = monthNumber === 12 ? year + 1 : year;
+  const nextMonth = monthNumber === 12 ? 1 : monthNumber + 1;
+  return `${nextYear}-${String(nextMonth).padStart(2, "0")}-01`;
+}
+
+function monthIndex(month: string) {
+  const [year, monthNumber] = month.split("-").map(Number);
+  return year * 12 + monthNumber;
+}

--- a/apps/worker/tests/features/classification/route.test.ts
+++ b/apps/worker/tests/features/classification/route.test.ts
@@ -30,6 +30,33 @@ function createDb(options: { existingLabel?: boolean } = {}) {
   return { calls, db };
 }
 
+function createReorderDb(ruleIds = ["user:rule-1", "user:rule-2"]) {
+  const calls: Array<{ sql: string; values: unknown[] }> = [];
+  const db = {
+    prepare(sql: string) {
+      let values: unknown[] = [];
+      const statement = {
+        bind(...nextValues: unknown[]) {
+          values = nextValues;
+          calls.push({ sql, values });
+          return statement;
+        },
+        async all() {
+          return { results: ruleIds.map((id) => ({ id })) };
+        },
+        async run() {
+          return { meta: { changes: 1 } };
+        },
+      };
+      return statement;
+    },
+    async batch() {
+      return [];
+    },
+  } as unknown as D1Database;
+  return { calls, db };
+}
+
 describe("classification categories", () => {
   it("creates a trimmed user category after the existing sort order", async () => {
     const { calls, db } = createDb();
@@ -127,5 +154,43 @@ describe("classification rule actions", () => {
     expect(update?.sql).toContain("is_system = 0");
     expect(update?.values).toContain("equals");
     expect(update?.values).toContain(0);
+  });
+
+  it("persists the order of editable rules", async () => {
+    const { calls, db } = createReorderDb();
+    const response = await classificationRoutes.request(
+      "/classification/rules/order",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ruleIds: ["user:rule-2", "user:rule-1"] }),
+      },
+      { DB: db } as Env,
+    );
+
+    expect(response.status).toBe(200);
+    const updates = calls.filter(({ sql }) =>
+      sql.includes("UPDATE classification_rules"),
+    );
+    expect(updates.map(({ values }) => values[0])).toEqual([1002, 1001]);
+    expect(updates.map(({ values }) => values[2])).toEqual([
+      "user:rule-2",
+      "user:rule-1",
+    ]);
+  });
+
+  it("rejects an order that does not contain the current editable rules", async () => {
+    const { db } = createReorderDb();
+    const response = await classificationRoutes.request(
+      "/classification/rules/order",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ruleIds: ["user:rule-1"] }),
+      },
+      { DB: db } as Env,
+    );
+
+    expect(response.status).toBe(400);
   });
 });

--- a/apps/worker/tests/features/month-range-routes.test.ts
+++ b/apps/worker/tests/features/month-range-routes.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { Env } from "../../src/platform/env";
+import { bankRoutes } from "../../src/features/bank/route";
+import { invoiceRoutes } from "../../src/features/invoices/route";
+import { investmentRoutes } from "../../src/features/investments/route";
+
+function createDb() {
+  const calls: Array<{ sql: string; values: unknown[] }> = [];
+  const db = {
+    prepare(sql: string) {
+      let values: unknown[] = [];
+      const statement = {
+        bind(...nextValues: unknown[]) {
+          values = nextValues;
+          calls.push({ sql, values });
+          return statement;
+        },
+        async all() {
+          if (!values.length) calls.push({ sql, values });
+          return { results: [] };
+        },
+      };
+      return statement;
+    },
+  } as unknown as D1Database;
+  return { db, calls };
+}
+
+describe("month-filtered resource APIs", () => {
+  it("filters bank transactions by a single month without pagination", async () => {
+    const { db, calls } = createDb();
+    const response = await bankRoutes.request("/bank?month=2026-07", {}, {
+      DB: db,
+    } as Env);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      accounts: [],
+      transactions: [],
+    });
+    expect(
+      calls.some(({ sql }) => sql.includes("COALESCE(txn.authorized_at")),
+    ).toBe(true);
+    expect(
+      calls.some(({ values }) => values.join(",") === "2026-07-01,2026-08-01"),
+    ).toBe(true);
+  });
+
+  it("filters credit-card bills by the same month boundary", async () => {
+    const { db, calls } = createDb();
+    const response = await bankRoutes.request("/bank/bills?month=2026-07", {}, {
+      DB: db,
+    } as Env);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual([]);
+    expect(calls.some(({ sql }) => sql.includes("b.billing_period >="))).toBe(
+      true,
+    );
+    expect(
+      calls.some(({ values }) => values.join(",") === "2026-07-01,2026-08-01"),
+    ).toBe(true);
+  });
+
+  it("accepts a bounded month range for invoices and investments", async () => {
+    const invoiceDb = createDb();
+    const invoiceResponse = await invoiceRoutes.request(
+      "/invoices?from=2026-02&to=2026-07",
+      {},
+      { DB: invoiceDb.db } as Env,
+    );
+    expect(invoiceResponse.status).toBe(200);
+    await expect(invoiceResponse.json()).resolves.toEqual([]);
+    expect(
+      invoiceDb.calls.some(
+        ({ values }) => values.join(",") === "2026-02-01,2026-08-01",
+      ),
+    ).toBe(true);
+
+    const investmentDb = createDb();
+    const investmentResponse = await investmentRoutes.request(
+      "/investment-transactions?from=2026-02&to=2026-07",
+      {},
+      { DB: investmentDb.db } as Env,
+    );
+    expect(investmentResponse.status).toBe(200);
+    await expect(investmentResponse.json()).resolves.toEqual([]);
+    expect(
+      investmentDb.calls.some(
+        ({ values }) => values.join(",") === "2026-02-01,2026-08-01",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects malformed or overly broad month ranges", async () => {
+    const { db } = createDb();
+    const malformed = await bankRoutes.request("/bank?month=2026-13", {}, {
+      DB: db,
+    } as Env);
+    expect(malformed.status).toBe(400);
+
+    const broad = await invoiceRoutes.request(
+      "/invoices?from=2025-01&to=2026-07",
+      {},
+      { DB: db } as Env,
+    );
+    expect(broad.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## 變更內容

- 移除設定頁標題列的「重新整理」按鈕與沒有實際資料的「最近套用」摘要，改以實際規則重新判定行為說明取代。
- 新增自訂分類規則的上移／下移排序功能，包含 Worker API、優先序更新與過期排序保護。
- 修正分類規則頁手機版水平溢位，行動版操作按鈕移到規則內容下方。
- 為銀行交易、信用卡帳單、發票及投資交易 API 新增 `month` 或 `from`／`to` 月份範圍查詢，並限制最長 12 個月。
- 活動頁固定顯示並查詢最近 6 個月；切換月份只更新選取狀態，不再把該月份移動到右側。
- 保留未帶月份參數的既有分頁 API 行為，避免影響其他畫面。

## 修正原因

活動頁原先只取得各資源預設分頁的第一批資料，前端再依月份篩選，因此較早月份可能只顯示總覽或資料不完整；月份按鈕也會依資料內容重新排序。分類規則頁則因手機版內容與操作按鈕同列而產生水平溢位。

## 使用者影響

活動頁會直接向後端取得完整的最近 6 個月資料，月份順序固定，歷史月份不再受第一頁資料量影響。分類規則可調整優先順序，且手機版可完整顯示。

## 驗證

- Svelte autofixer：無 issues／suggestions
- `npm run format:check`
- `npm run typecheck`
- `npm run test:unit`（49 tests passed）
- `npm run test:backend`（Worker 148、DB 4 tests passed；連接器 self-check 通過）
- `npm exec -w @taiwan-fin-hub/web -- playwright test e2e/shell.spec.ts`（8 tests passed）
- `git diff --check`