### PR TITLE
簡化發票自動配對條件

### DIFF
--- a/apps/web/src/features/activity/model/matching.test.ts
+++ b/apps/web/src/features/activity/model/matching.test.ts
@@ -43,8 +43,11 @@ function invoice(
 }
 
 describe("invoice transaction matching", () => {
-  it("matches an exact amount, same date, and normalized merchant name", () => {
-    const result = matchInvoicesToTransactions([transaction()], [invoice()]);
+  it("matches the same day and amount without checking the merchant", () => {
+    const result = matchInvoicesToTransactions(
+      [transaction({ counterparty: "完全不同的商家" })],
+      [invoice()],
+    );
 
     expect(result.invoiceToTransactionId.get("invoice-1")).toBe(
       "transaction-1",
@@ -54,25 +57,10 @@ describe("invoice transaction matching", () => {
     );
   });
 
-  it("matches a positive pending card amount through a payment processor", () => {
+  it("matches a positive pending credit-card expense by absolute amount", () => {
     const result = matchInvoicesToTransactions(
-      [
-        transaction({
-          accountType: "credit",
-          postedDate: "2026-07-06T00:00:00.000Z",
-          authorizedAt: undefined,
-          amount: 134,
-          description: "全支付﹘全聯",
-          counterparty: "全支付﹘全聯",
-        }),
-      ],
-      [
-        invoice({
-          invoiceDate: "2026-07-06T14:06:40.000Z",
-          sellerName: "全聯實業股份有限公司台中旅順分公司",
-          amount: 134,
-        }),
-      ],
+      [transaction({ accountType: "credit", amount: 860 })],
+      [invoice()],
     );
 
     expect(result.invoiceToTransactionId.get("invoice-1")).toBe(
@@ -80,91 +68,22 @@ describe("invoice transaction matching", () => {
     );
   });
 
-  it("matches a LINE Pay card charge reduced by redeemed points", () => {
-    const result = matchInvoicesToTransactions(
-      [
-        transaction({
-          accountType: "credit",
-          postedDate: "2026-07-09T00:00:00.000Z",
-          authorizedAt: undefined,
-          amount: -125,
-          description: "連支×楓康超市",
-          counterparty: "連支×楓康超市",
-        }),
-      ],
-      [
-        invoice({
-          invoiceDate: "2026-07-09T13:20:00.000Z",
-          sellerName: "台灣楓康超市股份有限公司大連分公司",
-          amount: 168,
-        }),
-      ],
-    );
-
-    expect(result.invoiceToTransactionId.get("invoice-1")).toBe(
-      "transaction-1",
-    );
-  });
-
-  it("prefers an exact amount over a possible LINE Pay points match", () => {
+  it("does not auto-match a payment with a different amount", () => {
     const result = matchInvoicesToTransactions(
       [
         transaction({
           accountType: "credit",
           amount: -125,
           description: "連支×楓康超市",
-          counterparty: "連支×楓康超市",
         }),
       ],
-      [
-        invoice({
-          id: "exact-invoice",
-          sellerName: "台灣楓康超市股份有限公司大連分公司",
-          amount: 125,
-        }),
-        invoice({
-          id: "points-invoice",
-          sellerName: "台灣楓康超市股份有限公司大連分公司",
-          amount: 168,
-        }),
-      ],
+      [invoice({ amount: 168 })],
     );
 
-    expect(result.invoiceToTransactionId.get("exact-invoice")).toBe(
-      "transaction-1",
-    );
-    expect(result.invoiceToTransactionId.has("points-invoice")).toBe(false);
+    expect(result.invoiceToTransactionId.size).toBe(0);
   });
 
-  it("does not allow amount differences outside LINE Pay point redemption", () => {
-    const ordinaryCard = transaction({
-      accountType: "credit",
-      amount: -125,
-      description: "楓康超市",
-      counterparty: "楓康超市",
-    });
-    const linePayOvercharge = transaction({
-      accountType: "credit",
-      amount: -180,
-      description: "連支×楓康超市",
-      counterparty: "連支×楓康超市",
-    });
-    const targetInvoice = invoice({
-      sellerName: "台灣楓康超市股份有限公司大連分公司",
-      amount: 168,
-    });
-
-    expect(
-      matchInvoicesToTransactions([ordinaryCard], [targetInvoice])
-        .invoiceToTransactionId.size,
-    ).toBe(0);
-    expect(
-      matchInvoicesToTransactions([linePayOvercharge], [targetInvoice])
-        .invoiceToTransactionId.size,
-    ).toBe(0);
-  });
-
-  it("offers same-day expenses for manual mapping without auto-linking unrelated merchants", () => {
+  it("still offers same-day expenses with different amounts for manual mapping", () => {
     const transactions = [
       transaction({
         id: "pxpay-tea",
@@ -237,29 +156,39 @@ describe("invoice transaction matching", () => {
     expect(result.transactionToInvoice.size).toBe(0);
   });
 
-  it("leaves unrelated payment-processor candidates unpaired when the remainder is ambiguous", () => {
+  it("pairs ambiguous same-day amounts deterministically and one-to-one", () => {
     const result = matchInvoicesToTransactions(
       [
         transaction({
-          id: "payment-1",
-          accountType: "credit",
-          amount: -37,
-          description: "全支付﹘品牌甲",
-          counterparty: "全支付﹘品牌甲",
+          id: "transaction-b",
+          amount: -860,
         }),
         transaction({
-          id: "payment-2",
-          accountType: "credit",
-          amount: -40,
-          description: "連支＊品牌乙",
-          counterparty: "連支＊品牌乙",
+          id: "transaction-a",
+          amount: -860,
         }),
+        transaction({ id: "transaction-c", amount: -860 }),
       ],
-      [invoice({ sellerName: "無關登記商號", amount: 50 })],
+      [
+        invoice({ id: "invoice-b" }),
+        invoice({ id: "invoice-a" }),
+      ],
     );
 
-    expect(result.invoiceToTransactionId.size).toBe(0);
-    expect(result.transactionToInvoice.size).toBe(0);
+    expect(Array.from(result.invoiceToTransactionId)).toEqual([
+      ["invoice-a", "transaction-a"],
+      ["invoice-b", "transaction-b"],
+    ]);
+    expect(
+      Array.from(result.transactionToInvoice, ([transactionId, row]) => [
+        transactionId,
+        row.id,
+      ]),
+    ).toEqual([
+      ["transaction-a", "invoice-a"],
+      ["transaction-b", "invoice-b"],
+    ]);
+    expect(result.transactionToInvoice.has("transaction-c")).toBe(false);
   });
 
   it("does not treat a positive bank deposit as an expense match", () => {
@@ -308,54 +237,7 @@ describe("invoice transaction matching", () => {
     ).toEqual([]);
   });
 
-  it("matches highly overlapping CJK merchant names with repeated branding", () => {
-    const result = matchInvoicesToTransactions(
-      [
-        transaction({
-          accountType: "credit",
-          postedDate: "2026-07-16T00:00:00.000Z",
-          authorizedAt: undefined,
-          amount: 129,
-          description: "全國加油站昌平站",
-          counterparty: "全國加油站昌平站",
-        }),
-      ],
-      [
-        invoice({
-          invoiceDate: "2026-07-16T10:26:00.000Z",
-          sellerName: "全國加油站股份有限公司全國昌平站",
-          amount: 129,
-        }),
-      ],
-    );
-
-    expect(result.invoiceToTransactionId.get("invoice-1")).toBe(
-      "transaction-1",
-    );
-  });
-
-  it("does not fuzzy-match a different branch", () => {
-    const result = matchInvoicesToTransactions(
-      [
-        transaction({
-          accountType: "credit",
-          amount: 129,
-          description: "全國加油站文心站",
-          counterparty: "全國加油站文心站",
-        }),
-      ],
-      [
-        invoice({
-          sellerName: "全國加油站股份有限公司全國昌平站",
-          amount: 129,
-        }),
-      ],
-    );
-
-    expect(result.invoiceToTransactionId.size).toBe(0);
-  });
-
-  it("does not match when amount, date, or merchant differs", () => {
+  it("does not match when the amount or date differs", () => {
     expect(
       matchInvoicesToTransactions([transaction({ amount: -861 })], [invoice()])
         .invoiceToTransactionId.size,
@@ -366,22 +248,15 @@ describe("invoice transaction matching", () => {
         [invoice()],
       ).invoiceToTransactionId.size,
     ).toBe(0);
-    expect(
-      matchInvoicesToTransactions(
-        [transaction({ counterparty: "另一間商店" })],
-        [invoice()],
-      ).invoiceToTransactionId.size,
-    ).toBe(0);
   });
 
-  it("leaves ambiguous matches unpaired", () => {
+  it("does not match a non-TWD transaction", () => {
     const result = matchInvoicesToTransactions(
-      [transaction(), transaction({ id: "transaction-2" })],
+      [transaction({ currency: "USD" })],
       [invoice()],
     );
 
     expect(result.invoiceToTransactionId.size).toBe(0);
-    expect(result.transactionToInvoice.size).toBe(0);
   });
 });
 

--- a/apps/web/src/features/activity/model/matching.ts
+++ b/apps/web/src/features/activity/model/matching.ts
@@ -4,16 +4,6 @@ import type {
   InvoiceTransactionPreference,
 } from "@/data/invoices/types";
 
-const MERCHANT_ENTITY_MARKERS = [
-  "股份有限公司",
-  "有限責任公司",
-  "有限公司",
-  "股份",
-  "公司",
-];
-const MERCHANT_BRANCH_SUFFIXES = ["分公司", "門市"];
-const LINE_PAY_PREFIXES = ["連加", "連支", "linepay"];
-const PAYMENT_PROCESSOR_PREFIXES = ["全支付", ...LINE_PAY_PREFIXES];
 const TAIPEI_DAY_FORMATTER = new Intl.DateTimeFormat("en", {
   timeZone: "Asia/Taipei",
   year: "numeric",
@@ -25,12 +15,6 @@ export interface InvoiceTransactionMatches {
   invoiceToTransactionId: Map<string, string>;
   transactionToInvoice: Map<string, InvoiceSummaryRow>;
 }
-
-type MatchCandidate = {
-  invoice: InvoiceSummaryRow;
-  transaction: BankTransactionRow;
-  kind: "exact" | "payment-points";
-};
 
 const ESUN_LIFECYCLE_MARKER = /:(已入帳|未入帳):(?=\d+$)/u;
 
@@ -96,35 +80,9 @@ export function matchInvoicesToTransactions(
   const autoTransactions = transactions.filter(
     (transaction) => !transactionToInvoice.has(transaction.id),
   );
-  const allStrongCandidates = autoInvoices.flatMap((invoice) =>
-    autoTransactions
-      .map((transaction) => ({
-        invoice,
-        transaction,
-        kind: matchCandidateKind(transaction, invoice),
-      }))
-      .filter(
-        (candidate): candidate is MatchCandidate => candidate.kind != null,
-      ),
-  );
-  const exactInvoiceIds = new Set(
-    allStrongCandidates
-      .filter(({ kind }) => kind === "exact")
-      .map(({ invoice }) => invoice.id),
-  );
-  const exactTransactionIds = new Set(
-    allStrongCandidates
-      .filter(({ kind }) => kind === "exact")
-      .map(({ transaction }) => transaction.id),
-  );
-  const strongCandidates = allStrongCandidates.filter(
-    ({ invoice, transaction, kind }) =>
-      kind === "exact" ||
-      (!exactInvoiceIds.has(invoice.id) &&
-        !exactTransactionIds.has(transaction.id)),
-  );
-  addUniqueMatches(
-    strongCandidates,
+  addAutomaticMatches(
+    autoInvoices,
+    autoTransactions,
     invoiceToTransactionId,
     transactionToInvoice,
   );
@@ -156,148 +114,58 @@ export function invoiceTransactionCandidates(
     });
 }
 
-function addUniqueMatches(
-  candidates: MatchCandidate[],
+function addAutomaticMatches(
+  invoices: InvoiceSummaryRow[],
+  transactions: BankTransactionRow[],
   invoiceToTransactionId: Map<string, string>,
   transactionToInvoice: Map<string, InvoiceSummaryRow>,
 ) {
-  const invoiceCandidateCount = countBy(
-    candidates,
-    ({ invoice }) => invoice.id,
-  );
-  const transactionCandidateCount = countBy(
-    candidates,
-    ({ transaction }) => transaction.id,
-  );
+  const invoicesByKey = groupByMatchKey(invoices, (invoice) => {
+    const invoiceDay = dayNumber(invoice.invoiceDate);
+    return invoiceDay == null ? undefined : `${invoiceDay}:${invoice.amount}`;
+  });
+  const transactionsByKey = groupByMatchKey(transactions, (transaction) => {
+    const transactionDay = expenseDay(transaction);
+    return transactionDay == null
+      ? undefined
+      : `${transactionDay}:${Math.abs(transaction.amount)}`;
+  });
 
-  for (const { invoice, transaction } of candidates) {
-    if (
-      invoiceCandidateCount.get(invoice.id) !== 1 ||
-      transactionCandidateCount.get(transaction.id) !== 1
-    )
-      continue;
-    invoiceToTransactionId.set(invoice.id, transaction.id);
-    transactionToInvoice.set(transaction.id, invoice);
+  for (const [key, matchingInvoices] of invoicesByKey) {
+    const matchingTransactions = transactionsByKey.get(key);
+    if (!matchingTransactions) continue;
+    matchingInvoices.sort(compareById);
+    matchingTransactions.sort(compareById);
+    const pairCount = Math.min(
+      matchingInvoices.length,
+      matchingTransactions.length,
+    );
+    for (let index = 0; index < pairCount; index += 1) {
+      const invoice = matchingInvoices[index];
+      const transaction = matchingTransactions[index];
+      invoiceToTransactionId.set(invoice.id, transaction.id);
+      transactionToInvoice.set(transaction.id, invoice);
+    }
   }
-}
-
-function matchCandidateKind(
-  transaction: BankTransactionRow,
-  invoice: InvoiceSummaryRow,
-): MatchCandidate["kind"] | undefined {
-  if (!isSameDayTwdExpense(transaction, invoice)) return undefined;
-
-  const merchants = [transaction.counterparty, transaction.description];
-  if (
-    !merchants.some((merchant) =>
-      merchantNamesMatch(invoice.sellerName, merchant),
-    )
-  )
-    return undefined;
-
-  const chargedAmount = Math.abs(transaction.amount);
-  if (chargedAmount === invoice.amount) return "exact";
-  if (
-    transaction.accountType === "credit" &&
-    chargedAmount < invoice.amount &&
-    merchants.some(isPaymentProcessorMerchant)
-  )
-    return "payment-points";
-  return undefined;
 }
 
 function isSameDayTwdExpense(
   transaction: BankTransactionRow,
   invoice: InvoiceSummaryRow,
 ) {
+  const transactionDate = expenseDay(transaction);
+  const invoiceDate = dayNumber(invoice.invoiceDate);
+  return invoiceDate != null && transactionDate === invoiceDate;
+}
+
+function expenseDay(transaction: BankTransactionRow) {
   if (
     transaction.amount === 0 ||
     (transaction.accountType !== "credit" && transaction.amount > 0) ||
     transaction.currency !== "TWD"
   )
-    return false;
-
-  const transactionDate = dayNumber(
-    transaction.authorizedAt ?? transaction.postedDate,
-  );
-  const invoiceDate = dayNumber(invoice.invoiceDate);
-  return invoiceDate != null && transactionDate === invoiceDate;
-}
-
-function isPaymentProcessorMerchant(value?: string) {
-  const normalized = normalizeMerchantName(value);
-  return PAYMENT_PROCESSOR_PREFIXES.some((prefix) =>
-    normalized.startsWith(prefix),
-  );
-}
-
-function merchantNamesMatch(left?: string, right?: string) {
-  const normalizedLeft = normalizeMerchantName(left);
-  const normalizedRight = stripPaymentProcessorPrefix(
-    normalizeMerchantName(right),
-  );
-  if (!normalizedLeft || !normalizedRight) return false;
-  if (normalizedLeft === normalizedRight) return true;
-  const shorter =
-    normalizedLeft.length <= normalizedRight.length
-      ? normalizedLeft
-      : normalizedRight;
-  const longer =
-    normalizedLeft.length > normalizedRight.length
-      ? normalizedLeft
-      : normalizedRight;
-  const isContainedName =
-    (shorter.length >= 4 || isShortCjkBrand(shorter)) &&
-    longer.includes(shorter);
-  return isContainedName || hasHighCjkSubsequenceOverlap(shorter, longer);
-}
-
-function normalizeMerchantName(value?: string) {
-  let normalized = (value ?? "")
-    .normalize("NFKC")
-    .toLocaleLowerCase("zh-TW")
-    .replace(/[^\p{Letter}\p{Number}]+/gu, "");
-  for (const marker of MERCHANT_ENTITY_MARKERS)
-    normalized = normalized.replaceAll(marker, "");
-  let removedSuffix = true;
-  while (removedSuffix) {
-    removedSuffix = false;
-    for (const suffix of MERCHANT_BRANCH_SUFFIXES) {
-      if (!normalized.endsWith(suffix)) continue;
-      normalized = normalized.slice(0, -suffix.length);
-      removedSuffix = true;
-      break;
-    }
-  }
-  return normalized;
-}
-
-function stripPaymentProcessorPrefix(value: string) {
-  for (const prefix of PAYMENT_PROCESSOR_PREFIXES) {
-    if (value.startsWith(prefix) && value.length - prefix.length >= 2)
-      return value.slice(prefix.length);
-  }
-  return value;
-}
-
-function isShortCjkBrand(value: string) {
-  return value.length >= 2 && /^[\p{Script=Han}]+$/u.test(value);
-}
-
-function hasHighCjkSubsequenceOverlap(shorter: string, longer: string) {
-  if (
-    shorter.length < 4 ||
-    shorter.length / longer.length < 0.75 ||
-    !isShortCjkBrand(shorter) ||
-    !isShortCjkBrand(longer)
-  )
-    return false;
-
-  let shorterIndex = 0;
-  for (const character of longer) {
-    if (character === shorter[shorterIndex]) shorterIndex += 1;
-  }
-  return shorterIndex === shorter.length;
+    return undefined;
+  return dayNumber(transaction.authorizedAt ?? transaction.postedDate);
 }
 
 function dayNumber(value?: string) {
@@ -323,11 +191,21 @@ function dayNumber(value?: string) {
   );
 }
 
-function countBy<T>(items: T[], key: (item: T) => string) {
-  const counts = new Map<string, number>();
+function groupByMatchKey<T>(
+  items: T[],
+  keyFor: (item: T) => string | undefined,
+) {
+  const groups = new Map<string, T[]>();
   for (const item of items) {
-    const value = key(item);
-    counts.set(value, (counts.get(value) ?? 0) + 1);
+    const key = keyFor(item);
+    if (key == null) continue;
+    const group = groups.get(key) ?? [];
+    group.push(item);
+    groups.set(key, group);
   }
-  return counts;
+  return groups;
+}
+
+function compareById(left: { id: string }, right: { id: string }) {
+  return left.id.localeCompare(right.id);
 }


### PR DESCRIPTION
## 變更內容

- 將發票自動配對條件簡化為台北日期相同且絕對金額相同
- 自動配對不再檢查商家名稱，也不再將金額不同的點數折抵交易自動連結
- 同日同額有多筆候選時，依穩定 ID 排序後逐筆一對一配對，多出的發票或消費維持未配對
- 保留人工 `linked`、`separate` 偏好的優先順序與既有消費資格判斷
- 更新 matching 單元測試，涵蓋跨商家配對、歧義候選的一對一關係、人工 mapping 與日期／幣別限制

## 原因與影響

使用者希望自動 mapping 僅依日期與金額判斷，不需要避免商家對應錯誤。修改後，同一天同金額的發票與消費會盡可能自動合併顯示，但每張發票及每筆消費仍只會出現在一組 mapping 中；金額不同的交易仍可透過既有流程人工 mapping。

## 驗證

- `npm run verify:web`
  - Svelte typecheck：0 errors、0 warnings
  - 前端單元測試：45 passed
  - Playwright E2E：9 passed
  - Production build：成功
- `git diff --check`