### PR TITLE
重新設計資產總覽與財務提醒

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -100,7 +100,7 @@ test("renders the mobile bottom navigation", async ({ page }) => {
   ).toBeVisible();
 });
 
-test("keeps long recent activity inside the overview card", async ({
+test("keeps the desktop overview within the viewport with long data", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
@@ -130,12 +130,71 @@ test("keeps long recent activity inside the overview card", async ({
   });
 
   await page.goto("/#/overview");
-  await expect(page.getByRole("heading", { name: "近期活動" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "本月財務脈動" }),
+  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "值得留意" })).toBeVisible();
   const pageWidth = await page.evaluate(() => ({
     client: document.documentElement.clientWidth,
     scroll: document.documentElement.scrollWidth,
   }));
   expect(pageWidth.scroll).toBe(pageWidth.client);
+});
+
+test("shows this month's cash flow on the overview and opens activity", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  const month = new Date().toISOString().slice(0, 7);
+  await page.route("**/api/bank**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        accounts: [],
+        transactions: [
+          {
+            id: "monthly-income",
+            connectorId: "cathaybk",
+            accountId: "account-1",
+            sourceId: "monthly-income",
+            postedDate: `${month}-02`,
+            amount: 50_000,
+            currency: "TWD",
+            description: "薪資",
+            status: "posted",
+          },
+          {
+            id: "monthly-expense",
+            connectorId: "cathaybk",
+            accountId: "account-1",
+            sourceId: "monthly-expense",
+            postedDate: `${month}-03`,
+            amount: -12_000,
+            currency: "TWD",
+            description: "生活支出",
+            status: "posted",
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto("/#/overview");
+  const cashFlowSection = page.getByRole("region", { name: "本月收支" });
+  await expect(cashFlowSection).toBeVisible();
+  await expect(cashFlowSection.getByText("+NT$50,000")).toBeVisible();
+  await expect(cashFlowSection.getByText("−NT$12,000")).toBeVisible();
+  await expect(cashFlowSection.getByText("NT$38,000")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "資產配置" })).toHaveCount(0);
+  const insightsSection = page.getByRole("region", { name: "值得留意" });
+  await expect(
+    insightsSection.getByText("目前沒有需要處理的事項"),
+  ).toBeVisible();
+  await expect(page.getByText(/存款佔全部資產/)).toHaveCount(0);
+
+  await cashFlowSection.getByRole("button", { name: "查看活動 →" }).click();
+  await expect(page).toHaveURL(/#\/activity$/);
 });
 
 test("uses app-like scrolling and history only in standalone display mode", async ({

--- a/apps/web/src/features/overview/OverviewPage.svelte
+++ b/apps/web/src/features/overview/OverviewPage.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
+  import {
+    ChartNoAxesCombined,
+    ChevronRight,
+    CircleCheckBig,
+    CreditCard,
+    RefreshCw,
+  } from "@lucide/svelte";
   import { createQuery } from "@tanstack/svelte-query";
   import Button from "@/shared/ui/Button.svelte";
-  import Badge from "@/shared/ui/Badge.svelte";
   import Card from "@/shared/ui/Card.svelte";
-  import CardHeader from "@/shared/ui/CardHeader.svelte";
   import CardContent from "@/shared/ui/CardContent.svelte";
   import EmptyState from "@/shared/ui/EmptyState.svelte";
   import type { ApiClient } from "@/shared/api/client";
@@ -14,26 +19,31 @@
   } from "@/data/assets/queries";
   import { bankQuery, bankRangeQuery } from "@/data/bank/queries";
   import { syncJobsQuery } from "@/data/connectors/queries";
-  import {
-    investmentsQuery,
-    investmentTransactionsQuery,
-  } from "@/data/investments/queries";
+  import { investmentsQuery } from "@/data/investments/queries";
   import {
     invoiceTransactionMappingsQuery,
-    invoicesQuery,
     invoicesRangeQuery,
   } from "@/data/invoices/queries";
   import { calculateMonthlyActivityTotals } from "@/data/activity/monthly-totals";
   import type { View } from "@/app/types";
   import {
-    formatBankAccountName,
     formatCompactTwd,
     formatCurrency,
-    formatDate,
-    normalizeFinancialDate,
     rateMap,
   } from "@/shared/format/financial";
   import NetWorthHistoryChart from "./components/NetWorthHistoryChart.svelte";
+
+  type InsightTone = "coral" | "amber" | "moss" | "steel";
+  type InsightIcon = "sync" | "card" | "cashflow";
+
+  interface OverviewInsight {
+    id: string;
+    title: string;
+    detail: string;
+    tone: InsightTone;
+    icon: InsightIcon;
+    view: View;
+  }
 
   let { api, navigate }: { api: ApiClient; navigate: (view: View) => void } =
     $props();
@@ -43,14 +53,12 @@
   const currentMonthRange = { from: monthKey, to: monthKey };
   const monthlyBank = createQuery(bankRangeQuery(() => api, currentMonthRange));
   const investments = createQuery(investmentsQuery(() => api));
-  const invoices = createQuery(invoicesQuery(() => api));
   const monthlyInvoices = createQuery(
     invoicesRangeQuery(() => api, currentMonthRange),
   );
   const invoiceMappings = createQuery(
     invoiceTransactionMappingsQuery(() => api),
   );
-  const trades = createQuery(investmentTransactionsQuery(() => api));
   const manualAssets = createQuery(manualAssetsQuery(() => api));
   const rates = createQuery(exchangeRatesQuery(() => api));
   const jobs = createQuery(syncJobsQuery(() => api));
@@ -130,46 +138,84 @@
   );
   const monthlyIncome = $derived(monthlyTotals.income);
   const monthlyExpense = $derived(monthlyTotals.expense);
+  const monthlyNet = $derived(monthlyIncome - monthlyExpense);
   const unhealthy = $derived(
     ($jobs.data ?? []).filter(
       (job) =>
         job.lastStatus === "failed" || job.lastStatus === "needs_user_action",
     ),
   );
+  const staleJobs = $derived(
+    ($jobs.data ?? []).filter(
+      (job) =>
+        job.enabled &&
+        !job.running &&
+        !unhealthy.some((unhealthyJob) => unhealthyJob.id === job.id) &&
+        (!job.lastSuccessAt ||
+          Date.now() - new Date(job.lastSuccessAt).getTime() >
+            48 * 60 * 60 * 1000),
+    ),
+  );
   const sourceCount = $derived(Math.max(($jobs.data ?? []).length, 4));
   const healthyCount = $derived(Math.max(sourceCount - unhealthy.length, 0));
-  const accountRows = $derived(bankData.accounts.slice(0, 4));
-  const recent = $derived.by(() =>
-    [
-      ...bankData.transactions.map((transaction) => ({
-        id: `bank-${transaction.id}`,
-        date: transaction.postedDate ?? transaction.authorizedAt ?? "",
-        title:
-          transaction.description ?? transaction.counterparty ?? "銀行交易",
-        detail: transaction.institutionName ?? "銀行",
-        amount: transaction.amount,
-        currency: transaction.currency,
-      })),
-      ...($trades.data ?? []).map((trade) => ({
-        id: `trade-${trade.id}`,
-        date: normalizeFinancialDate(trade.tradeDate ?? trade.postedDate),
-        title: trade.name ?? trade.transactionName ?? "投資交易",
-        detail: trade.brokerName ?? "投資",
-        amount: trade.price === 1 ? undefined : trade.amount,
-        currency: trade.currency,
-      })),
-      ...($invoices.data ?? []).map((invoice) => ({
-        id: `invoice-${invoice.id}`,
-        date: invoice.invoiceDate,
-        title: invoice.sellerName ?? "電子發票",
-        detail: "電子發票",
-        amount: -Math.abs(invoice.amount),
-        currency: "TWD",
-      })),
-    ]
-      .sort((a, b) => b.date.localeCompare(a.date))
-      .slice(0, 4),
-  );
+  const insights = $derived.by(() => {
+    const items: OverviewInsight[] = [];
+
+    if (unhealthy.length > 0) {
+      items.push({
+        id: "sync",
+        title: `${unhealthy.length} 個資料來源需要處理`,
+        detail: `目前 ${healthyCount} / ${sourceCount} 個來源正常`,
+        tone: "amber",
+        icon: "sync",
+        view: "data-sources",
+      });
+    }
+
+    if (staleJobs.length > 0) {
+      items.push({
+        id: "stale-sync",
+        title: `${staleJobs.length} 個資料來源超過 48 小時未更新`,
+        detail: "重新同步以取得最新的資產與活動資料",
+        tone: "amber",
+        icon: "sync",
+        view: "data-sources",
+      });
+    }
+
+    if (monthlyNet < 0) {
+      items.push({
+        id: "negative-cashflow",
+        title: `本月支出高於收入 ${formatCurrency(Math.abs(monthlyNet))}`,
+        detail: "查看活動分類，確認主要支出來源",
+        tone: "coral",
+        icon: "cashflow",
+        view: "activity",
+      });
+    }
+
+    const highCardDebt =
+      cardDebt > 0 &&
+      (monthlyIncome > 0
+        ? cardDebt > monthlyIncome * 0.5
+        : depositTotal > 0 && cardDebt > depositTotal * 0.2);
+
+    if (highCardDebt) {
+      items.push({
+        id: "high-card-debt",
+        title: `信用卡負債已達 ${formatCurrency(cardDebt)}`,
+        detail:
+          monthlyIncome > 0
+            ? `約為本月收入的 ${Math.round((cardDebt / monthlyIncome) * 100)}%`
+            : "信用卡負債相對可動用存款偏高",
+        tone: "coral",
+        icon: "card",
+        view: "cards",
+      });
+    }
+
+    return items.slice(0, 2);
+  });
   const missingRates = $derived([
     ...new Set(
       bankData.accounts
@@ -219,18 +265,27 @@
       </div>
     {/if}
 
-    <div class="grid gap-4 xl:grid-cols-[minmax(0,1.8fr)_minmax(300px,1fr)]">
-      <section class="rounded-2xl bg-ink p-5 text-white shadow-xs md:p-6">
-        <p class="text-xs font-semibold text-white/55">全部資產</p>
+    <div class="grid gap-4 xl:grid-cols-[minmax(0,1.8fr)_340px]">
+      <section class="rounded-xl bg-ink p-5 text-white shadow-xs md:p-6">
+        <div class="flex items-center justify-between gap-3">
+          <p class="text-xs font-semibold text-white/55">淨資產</p>
+          <p class="hidden text-xs text-white/40 sm:block">
+            {new Intl.DateTimeFormat("zh-TW", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            }).format(new Date())}
+          </p>
+        </div>
         <p
           class="mt-3 text-4xl font-bold tracking-tight tabular-nums md:text-[40px]"
         >
           {formatCurrency(netWorth)}
         </p>
         <p class="mt-3 text-sm font-semibold text-emerald-300">
-          淨資產 · 已扣除 {formatCurrency(cardDebt)} 信用卡負債
+          已扣除 {formatCurrency(cardDebt)} 信用卡負債
         </p>
-        <div class="mt-5 flex h-3 overflow-hidden rounded-full bg-white/10">
+        <div class="mt-5 flex h-2.5 overflow-hidden rounded-full bg-white/10">
           {#each allocation as item (item.label)}
             <span
               class={`h-full ${item.bar}`}
@@ -238,185 +293,280 @@
             ></span>
           {/each}
         </div>
-        <p class="mt-3 hidden text-xs text-white/65 md:block">
-          {allocation
-            .map((item) => `${item.label} ${pct(item.value)}%`)
-            .join("　")}
-        </p>
       </section>
 
-      <Card class="hidden xl:block">
-        <CardContent class="pt-6">
-          <h2 class="text-lg font-semibold">同步健康度</h2>
-          <p class="mt-3 text-3xl font-bold">
-            {healthyCount} / {sourceCount} 來源正常
-          </p>
-          <Badge
-            class="mt-3"
-            variant={unhealthy.length ? "destructive" : "success"}
-            >{unhealthy.length
-              ? `${unhealthy.length} 個來源需要處理`
-              : "所有來源同步正常"}</Badge
-          >
-          <p class="mt-2 text-xs text-ink/45">銀行與發票使用最近同步紀錄</p>
-          <Button
-            class="mt-4"
-            variant="secondary"
-            size="sm"
-            onclick={() => navigate("settings")}>前往同步設定</Button
-          >
-        </CardContent>
-      </Card>
+      <section
+        class="hidden xl:block"
+        aria-labelledby="overview-desktop-cashflow"
+      >
+        <Card class="h-full">
+          <CardContent class="grid h-full gap-3 p-5">
+            <div class="flex items-center justify-between gap-3">
+              <h2
+                id="overview-desktop-cashflow"
+                class="text-base font-semibold"
+              >
+                本月財務脈動
+              </h2>
+              <Button
+                variant="ghost"
+                size="sm"
+                onclick={() => navigate("activity")}>查看活動 →</Button
+              >
+            </div>
+            <div class="grid grid-cols-2 gap-3">
+              <div class="min-w-0 rounded-xl bg-moss/10 p-3">
+                <p class="text-[11px] font-semibold text-ink/50">收入</p>
+                <p
+                  class="mt-1.5 truncate text-base font-bold text-moss tabular-nums"
+                >
+                  +{formatCurrency(monthlyIncome)}
+                </p>
+              </div>
+              <div class="min-w-0 rounded-xl bg-coral/10 p-3">
+                <p class="text-[11px] font-semibold text-ink/50">支出</p>
+                <p
+                  class="mt-1.5 truncate text-base font-bold text-coral tabular-nums"
+                >
+                  −{formatCurrency(monthlyExpense)}
+                </p>
+              </div>
+            </div>
+            <div class="flex items-end justify-between gap-3 px-0.5">
+              <div>
+                <p class="text-xs font-semibold text-ink/50">本月淨流入</p>
+                <p class="mt-1 text-xs text-ink/40">收入 − 支出</p>
+              </div>
+              <p
+                class={`text-xl font-bold tabular-nums ${monthlyNet >= 0 ? "text-moss" : "text-coral"}`}
+              >
+                {formatCurrency(monthlyNet)}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
     </div>
 
-    <div class="grid grid-cols-3 gap-2 md:grid-cols-4 md:gap-4">
-      {#each allocation as item (item.label)}
-        <Card>
-          <CardContent class="p-3 md:p-5">
-            <p class="text-xs font-semibold text-ink/50 md:mt-0">
-              {item.label === "其他" ? "其他資產" : item.label}
-            </p>
+    <Card class="overflow-hidden">
+      <CardContent class="grid grid-cols-3 divide-x divide-border p-0">
+        {#each allocation as item (item.label)}
+          <div
+            class="flex min-w-0 flex-col justify-center px-3 py-4 md:min-h-28 md:px-5 md:py-5"
+          >
+            <div class="flex min-w-0 items-center gap-2">
+              <span class={`size-2 shrink-0 rounded-full ${item.bar}`}></span>
+              <p class="truncate text-xs font-semibold text-ink/50">
+                {item.label === "其他" ? "其他資產" : item.label}
+              </p>
+            </div>
             <p
-              class={`mt-2 text-xl font-bold tabular-nums md:hidden ${item.text}`}
+              class={`mt-2 truncate text-lg font-bold tracking-tight tabular-nums sm:text-xl md:hidden ${item.text}`}
             >
               {formatCompactTwd(item.value)}
             </p>
-            <p class="mt-1 text-[11px] text-ink/40 md:hidden">
-              佔全部資產 {pct(item.value)}%
-            </p>
             <p
-              class={`mt-2 hidden text-2xl font-bold tabular-nums md:block ${item.text}`}
+              class="mt-2 hidden truncate text-2xl font-bold tracking-tight tabular-nums md:block"
             >
               {formatCurrency(item.value)}
             </p>
-            <p class="mt-1 hidden text-xs text-ink/40 md:block">
+            <p class="mt-1 truncate text-[11px] text-ink/40 md:text-xs">
               {item.detail}
             </p>
-          </CardContent>
-        </Card>
-      {/each}
-      <Card class="hidden md:block">
-        <CardContent class="p-5">
-          <p class="text-xs font-semibold text-ink/50">本月淨流入</p>
-          <p
-            class={`mt-2 text-2xl font-bold tracking-tight tabular-nums ${monthlyIncome >= monthlyExpense ? "text-moss" : "text-coral"}`}
-          >
-            {formatCurrency(monthlyIncome - monthlyExpense)}
-          </p>
-          <p class="mt-1 text-xs text-ink/45">收入 − 支出</p>
-        </CardContent>
-      </Card>
-    </div>
+          </div>
+        {/each}
+      </CardContent>
+    </Card>
 
-    <div class="xl:hidden">
-      <NetWorthHistoryChart
-        data={$history.data ?? []}
-        loading={$history.isPending}
-      />
-    </div>
-
-    <div class="grid gap-4 xl:grid-cols-[minmax(0,1.8fr)_minmax(300px,1fr)]">
-      <div class="hidden min-w-0 xl:block">
+    <div class="grid gap-4 xl:grid-cols-[minmax(0,1.8fr)_340px]">
+      <div class="min-w-0">
         <NetWorthHistoryChart
           data={$history.data ?? []}
           loading={$history.isPending}
         />
       </div>
-      <Card>
-        <CardHeader class="flex-row items-center justify-between">
-          <h2 class="text-lg font-semibold">資產配置</h2>
-          <Button variant="ghost" size="sm" onclick={() => navigate("assets")}
-            >查看全部 →</Button
-          >
-        </CardHeader>
-        <CardContent class="grid gap-5">
-          {#each allocation as item (item.label)}
-            <div>
-              <div class="flex items-center justify-between gap-3">
-                <div>
-                  <span class="text-sm font-semibold">{item.label}</span><span
-                    class="ml-2 text-xs text-ink/40">{item.detail}</span
-                  >
+
+      <section
+        class="hidden xl:block"
+        aria-labelledby="overview-desktop-insights"
+      >
+        <Card class="h-full">
+          <CardContent class="grid gap-3 p-5">
+            <h2 id="overview-desktop-insights" class="text-base font-semibold">
+              值得留意
+            </h2>
+            {#if insights.length === 0}
+              <div
+                class="flex items-center gap-3 rounded-lg border border-emerald-200 bg-emerald-50/60 p-4"
+              >
+                <CircleCheckBig class="size-5 shrink-0 text-moss" />
+                <div class="min-w-0">
+                  <p class="text-xs font-semibold">目前沒有需要處理的事項</p>
+                  <p class="mt-1 text-[11px] text-ink/45">
+                    同步與本月收支狀態正常
+                  </p>
                 </div>
-                <span class={`text-sm font-bold tabular-nums ${item.text}`}
-                  >{formatCurrency(item.value)}</span
+              </div>
+            {:else}
+              {#each insights as insight (insight.id)}
+                <button
+                  class={`flex min-w-0 items-center gap-3 rounded-lg border p-3 text-left transition hover:brightness-[0.98] ${
+                    insight.tone === "coral"
+                      ? "border-red-200 bg-red-50/70"
+                      : insight.tone === "amber"
+                        ? "border-amber-200 bg-amber-50/70"
+                        : insight.tone === "moss"
+                          ? "border-emerald-200 bg-emerald-50/70"
+                          : "border-sky-200 bg-sky-50/70"
+                  }`}
+                  onclick={() => navigate(insight.view)}
                 >
-              </div>
-              <div class="mt-2 h-2 overflow-hidden rounded-full bg-ink/10">
-                <span
-                  class={`block h-full rounded-full ${item.bar}`}
-                  style={`width:${pct(item.value)}%`}
-                ></span>
-              </div>
-            </div>
-          {/each}
-        </CardContent>
-      </Card>
-    </div>
-
-    {#if unhealthy.length > 0}
-      <section class="rounded-2xl bg-amber-50 p-5 text-amber-900 md:hidden">
-        <p class="font-semibold">{unhealthy.length} 個來源需要更新</p>
-        <button
-          class="mt-3 text-sm font-semibold"
-          onclick={() => navigate("data-sources")}>立即處理 →</button
-        >
+                  {#if insight.icon === "sync"}
+                    <RefreshCw class="size-5 shrink-0 text-amber-600" />
+                  {:else if insight.icon === "card"}
+                    <CreditCard class="size-5 shrink-0 text-coral" />
+                  {:else}
+                    <ChartNoAxesCombined
+                      class={`size-5 shrink-0 ${insight.tone === "moss" ? "text-moss" : "text-coral"}`}
+                    />
+                  {/if}
+                  <span class="min-w-0 flex-1">
+                    <span class="block truncate text-xs font-semibold"
+                      >{insight.title}</span
+                    >
+                    <span class="mt-1 block truncate text-[11px] text-ink/45"
+                      >{insight.detail}</span
+                    >
+                  </span>
+                  <ChevronRight class="size-4 shrink-0 text-ink/40" />
+                </button>
+              {/each}
+            {/if}
+          </CardContent>
+        </Card>
       </section>
-    {/if}
-
-    <div
-      class="hidden gap-5 xl:grid xl:grid-cols-[minmax(0,1.8fr)_minmax(300px,1fr)]"
-    >
-      <Card>
-        <CardHeader class="flex-row items-center justify-between"
-          ><h2 class="text-lg font-semibold">銀行與信用卡</h2>
-          <Button variant="ghost" size="sm" onclick={() => navigate("assets")}
-            >查看資產 →</Button
-          ></CardHeader
-        >
-        <CardContent class="grid gap-4">
-          {#each accountRows as account (account.id)}
-            <div
-              class="grid grid-cols-[120px_minmax(0,1fr)_auto_auto] gap-3 text-sm"
-            >
-              <span class="font-semibold"
-                >{account.institutionName ?? account.connectorId}</span
-              >
-              <span class="truncate text-ink/45"
-                >{account.accountName ?? formatBankAccountName(account)}</span
-              >
-              <span
-                class={`font-semibold tabular-nums ${account.accountType === "credit" ? "text-coral" : ""}`}
-                >{formatCurrency(account.balance ?? 0, account.currency)}</span
-              >
-              <span class="text-xs text-ink/40"
-                >{account.asOfAt ? formatDate(account.asOfAt) : "—"}</span
-              >
-            </div>
-          {/each}
-        </CardContent>
-      </Card>
-      <Card class="min-w-0 overflow-hidden">
-        <CardHeader><h2 class="text-lg font-semibold">近期活動</h2></CardHeader>
-        <CardContent class="grid min-w-0 gap-4">
-          {#each recent as item (item.id)}
-            <div
-              class="flex min-w-0 items-center justify-between gap-3 text-sm"
-            >
-              <div class="min-w-0 flex-1 overflow-hidden">
-                <p class="truncate font-semibold">{item.title}</p>
-                <p class="truncate text-xs text-ink/40">{item.detail}</p>
-              </div>
-              <span
-                class={`max-w-[42%] shrink-0 truncate font-semibold tabular-nums ${item.amount != null && item.amount < 0 ? "text-coral" : item.amount != null ? "text-moss" : "text-ink/40"}`}
-                >{item.amount == null
-                  ? "—"
-                  : `${item.amount >= 0 ? "+" : ""}${formatCurrency(item.amount, item.currency)}`}</span
-              >
-            </div>
-          {/each}
-        </CardContent>
-      </Card>
     </div>
+
+    <section
+      class="grid gap-3 xl:hidden"
+      aria-labelledby="overview-mobile-cashflow"
+    >
+      <div class="flex items-center justify-between gap-3 px-1">
+        <h2 id="overview-mobile-cashflow" class="text-lg font-semibold">
+          本月收支
+        </h2>
+        <Button variant="ghost" size="sm" onclick={() => navigate("activity")}
+          >查看活動 →</Button
+        >
+      </div>
+      <div class="grid grid-cols-2 gap-3">
+        <Card>
+          <CardContent class="p-4">
+            <p class="text-xs font-semibold text-ink/50">
+              {Number(monthKey.slice(5))} 月收入
+            </p>
+            <p
+              class="mt-2 truncate text-lg font-bold text-moss tabular-nums sm:text-xl"
+            >
+              +{formatCurrency(monthlyIncome)}
+            </p>
+            <p class="mt-1 text-[11px] text-ink/45">銀行與信用卡活動</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent class="p-4">
+            <p class="text-xs font-semibold text-ink/50">
+              {Number(monthKey.slice(5))} 月支出
+            </p>
+            <p
+              class="mt-2 truncate text-lg font-bold text-coral tabular-nums sm:text-xl"
+            >
+              −{formatCurrency(monthlyExpense)}
+            </p>
+            <p class="mt-1 text-[11px] text-ink/45">含未配對發票</p>
+          </CardContent>
+        </Card>
+        <Card class="col-span-2">
+          <CardContent
+            class="grid min-h-20 grid-cols-[minmax(0,1fr)_auto] items-center gap-4 p-4 sm:min-h-24 sm:p-5"
+          >
+            <div>
+              <p class="text-xs font-semibold text-ink/50">
+                {Number(monthKey.slice(5))} 月淨流入
+              </p>
+              <p class="mt-1 text-[11px] text-ink/45">收入 − 支出</p>
+            </div>
+            <p
+              class={`text-2xl font-bold tracking-tight tabular-nums sm:text-3xl ${monthlyNet >= 0 ? "text-moss" : "text-coral"}`}
+            >
+              {formatCurrency(monthlyNet)}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+
+    <section class="xl:hidden" aria-labelledby="overview-mobile-insights">
+      <Card>
+        <CardContent class="grid gap-3 p-4">
+          <div class="flex items-center justify-between gap-3">
+            <h2 id="overview-mobile-insights" class="text-base font-semibold">
+              值得留意
+            </h2>
+            <span
+              class="rounded-full bg-paper px-2.5 py-1 text-xs font-semibold text-ink/50"
+              >{insights.length}</span
+            >
+          </div>
+          {#if insights.length === 0}
+            <div
+              class="flex items-center gap-3 rounded-lg border border-emerald-200 bg-emerald-50/60 p-3"
+            >
+              <CircleCheckBig class="size-5 shrink-0 text-moss" />
+              <div class="min-w-0">
+                <p class="text-xs font-semibold">目前沒有需要處理的事項</p>
+                <p class="mt-1 text-[11px] text-ink/45">
+                  同步與本月收支狀態正常
+                </p>
+              </div>
+            </div>
+          {:else}
+            {#each insights as insight (insight.id)}
+              <button
+                class={`flex min-w-0 items-center gap-3 rounded-lg border p-3 text-left ${
+                  insight.tone === "coral"
+                    ? "border-red-200 bg-red-50/70"
+                    : insight.tone === "amber"
+                      ? "border-amber-200 bg-amber-50/70"
+                      : insight.tone === "moss"
+                        ? "border-emerald-200 bg-emerald-50/70"
+                        : "border-sky-200 bg-sky-50/70"
+                }`}
+                onclick={() => navigate(insight.view)}
+              >
+                {#if insight.icon === "sync"}
+                  <RefreshCw class="size-5 shrink-0 text-amber-600" />
+                {:else if insight.icon === "card"}
+                  <CreditCard class="size-5 shrink-0 text-coral" />
+                {:else}
+                  <ChartNoAxesCombined
+                    class={`size-5 shrink-0 ${insight.tone === "moss" ? "text-moss" : "text-coral"}`}
+                  />
+                {/if}
+                <span class="min-w-0 flex-1">
+                  <span class="block truncate text-xs font-semibold"
+                    >{insight.title}</span
+                  >
+                  <span class="mt-1 block truncate text-[11px] text-ink/45"
+                    >{insight.detail}</span
+                  >
+                </span>
+                <ChevronRight class="size-4 shrink-0 text-ink/40" />
+              </button>
+            {/each}
+          {/if}
+        </CardContent>
+      </Card>
+    </section>
   </div>
 {/if}

--- a/design/dashboard.pen
+++ b/design/dashboard.pen
@@ -1,0 +1,2720 @@
+{
+  "version": "2.14",
+  "children": [
+    {
+      "type": "frame",
+      "id": "g9BPq",
+      "x": 0,
+      "y": 0,
+      "name": "A 平衡總覽｜Desktop",
+      "clip": true,
+      "width": 1440,
+      "height": 1100,
+      "fill": "$canvas",
+      "children": [
+        {
+          "type": "frame",
+          "id": "a4Dtxp",
+          "name": "A Sidebar",
+          "width": 220,
+          "height": "fill_container",
+          "fill": "$surface",
+          "stroke": "$line",
+          "strokeWidth": {
+            "right": 1
+          },
+          "layout": "vertical",
+          "gap": 28,
+          "padding": [
+            28,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "MMTx7",
+              "name": "Brand",
+              "gap": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "w7ogHo",
+                  "name": "Brand Mark",
+                  "width": 34,
+                  "height": 34,
+                  "fill": "$ink",
+                  "cornerRadius": 10,
+                  "layout": "vertical",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "V0lfE",
+                      "name": "Brand Glyph",
+                      "fill": "#FFFFFF",
+                      "content": "T",
+                      "fontFamily": "$font-data",
+                      "fontSize": 18,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "U7WScK",
+                  "name": "Brand Name",
+                  "fill": "$ink",
+                  "content": "Taiwan Fin Hub",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 16,
+                  "fontWeight": "700"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "y37wF",
+              "name": "Primary Navigation",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ptq8y",
+                  "name": "Nav 總覽",
+                  "width": "fill_container",
+                  "fill": "$ink",
+                  "cornerRadius": 10,
+                  "gap": 12,
+                  "padding": [
+                    11,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "FghFO",
+                      "name": "總覽 Icon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "layout-dashboard",
+                      "library": "lucide",
+                      "fill": "#FFFFFF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "FC5YA",
+                      "name": "總覽 Label",
+                      "fill": "#FFFFFF",
+                      "content": "總覽",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "pPIMw",
+                  "name": "Nav 資產",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 10,
+                  "gap": 12,
+                  "padding": [
+                    11,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "lsKjr",
+                      "name": "資產 Icon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "wallet-cards",
+                      "library": "lucide",
+                      "fill": "$muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "yqn9c",
+                      "name": "資產 Label",
+                      "fill": "$muted",
+                      "content": "資產",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "sl1uG",
+                  "name": "Nav 活動",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 10,
+                  "gap": 12,
+                  "padding": [
+                    11,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "Z0cIS",
+                      "name": "活動 Icon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "history",
+                      "library": "lucide",
+                      "fill": "$muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "IMusY",
+                      "name": "活動 Label",
+                      "fill": "$muted",
+                      "content": "活動",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "B0HFs",
+                  "name": "Nav 發票",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 10,
+                  "gap": 12,
+                  "padding": [
+                    11,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "TKvFR",
+                      "name": "發票 Icon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "receipt-text",
+                      "library": "lucide",
+                      "fill": "$muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "mkrXG",
+                      "name": "發票 Label",
+                      "fill": "$muted",
+                      "content": "發票",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "m9HpY",
+                  "name": "Nav 設定",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 10,
+                  "gap": 12,
+                  "padding": [
+                    11,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "xokGQ",
+                      "name": "設定 Icon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "settings",
+                      "library": "lucide",
+                      "fill": "$muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Cwy1T",
+                      "name": "設定 Label",
+                      "fill": "$muted",
+                      "content": "設定",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "mozX2",
+              "name": "Sidebar Spacer",
+              "width": "fill_container",
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "mNPFK",
+              "name": "Sync Status",
+              "width": "fill_container",
+              "fill": "$soft-moss",
+              "cornerRadius": 12,
+              "layout": "vertical",
+              "gap": 8,
+              "padding": 14,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "JWfYL",
+                  "name": "Sync Label",
+                  "fill": "$muted",
+                  "content": "同步狀態",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 11,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "W61XxT",
+                  "name": "Sync Value",
+                  "fill": "$moss",
+                  "content": "4 / 4 來源正常",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 14,
+                  "fontWeight": "700"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "t3GEk",
+          "name": "A Main",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 20,
+          "padding": [
+            30,
+            36
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "Wi8cM",
+              "name": "Page Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "m3nrG",
+                  "name": "Header Copy",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "iUS8e",
+                      "name": "Financial Overview Eyebrow",
+                      "fill": "$steel",
+                      "content": "FINANCIAL OVERVIEW",
+                      "fontFamily": "$font-data",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.12
+                    },
+                    {
+                      "type": "text",
+                      "id": "Fe7bj",
+                      "name": "Page Title",
+                      "fill": "$ink",
+                      "content": "資產總覽",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 28,
+                      "fontWeight": "750"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dI8Qb",
+                  "name": "Header Actions",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "nzeZd",
+                      "name": "Last Sync",
+                      "fill": "$surface",
+                      "cornerRadius": 9,
+                      "stroke": "$line",
+                      "strokeWidth": 1,
+                      "gap": 8,
+                      "padding": [
+                        9,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "H3ovc",
+                          "name": "Refresh Icon",
+                          "width": 15,
+                          "height": 15,
+                          "icon": "refresh-cw",
+                          "library": "lucide",
+                          "fill": "$muted"
+                        },
+                        {
+                          "type": "text",
+                          "id": "SSamd",
+                          "name": "Last Sync Text",
+                          "fill": "$muted",
+                          "content": "剛剛更新",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "w9f2F",
+                      "name": "Hide Amount",
+                      "width": 38,
+                      "height": 38,
+                      "fill": "$surface",
+                      "cornerRadius": 19,
+                      "stroke": "$line",
+                      "strokeWidth": 1,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "offAM",
+                          "name": "Eye Off",
+                          "width": 17,
+                          "height": 17,
+                          "icon": "eye-off",
+                          "library": "lucide",
+                          "fill": "$ink"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "a2IMv",
+              "name": "Hero Row",
+              "width": "fill_container",
+              "height": 188,
+              "gap": 18,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "KMBTn",
+                  "name": "Net Worth Hero",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "$ink",
+                  "cornerRadius": 12,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000A",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 3
+                  },
+                  "layout": "vertical",
+                  "gap": 13,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "x9GJ1W",
+                      "name": "Worth Header",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ogwTw",
+                          "name": "Worth Label",
+                          "fill": "#FFFFFF99",
+                          "content": "淨資產",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "RYARU",
+                          "name": "Worth Date",
+                          "fill": "#FFFFFF66",
+                          "content": "2026 年 7 月 27 日",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Rcj5a",
+                      "name": "Worth Amount",
+                      "fill": "#FFFFFF",
+                      "content": "NT$2,486,350",
+                      "fontFamily": "$font-data",
+                      "fontSize": 42,
+                      "fontWeight": "650",
+                      "letterSpacing": -0.03
+                    },
+                    {
+                      "type": "text",
+                      "id": "UMwt4",
+                      "name": "Worth Debt",
+                      "fill": "#6EE7B7",
+                      "content": "已扣除 NT$40,000 信用卡負債",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "MfuR5",
+                      "name": "Allocation Bar",
+                      "clip": true,
+                      "width": "fill_container",
+                      "height": 10,
+                      "cornerRadius": 5,
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "id": "kqVNg",
+                          "name": "Investment Segment",
+                          "fill": "$steel",
+                          "width": 430,
+                          "height": 10
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "pPczo",
+                          "name": "Deposit Segment",
+                          "fill": "$moss",
+                          "width": 95,
+                          "height": 10
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "iobkm",
+                          "name": "Other Segment",
+                          "fill": "$coral",
+                          "width": "fill_container",
+                          "height": 10
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "qldUC",
+                  "name": "Monthly Pulse",
+                  "width": 340,
+                  "height": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": 12,
+                  "stroke": "$line",
+                  "strokeWidth": 1,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000A",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 3
+                  },
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": 20,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "S6evoW",
+                      "name": "Pulse Header",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "D8Gppj",
+                          "name": "Pulse Title",
+                          "fill": "$ink",
+                          "content": "本月財務脈動",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 15,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "E8lnqj",
+                          "name": "Pulse Link",
+                          "fill": "$steel",
+                          "content": "查看活動 →",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "M8cWo",
+                      "name": "Pulse Values",
+                      "width": "fill_container",
+                      "gap": 12,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "W6l8IA",
+                          "name": "收入 Metric",
+                          "width": "fill_container",
+                          "fill": "$soft-moss",
+                          "cornerRadius": 10,
+                          "layout": "vertical",
+                          "gap": 6,
+                          "padding": 12,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "CerOa",
+                              "name": "收入 Label",
+                              "fill": "$muted",
+                              "content": "收入",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "CWRcQ",
+                              "name": "收入 Value",
+                              "fill": "$moss",
+                              "content": "+NT$88,500",
+                              "fontFamily": "$font-data",
+                              "fontSize": 16,
+                              "fontWeight": "650"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "umMMt",
+                          "name": "支出 Metric",
+                          "width": "fill_container",
+                          "fill": "$soft-coral",
+                          "cornerRadius": 10,
+                          "layout": "vertical",
+                          "gap": 6,
+                          "padding": 12,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "hHrjN",
+                              "name": "支出 Label",
+                              "fill": "$muted",
+                              "content": "支出",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "fclwG",
+                              "name": "支出 Value",
+                              "fill": "$coral",
+                              "content": "−NT$61,240",
+                              "fontFamily": "$font-data",
+                              "fontSize": 16,
+                              "fontWeight": "650"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "H4sEX7",
+                      "name": "Net Flow",
+                      "width": "fill_container",
+                      "padding": [
+                        3,
+                        2
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XI8zQ",
+                          "name": "Net Flow Label",
+                          "fill": "$muted",
+                          "content": "本月淨流入",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "eLiAz",
+                          "name": "Net Flow Value",
+                          "fill": "$moss",
+                          "content": "NT$27,260",
+                          "fontFamily": "$font-data",
+                          "fontSize": 20,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "cc4wp",
+              "name": "Asset Summary",
+              "width": "fill_container",
+              "height": 104,
+              "fill": "$surface",
+              "cornerRadius": 12,
+              "stroke": "$line",
+              "strokeWidth": 1,
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000A",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "blur": 3
+              },
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "HXHBa",
+                  "name": "投資 Summary",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "#FFFFFF00",
+                  "stroke": "$line",
+                  "strokeWidth": {
+                    "right": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 7,
+                  "padding": [
+                    16,
+                    18
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "yLu7R",
+                      "name": "投資 Header",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "lS6fj",
+                          "name": "投資 Label",
+                          "fill": "$muted",
+                          "content": "投資",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "hrc1Q",
+                          "name": "投資 Percent",
+                          "fill": "$steel",
+                          "content": "52%",
+                          "fontFamily": "$font-data",
+                          "fontSize": 12,
+                          "fontWeight": "650"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "RY8D7",
+                      "name": "投資 Amount",
+                      "fill": "$ink",
+                      "content": "NT$1,320,000",
+                      "fontFamily": "$font-data",
+                      "fontSize": 21,
+                      "fontWeight": "650"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "r58J74",
+                  "name": "存款 Summary",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "#FFFFFF00",
+                  "stroke": "$line",
+                  "strokeWidth": {
+                    "right": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 7,
+                  "padding": [
+                    16,
+                    18
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "cTPPh",
+                      "name": "存款 Header",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "V1TFE",
+                          "name": "存款 Label",
+                          "fill": "$muted",
+                          "content": "存款",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "KOhKB",
+                          "name": "存款 Percent",
+                          "fill": "$moss",
+                          "content": "19%",
+                          "fontFamily": "$font-data",
+                          "fontSize": 12,
+                          "fontWeight": "650"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "A5ls5",
+                      "name": "存款 Amount",
+                      "fill": "$ink",
+                      "content": "NT$486,350",
+                      "fontFamily": "$font-data",
+                      "fontSize": 21,
+                      "fontWeight": "650"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "d4VOw",
+                  "name": "其他資產 Summary",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "#FFFFFF00",
+                  "stroke": "#FFFFFF00",
+                  "layout": "vertical",
+                  "gap": 7,
+                  "padding": [
+                    16,
+                    18
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "sCj4z",
+                      "name": "其他資產 Header",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mlaWz",
+                          "name": "其他資產 Label",
+                          "fill": "$muted",
+                          "content": "其他資產",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "obXXD",
+                          "name": "其他資產 Percent",
+                          "fill": "$coral",
+                          "content": "29%",
+                          "fontFamily": "$font-data",
+                          "fontSize": 12,
+                          "fontWeight": "650"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Q3a0ps",
+                      "name": "其他資產 Amount",
+                      "fill": "$ink",
+                      "content": "NT$720,000",
+                      "fontFamily": "$font-data",
+                      "fontSize": 21,
+                      "fontWeight": "650"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "PetCs",
+              "name": "Trend and Insights",
+              "width": "fill_container",
+              "height": 330,
+              "gap": 18,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "xrUoz",
+                  "name": "Asset Trend",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": 12,
+                  "stroke": "$line",
+                  "strokeWidth": 1,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000A",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 3
+                  },
+                  "layout": "vertical",
+                  "gap": 14,
+                  "padding": 20,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "fLYeY",
+                      "name": "Trend Header",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "CMviw",
+                          "name": "Trend Copy",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "jlKcn",
+                              "name": "Trend Title",
+                              "fill": "$ink",
+                              "content": "資產走勢",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 16,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "DGUKu",
+                              "name": "Trend Subtitle",
+                              "fill": "$muted",
+                              "content": "每日資產總額",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "bjqb0",
+                          "name": "Trend Range",
+                          "fill": "$canvas",
+                          "cornerRadius": 9,
+                          "gap": 4,
+                          "padding": 3,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "QZAXi",
+                              "name": "Range 1M",
+                              "fill": "#FFFFFF00",
+                              "cornerRadius": 7,
+                              "padding": [
+                                6,
+                                9
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "pRmi5",
+                                  "name": "Range Label 1M",
+                                  "fill": "$muted",
+                                  "content": "1M",
+                                  "fontFamily": "$font-ui",
+                                  "fontSize": 10,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "U58WKx",
+                              "name": "Range 3M",
+                              "fill": "#FFFFFF00",
+                              "cornerRadius": 7,
+                              "padding": [
+                                6,
+                                9
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "uScTC",
+                                  "name": "Range Label 3M",
+                                  "fill": "$muted",
+                                  "content": "3M",
+                                  "fontFamily": "$font-ui",
+                                  "fontSize": 10,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "T9w3i",
+                              "name": "Range 6M",
+                              "fill": "#FFFFFF00",
+                              "cornerRadius": 7,
+                              "padding": [
+                                6,
+                                9
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "g40SB",
+                                  "name": "Range Label 6M",
+                                  "fill": "$muted",
+                                  "content": "6M",
+                                  "fontFamily": "$font-ui",
+                                  "fontSize": 10,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "WtHw6",
+                              "name": "Range 1Y",
+                              "fill": "$surface",
+                              "cornerRadius": 7,
+                              "padding": [
+                                6,
+                                9
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "TRHBm",
+                                  "name": "Range Label 1Y",
+                                  "fill": "$ink",
+                                  "content": "1Y",
+                                  "fontFamily": "$font-ui",
+                                  "fontSize": 10,
+                                  "fontWeight": "700"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "G5V3D",
+                              "name": "Range 全部",
+                              "fill": "#FFFFFF00",
+                              "cornerRadius": 7,
+                              "padding": [
+                                6,
+                                9
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "c7Vf0f",
+                                  "name": "Range Label 全部",
+                                  "fill": "$muted",
+                                  "content": "全部",
+                                  "fontFamily": "$font-ui",
+                                  "fontSize": 10,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UJbqR",
+                      "name": "Asset Trend Line Chart",
+                      "width": "fill_container",
+                      "height": 180,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "id": "LyBVM",
+                          "x": 0,
+                          "y": 10,
+                          "name": "Grid Line Top",
+                          "fill": "#DDE2DE88",
+                          "width": 750,
+                          "height": 1
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "o7QYz",
+                          "x": 0,
+                          "y": 64,
+                          "name": "Grid Line Upper",
+                          "fill": "#DDE2DE88",
+                          "width": 750,
+                          "height": 1
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "DWq7N",
+                          "x": 0,
+                          "y": 118,
+                          "name": "Grid Line Lower",
+                          "fill": "#DDE2DE88",
+                          "width": 750,
+                          "height": 1
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "Oz4lT",
+                          "x": 0,
+                          "y": 171,
+                          "name": "Grid Line Bottom",
+                          "fill": "#DDE2DE",
+                          "width": 750,
+                          "height": 1
+                        },
+                        {
+                          "type": "path",
+                          "id": "Mn7lA",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Asset Trend Area",
+                          "geometry": "M0 146l34-4 34 1 35-8 35-7 34 4 35-9 34-8 35 4 34-12 35-11 34 4 34-12 35-13 34 7 35-15 34-13 35 5 34-24 35-19 34 10 35-8 26 2 0 152-750 0z",
+                          "viewBox": [
+                            0,
+                            0,
+                            750,
+                            172
+                          ],
+                          "fill": "#EAF2F5AA",
+                          "width": 750,
+                          "height": 172
+                        },
+                        {
+                          "type": "path",
+                          "id": "LduCB",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Asset Trend Line",
+                          "geometry": "M0 146l34-4 34 1 35-8 35-7 34 4 35-9 34-8 35 4 34-12 35-11 34 4 34-12 35-13 34 7 35-15 34-13 35 5 34-24 35-19 34 10 35-8 26 2",
+                          "viewBox": [
+                            0,
+                            0,
+                            750,
+                            172
+                          ],
+                          "fill": "#FFFFFF00",
+                          "width": 750,
+                          "height": 172,
+                          "stroke": "#2F6F89",
+                          "strokeWidth": 3,
+                          "strokeLinejoin": "round",
+                          "strokeLinecap": "round"
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "YFEek",
+                          "x": 738,
+                          "y": 14,
+                          "name": "Latest Value Point",
+                          "fill": "#2F6F89",
+                          "width": 12,
+                          "height": 12,
+                          "stroke": "#FFFFFF",
+                          "strokeWidth": 3
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Bk981",
+                      "name": "Trend Axis",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "OuF5A",
+                          "name": "Axis 10/1",
+                          "fill": "$muted",
+                          "content": "10/1",
+                          "fontFamily": "$font-data",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "g79qXD",
+                          "name": "Axis 1/1",
+                          "fill": "$muted",
+                          "content": "1/1",
+                          "fontFamily": "$font-data",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "w8IeRn",
+                          "name": "Axis 4/1",
+                          "fill": "$muted",
+                          "content": "4/1",
+                          "fontFamily": "$font-data",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "s5lGIi",
+                          "name": "Axis 7/1",
+                          "fill": "$muted",
+                          "content": "7/1",
+                          "fontFamily": "$font-data",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "m2Qj3w",
+                  "name": "Financial Insights",
+                  "width": 340,
+                  "height": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": 12,
+                  "stroke": "$line",
+                  "strokeWidth": 1,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000A",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 3
+                  },
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": 20,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "HFxHm",
+                      "name": "Insights Title",
+                      "fill": "$ink",
+                      "content": "值得留意",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 16,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jKrTP",
+                      "name": "信用卡到期提醒",
+                      "width": "fill_container",
+                      "fill": "#FFF7F5",
+                      "cornerRadius": 8,
+                      "stroke": "#F1D5CE",
+                      "strokeWidth": 1,
+                      "gap": 12,
+                      "padding": 13,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "IgjdA",
+                          "name": "信用卡到期 Icon",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "credit-card",
+                          "library": "lucide",
+                          "fill": "#C45A45"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "A26w5",
+                          "name": "信用卡 8/03 到期 Copy",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "CElrL",
+                              "name": "信用卡到期 Title",
+                              "fill": "$ink",
+                              "content": "信用卡將於 7 天內到期",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 12,
+                              "fontWeight": "650"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Vkpcg",
+                              "name": "信用卡到期 Detail",
+                              "fill": "$muted",
+                              "content": "台新 · 待繳 NT$40,000 · 8/03",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "zThlJ",
+                          "name": "信用卡提醒 Chevron",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#6B7A80"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "t3WdB",
+                      "name": "支出速度偏高提醒",
+                      "width": "fill_container",
+                      "fill": "#FFF9EB",
+                      "cornerRadius": 8,
+                      "stroke": "#F2E2BA",
+                      "strokeWidth": 1,
+                      "gap": 12,
+                      "padding": 13,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "W9tjVi",
+                          "name": "支出速度偏高 Icon",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "chart-no-axes-combined",
+                          "library": "lucide",
+                          "fill": "#C38B2C"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vfYTX",
+                          "name": "本月支出較上月少 8% Copy",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 3,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "B64JX",
+                              "name": "支出速度偏高 Title",
+                              "fill": "$ink",
+                              "content": "本月支出速度偏高 28%",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 12,
+                              "fontWeight": "650"
+                            },
+                            {
+                              "type": "text",
+                              "id": "DsIqc",
+                              "name": "支出速度偏高 Detail",
+                              "fill": "$muted",
+                              "content": "較近三月同期多 NT$8,420",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "b9TPIx",
+                          "name": "支出提醒 Chevron",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#6B7A80"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "Q215W",
+      "x": 1540,
+      "y": 0,
+      "name": "A 平衡總覽｜Mobile",
+      "clip": true,
+      "width": 390,
+      "height": 1180,
+      "fill": "$canvas",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "SQq5f",
+          "name": "A Mobile Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "padding": [
+            20,
+            16,
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "v7PsH",
+              "name": "Mobile Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "QZsZp",
+                  "name": "Mobile Header Copy",
+                  "layout": "vertical",
+                  "gap": 3,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "oizFx",
+                      "name": "Mobile Financial Overview Eyebrow",
+                      "fill": "$steel",
+                      "content": "FINANCIAL OVERVIEW",
+                      "fontFamily": "$font-data",
+                      "fontSize": 9,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "b1cb8E",
+                      "name": "Mobile Title",
+                      "fill": "$ink",
+                      "content": "資產總覽",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 23,
+                      "fontWeight": "750"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JcZzf",
+                  "name": "Mobile Hide Amount",
+                  "width": 36,
+                  "height": 36,
+                  "fill": "$surface",
+                  "cornerRadius": 18,
+                  "stroke": "$line",
+                  "strokeWidth": 1,
+                  "layout": "vertical",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "bdet7",
+                      "name": "Mobile Eye Off",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "eye-off",
+                      "library": "lucide",
+                      "fill": "$ink"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "jaAOg",
+              "name": "Mobile Net Worth",
+              "width": "fill_container",
+              "height": 176,
+              "fill": "$ink",
+              "cornerRadius": 12,
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000A",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "blur": 3
+              },
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 20,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "HV3qy",
+                  "name": "Mobile Worth Label",
+                  "fill": "#FFFFFF88",
+                  "content": "淨資產",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 11,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "Uverw",
+                  "name": "Mobile Worth Amount",
+                  "fill": "#FFFFFF",
+                  "content": "NT$2,486,350",
+                  "fontFamily": "$font-data",
+                  "fontSize": 31,
+                  "fontWeight": "650",
+                  "letterSpacing": -0.03
+                },
+                {
+                  "type": "text",
+                  "id": "kynqg",
+                  "name": "Mobile Worth Debt",
+                  "fill": "#6EE7B7",
+                  "content": "已扣除 NT$40,000 信用卡負債",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 11,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "frame",
+                  "id": "lUFCw",
+                  "name": "Mobile Allocation Bar",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": 9,
+                  "cornerRadius": 5,
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "ji6r7",
+                      "name": "Mobile Investment Segment",
+                      "fill": "$steel",
+                      "width": 168,
+                      "height": 9
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "i91Xg7",
+                      "name": "Mobile Deposit Segment",
+                      "fill": "$moss",
+                      "width": 36,
+                      "height": 9
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "vdUGg",
+                      "name": "Mobile Other Segment",
+                      "fill": "$coral",
+                      "width": "fill_container",
+                      "height": 9
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zR1u0",
+              "name": "Mobile Asset Summary",
+              "width": "fill_container",
+              "height": 88,
+              "fill": "$surface",
+              "cornerRadius": 12,
+              "stroke": "$line",
+              "strokeWidth": 1,
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000A",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "blur": 3
+              },
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "AiNN9",
+                  "name": "Mobile 投資",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "#FFFFFF00",
+                  "stroke": "$line",
+                  "strokeWidth": {
+                    "right": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 5,
+                  "padding": [
+                    12,
+                    13
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "GmT7R",
+                      "name": "Mobile 投資 Label",
+                      "fill": "$muted",
+                      "content": "投資",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 10,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "VSEpI",
+                      "name": "Mobile 投資 Value",
+                      "fill": "$steel",
+                      "content": "132萬",
+                      "fontFamily": "$font-data",
+                      "fontSize": 17,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "uoDiR",
+                      "name": "Mobile 投資 Percent",
+                      "fill": "$muted",
+                      "content": "52%",
+                      "fontFamily": "$font-data",
+                      "fontSize": 9,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "FqhRq",
+                  "name": "Mobile 存款",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "#FFFFFF00",
+                  "stroke": "$line",
+                  "strokeWidth": {
+                    "right": 1
+                  },
+                  "layout": "vertical",
+                  "gap": 5,
+                  "padding": [
+                    12,
+                    13
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Hk7qv",
+                      "name": "Mobile 存款 Label",
+                      "fill": "$muted",
+                      "content": "存款",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 10,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "k2p47",
+                      "name": "Mobile 存款 Value",
+                      "fill": "$moss",
+                      "content": "49萬",
+                      "fontFamily": "$font-data",
+                      "fontSize": 17,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "JOKRd",
+                      "name": "Mobile 存款 Percent",
+                      "fill": "$muted",
+                      "content": "19%",
+                      "fontFamily": "$font-data",
+                      "fontSize": 9,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "r47BX",
+                  "name": "Mobile 其他",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "#FFFFFF00",
+                  "stroke": "#FFFFFF00",
+                  "layout": "vertical",
+                  "gap": 5,
+                  "padding": [
+                    12,
+                    13
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "q3XxV",
+                      "name": "Mobile 其他 Label",
+                      "fill": "$muted",
+                      "content": "其他",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 10,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ntvqb",
+                      "name": "Mobile 其他 Value",
+                      "fill": "$coral",
+                      "content": "72萬",
+                      "fontFamily": "$font-data",
+                      "fontSize": 17,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Q89m7R",
+                      "name": "Mobile 其他 Percent",
+                      "fill": "$muted",
+                      "content": "29%",
+                      "fontFamily": "$font-data",
+                      "fontSize": 9,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "eEDAm",
+              "name": "Mobile Trend",
+              "width": "fill_container",
+              "height": 250,
+              "fill": "$surface",
+              "cornerRadius": 12,
+              "stroke": "$line",
+              "strokeWidth": 1,
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000A",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "blur": 3
+              },
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "n3DVGH",
+                  "name": "Mobile Trend Header",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "W720h3",
+                      "name": "Mobile Trend Copy",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "DVPwM",
+                          "name": "Mobile Trend Title",
+                          "fill": "$ink",
+                          "content": "資產走勢",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 15,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "pruNi",
+                          "name": "Mobile Trend Subtitle",
+                          "fill": "$moss",
+                          "content": "近一年資產總額",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BPUKP",
+                      "name": "Mobile Trend Range",
+                      "fill": "$canvas",
+                      "cornerRadius": 8,
+                      "gap": 3,
+                      "padding": 3,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "WLG8T",
+                          "name": "Mobile Range 6M",
+                          "fill": "#FFFFFF00",
+                          "cornerRadius": 6,
+                          "padding": [
+                            5,
+                            7
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "o5GrN",
+                              "name": "Mobile Range Label 6M",
+                              "fill": "$muted",
+                              "content": "6M",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 9,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "yDXNC",
+                          "name": "Mobile Range 1Y",
+                          "fill": "$surface",
+                          "cornerRadius": 6,
+                          "padding": [
+                            5,
+                            7
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "V4pliX",
+                              "name": "Mobile Range Label 1Y",
+                              "fill": "$ink",
+                              "content": "1Y",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 9,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "SLbi0",
+                          "name": "Mobile Range 全部",
+                          "fill": "#FFFFFF00",
+                          "cornerRadius": 6,
+                          "padding": [
+                            5,
+                            7
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "J2kKBK",
+                              "name": "Mobile Range Label 全部",
+                              "fill": "$muted",
+                              "content": "全部",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 9,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "YXODm",
+                  "name": "Mobile Asset Trend Line Chart",
+                  "width": 326,
+                  "height": 145,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "COjJl",
+                      "x": 0,
+                      "y": 8,
+                      "name": "Mobile Grid Line Top",
+                      "fill": "#DDE2DE88",
+                      "width": 326,
+                      "height": 1
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "Q2XBtp",
+                      "x": 0,
+                      "y": 53,
+                      "name": "Mobile Grid Line Upper",
+                      "fill": "#DDE2DE88",
+                      "width": 326,
+                      "height": 1
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "dBWSJ",
+                      "x": 0,
+                      "y": 98,
+                      "name": "Mobile Grid Line Lower",
+                      "fill": "#DDE2DE88",
+                      "width": 326,
+                      "height": 1
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "j5Cg6C",
+                      "x": 0,
+                      "y": 144,
+                      "name": "Mobile Grid Line Bottom",
+                      "fill": "#DDE2DE",
+                      "width": 326,
+                      "height": 1
+                    },
+                    {
+                      "type": "path",
+                      "id": "TqLXK",
+                      "x": 0,
+                      "y": 0,
+                      "name": "Mobile Asset Trend Area",
+                      "geometry": "M0 124l15-3 15-2 15 1 15-7 15-4 15 2 15-8 15-4 15 2 15-9 15-8 16 3 15-10 15-10 15 4 15-13 15-13 15 4 15-21 15 6 15-9 10 2 0 118-326 0z",
+                      "viewBox": [
+                        0,
+                        0,
+                        326,
+                        145
+                      ],
+                      "fill": "#EAF2F5AA",
+                      "width": 326,
+                      "height": 145
+                    },
+                    {
+                      "type": "path",
+                      "id": "cdxnI",
+                      "x": 0,
+                      "y": 0,
+                      "name": "Mobile Asset Trend Line",
+                      "geometry": "M0 124l15-3 15-2 15 1 15-7 15-4 15 2 15-8 15-4 15 2 15-9 15-8 16 3 15-10 15-10 15 4 15-13 15-13 15 4 15-21 15 6 15-9 10 2",
+                      "viewBox": [
+                        0,
+                        0,
+                        326,
+                        145
+                      ],
+                      "fill": "#FFFFFF00",
+                      "width": 326,
+                      "height": 145,
+                      "stroke": "#2F6F89",
+                      "strokeWidth": 3,
+                      "strokeLinejoin": "round",
+                      "strokeLinecap": "round"
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "ryVHg",
+                      "x": 316,
+                      "y": 22,
+                      "name": "Mobile Latest Value Point",
+                      "fill": "#2F6F89",
+                      "width": 10,
+                      "height": 10,
+                      "stroke": "#FFFFFF",
+                      "strokeWidth": 2
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "SHXoz",
+                  "name": "Mobile Trend Axis",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "FPpq1",
+                      "name": "Mobile Axis 10/1",
+                      "fill": "$muted",
+                      "content": "10/1",
+                      "fontFamily": "$font-data",
+                      "fontSize": 9,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "UUi22",
+                      "name": "Mobile Axis 1/1",
+                      "fill": "$muted",
+                      "content": "1/1",
+                      "fontFamily": "$font-data",
+                      "fontSize": 9,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "y6dQd",
+                      "name": "Mobile Axis 4/1",
+                      "fill": "$muted",
+                      "content": "4/1",
+                      "fontFamily": "$font-data",
+                      "fontSize": 9,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "n1a38",
+                      "name": "Mobile Axis 7/1",
+                      "fill": "$muted",
+                      "content": "7/1",
+                      "fontFamily": "$font-data",
+                      "fontSize": 9,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "qE9Ue",
+              "name": "Mobile Cash Flow Section",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "GbKkw",
+                  "name": "Mobile Cash Header",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "AdUVS",
+                      "name": "Mobile Cash Title",
+                      "fill": "$ink",
+                      "content": "本月收支",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 16,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "BkXhv",
+                      "name": "Mobile Cash Link",
+                      "fill": "$steel",
+                      "content": "查看活動 →",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 10,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "s9CeKC",
+                  "name": "Mobile Cash Metrics",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "I0OFu",
+                      "name": "Mobile 7 月收入",
+                      "width": "fill_container",
+                      "fill": "$surface",
+                      "cornerRadius": 12,
+                      "stroke": "$line",
+                      "strokeWidth": 1,
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#0000000A",
+                        "offset": {
+                          "x": 0,
+                          "y": 1
+                        },
+                        "blur": 3
+                      },
+                      "layout": "vertical",
+                      "gap": 6,
+                      "padding": 13,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "g26o4l",
+                          "name": "Mobile 7 月收入 Label",
+                          "fill": "$muted",
+                          "content": "7 月收入",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "fx6hq",
+                          "name": "Mobile 7 月收入 Value",
+                          "fill": "$moss",
+                          "content": "+NT$88,500",
+                          "fontFamily": "$font-data",
+                          "fontSize": 16,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "sMrGM",
+                          "name": "Mobile 7 月收入 Detail",
+                          "fill": "$muted",
+                          "content": "銀行與信用卡活動",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bViy7",
+                      "name": "Mobile 7 月支出",
+                      "width": "fill_container",
+                      "fill": "$surface",
+                      "cornerRadius": 12,
+                      "stroke": "$line",
+                      "strokeWidth": 1,
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#0000000A",
+                        "offset": {
+                          "x": 0,
+                          "y": 1
+                        },
+                        "blur": 3
+                      },
+                      "layout": "vertical",
+                      "gap": 6,
+                      "padding": 13,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "P1h0H",
+                          "name": "Mobile 7 月支出 Label",
+                          "fill": "$muted",
+                          "content": "7 月支出",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "yh67k",
+                          "name": "Mobile 7 月支出 Value",
+                          "fill": "$coral",
+                          "content": "−NT$61,240",
+                          "fontFamily": "$font-data",
+                          "fontSize": 16,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "oPpxk",
+                          "name": "Mobile 7 月支出 Detail",
+                          "fill": "$muted",
+                          "content": "含未配對發票",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Mt1g1",
+                  "name": "Mobile Net Flow",
+                  "width": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": 12,
+                  "stroke": "$line",
+                  "strokeWidth": 1,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000A",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 3
+                  },
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "B1280",
+                      "name": "Mobile Net Flow Copy",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "kRXeu",
+                          "name": "Mobile Net Flow Label",
+                          "fill": "$muted",
+                          "content": "7 月淨流入",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "HluBY",
+                          "name": "Mobile Net Flow Detail",
+                          "fill": "$muted",
+                          "content": "收入 − 支出",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "mJblv",
+                      "name": "Mobile Net Flow Value",
+                      "fill": "$moss",
+                      "content": "NT$27,260",
+                      "fontFamily": "$font-data",
+                      "fontSize": 20,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "J3qpa3",
+              "name": "Mobile Financial Alerts",
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": 12,
+              "stroke": "$line",
+              "strokeWidth": 1,
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000A",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "blur": 3
+              },
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "q4EkfE",
+                  "name": "Mobile Alerts Header",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Z6fRsM",
+                      "name": "Mobile Alerts Title",
+                      "fill": "$ink",
+                      "content": "值得留意",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "TXjMH",
+                      "name": "Mobile Alerts Count",
+                      "fill": "$canvas",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "lf2Qc",
+                          "name": "Mobile Alerts Count Label",
+                          "fill": "$muted",
+                          "content": "2",
+                          "fontFamily": "Geist Mono",
+                          "fontSize": 10,
+                          "fontWeight": "650"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "D4tUok",
+                  "name": "Mobile Credit Card Due Alert",
+                  "width": "fill_container",
+                  "fill": "#FFF7F5",
+                  "cornerRadius": 8,
+                  "stroke": "#F1D5CE",
+                  "strokeWidth": 1,
+                  "gap": 10,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "YLAUz",
+                      "name": "Mobile Credit Card Due Icon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "credit-card",
+                      "library": "lucide",
+                      "fill": "$coral"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "OVSEh",
+                      "name": "Mobile Credit Card Due Copy",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "uh0a4",
+                          "name": "Mobile Credit Card Due Title",
+                          "fill": "$ink",
+                          "content": "信用卡將於 7 天內到期",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "650"
+                        },
+                        {
+                          "type": "text",
+                          "id": "c7dxJN",
+                          "name": "Mobile Credit Card Due Detail",
+                          "fill": "$muted",
+                          "content": "台新 · 待繳 NT$40,000 · 8/03",
+                          "fontFamily": "Inter",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "ysNCk",
+                      "name": "Mobile Credit Card Due Chevron",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-right",
+                      "library": "lucide",
+                      "fill": "$muted"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "lHX1D",
+                  "name": "Mobile Spending Pace Alert",
+                  "width": "fill_container",
+                  "fill": "#FFF9EB",
+                  "cornerRadius": 8,
+                  "stroke": "#F2E2BA",
+                  "strokeWidth": 1,
+                  "gap": 10,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "TEYBV",
+                      "name": "Mobile Spending Pace Icon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "chart-no-axes-combined",
+                      "library": "lucide",
+                      "fill": "$gold"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qYAOC",
+                      "name": "Mobile Spending Pace Copy",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "DTxt9",
+                          "name": "Mobile Spending Pace Title",
+                          "fill": "$ink",
+                          "content": "本月支出速度偏高 28%",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "650"
+                        },
+                        {
+                          "type": "text",
+                          "id": "w8Z3y5",
+                          "name": "Mobile Spending Pace Detail",
+                          "fill": "$muted",
+                          "content": "較近三月同期多 NT$8,420",
+                          "fontFamily": "Inter",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "icon",
+                      "id": "Kv4Bz",
+                      "name": "Mobile Spending Pace Chevron",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "chevron-right",
+                      "library": "lucide",
+                      "fill": "$muted"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "k2xhAW",
+          "name": "Mobile Bottom Navigation",
+          "width": "fill_container",
+          "height": 72,
+          "fill": "$ink",
+          "gap": 8,
+          "padding": [
+            10,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "TkqAe",
+              "name": "Mobile Nav 總覽",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF16",
+              "cornerRadius": 10,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "a8TCfP",
+                  "name": "Mobile Nav 總覽 Icon",
+                  "width": 17,
+                  "height": 17,
+                  "icon": "layout-dashboard",
+                  "library": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "text",
+                  "id": "EQi52",
+                  "name": "Mobile Nav 總覽 Label",
+                  "fill": "#FFFFFF",
+                  "content": "總覽",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 9,
+                  "fontWeight": "700"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "vGQGH",
+              "name": "Mobile Nav 資產",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 10,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "vzb6A",
+                  "name": "Mobile Nav 資產 Icon",
+                  "width": 17,
+                  "height": 17,
+                  "icon": "wallet-cards",
+                  "library": "lucide",
+                  "fill": "#FFFFFF99"
+                },
+                {
+                  "type": "text",
+                  "id": "iy6Nc",
+                  "name": "Mobile Nav 資產 Label",
+                  "fill": "#FFFFFF99",
+                  "content": "資產",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 9,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "kiyH2",
+              "name": "Mobile Nav 活動",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 10,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "Q9rsC",
+                  "name": "Mobile Nav 活動 Icon",
+                  "width": 17,
+                  "height": 17,
+                  "icon": "history",
+                  "library": "lucide",
+                  "fill": "#FFFFFF99"
+                },
+                {
+                  "type": "text",
+                  "id": "ebkBe",
+                  "name": "Mobile Nav 活動 Label",
+                  "fill": "#FFFFFF99",
+                  "content": "活動",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 9,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "PU3Fu",
+              "name": "Mobile Nav 更多",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF00",
+              "cornerRadius": 10,
+              "layout": "vertical",
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "HuCmp",
+                  "name": "Mobile Nav 更多 Icon",
+                  "width": 17,
+                  "height": 17,
+                  "icon": "ellipsis",
+                  "library": "lucide",
+                  "fill": "#FFFFFF99"
+                },
+                {
+                  "type": "text",
+                  "id": "i9Y9S",
+                  "name": "Mobile Nav 更多 Label",
+                  "fill": "#FFFFFF99",
+                  "content": "更多",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 9,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "canvas": {
+      "type": "color",
+      "value": "#F4F5F0"
+    },
+    "surface": {
+      "type": "color",
+      "value": "#FFFFFF"
+    },
+    "ink": {
+      "type": "color",
+      "value": "#1B2B34"
+    },
+    "muted": {
+      "type": "color",
+      "value": "#6B7A80"
+    },
+    "line": {
+      "type": "color",
+      "value": "#DDE2DE"
+    },
+    "steel": {
+      "type": "color",
+      "value": "#2F6F89"
+    },
+    "moss": {
+      "type": "color",
+      "value": "#5E7B3D"
+    },
+    "coral": {
+      "type": "color",
+      "value": "#C45A45"
+    },
+    "gold": {
+      "type": "color",
+      "value": "#C38B2C"
+    },
+    "soft-blue": {
+      "type": "color",
+      "value": "#EAF2F5"
+    },
+    "soft-moss": {
+      "type": "color",
+      "value": "#EFF3EA"
+    },
+    "soft-coral": {
+      "type": "color",
+      "value": "#F8ECE9"
+    },
+    "font-ui": {
+      "type": "string",
+      "value": "Inter"
+    },
+    "font-data": {
+      "type": "string",
+      "value": "Geist Mono"
+    }
+  },
+  "fileToken": "9ef986b1-2b0e-4d9a-9b7d-c571893dc926"
+}


### PR DESCRIPTION
## 變更內容

- 依設計重新整理桌機與手機總覽頁的資訊層級
- 以本月收入、支出與淨流入取代重複的資產配置內容
- 將「值得留意」收斂為同步異常、資料過期、負淨流入與高信用卡負債等可採取行動的提醒
- 無異常時顯示明確的正常狀態
- 移除投資、存款與其他資產的百分比文字，改善三欄摘要與手機淨流入排版
- 納入桌機與手機 A 版 `design/dashboard.pen` 設計稿
- 更新總覽頁 E2E，涵蓋本月收支、空提醒狀態與響應式寬度

## 影響

總覽頁會更聚焦淨資產趨勢、本月現金流與真正需要處理的事項，減少重複資訊及不具行動價值的資產比例。

## 驗證

- `npm run verify:web`：主要重構完成後通過（47 個單元測試、10 個 E2E、production build）
- Svelte autofixer：0 issues / 0 suggestions
- `git diff --check`：通過
- 依需求，最後移除百分比與排版微調後未再重跑測試