### PR TITLE
移除不存在的「新增連接器」入口

### DIFF
--- a/apps/web/src/features/settings/SettingsPage.svelte
+++ b/apps/web/src/features/settings/SettingsPage.svelte
@@ -165,7 +165,7 @@
     <div class="grid min-w-0 gap-4">
       <section
         aria-label="資料來源頁標題"
-        class="hidden min-w-0 items-center justify-between gap-4 md:flex"
+        class="hidden min-w-0 md:block"
       >
         <div>
           <h2 class="text-2xl font-bold tracking-tight">資料來源與連接器</h2>
@@ -173,10 +173,6 @@
             管理連線、驗證狀態與最近同步結果。
           </p>
         </div>
-        <span
-          class="rounded-lg bg-steel px-4 py-2 text-sm font-bold text-white transition hover:bg-steel/90"
-          >＋ 新增連接器</span
-        >
       </section>
 
       <div


### PR DESCRIPTION
### Motivation
- 移除設定頁面中一個沒有對應功能的 UI 元件（「＋ 新增連接器」按鈕），避免誤導使用者並簡化頁首佈局。

### Description
- 刪除了 `apps/web/src/features/settings/SettingsPage.svelte` 中顯示的「＋ 新增連接器」按鈕，並調整頁首區塊的 CSS 類別以維持單欄顯示（將 `class="hidden min-w-0 items-center justify-between gap-4 md:flex"` 改為 `class="hidden min-w-0 md:block"`）。

### Testing
- 執行 `git diff --check`，結果通過且檔案已提交。 
- 執行 `npm run typecheck -w @taiwan-fin-hub/web`，Svelte 型別檢查通過。 
- 執行 `npm run test:unit -w @taiwan-fin-hub/web`，所有單元測試通過（14 個測試檔案，47 個測試皆通過）。 
- 執行 `npm run build -w @taiwan-fin-hub/web`，建置成功。 
- `npm run verify:web` 的 Playwright E2E 在本環境失敗，因為系統無法下載 Chromium（`npx playwright install chromium` 從 CDN 下載時回傳 403），因此 E2E 測試未能執行。