### PR TITLE
修正台新即時交易同步的瞬時連線失敗

### DIFF
--- a/apps/worker/src/connectors/taishin.ts
+++ b/apps/worker/src/connectors/taishin.ts
@@ -24,7 +24,7 @@ const LOGIN_RESULT_ATTEMPTS = 10;
 const LOGIN_RESULT_POLL_MS = 500;
 const REQUIRED_API_TIMEOUT_MS = 8_000;
 const OPTIONAL_API_TIMEOUT_MS = 4_000;
-const REALTIME_BUSY_RETRY_ATTEMPTS = 3;
+const REALTIME_RETRY_ATTEMPTS = 3;
 const USER_AGENT =
   "Mozilla/5.0 (Linux; Android 14; Pixel 7 Build/UP1A.231105.003) " +
   "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36";
@@ -75,6 +75,13 @@ class TaishinCaptchaUnavailableError extends TaishinConnectionError {
   constructor(message: string) {
     super(message);
     this.name = "TaishinCaptchaUnavailableError";
+  }
+}
+
+class TaishinTransientConnectionError extends TaishinConnectionError {
+  constructor(message: string) {
+    super(message);
+    this.name = "TaishinTransientConnectionError";
   }
 }
 
@@ -330,20 +337,28 @@ async function fetchCreditCardPayloads(
 }
 
 async function fetchRealtimeTransactions(page: BrowserPage) {
-  for (let attempt = 1; attempt <= REALTIME_BUSY_RETRY_ATTEMPTS; attempt += 1) {
+  for (let attempt = 1; attempt <= REALTIME_RETRY_ATTEMPTS; attempt += 1) {
     try {
       return await postJson(page, REALTIME_PATH, "", REQUIRED_API_TIMEOUT_MS);
     } catch (error) {
       const isBusy =
         error instanceof TaishinConnectionError &&
         /系統忙碌|無法取得資料/.test(error.message);
-      if (!isBusy) throw error;
-      if (attempt < REALTIME_BUSY_RETRY_ATTEMPTS) {
+      const isTransient = error instanceof TaishinTransientConnectionError;
+      if (!isBusy && !isTransient) throw error;
+      if (attempt < REALTIME_RETRY_ATTEMPTS) {
+        console.warn(
+          `[taishin] realtime retry ${attempt}/${REALTIME_RETRY_ATTEMPTS}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
         await new Promise((resolve) => setTimeout(resolve, attempt * 250));
-      } else {
+      } else if (isBusy) {
         console.warn(
           `[taishin] realtime sync skipped after ${attempt} busy responses`,
         );
+      } else {
+        throw error;
       }
     }
   }
@@ -411,15 +426,21 @@ async function postJson(
           contentType: response.headers.get("content-type") ?? "",
           text: await response.text(),
           timedOut: false,
+          errorName: "",
+          errorMessage: "",
         };
       } catch (error) {
+        const errorName = error instanceof Error ? error.name : "UnknownError";
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
         return {
           ok: false,
           status: 0,
           contentType: "",
           text: "",
-          timedOut:
-            error instanceof DOMException && error.name === "AbortError",
+          timedOut: controller.signal.aborted || errorName === "AbortError",
+          errorName,
+          errorMessage,
         };
       } finally {
         clearTimeout(timeout);
@@ -429,10 +450,25 @@ async function postJson(
   );
   const endpoint = path.split("/").at(-1) ?? path;
   if (response.timedOut) {
-    throw new TaishinConnectionError(`台新信用卡 API ${endpoint} 請求逾時。`);
+    throw new TaishinTransientConnectionError(
+      `台新信用卡 API ${endpoint} 請求逾時。`,
+    );
+  }
+  if (response.status === 0) {
+    const detail = browserFetchErrorDetail(
+      response.errorName,
+      response.errorMessage,
+    );
+    throw new TaishinTransientConnectionError(
+      `台新信用卡 API ${endpoint} 網路請求失敗${detail ? `（${detail}）` : ""}。`,
+    );
   }
   if (!response.ok) {
-    throw new TaishinConnectionError(
+    const ErrorClass =
+      response.status >= 500
+        ? TaishinTransientConnectionError
+        : TaishinConnectionError;
+    throw new ErrorClass(
       `台新信用卡 API ${endpoint} 回應 HTTP ${response.status}。`,
     );
   }
@@ -458,6 +494,20 @@ async function postJson(
     if (error instanceof TaishinConnectionError) throw error;
     throw new TaishinConnectionError("台新信用卡 API 回應格式無效。");
   }
+}
+
+function browserFetchErrorDetail(name: string, message: string) {
+  const safeName = sanitizeBrowserErrorPart(name, 40);
+  const safeMessage = sanitizeBrowserErrorPart(message, 160);
+  return [safeName, safeMessage].filter(Boolean).join(": ");
+}
+
+function sanitizeBrowserErrorPart(value: string, maxLength: number) {
+  return value
+    .replace(/https?:\/\/\S+/gi, "[URL]")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
 }
 
 async function openLoginAndFill(page: Page, config: TaishinConfig) {

--- a/apps/worker/tests/connectors/taishin-session.test.ts
+++ b/apps/worker/tests/connectors/taishin-session.test.ts
@@ -328,6 +328,80 @@ describe("Taishin browser session lifecycle", () => {
     warn.mockRestore();
   });
 
+  it("retries a transient realtime fetch failure and keeps its diagnostics", async () => {
+    const browserPage = page();
+    const response = (value: unknown) => ({
+      ok: true,
+      status: 200,
+      contentType: "application/json",
+      text: JSON.stringify({ value, error: null }),
+    });
+    browserPage.evaluate
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        contentType: "application/json",
+        text: JSON.stringify({
+          RESULT: "SUCCESS",
+          DBSESSIONID: "database-session",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 0,
+        contentType: "",
+        text: "",
+        timedOut: false,
+        errorName: "TypeError",
+        errorMessage:
+          "Failed to fetch https://my.taishinbank.com.tw/private-path",
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        contentType: "application/json",
+        text: "{}",
+      })
+      .mockResolvedValueOnce(response({ fmtRealTxListMap: [] }))
+      .mockResolvedValueOnce(
+        response({
+          "001": { "OUT-DTE-LST-STMT": "20260720" },
+        }),
+      )
+      .mockResolvedValueOnce(response({}));
+    const browserInstance = browser(browserPage);
+    puppeteerMock.launch.mockResolvedValue(browserInstance);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await createTaishinConnector({} as Fetcher).sync({
+      ...credentials,
+      lookbackMonths: 1,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "valid",
+          domain: "my.taishinbank.com.tw",
+        },
+      ]),
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      "[taishin] realtime retry 1/3: 台新信用卡 API qryRealTime 網路請求失敗（TypeError: Failed to fetch [URL]）。",
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "[taishin] realtime retry 2/3: 台新信用卡 API qryRealTime 回應 HTTP 502。",
+    );
+    const realtimeCalls = browserPage.evaluate.mock.calls.filter(
+      ([, input]) =>
+        typeof input === "object" &&
+        input !== null &&
+        "path" in input &&
+        input.path === "/TIBNetBank/svc/web4/rb0708rwd/qryRealTime",
+    );
+    expect(realtimeCalls).toHaveLength(3);
+    warn.mockRestore();
+  });
+
   it("returns fresh session cookies when an API fails after login", async () => {
     const browserPage = page();
     const activeSession = {
@@ -339,16 +413,18 @@ describe("Taishin browser session lifecycle", () => {
         DBSESSIONID: "database-session",
       }),
     };
-    browserPage.evaluate
-      .mockResolvedValueOnce(activeSession)
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 502,
-        contentType: "application/json",
-        text: "{}",
-      });
+    browserPage.evaluate.mockResolvedValueOnce(activeSession).mockResolvedValue({
+      ok: false,
+      status: 0,
+      contentType: "",
+      text: "",
+      timedOut: false,
+      errorName: "TypeError",
+      errorMessage: "Failed to fetch",
+    });
     const browserInstance = browser(browserPage);
     puppeteerMock.launch.mockResolvedValue(browserInstance);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     const error = await createTaishinConnector({} as Fetcher)
       .sync({
@@ -366,7 +442,8 @@ describe("Taishin browser session lifecycle", () => {
 
     expect(error).toBeInstanceOf(TaishinConnectionError);
     expect(error).toMatchObject({
-      message: "台新信用卡 API qryRealTime 回應 HTTP 502。",
+      message:
+        "台新信用卡 API qryRealTime 網路請求失敗（TypeError: Failed to fetch）。",
       sessionCookies: JSON.stringify([
         {
           name: "SESSION",
@@ -376,7 +453,18 @@ describe("Taishin browser session lifecycle", () => {
       ]),
       sessionCreatedAt: expect.any(String),
     });
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(
+      browserPage.evaluate.mock.calls.filter(
+        ([, input]) =>
+          typeof input === "object" &&
+          input !== null &&
+          "path" in input &&
+          input.path === "/TIBNetBank/svc/web4/rb0708rwd/qryRealTime",
+      ),
+    ).toHaveLength(3);
     expect(browserInstance.close).toHaveBeenCalledOnce();
+    warn.mockRestore();
   });
 
   it("reuses the same browser for manual CAPTCHA and disconnects it", async () => {


### PR DESCRIPTION
## 問題

台新排程同步連續出現 `qryRealTime 回應 HTTP 0`。這不是實際 HTTP 狀態碼，而是 Browser Rendering 內的 `fetch` 例外被統一轉成 `status: 0`，原始錯誤資訊也因此遺失；現有重試只涵蓋台新回傳的「系統忙碌」，瞬時網路錯誤會直接讓整次同步失敗。

## 修改

- 將逾時、沒有收到 HTTP 回應及 HTTP 5xx 分類為可重試的瞬時連線錯誤。
- `qryRealTime` 最多嘗試 3 次，沿用有限退避等待；重試耗盡後仍維持同步失敗，不把缺少即時交易誤判為成功。
- 保留並清理瀏覽器 `fetch` 的錯誤名稱與訊息，遮蔽 URL、限制長度，避免再顯示沒有診斷價值的 `HTTP 0`。
- 維持台新明確回覆「系統忙碌」時可略過即時交易的既有行為。
- 補上 transport error、HTTP 5xx、重試成功、重試耗盡及 session cookies 保留測試。

## 影響

短暫的 Browser Rendering／台新網路瞬斷可在同一次同步內自行恢復；若持續失敗，排程狀態會顯示可辨識的錯誤原因，且不會誤清除現有 session。

## 驗證

- `npm run typecheck`
- `npm run test:backend`（Worker 150 tests、DB 4 tests、connector self-check）
- `npm run verify:web`（49 unit、9 E2E、build）
- `npm run format:check`
- `npm run build`
- 台新 session targeted tests（13 tests）
- `git diff --check`