### PR TITLE
將一般手動同步改為可恢復的背景工作

### DIFF
--- a/apps/web/src/app/query-client.ts
+++ b/apps/web/src/app/query-client.ts
@@ -1,5 +1,14 @@
 import { QueryClient } from "@tanstack/svelte-query";
+import { queryKeys } from "@/shared/api/query-keys";
 
 export const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false, staleTime: 30_000 } },
 });
+
+if (typeof window !== "undefined") {
+  window.addEventListener("taiwan-fin-hub:sync-jobs-completed", () => {
+    void queryClient.invalidateQueries({
+      predicate: (query) => query.queryKey !== queryKeys.syncJobs,
+    });
+  });
+}

--- a/apps/web/src/app/query-client.ts
+++ b/apps/web/src/app/query-client.ts
@@ -1,5 +1,4 @@
 import { QueryClient } from "@tanstack/svelte-query";
-import { queryKeys } from "@/shared/api/query-keys";
 
 export const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false, staleTime: 30_000 } },
@@ -7,8 +6,6 @@ export const queryClient = new QueryClient({
 
 if (typeof window !== "undefined") {
   window.addEventListener("taiwan-fin-hub:sync-jobs-completed", () => {
-    void queryClient.invalidateQueries({
-      predicate: (query) => query.queryKey !== queryKeys.syncJobs,
-    });
+    void queryClient.invalidateQueries();
   });
 }

--- a/apps/web/src/data/connectors/queries.ts
+++ b/apps/web/src/data/connectors/queries.ts
@@ -9,10 +9,44 @@ import type {
 
 type ApiProvider = () => ApiClient;
 
+const syncJobSnapshots = new Map<
+  string,
+  Pick<SyncJobRow, "updatedAt" | "running" | "lastStatus">
+>();
+
+function publishCompletedSyncJobs(jobs: SyncJobRow[]) {
+  if (typeof window === "undefined") return;
+
+  const completed: SyncJobRow[] = [];
+  for (const job of jobs) {
+    const previous = syncJobSnapshots.get(job.id);
+    if (previous && previous.updatedAt !== job.updatedAt && !job.running) {
+      completed.push(job);
+    }
+    syncJobSnapshots.set(job.id, {
+      updatedAt: job.updatedAt,
+      running: job.running,
+      lastStatus: job.lastStatus,
+    });
+  }
+
+  if (completed.length > 0) {
+    window.dispatchEvent(
+      new CustomEvent("taiwan-fin-hub:sync-jobs-completed", {
+        detail: completed,
+      }),
+    );
+  }
+}
+
 export const syncJobsQuery = (getApi: ApiProvider) =>
   queryOptions({
     queryKey: queryKeys.syncJobs,
-    queryFn: () => getApi().get<SyncJobRow[]>("/api/sync-jobs"),
+    queryFn: async () => {
+      const jobs = await getApi().get<SyncJobRow[]>("/api/sync-jobs");
+      publishCompletedSyncJobs(jobs);
+      return jobs;
+    },
     refetchInterval: (query) => {
       const jobs = query.state.data as SyncJobRow[] | undefined;
       return jobs?.some((job) => job.running) ? 2_000 : false;

--- a/apps/web/src/data/connectors/queries.ts
+++ b/apps/web/src/data/connectors/queries.ts
@@ -13,6 +13,10 @@ export const syncJobsQuery = (getApi: ApiProvider) =>
   queryOptions({
     queryKey: queryKeys.syncJobs,
     queryFn: () => getApi().get<SyncJobRow[]>("/api/sync-jobs"),
+    refetchInterval: (query) => {
+      const jobs = query.state.data as SyncJobRow[] | undefined;
+      return jobs?.some((job) => job.running) ? 2_000 : false;
+    },
   });
 
 export const syncScheduleQuery = (getApi: ApiProvider) =>

--- a/apps/worker/src/features/sync/manual-job.ts
+++ b/apps/worker/src/features/sync/manual-job.ts
@@ -1,0 +1,82 @@
+import type { ConnectorId } from "@taiwan-fin-hub/core";
+import {
+  acquireSyncJobLock,
+  markManualSyncFailure,
+  markManualSyncSuccess,
+  releaseSyncJobLock,
+  type SyncStatus,
+} from "@taiwan-fin-hub/db";
+import type { Env } from "../../platform/env";
+import {
+  canonicalSyncLockRowId,
+  isUserActionError,
+  safeErrorMessage,
+  startSyncLockHeartbeat,
+  SYNC_LOCK_LEASE_MS,
+  SyncAlreadyRunningError,
+  type SyncOutcome,
+  type SyncScope,
+} from "./service";
+
+export type ManualSyncJob = {
+  runId: string;
+  completion: Promise<SyncOutcome>;
+};
+
+export async function startManualSyncJob(
+  env: Env,
+  connectorId: ConnectorId,
+  scope: SyncScope,
+  task: () => Promise<SyncOutcome>,
+): Promise<ManualSyncJob> {
+  const runId = crypto.randomUUID();
+  const lockRowId = canonicalSyncLockRowId(connectorId);
+  const locked = await acquireSyncJobLock(env.DB, {
+    lockRowId,
+    scope,
+    trigger: "manual",
+    runId,
+    leaseMs: SYNC_LOCK_LEASE_MS,
+  });
+
+  if (!locked) throw new SyncAlreadyRunningError(connectorId);
+
+  const completion = runManualSyncJob(
+    env,
+    connectorId,
+    scope,
+    lockRowId,
+    runId,
+    task,
+  );
+
+  return { runId, completion };
+}
+
+async function runManualSyncJob(
+  env: Env,
+  connectorId: ConnectorId,
+  scope: SyncScope,
+  lockRowId: string,
+  runId: string,
+  task: () => Promise<SyncOutcome>,
+) {
+  const stopHeartbeat = startSyncLockHeartbeat(env.DB, lockRowId, runId);
+  try {
+    const outcome = await task();
+    await markManualSyncSuccess(env.DB, connectorId, scope);
+    return outcome;
+  } catch (error) {
+    const status: SyncStatus = isUserActionError(error)
+      ? "needs_user_action"
+      : "failed";
+    await markManualSyncFailure(env.DB, connectorId, scope, {
+      status,
+      errorMessage: safeErrorMessage(error),
+    });
+    throw error;
+  } finally {
+    stopHeartbeat();
+    await releaseSyncJobLock(env.DB, lockRowId, runId);
+  }
+}

--- a/apps/worker/src/features/sync/route.ts
+++ b/apps/worker/src/features/sync/route.ts
@@ -34,7 +34,9 @@ import {
   TDCC_SCOPE_TRADES,
   withManualSyncLock,
   type SyncOutcome,
+  type SyncScope,
 } from "./service";
+import type { ConnectorId } from "@taiwan-fin-hub/core";
 
 const tdccSyncBodySchema = z.object({
   otp: z.string().min(1).optional(),
@@ -46,17 +48,11 @@ const einvoiceSyncBodySchema = z.object({
 });
 
 const sinopacSyncBodySchema = z.object({
-  captcha: z
-    .string()
-    .regex(/^\d{6}$/)
-    .optional(),
+  captcha: z.string().regex(/^\d{6}$/).optional(),
 });
 
 const taishinSyncBodySchema = z.object({
-  captcha: z
-    .string()
-    .regex(/^\d{4,8}$/)
-    .optional(),
+  captcha: z.string().regex(/^\d{4,8}$/).optional(),
 });
 
 export const syncRoutes = honoFactory.createApp();
@@ -70,15 +66,13 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
       einvoiceSyncBodySchema,
       validationHook("INVALID_REQUEST", "E-Invoice sync options are invalid."),
     ),
-    async (c) => {
-      const overrides = c.req.valid("json");
-      return syncRouteResponse(
+    async (c) =>
+      acceptManualSync(
         c,
-        withManualSyncLock(c.env, "einvoice", SYNC_SCOPE_ALL, () =>
-          syncEinvoice(c.env, "manual", overrides),
-        ),
-      );
-    },
+        "einvoice",
+        SYNC_SCOPE_ALL,
+        () => syncEinvoice(c.env, "manual", c.req.valid("json")),
+      ),
   );
 
   api.post(
@@ -90,15 +84,17 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
     ),
     async (c) => {
       const overrides = c.req.valid("json");
-      return syncRouteResponse(
+      return syncInteractiveOrBackground(
         c,
-        withManualSyncLock(c.env, "tdcc", SYNC_SCOPE_ALL, () =>
+        "tdcc",
+        SYNC_SCOPE_ALL,
+        Boolean(overrides.otp),
+        () =>
           syncTdcc(c.env, "manual", overrides, [
             TDCC_SCOPE_INVESTMENTS,
             TDCC_SCOPE_BANK,
             TDCC_SCOPE_TRADES,
           ]),
-        ),
       );
     },
   );
@@ -112,11 +108,12 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
     ),
     async (c) => {
       const overrides = c.req.valid("json");
-      return syncRouteResponse(
+      return syncInteractiveOrBackground(
         c,
-        withManualSyncLock(c.env, "tdcc", TDCC_SCOPE_INVESTMENTS, () =>
-          syncTdcc(c.env, "manual", overrides, [TDCC_SCOPE_INVESTMENTS]),
-        ),
+        "tdcc",
+        TDCC_SCOPE_INVESTMENTS,
+        Boolean(overrides.otp),
+        () => syncTdcc(c.env, "manual", overrides, [TDCC_SCOPE_INVESTMENTS]),
       );
     },
   );
@@ -130,11 +127,12 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
     ),
     async (c) => {
       const overrides = c.req.valid("json");
-      return syncRouteResponse(
+      return syncInteractiveOrBackground(
         c,
-        withManualSyncLock(c.env, "tdcc", TDCC_SCOPE_BANK, () =>
-          syncTdcc(c.env, "manual", overrides, [TDCC_SCOPE_BANK]),
-        ),
+        "tdcc",
+        TDCC_SCOPE_BANK,
+        Boolean(overrides.otp),
+        () => syncTdcc(c.env, "manual", overrides, [TDCC_SCOPE_BANK]),
       );
     },
   );
@@ -148,32 +146,27 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
     ),
     async (c) => {
       const overrides = c.req.valid("json");
-      return syncRouteResponse(
+      return syncInteractiveOrBackground(
         c,
-        withManualSyncLock(c.env, "tdcc", TDCC_SCOPE_TRADES, () =>
-          syncTdcc(c.env, "manual", overrides, [TDCC_SCOPE_TRADES]),
-        ),
+        "tdcc",
+        TDCC_SCOPE_TRADES,
+        Boolean(overrides.otp),
+        () => syncTdcc(c.env, "manual", overrides, [TDCC_SCOPE_TRADES]),
       );
     },
   );
 
-  api.post("/connectors/esun/sync", async (c) => {
-    return syncRouteResponse(
-      c,
-      withManualSyncLock(c.env, "esun", SYNC_SCOPE_ALL, () =>
-        syncEsun(c.env, "manual"),
-      ),
-    );
-  });
+  api.post("/connectors/esun/sync", async (c) =>
+    acceptManualSync(c, "esun", SYNC_SCOPE_ALL, () =>
+      syncEsun(c.env, "manual"),
+    ),
+  );
 
-  api.post("/connectors/cathaybk/sync", async (c) => {
-    return syncRouteResponse(
-      c,
-      withManualSyncLock(c.env, "cathaybk", SYNC_SCOPE_ALL, () =>
-        syncCathaybk(c.env, "manual"),
-      ),
-    );
-  });
+  api.post("/connectors/cathaybk/sync", async (c) =>
+    acceptManualSync(c, "cathaybk", SYNC_SCOPE_ALL, () =>
+      syncCathaybk(c.env, "manual"),
+    ),
+  );
 
   api.post("/connectors/sinopac/captcha", async (c) => {
     try {
@@ -207,11 +200,12 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
     ),
     async (c) => {
       const overrides = c.req.valid("json");
-      return syncRouteResponse(
+      return syncInteractiveOrBackground(
         c,
-        withManualSyncLock(c.env, "sinopac", SYNC_SCOPE_ALL, () =>
-          syncSinopac(c.env, "manual", overrides),
-        ),
+        "sinopac",
+        SYNC_SCOPE_ALL,
+        Boolean(overrides.captcha),
+        () => syncSinopac(c.env, "manual", overrides),
       );
     },
   );
@@ -252,35 +246,59 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
     ),
     async (c) => {
       const overrides = c.req.valid("json");
-      try {
-        const job = await startManualSyncJob(
-          c.env,
-          "taishin",
-          SYNC_SCOPE_ALL,
-          () => syncTaishin(c.env, "manual", overrides),
-        );
-        c.executionCtx.waitUntil(
-          job.completion.catch((error) => {
-            console.error(
-              `[sync] taishin/${SYNC_SCOPE_ALL}: background job ${job.runId} failed`,
-              error,
-            );
-          }),
-        );
-        return c.json(
-          {
-            accepted: true,
-            connectorId: "taishin",
-            scope: SYNC_SCOPE_ALL,
-            runId: job.runId,
-          },
-          202,
-        );
-      } catch (error) {
-        return syncRouteErrorResponse(c, error);
-      }
+      return syncInteractiveOrBackground(
+        c,
+        "taishin",
+        SYNC_SCOPE_ALL,
+        Boolean(overrides.captcha),
+        () => syncTaishin(c.env, "manual", overrides),
+      );
     },
   );
+}
+
+async function syncInteractiveOrBackground(
+  c: Context<AppBindings>,
+  connectorId: ConnectorId,
+  scope: SyncScope,
+  interactive: boolean,
+  task: () => Promise<SyncOutcome>,
+) {
+  if (!interactive) return acceptManualSync(c, connectorId, scope, task);
+  return syncRouteResponse(
+    c,
+    withManualSyncLock(c.env, connectorId, scope, task),
+  );
+}
+
+async function acceptManualSync(
+  c: Context<AppBindings>,
+  connectorId: ConnectorId,
+  scope: SyncScope,
+  task: () => Promise<SyncOutcome>,
+) {
+  try {
+    const job = await startManualSyncJob(c.env, connectorId, scope, task);
+    c.executionCtx.waitUntil(
+      job.completion.catch((error) => {
+        console.error(
+          `[sync] ${connectorId}/${scope}: background job ${job.runId} failed`,
+          error,
+        );
+      }),
+    );
+    return c.json(
+      {
+        accepted: true,
+        connectorId,
+        scope,
+        runId: job.runId,
+      },
+      202,
+    );
+  } catch (error) {
+    return syncRouteErrorResponse(c, error);
+  }
 }
 
 async function syncRouteResponse(

--- a/apps/worker/src/features/sync/route.ts
+++ b/apps/worker/src/features/sync/route.ts
@@ -15,6 +15,7 @@ import type { AppBindings } from "../../platform/env";
 import { honoFactory } from "../../platform/hono";
 import { jsonError } from "../../platform/http";
 import { validationHook } from "../../platform/validation";
+import { startManualSyncJob } from "./manual-job";
 import {
   NeedsUserActionError,
   prepareSinopacCaptchaSession,
@@ -251,12 +252,33 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
     ),
     async (c) => {
       const overrides = c.req.valid("json");
-      return syncRouteResponse(
-        c,
-        withManualSyncLock(c.env, "taishin", SYNC_SCOPE_ALL, () =>
-          syncTaishin(c.env, "manual", overrides),
-        ),
-      );
+      try {
+        const job = await startManualSyncJob(
+          c.env,
+          "taishin",
+          SYNC_SCOPE_ALL,
+          () => syncTaishin(c.env, "manual", overrides),
+        );
+        c.executionCtx.waitUntil(
+          job.completion.catch((error) => {
+            console.error(
+              `[sync] taishin/${SYNC_SCOPE_ALL}: background job ${job.runId} failed`,
+              error,
+            );
+          }),
+        );
+        return c.json(
+          {
+            accepted: true,
+            connectorId: "taishin",
+            scope: SYNC_SCOPE_ALL,
+            runId: job.runId,
+          },
+          202,
+        );
+      } catch (error) {
+        return syncRouteErrorResponse(c, error);
+      }
     },
   );
 }
@@ -268,40 +290,44 @@ async function syncRouteResponse(
   try {
     return c.json(await result);
   } catch (error) {
-    if (error instanceof SyncAlreadyRunningError) {
-      return jsonError("SYNC_ALREADY_RUNNING", error.message, 409);
-    }
-    if (error instanceof TdccVerificationRequiredError) {
-      return jsonError(
-        error.channel === "sms"
-          ? "TDCC_SMS_OTP_REQUIRED"
-          : "TDCC_EMAIL_OTP_REQUIRED",
-        error.message,
-        400,
-      );
-    }
-    if (error instanceof TdccConnectionError) {
-      return jsonError("TDCC_CONNECTION_FAILED", error.message, 400);
-    }
-    if (error instanceof NeedsUserActionError) {
-      return jsonError("USER_ACTION_REQUIRED", error.message, 400);
-    }
-    if (error instanceof EInvoiceProtocolUnavailableError) {
-      return jsonError("CONNECTOR_PROTOCOL_UNAVAILABLE", error.message, 503);
-    }
-    if (error instanceof SinopacBrowserCapacityError) {
-      const response = jsonError("SINOPAC_BROWSER_BUSY", error.message, 429);
-      response.headers.set("Retry-After", String(error.retryAfterSeconds));
-      return response;
-    }
-    if (error instanceof TaishinBrowserCapacityError) {
-      const response = jsonError("TAISHIN_BROWSER_BUSY", error.message, 429);
-      response.headers.set("Retry-After", String(error.retryAfterSeconds));
-      return response;
-    }
-    if (error instanceof TaishinConnectionError) {
-      return jsonError("TAISHIN_CONNECTION_FAILED", error.message, 502);
-    }
-    throw error;
+    return syncRouteErrorResponse(c, error);
   }
+}
+
+function syncRouteErrorResponse(c: Context<AppBindings>, error: unknown) {
+  if (error instanceof SyncAlreadyRunningError) {
+    return jsonError("SYNC_ALREADY_RUNNING", error.message, 409);
+  }
+  if (error instanceof TdccVerificationRequiredError) {
+    return jsonError(
+      error.channel === "sms"
+        ? "TDCC_SMS_OTP_REQUIRED"
+        : "TDCC_EMAIL_OTP_REQUIRED",
+      error.message,
+      400,
+    );
+  }
+  if (error instanceof TdccConnectionError) {
+    return jsonError("TDCC_CONNECTION_FAILED", error.message, 400);
+  }
+  if (error instanceof NeedsUserActionError) {
+    return jsonError("USER_ACTION_REQUIRED", error.message, 400);
+  }
+  if (error instanceof EInvoiceProtocolUnavailableError) {
+    return jsonError("CONNECTOR_PROTOCOL_UNAVAILABLE", error.message, 503);
+  }
+  if (error instanceof SinopacBrowserCapacityError) {
+    const response = jsonError("SINOPAC_BROWSER_BUSY", error.message, 429);
+    response.headers.set("Retry-After", String(error.retryAfterSeconds));
+    return response;
+  }
+  if (error instanceof TaishinBrowserCapacityError) {
+    const response = jsonError("TAISHIN_BROWSER_BUSY", error.message, 429);
+    response.headers.set("Retry-After", String(error.retryAfterSeconds));
+    return response;
+  }
+  if (error instanceof TaishinConnectionError) {
+    return jsonError("TAISHIN_CONNECTION_FAILED", error.message, 502);
+  }
+  throw error;
 }

--- a/apps/worker/src/features/sync/route.ts
+++ b/apps/worker/src/features/sync/route.ts
@@ -3,6 +3,7 @@ import {
   TdccConnectionError,
   TdccVerificationRequiredError,
 } from "@taiwan-fin-hub/connectors";
+import type { ConnectorId } from "@taiwan-fin-hub/core";
 import { zValidator } from "@hono/zod-validator";
 import { type Context, type Hono } from "hono";
 import { z } from "zod";
@@ -36,21 +37,15 @@ import {
   type SyncOutcome,
   type SyncScope,
 } from "./service";
-import type { ConnectorId } from "@taiwan-fin-hub/core";
 
 const tdccSyncBodySchema = z.object({
   otp: z.string().min(1).optional(),
   otpChannel: z.enum(["email", "sms"]).optional(),
 });
-
-const einvoiceSyncBodySchema = z.object({
-  fetchDetails: z.boolean().optional(),
-});
-
+const einvoiceSyncBodySchema = z.object({ fetchDetails: z.boolean().optional() });
 const sinopacSyncBodySchema = z.object({
   captcha: z.string().regex(/^\d{6}$/).optional(),
 });
-
 const taishinSyncBodySchema = z.object({
   captcha: z.string().regex(/^\d{4,8}$/).optional(),
 });
@@ -67,130 +62,27 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
       validationHook("INVALID_REQUEST", "E-Invoice sync options are invalid."),
     ),
     async (c) =>
-      acceptManualSync(
-        c,
-        "einvoice",
-        SYNC_SCOPE_ALL,
-        () => syncEinvoice(c.env, "manual", c.req.valid("json")),
+      acceptManualSync(c, "einvoice", SYNC_SCOPE_ALL, () =>
+        syncEinvoice(c.env, "manual", c.req.valid("json")),
       ),
   );
 
-  api.post(
-    "/connectors/tdcc/sync",
-    zValidator(
-      "json",
-      tdccSyncBodySchema,
-      validationHook("INVALID_REQUEST", "TDCC sync options are invalid."),
-    ),
-    async (c) => {
-      const overrides = c.req.valid("json");
-      return syncInteractiveOrBackground(
-        c,
-        "tdcc",
-        SYNC_SCOPE_ALL,
-        Boolean(overrides.otp),
-        () =>
-          syncTdcc(c.env, "manual", overrides, [
-            TDCC_SCOPE_INVESTMENTS,
-            TDCC_SCOPE_BANK,
-            TDCC_SCOPE_TRADES,
-          ]),
-      );
-    },
-  );
-
-  api.post(
-    "/connectors/tdcc/sync/investments",
-    zValidator(
-      "json",
-      tdccSyncBodySchema,
-      validationHook("INVALID_REQUEST", "TDCC sync options are invalid."),
-    ),
-    async (c) => {
-      const overrides = c.req.valid("json");
-      return syncInteractiveOrBackground(
-        c,
-        "tdcc",
-        TDCC_SCOPE_INVESTMENTS,
-        Boolean(overrides.otp),
-        () => syncTdcc(c.env, "manual", overrides, [TDCC_SCOPE_INVESTMENTS]),
-      );
-    },
-  );
-
-  api.post(
-    "/connectors/tdcc/sync/bank",
-    zValidator(
-      "json",
-      tdccSyncBodySchema,
-      validationHook("INVALID_REQUEST", "TDCC sync options are invalid."),
-    ),
-    async (c) => {
-      const overrides = c.req.valid("json");
-      return syncInteractiveOrBackground(
-        c,
-        "tdcc",
-        TDCC_SCOPE_BANK,
-        Boolean(overrides.otp),
-        () => syncTdcc(c.env, "manual", overrides, [TDCC_SCOPE_BANK]),
-      );
-    },
-  );
-
-  api.post(
-    "/connectors/tdcc/sync/trades",
-    zValidator(
-      "json",
-      tdccSyncBodySchema,
-      validationHook("INVALID_REQUEST", "TDCC sync options are invalid."),
-    ),
-    async (c) => {
-      const overrides = c.req.valid("json");
-      return syncInteractiveOrBackground(
-        c,
-        "tdcc",
-        TDCC_SCOPE_TRADES,
-        Boolean(overrides.otp),
-        () => syncTdcc(c.env, "manual", overrides, [TDCC_SCOPE_TRADES]),
-      );
-    },
-  );
+  registerTdccRoutes(api);
 
   api.post("/connectors/esun/sync", async (c) =>
     acceptManualSync(c, "esun", SYNC_SCOPE_ALL, () =>
       syncEsun(c.env, "manual"),
     ),
   );
-
   api.post("/connectors/cathaybk/sync", async (c) =>
     acceptManualSync(c, "cathaybk", SYNC_SCOPE_ALL, () =>
       syncCathaybk(c.env, "manual"),
     ),
   );
 
-  api.post("/connectors/sinopac/captcha", async (c) => {
-    try {
-      return c.json(await prepareSinopacCaptchaSession(c.env));
-    } catch (error) {
-      if (error instanceof SyncAlreadyRunningError) {
-        return jsonError(
-          "SYNC_ALREADY_RUNNING",
-          "永豐已有驗證或同步作業正在進行。",
-          409,
-        );
-      }
-      if (error instanceof SinopacBrowserCapacityError) {
-        const response = jsonError("SINOPAC_BROWSER_BUSY", error.message, 429);
-        response.headers.set("Retry-After", String(error.retryAfterSeconds));
-        return response;
-      }
-      if (error instanceof NeedsUserActionError) {
-        return jsonError("USER_ACTION_REQUIRED", error.message, 400);
-      }
-      return jsonError("SINOPAC_CAPTCHA_FAILED", safeErrorMessage(error), 502);
-    }
-  });
-
+  api.post("/connectors/sinopac/captcha", (c) =>
+    prepareCaptchaResponse(c, "sinopac"),
+  );
   api.post(
     "/connectors/sinopac/sync",
     zValidator(
@@ -203,40 +95,15 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
       return syncInteractiveOrBackground(
         c,
         "sinopac",
-        SYNC_SCOPE_ALL,
         Boolean(overrides.captcha),
         () => syncSinopac(c.env, "manual", overrides),
       );
     },
   );
 
-  api.post("/connectors/taishin/captcha", async (c) => {
-    try {
-      return c.json(await prepareTaishinCaptchaSession(c.env));
-    } catch (error) {
-      if (error instanceof SyncAlreadyRunningError) {
-        return jsonError(
-          "SYNC_ALREADY_RUNNING",
-          "台新已有驗證或同步作業正在進行。",
-          409,
-        );
-      }
-      if (error instanceof TaishinBrowserCapacityError) {
-        const response = jsonError("TAISHIN_BROWSER_BUSY", error.message, 429);
-        response.headers.set("Retry-After", String(error.retryAfterSeconds));
-        return response;
-      }
-      if (error instanceof NeedsUserActionError) {
-        return jsonError("USER_ACTION_REQUIRED", error.message, 400);
-      }
-      return jsonError(
-        "TAISHIN_CONNECTION_FAILED",
-        safeErrorMessage(error),
-        502,
-      );
-    }
-  });
-
+  api.post("/connectors/taishin/captcha", (c) =>
+    prepareCaptchaResponse(c, "taishin"),
+  );
   api.post(
     "/connectors/taishin/sync",
     zValidator(
@@ -249,7 +116,6 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
       return syncInteractiveOrBackground(
         c,
         "taishin",
-        SYNC_SCOPE_ALL,
         Boolean(overrides.captcha),
         () => syncTaishin(c.env, "manual", overrides),
       );
@@ -257,17 +123,103 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
   );
 }
 
+function registerTdccRoutes(api: Hono<AppBindings>) {
+  const register = (
+    path: string,
+    scope: SyncScope,
+    scopes: Array<
+      | typeof TDCC_SCOPE_INVESTMENTS
+      | typeof TDCC_SCOPE_BANK
+      | typeof TDCC_SCOPE_TRADES
+    >,
+  ) =>
+    api.post(
+      path,
+      zValidator(
+        "json",
+        tdccSyncBodySchema,
+        validationHook("INVALID_REQUEST", "TDCC sync options are invalid."),
+      ),
+      async (c) => {
+        const overrides = c.req.valid("json");
+        return syncRouteResponse(
+          c,
+          withManualSyncLock(c.env, "tdcc", scope, () =>
+            syncTdcc(c.env, "manual", overrides, scopes),
+          ),
+        );
+      },
+    );
+
+  register("/connectors/tdcc/sync", SYNC_SCOPE_ALL, [
+    TDCC_SCOPE_INVESTMENTS,
+    TDCC_SCOPE_BANK,
+    TDCC_SCOPE_TRADES,
+  ]);
+  register(
+    "/connectors/tdcc/sync/investments",
+    TDCC_SCOPE_INVESTMENTS,
+    [TDCC_SCOPE_INVESTMENTS],
+  );
+  register("/connectors/tdcc/sync/bank", TDCC_SCOPE_BANK, [TDCC_SCOPE_BANK]);
+  register("/connectors/tdcc/sync/trades", TDCC_SCOPE_TRADES, [
+    TDCC_SCOPE_TRADES,
+  ]);
+}
+
+async function prepareCaptchaResponse(
+  c: Context<AppBindings>,
+  connectorId: "sinopac" | "taishin",
+) {
+  try {
+    return c.json(
+      connectorId === "sinopac"
+        ? await prepareSinopacCaptchaSession(c.env)
+        : await prepareTaishinCaptchaSession(c.env),
+    );
+  } catch (error) {
+    if (error instanceof SyncAlreadyRunningError) {
+      return jsonError(
+        "SYNC_ALREADY_RUNNING",
+        `${connectorId === "sinopac" ? "永豐" : "台新"}已有驗證或同步作業正在進行。`,
+        409,
+      );
+    }
+    if (error instanceof SinopacBrowserCapacityError) {
+      const response = jsonError("SINOPAC_BROWSER_BUSY", error.message, 429);
+      response.headers.set("Retry-After", String(error.retryAfterSeconds));
+      return response;
+    }
+    if (error instanceof TaishinBrowserCapacityError) {
+      const response = jsonError("TAISHIN_BROWSER_BUSY", error.message, 429);
+      response.headers.set("Retry-After", String(error.retryAfterSeconds));
+      return response;
+    }
+    if (error instanceof NeedsUserActionError) {
+      return jsonError("USER_ACTION_REQUIRED", error.message, 400);
+    }
+    return jsonError(
+      connectorId === "sinopac"
+        ? "SINOPAC_CAPTCHA_FAILED"
+        : "TAISHIN_CONNECTION_FAILED",
+      safeErrorMessage(error),
+      502,
+    );
+  }
+}
+
 async function syncInteractiveOrBackground(
   c: Context<AppBindings>,
-  connectorId: ConnectorId,
-  scope: SyncScope,
+  connectorId: "sinopac" | "taishin",
   interactive: boolean,
   task: () => Promise<SyncOutcome>,
 ) {
-  if (!interactive) return acceptManualSync(c, connectorId, scope, task);
+  if (!interactive) {
+    return acceptManualSync(c, connectorId, SYNC_SCOPE_ALL, task);
+  }
   return syncRouteResponse(
     c,
-    withManualSyncLock(c.env, connectorId, scope, task),
+    withManualSyncLock(c.env, connectorId, SYNC_SCOPE_ALL, task),
   );
 }
 
@@ -288,12 +240,7 @@ async function acceptManualSync(
       }),
     );
     return c.json(
-      {
-        accepted: true,
-        connectorId,
-        scope,
-        runId: job.runId,
-      },
+      { accepted: true, connectorId, scope, runId: job.runId },
       202,
     );
   } catch (error) {

--- a/apps/worker/tests/features/sync/route.test.ts
+++ b/apps/worker/tests/features/sync/route.test.ts
@@ -7,7 +7,12 @@ import type { Env } from "../../../src/platform/env";
 
 const mocks = vi.hoisted(() => ({
   prepareTaishinCaptchaSession: vi.fn(),
+  startManualSyncJob: vi.fn(),
   syncTaishin: vi.fn(),
+}));
+
+vi.mock("../../../src/features/sync/manual-job", () => ({
+  startManualSyncJob: mocks.startManualSyncJob,
 }));
 
 vi.mock("../../../src/features/sync/service", () => ({
@@ -38,6 +43,11 @@ vi.mock("../../../src/features/sync/service", () => ({
 import { syncRoutes } from "../../../src/features/sync/route";
 
 const env = {} as Env;
+const executionCtx = {
+  waitUntil: vi.fn(),
+  passThroughOnException: vi.fn(),
+  props: {},
+} as unknown as ExecutionContext;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -53,18 +63,39 @@ beforeEach(() => {
     records: 3,
     cursorUpdated: true,
   });
+  mocks.startManualSyncJob.mockImplementation(
+    async (
+      _env: Env,
+      connectorId: string,
+      scope: string,
+      task: () => Promise<unknown>,
+    ) => ({
+      runId: "manual-run-1",
+      completion: task(),
+      connectorId,
+      scope,
+    }),
+  );
 });
 
 describe("Taishin sync routes", () => {
-  it("accepts an empty sync body and dispatches the manual sync", async () => {
+  it("accepts an empty sync body as a background manual sync", async () => {
     const response = await syncRoutes.request(
       "/connectors/taishin/sync",
       { method: "POST" },
       env,
+      executionCtx,
     );
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      accepted: true,
+      connectorId: "taishin",
+      scope: "all",
+      runId: "manual-run-1",
+    });
     expect(mocks.syncTaishin).toHaveBeenCalledWith(env, "manual", {});
+    expect(executionCtx.waitUntil).toHaveBeenCalledOnce();
   });
 
   it("rejects malformed manual CAPTCHA input", async () => {
@@ -76,6 +107,7 @@ describe("Taishin sync routes", () => {
         body: JSON.stringify({ captcha: "12AB" }),
       },
       env,
+      executionCtx,
     );
 
     expect(response.status).toBe(400);
@@ -90,6 +122,7 @@ describe("Taishin sync routes", () => {
       "/connectors/taishin/captcha",
       { method: "POST" },
       env,
+      executionCtx,
     );
 
     expect(response.status).toBe(200);
@@ -99,7 +132,7 @@ describe("Taishin sync routes", () => {
     });
   });
 
-  it("maps Browser Rendering capacity and connection failures", async () => {
+  it("maps Browser Rendering capacity and interactive connection failures", async () => {
     mocks.prepareTaishinCaptchaSession.mockRejectedValueOnce(
       new TaishinBrowserCapacityError("browser busy", 17),
     );
@@ -107,6 +140,7 @@ describe("Taishin sync routes", () => {
       "/connectors/taishin/captcha",
       { method: "POST" },
       env,
+      executionCtx,
     );
     expect(busy.status).toBe(429);
     expect(busy.headers.get("Retry-After")).toBe("17");
@@ -119,8 +153,13 @@ describe("Taishin sync routes", () => {
     );
     const failed = await syncRoutes.request(
       "/connectors/taishin/sync",
-      { method: "POST" },
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ captcha: "123456" }),
+      },
       env,
+      executionCtx,
     );
     expect(failed.status).toBe(502);
     await expect(failed.json()).resolves.toMatchObject({


### PR DESCRIPTION
## 變更內容

- 將電子發票、玉山、國泰、永豐與台新的一般手動同步改為非同步背景工作
- API 成功取得同步鎖後立即回傳 `202 Accepted` 與 `runId`
- 使用 Cloudflare `executionCtx.waitUntil`，讓前端切到背景或連線中斷後同步仍可完成
- 沿用既有 `sync_jobs` 的鎖定、執行中、成功與失敗狀態，不新增資料表
- 同步執行期間前端每 2 秒重新查詢工作狀態，完成後停止輪詢
- 共用背景 Job 啟動器，避免各連接器重複處理 lock、heartbeat、成功與失敗紀錄

## 互動式驗證例外

下列流程仍維持同步 HTTP 回應，因為前端必須立即取得驗證結果或下一個操作步驟：

- 集保 Email／SMS OTP 流程
- 永豐與台新 CAPTCHA 提交
- CAPTCHA 圖片準備 API

驗證完成後的普通同步則使用背景工作。

## 問題原因

原本手動同步 API 會等待整個外部服務同步完成才回應。手機切換到其他 App 時，iOS 可能中止前端 `fetch` 並顯示 `Load failed`，但 Cloudflare Worker 仍完成同步與資料寫入，造成畫面顯示失敗、實際同步成功的不一致。

## 使用者影響

一般手動同步會快速回應，不再要求手機持續停留於前景。最終結果由既有同步工作狀態確認；需要 OTP 或 CAPTCHA 的流程仍可正常顯示即時錯誤與下一步。

## 驗證

- 確認背景工作仍使用既有同步鎖、heartbeat 與結果寫入
- 確認重複同步仍回傳 `SYNC_ALREADY_RUNNING`
- 確認 OTP／CAPTCHA 提交沒有改為背景執行
- 交由 PR CI 驗證 TypeScript、測試與建置
