### PR TITLE
修正發票月份查詢並改為按需載入明細

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -582,29 +582,34 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
     });
   });
   await page.route("**/api/invoices**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const invoice = {
+      id: "invoice-1",
+      connectorId: "einvoice",
+      sourceId: "invoice-source-1",
+      invoiceDate: `${month}-06T04:39:18.000Z`,
+      invoiceNumber: "DR95850239",
+      sellerName: "菲尖極道商行",
+      amount: 50,
+    };
     await route.fulfill({
-      json: [
-        {
-          id: "invoice-1",
-          connectorId: "einvoice",
-          sourceId: "invoice-source-1",
-          invoiceDate: `${month}-06T04:39:18.000Z`,
-          invoiceNumber: "DR95850239",
-          sellerName: "菲尖極道商行",
-          amount: 50,
-          items: [
-            {
-              id: "invoice-line-1",
-              sourceId: "invoice-line-source-1",
-              lineNumber: 1,
-              description: "瓶裝飲料",
-              quantity: 1,
-              unitPrice: 50,
-              amount: 50,
-            },
-          ],
-        },
-      ],
+      json:
+        path === "/api/invoices/invoice-1"
+          ? {
+              ...invoice,
+              items: [
+                {
+                  id: "invoice-line-1",
+                  sourceId: "invoice-line-source-1",
+                  lineNumber: 1,
+                  description: "瓶裝飲料",
+                  quantity: 1,
+                  unitPrice: 50,
+                  amount: 50,
+                },
+              ],
+            }
+          : [invoice],
     });
   });
 
@@ -655,4 +660,52 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
   await expect(page.getByText("已解除配對，兩筆活動將保持分開")).toBeVisible();
   await expect(page.getByText("菲尖極道商行").first()).toBeVisible();
   await expect(page.getByText("全支付﹘樂法 台中漢口店").first()).toBeVisible();
+});
+
+test("loads invoice line items only after expanding an invoice", async ({
+  page,
+}) => {
+  const month = new Date().toISOString().slice(0, 7);
+  let detailRequests = 0;
+  const invoice = {
+    id: "lazy-invoice",
+    connectorId: "einvoice",
+    sourceId: "lazy-source",
+    invoiceDate: `${month}-12T10:00:00.000Z`,
+    invoiceNumber: "AB12345678",
+    sellerName: "延遲載入商店",
+    amount: 120,
+  };
+  await page.route("**/api/invoices**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    if (path === "/api/invoices/lazy-invoice") {
+      detailRequests += 1;
+      await route.fulfill({
+        json: {
+          ...invoice,
+          items: [
+            {
+              id: "lazy-line",
+              sourceId: "lazy-line-source",
+              lineNumber: 1,
+              description: "延遲載入品項",
+              quantity: 1,
+              unitPrice: 120,
+              amount: 120,
+            },
+          ],
+        },
+      });
+      return;
+    }
+    await route.fulfill({ json: [invoice] });
+  });
+
+  await page.goto("/#/invoices");
+  await expect(page.getByText("延遲載入商店")).toBeVisible();
+  expect(detailRequests).toBe(0);
+
+  await page.getByRole("button", { name: /延遲載入商店/ }).click();
+  await expect(page.getByText("延遲載入品項", { exact: true })).toBeVisible();
+  expect(detailRequests).toBe(1);
 });

--- a/apps/web/src/data/invoices/queries.ts
+++ b/apps/web/src/data/invoices/queries.ts
@@ -3,7 +3,11 @@ import type { CreateQueryOptions } from "@tanstack/svelte-query";
 import type { ApiClient } from "@/shared/api/client";
 import { queryKeys } from "@/shared/api/query-keys";
 import type { MonthRange } from "@/shared/date-range";
-import type { InvoiceRow, InvoiceTransactionPreference } from "./types";
+import type {
+  InvoiceRow,
+  InvoiceSummaryRow,
+  InvoiceTransactionPreference,
+} from "./types";
 
 type ApiProvider = () => ApiClient;
 
@@ -11,7 +15,7 @@ export const invoicesRangeQuery = (getApi: ApiProvider, range: MonthRange) =>
   queryOptions({
     queryKey: queryKeys.invoicesRange(range.from, range.to),
     queryFn: () =>
-      getApi().get<InvoiceRow[]>(
+      getApi().get<InvoiceSummaryRow[]>(
         `/api/invoices?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}`,
       ),
   });
@@ -19,17 +23,30 @@ export const invoicesRangeQuery = (getApi: ApiProvider, range: MonthRange) =>
 export const invoicesQuery = (
   getApi: ApiProvider,
   range?: MonthRange,
-): CreateQueryOptions<InvoiceRow[]> => ({
+): CreateQueryOptions<InvoiceSummaryRow[]> => ({
   queryKey: range
     ? queryKeys.invoicesRange(range.from, range.to)
     : queryKeys.invoices,
   queryFn: () =>
-    getApi().get<InvoiceRow[]>(
+    getApi().get<InvoiceSummaryRow[]>(
       range
         ? `/api/invoices?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}`
         : "/api/invoices",
     ),
 });
+
+export const invoiceDetailQuery = (
+  getApi: ApiProvider,
+  invoiceId: string | null,
+) =>
+  queryOptions({
+    queryKey: queryKeys.invoiceDetail(invoiceId ?? ""),
+    queryFn: () =>
+      getApi().get<InvoiceRow>(
+        `/api/invoices/${encodeURIComponent(invoiceId ?? "")}`,
+      ),
+    enabled: Boolean(invoiceId),
+  });
 
 export const invoiceTransactionMappingsQuery = (getApi: ApiProvider) =>
   queryOptions({

--- a/apps/web/src/data/invoices/types.ts
+++ b/apps/web/src/data/invoices/types.ts
@@ -11,7 +11,7 @@ export interface InvoiceLineItemRow {
   amount: number;
 }
 
-export interface InvoiceRow {
+export interface InvoiceSummaryRow {
   id: string;
   connectorId: ConnectorId;
   sourceId: string;
@@ -19,6 +19,9 @@ export interface InvoiceRow {
   invoiceNumber?: string;
   sellerName?: string;
   amount: number;
+}
+
+export interface InvoiceRow extends InvoiceSummaryRow {
   items: InvoiceLineItemRow[];
 }
 

--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { toStore } from "svelte/store";
   import {
     createMutation,
     createQuery,
@@ -40,11 +41,12 @@
   import { classificationCategoriesQuery } from "@/data/classification/queries";
   import { investmentTransactionsRangeQuery } from "@/data/investments/queries";
   import {
+    invoiceDetailQuery,
     invoiceTransactionMappingsQuery,
     invoicesRangeQuery,
   } from "@/data/invoices/queries";
   import type {
-    InvoiceRow,
+    InvoiceSummaryRow,
     InvoiceTransactionPreference,
   } from "@/data/invoices/types";
   import type { ActivityItem, PendingCategoryUpdate } from "./model/types";
@@ -93,7 +95,7 @@
   } | null>(null);
   let pending = $state<PendingCategoryUpdate | null>(null);
   let mappingDialog = $state<{
-    invoice: InvoiceRow;
+    invoice: InvoiceSummaryRow;
     step: "candidates" | "confirm" | "actions";
     transactionId?: string;
   } | null>(null);
@@ -179,9 +181,6 @@
           transactionId: t.id,
           invoiceId: matchedInvoice?.id,
           invoiceAmount: matchedInvoice?.amount,
-          invoiceSearchText: matchedInvoice
-            ? `${matchedInvoice.sellerName ?? ""} ${matchedInvoice.invoiceNumber ?? ""} ${matchedInvoice.items.map((item) => item.description).join(" ")}`
-            : undefined,
           excludedFromCalculation: t.excludedFromCalculation,
           status: t.status,
         };
@@ -199,7 +198,6 @@
           category: "發票",
           invoiceId: i.id,
           invoiceAmount: i.amount,
-          invoiceSearchText: i.items.map((item) => item.description).join(" "),
           status: "已開立",
         })),
       ...($trades.data ?? []).map((t) => ({
@@ -222,6 +220,10 @@
   );
   const detailItem = $derived(
     rawItems.find((item) => activityKey(item) === detailKey),
+  );
+  const detailInvoiceId = $derived(detailItem?.invoiceId ?? null);
+  const detailInvoice = createQuery(
+    toStore(() => invoiceDetailQuery(() => api, detailInvoiceId)),
   );
   const cashFlowMonths = recentMonthKeys(6);
   const months = [...cashFlowMonths].reverse();
@@ -296,7 +298,7 @@
         matchesSource &&
         item.date.startsWith(selectedMonth) &&
         (!search.trim() ||
-          `${item.title} ${item.subtitle} ${item.category} ${item.invoiceSearchText ?? ""}`
+          `${item.title} ${item.subtitle} ${item.category}`
             .toLowerCase()
             .includes(search.toLowerCase())) &&
         (!selectedCategory ||
@@ -500,7 +502,7 @@
     );
   }
   function mappingDifference(
-    invoice: InvoiceRow,
+    invoice: InvoiceSummaryRow,
     transaction: BankTransactionRow,
   ) {
     return Math.abs(invoice.amount - Math.abs(transaction.amount));
@@ -955,12 +957,20 @@
 
             {#if invoice}<section class="border-b border-ink/10 py-5">
                 <h3 class="text-base font-semibold">發票細項</h3>
-                {#if invoice.items.length === 0}<p
+                {#if $detailInvoice.isPending}<p
+                    class="mt-3 rounded-xl bg-paper p-4 text-sm text-ink/50"
+                  >
+                    載入發票細項中。
+                  </p>{:else if $detailInvoice.isError}<p
+                    class="mt-3 rounded-xl bg-coral/10 p-4 text-sm text-coral"
+                  >
+                    無法載入發票細項，請稍後再試。
+                  </p>{:else if !$detailInvoice.data || $detailInvoice.data.items.length === 0}<p
                     class="mt-3 rounded-xl bg-paper p-4 text-sm text-ink/50"
                   >
                     此發票沒有品項明細。
                   </p>{:else}<div class="mt-2 divide-y divide-ink/10">
-                    {#each invoice.items as line (line.id)}<div
+                    {#each $detailInvoice.data.items as line (line.id)}<div
                         class="flex items-start justify-between gap-4 py-3"
                       >
                         <div class="min-w-0">

--- a/apps/web/src/features/activity/model/matching.test.ts
+++ b/apps/web/src/features/activity/model/matching.test.ts
@@ -5,7 +5,7 @@ import {
   matchInvoicesToTransactions,
 } from "./matching";
 import type { BankTransactionRow } from "@/data/bank/types";
-import type { InvoiceRow } from "@/data/invoices/types";
+import type { InvoiceSummaryRow } from "@/data/invoices/types";
 
 function transaction(
   overrides: Partial<BankTransactionRow> = {},
@@ -27,7 +27,9 @@ function transaction(
   };
 }
 
-function invoice(overrides: Partial<InvoiceRow> = {}): InvoiceRow {
+function invoice(
+  overrides: Partial<InvoiceSummaryRow> = {},
+): InvoiceSummaryRow {
   return {
     id: "invoice-1",
     connectorId: "einvoice",
@@ -36,7 +38,6 @@ function invoice(overrides: Partial<InvoiceRow> = {}): InvoiceRow {
     invoiceNumber: "AB12345678",
     sellerName: "好食餐飲有限公司",
     amount: 860,
-    items: [],
     ...overrides,
   };
 }

--- a/apps/web/src/features/activity/model/matching.ts
+++ b/apps/web/src/features/activity/model/matching.ts
@@ -1,6 +1,6 @@
 import type { BankTransactionRow } from "@/data/bank/types";
 import type {
-  InvoiceRow,
+  InvoiceSummaryRow,
   InvoiceTransactionPreference,
 } from "@/data/invoices/types";
 
@@ -23,11 +23,11 @@ const TAIPEI_DAY_FORMATTER = new Intl.DateTimeFormat("en", {
 
 export interface InvoiceTransactionMatches {
   invoiceToTransactionId: Map<string, string>;
-  transactionToInvoice: Map<string, InvoiceRow>;
+  transactionToInvoice: Map<string, InvoiceSummaryRow>;
 }
 
 type MatchCandidate = {
-  invoice: InvoiceRow;
+  invoice: InvoiceSummaryRow;
   transaction: BankTransactionRow;
   kind: "exact" | "payment-points";
 };
@@ -63,7 +63,7 @@ export function deduplicateBankTransactions(
 
 export function matchInvoicesToTransactions(
   transactions: BankTransactionRow[],
-  invoices: InvoiceRow[],
+  invoices: InvoiceSummaryRow[],
   preferences: InvoiceTransactionPreference[] = [],
 ): InvoiceTransactionMatches {
   const invoiceById = new Map(invoices.map((invoice) => [invoice.id, invoice]));
@@ -71,7 +71,7 @@ export function matchInvoicesToTransactions(
     transactions.map((transaction) => [transaction.id, transaction]),
   );
   const invoiceToTransactionId = new Map<string, string>();
-  const transactionToInvoice = new Map<string, InvoiceRow>();
+  const transactionToInvoice = new Map<string, InvoiceSummaryRow>();
   const separateInvoiceIds = new Set(
     preferences
       .filter(({ decision }) => decision === "separate")
@@ -134,7 +134,7 @@ export function matchInvoicesToTransactions(
 
 export function invoiceTransactionCandidates(
   transactions: BankTransactionRow[],
-  invoice: InvoiceRow,
+  invoice: InvoiceSummaryRow,
   unavailableTransactionIds: ReadonlySet<string> = new Set(),
 ) {
   return transactions
@@ -159,7 +159,7 @@ export function invoiceTransactionCandidates(
 function addUniqueMatches(
   candidates: MatchCandidate[],
   invoiceToTransactionId: Map<string, string>,
-  transactionToInvoice: Map<string, InvoiceRow>,
+  transactionToInvoice: Map<string, InvoiceSummaryRow>,
 ) {
   const invoiceCandidateCount = countBy(
     candidates,
@@ -183,7 +183,7 @@ function addUniqueMatches(
 
 function matchCandidateKind(
   transaction: BankTransactionRow,
-  invoice: InvoiceRow,
+  invoice: InvoiceSummaryRow,
 ): MatchCandidate["kind"] | undefined {
   if (!isSameDayTwdExpense(transaction, invoice)) return undefined;
 
@@ -208,7 +208,7 @@ function matchCandidateKind(
 
 function isSameDayTwdExpense(
   transaction: BankTransactionRow,
-  invoice: InvoiceRow,
+  invoice: InvoiceSummaryRow,
 ) {
   if (
     transaction.amount === 0 ||

--- a/apps/web/src/features/activity/model/types.ts
+++ b/apps/web/src/features/activity/model/types.ts
@@ -13,7 +13,6 @@ export interface ActivityItem {
   excludedFromCalculation?: boolean;
   invoiceId?: string;
   invoiceAmount?: number;
-  invoiceSearchText?: string;
   status: string;
 }
 

--- a/apps/web/src/features/invoices/InvoicesPage.svelte
+++ b/apps/web/src/features/invoices/InvoicesPage.svelte
@@ -1,22 +1,25 @@
 <script lang="ts">
+  import { toStore } from "svelte/store";
   import { createQuery } from "@tanstack/svelte-query";
   import { ChevronDown, Search } from "@lucide/svelte";
-  import Button from "@/shared/ui/Button.svelte";
   import EmptyState from "@/shared/ui/EmptyState.svelte";
   import Input from "@/shared/ui/Input.svelte";
   import type { ApiClient } from "@/shared/api/client";
-  import { invoicesQuery } from "@/data/invoices/queries";
+  import { invoiceDetailQuery, invoicesQuery } from "@/data/invoices/queries";
   import { formatCurrency, formatDate } from "@/shared/format/financial";
 
   let { api }: { api: ApiClient } = $props();
   const invoices = createQuery(invoicesQuery(() => api));
   let search = $state("");
-  let expanded = $state<Record<string, boolean>>({});
+  let expandedInvoiceId = $state<string | null>(null);
+  const invoiceDetail = createQuery(
+    toStore(() => invoiceDetailQuery(() => api, expandedInvoiceId)),
+  );
   const all = $derived($invoices.data ?? []);
   const filtered = $derived(
     all
       .filter((invoice) =>
-        `${invoice.sellerName ?? ""} ${invoice.invoiceNumber ?? ""} ${invoice.items.map((item) => item.description).join(" ")}`
+        `${invoice.sellerName ?? ""} ${invoice.invoiceNumber ?? ""}`
           .toLowerCase()
           .includes(search.trim().toLowerCase()),
       )
@@ -34,16 +37,6 @@
   const thisMonthTotal = $derived(
     thisMonthInvoices.reduce((sum, invoice) => sum + invoice.amount, 0),
   );
-  const allExpanded = $derived(
-    filtered.length > 0 && filtered.every((invoice) => expanded[invoice.id]),
-  );
-  function toggleAll() {
-    if (allExpanded) expanded = {};
-    else
-      expanded = Object.fromEntries(
-        filtered.map((invoice) => [invoice.id, true]),
-      );
-  }
 </script>
 
 {#if $invoices.isPending}
@@ -78,21 +71,16 @@
       </div>
     </div>
 
-    <div class="flex gap-2">
+    <div>
       <div class="relative min-w-0 flex-1">
         <Search
           class="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-muted-foreground"
         /><Input
           class="h-11 pl-9"
-          placeholder="搜尋商店、發票號碼或品項"
+          placeholder="搜尋商店或發票號碼"
           bind:value={search}
         />
       </div>
-      {#if filtered.length > 0}<Button
-          class="h-11"
-          variant="outline"
-          onclick={toggleAll}>{allExpanded ? "全部收合" : "全部展開"}</Button
-        >{/if}
     </div>
 
     {#if months.length === 0}
@@ -122,11 +110,13 @@
             </div>
             <div class="divide-y divide-ink/8">
               {#each group as invoice (invoice.id)}
+                {@const isExpanded = expandedInvoiceId === invoice.id}
                 <div>
                   <button
-                    class={`flex w-full items-center gap-3 px-4 py-3 text-left transition ${expanded[invoice.id] ? "bg-blue-50" : "hover:bg-ink/3"}`}
-                    onclick={() =>
-                      (expanded[invoice.id] = !expanded[invoice.id])}
+                    class={`flex w-full items-center gap-3 px-4 py-3 text-left transition ${isExpanded ? "bg-blue-50" : "hover:bg-ink/3"}`}
+                    onclick={() => {
+                      expandedInvoiceId = isExpanded ? null : invoice.id;
+                    }}
                   >
                     <div class="min-w-0 flex-1">
                       <p class="truncate text-sm font-medium">
@@ -143,22 +133,30 @@
                         <p class="text-sm font-semibold tabular-nums">
                           {formatCurrency(invoice.amount)}
                         </p>
-                        {#if invoice.items.length > 0}<p
+                        {#if isExpanded && $invoiceDetail.data?.id === invoice.id && $invoiceDetail.data.items.length > 0}<p
                             class="text-xs text-ink/40"
                           >
-                            {invoice.items.length} 項
+                            {$invoiceDetail.data.items.length} 項
                           </p>{/if}
                       </div>
                       <ChevronDown
-                        class={`size-4 text-ink/30 transition-transform ${expanded[invoice.id] ? "rotate-180" : ""}`}
+                        class={`size-4 text-ink/30 transition-transform ${isExpanded ? "rotate-180" : ""}`}
                       />
                     </div>
                   </button>
-                  {#if expanded[invoice.id]}
+                  {#if isExpanded}
                     <div class="border-t border-ink/8 bg-paper/60">
-                      {#if invoice.items.length > 0}
+                      {#if $invoiceDetail.isPending}
+                        <p class="px-5 py-3 text-xs text-ink/40">
+                          載入品項明細中。
+                        </p>
+                      {:else if $invoiceDetail.isError}
+                        <p class="px-5 py-3 text-xs text-coral">
+                          無法載入品項明細，請稍後再試。
+                        </p>
+                      {:else if $invoiceDetail.data?.id === invoice.id && $invoiceDetail.data.items.length > 0}
                         <div class="divide-y divide-ink/6">
-                          {#each invoice.items as item (item.id)}<div
+                          {#each $invoiceDetail.data.items as item (item.id)}<div
                               class="flex items-start gap-3 px-5 py-2.5"
                             >
                               <div class="min-w-0 flex-1">

--- a/apps/web/src/shared/api/query-keys.ts
+++ b/apps/web/src/shared/api/query-keys.ts
@@ -13,6 +13,8 @@ export const queryKeys = {
   invoices: ["invoices"] as const,
   invoicesRange: (from: string, to: string) =>
     ["invoices", "range", from, to] as const,
+  invoiceDetail: (invoiceId: string) =>
+    ["invoices", "detail", invoiceId] as const,
   invoiceTransactionMappings: ["invoice-transaction-mappings"] as const,
   manualAssets: ["manualAssets"] as const,
   exchangeRates: ["exchange-rates"] as const,

--- a/apps/web/src/shared/date-range.test.ts
+++ b/apps/web/src/shared/date-range.test.ts
@@ -2,17 +2,17 @@ import { describe, expect, it } from "vitest";
 import { recentMonthRange } from "./date-range";
 
 describe("recentMonthRange", () => {
-  it("includes the ending month and uses the following month as the exclusive end", () => {
+  it("returns the inclusive range for the most recent six months", () => {
     expect(recentMonthRange(6, new Date(2026, 6, 25))).toEqual({
       from: "2026-02",
-      to: "2026-08",
+      to: "2026-07",
     });
   });
 
   it("handles a year boundary", () => {
     expect(recentMonthRange(6, new Date(2026, 0, 25))).toEqual({
       from: "2025-08",
-      to: "2026-02",
+      to: "2026-01",
     });
   });
 });

--- a/apps/web/src/shared/date-range.ts
+++ b/apps/web/src/shared/date-range.ts
@@ -10,10 +10,9 @@ export function recentMonthRange(count: number, now = new Date()): MonthRange {
 export function monthRangeEndingAt(month: string, count: number): MonthRange {
   const [year, monthNumber] = month.split("-").map(Number);
   const start = new Date(year, monthNumber - count, 1);
-  const end = new Date(year, monthNumber, 1);
   return {
     from: monthKey(start),
-    to: monthKey(end),
+    to: month,
   };
 }
 

--- a/apps/worker/src/features/invoices/service.ts
+++ b/apps/worker/src/features/invoices/service.ts
@@ -18,28 +18,16 @@ export async function getInvoicePage(
   const rows = await listInvoices(db, limit + 1, cursor);
   const hasMore = rows.length > limit;
   const page = rows.slice(0, limit);
-  const items = await listInvoiceItems(
-    db,
-    page.map((invoice) => invoice.id),
-  );
-  const itemsByInvoiceId = new Map<string, typeof items>();
-  for (const item of items) {
-    const current = itemsByInvoiceId.get(item.invoiceId) ?? [];
-    current.push(item);
-    itemsByInvoiceId.set(item.invoiceId, current);
-  }
   return {
     hasMore,
     last: page.at(-1),
-    invoices: page.map((invoice) =>
-      presentInvoice(invoice, itemsByInvoiceId.get(invoice.id) ?? []),
-    ),
+    invoices: page.map(presentInvoiceSummary),
   };
 }
 
 export async function getInvoicesRange(db: D1Database, range: MonthDateRange) {
   const rows = await listInvoicesInRange(db, range);
-  return presentInvoices(db, rows);
+  return rows.map(presentInvoiceSummary);
 }
 
 export async function getInvoiceDetail(db: D1Database, invoiceId: string) {
@@ -56,27 +44,19 @@ function presentInvoice<T extends Omit<InvoiceRow, "updatedAt"> | InvoiceRow>(
   invoice: T,
   items: unknown[],
 ) {
+  return {
+    ...presentInvoiceSummary(invoice),
+    items,
+  };
+}
+
+function presentInvoiceSummary<
+  T extends Omit<InvoiceRow, "updatedAt"> | InvoiceRow,
+>(invoice: T) {
   const { updatedAt: _updatedAt, ...presented } = invoice as InvoiceRow;
   return {
     ...presented,
     invoiceNumber: invoice.invoiceNumber ?? undefined,
     sellerName: invoice.sellerName ?? undefined,
-    items,
   };
-}
-
-async function presentInvoices(db: D1Database, rows: InvoiceRow[]) {
-  const items = await listInvoiceItems(
-    db,
-    rows.map((invoice) => invoice.id),
-  );
-  const itemsByInvoiceId = new Map<string, typeof items>();
-  for (const item of items) {
-    const current = itemsByInvoiceId.get(item.invoiceId) ?? [];
-    current.push(item);
-    itemsByInvoiceId.set(item.invoiceId, current);
-  }
-  return rows.map((invoice) =>
-    presentInvoice(invoice, itemsByInvoiceId.get(invoice.id) ?? []),
-  );
 }

--- a/apps/worker/tests/features/month-range-routes.test.ts
+++ b/apps/worker/tests/features/month-range-routes.test.ts
@@ -92,6 +92,48 @@ describe("month-filtered resource APIs", () => {
     ).toBe(true);
   });
 
+  it("returns invoice summaries without loading every line item", async () => {
+    const queries: string[] = [];
+    const invoiceRows = Array.from({ length: 144 }, (_, index) => ({
+      id: `invoice-${index}`,
+      connectorId: "einvoice",
+      sourceId: `source-${index}`,
+      invoiceNumber: `AB${String(index).padStart(8, "0")}`,
+      invoiceDate: "2026-07-01T00:00:00.000Z",
+      sellerName: `商家 ${index}`,
+      amount: index + 1,
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    }));
+    const db = {
+      prepare(sql: string) {
+        queries.push(sql);
+        if (sql.includes("invoice_line_items"))
+          throw new Error("invoice summaries must not load line items");
+        const statement = {
+          bind() {
+            return statement;
+          },
+          async all() {
+            return { results: invoiceRows };
+          },
+        };
+        return statement;
+      },
+    } as unknown as D1Database;
+
+    const response = await invoiceRoutes.request(
+      "/invoices?from=2026-02&to=2026-07",
+      {},
+      { DB: db } as Env,
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Array<Record<string, unknown>>;
+    expect(body).toHaveLength(144);
+    expect(body[0]).not.toHaveProperty("items");
+    expect(queries).toHaveLength(1);
+  });
+
   it("rejects malformed or overly broad month ranges", async () => {
     const { db } = createDb();
     const malformed = await bankRoutes.request("/bank?month=2026-13", {}, {


### PR DESCRIPTION
## 變更內容

- 修正近 6 個月範圍的結束月份，7 月現在查詢 2–7 月，不再多查到 8 月。
- `/api/invoices` 的一般列表與月份範圍列表只回傳發票摘要，不再預先查詢所有品項明細。
- 活動明細與發票頁改用既有 `/api/invoices/:invoiceId`，只有使用者打開單張發票時才載入品項。
- 發票頁一次展開一張發票，移除「全部展開」與品項關鍵字搜尋，避免重新形成全量明細讀取。
- 新增 144 張發票仍只執行摘要查詢的 Worker 回歸測試，以及點開後才發出明細請求的 E2E 測試。

## 根本原因

月份 API 原本一次載入範圍內所有發票與品項。實際 6 個月共有 144 張發票，品項查詢把 144 個 ID 綁進同一個 D1 statement，超過每次 100 個 bound parameters 的限制，因此 `/api/invoices?from=2026-02&to=2026-08` 回傳 500，前端最終顯示沒有發票。

此外，前端將 `to` 當成 exclusive 次月，但 Worker API 將 `from`／`to` 都視為 inclusive 月份，造成固定 6 個月實際送出 7 個月範圍。

## 使用者影響

活動頁可正常取得最近 6 個月的發票摘要，初始載入資料量更小；發票品項會在開啟活動明細或展開單張發票時載入。

## 驗證

- Svelte autofixer：兩個受影響元件皆無 issues／suggestions
- `npm run format:check`
- `npm run typecheck`
- `npm run test:unit`（49 tests passed）
- `npm run test:backend`（Worker 149、DB 4 tests passed；連接器 self-check 通過）
- `npm run build -w @taiwan-fin-hub/web`
- `npm exec -w @taiwan-fin-hub/web -- playwright test e2e/shell.spec.ts`（9 tests passed）
- 實際 API：月份列表回傳 144 張摘要且不含 `items`；單張明細 API 回傳 200 且包含品項
- `git diff --check`