### PR TITLE
排除交易計算時詢問分類與規則設定

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -331,6 +331,27 @@ test("excludes a bank transaction from activity calculations and restores it", a
   await page
     .getByRole("checkbox", { name: "排除 台新卡費 的統計計算" })
     .click();
+  const calculationDialog = page.getByRole("dialog", {
+    name: "排除統計計算",
+  });
+  await expect(calculationDialog).toBeVisible();
+  await expect(
+    calculationDialog.getByRole("checkbox", {
+      name: "同時新增分類規則",
+    }),
+  ).not.toBeChecked();
+  await calculationDialog.getByRole("button", { name: "取消" }).click();
+  await expect(calculationDialog).toBeHidden();
+  await expect(
+    page.getByRole("checkbox", { name: "排除 台新卡費 的統計計算" }),
+  ).not.toBeChecked();
+  await expect(expenseSlice).toBeVisible();
+
+  await page
+    .getByRole("checkbox", { name: "排除 台新卡費 的統計計算" })
+    .click();
+  await calculationDialog.getByRole("button", { name: "確認排除" }).click();
+  await expect(calculationDialog).toBeHidden();
   await expect(
     page.getByRole("checkbox", { name: "恢復 台新卡費 的統計計算" }),
   ).toBeChecked();
@@ -443,6 +464,187 @@ test("excludes a bank transaction from activity calculations and restores it", a
     );
   });
   await expect(detailDialog).toBeHidden();
+});
+
+test("can add a classification rule while excluding a transaction", async ({
+  page,
+}) => {
+  const month = new Date().toISOString().slice(0, 7);
+  let ruleBody: Record<string, unknown> | undefined;
+  let overrideBody: Record<string, unknown> | undefined;
+
+  await page.route("**/api/bank**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        accounts: [],
+        transactions: [
+          {
+            id: "fallback-transaction",
+            connectorId: "cathaybk",
+            accountId: "account-1",
+            sourceId: "fallback-source",
+            postedDate: `${month}-08`,
+            amount: -1200,
+            currency: "TWD",
+            description: "每月家庭轉帳",
+            status: "posted",
+            excludedFromCalculation: false,
+            classification: {
+              categoryId: "other",
+              label: "其他",
+              source: "fallback",
+            },
+          },
+        ],
+      }),
+    });
+  });
+  await page.route(
+    "**/api/bank/transactions/fallback-transaction/calculation",
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          excludedFromCalculation: true,
+        }),
+      });
+    },
+  );
+  await page.route(
+    "**/api/classification/overrides/bank_transaction/fallback-transaction",
+    async (route) => {
+      overrideBody = route.request().postDataJSON() as Record<string, unknown>;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true }),
+      });
+    },
+  );
+  await page.route("**/api/classification/rules", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    ruleBody = route.request().postDataJSON() as Record<string, unknown>;
+    await route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({ id: "user:new-rule", success: true }),
+    });
+  });
+
+  await page.goto("/#/activity");
+  await page
+    .getByRole("button", { name: "查看 每月家庭轉帳 活動詳情" })
+    .click();
+  await page
+    .getByRole("checkbox", { name: "排除 每月家庭轉帳 的統計計算" })
+    .click();
+
+  const dialog = page.getByRole("dialog", { name: "排除統計計算" });
+  await dialog.getByRole("combobox", { name: "分類" }).selectOption("transfer");
+  await dialog.getByRole("checkbox", { name: "同時新增分類規則" }).check();
+  await dialog.getByRole("textbox").fill("每月家庭轉帳");
+  await dialog.getByRole("button", { name: "確認排除" }).click();
+
+  await expect(dialog).toBeHidden();
+  expect(overrideBody).toEqual({ categoryId: "transfer" });
+  expect(ruleBody).toMatchObject({
+    categoryId: "transfer",
+    targetType: "bank_transaction",
+    field: "any_text",
+    operator: "contains",
+    pattern: "每月家庭轉帳",
+    excludedFromCalculation: true,
+  });
+});
+
+test("can modify an existing user rule while excluding a transaction", async ({
+  page,
+}) => {
+  const month = new Date().toISOString().slice(0, 7);
+  let updatedRuleBody: Record<string, unknown> | undefined;
+
+  await page.route("**/api/bank**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        accounts: [],
+        transactions: [
+          {
+            id: "rule-transaction",
+            connectorId: "cathaybk",
+            accountId: "account-1",
+            sourceId: "rule-source",
+            postedDate: `${month}-09`,
+            amount: -350,
+            currency: "TWD",
+            description: "固定轉帳",
+            status: "posted",
+            excludedFromCalculation: false,
+            classification: {
+              categoryId: "transfer",
+              label: "轉帳",
+              source: "user_rule",
+              ruleId: "user:transfer-rule",
+            },
+          },
+        ],
+      }),
+    });
+  });
+  await page.route(
+    "**/api/bank/transactions/rule-transaction/calculation",
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          excludedFromCalculation: true,
+        }),
+      });
+    },
+  );
+  await page.route(
+    "**/api/classification/rules/user%3Atransfer-rule",
+    async (route) => {
+      updatedRuleBody = route.request().postDataJSON() as Record<
+        string,
+        unknown
+      >;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true }),
+      });
+    },
+  );
+
+  await page.goto("/#/activity");
+  await page.getByRole("button", { name: "查看 固定轉帳 活動詳情" }).click();
+  await page
+    .getByRole("checkbox", { name: "排除 固定轉帳 的統計計算" })
+    .click();
+
+  const dialog = page.getByRole("dialog", { name: "排除統計計算" });
+  await expect(
+    dialog.getByRole("checkbox", { name: "同時修改目前分類規則" }),
+  ).not.toBeChecked();
+  await dialog.getByRole("checkbox", { name: "同時修改目前分類規則" }).check();
+  await dialog.getByRole("button", { name: "確認排除" }).click();
+
+  await expect(dialog).toBeHidden();
+  expect(updatedRuleBody).toEqual({
+    categoryId: "transfer",
+    excludedFromCalculation: true,
+  });
 });
 
 test("merges a matching invoice and counts an unmatched invoice as expense", async ({

--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -31,6 +31,7 @@
   import TabsList from "@/shared/ui/TabsList.svelte";
   import TabsTrigger from "@/shared/ui/TabsTrigger.svelte";
   import ActivityCategoryChart from "./components/ActivityCategoryChart.svelte";
+  import CalculationUpdateDialog from "./components/CalculationUpdateDialog.svelte";
   import CategoryUpdateDialog from "./components/CategoryUpdateDialog.svelte";
   import type { ApiClient } from "@/shared/api/client";
   import { queryKeys } from "@/shared/api/query-keys";
@@ -49,7 +50,12 @@
     InvoiceSummaryRow,
     InvoiceTransactionPreference,
   } from "@/data/invoices/types";
-  import type { ActivityItem, PendingCategoryUpdate } from "./model/types";
+  import type {
+    ActivityItem,
+    CalculationUpdateInput,
+    PendingCalculationUpdate,
+    PendingCategoryUpdate,
+  } from "./model/types";
   import {
     buildActivityCategorySlices,
     activityCashAmountTwd,
@@ -94,6 +100,7 @@
     category: string;
   } | null>(null);
   let pending = $state<PendingCategoryUpdate | null>(null);
+  let pendingCalculation = $state<PendingCalculationUpdate | null>(null);
   let mappingDialog = $state<{
     invoice: InvoiceSummaryRow;
     step: "candidates" | "confirm" | "actions";
@@ -178,6 +185,8 @@
           category: t.classification?.label ?? "其他",
           categoryId: t.classification?.categoryId ?? "other",
           classificationPattern: t.counterparty ?? t.description,
+          classificationSource: t.classification?.source ?? "fallback",
+          classificationRuleId: t.classification?.ruleId,
           transactionId: t.id,
           invoiceId: matchedInvoice?.id,
           invoiceAmount: matchedInvoice?.amount,
@@ -358,22 +367,61 @@
         { excludedFromCalculation: payload.excludedFromCalculation },
       ),
     onSuccess: (_result, payload) => {
-      qc.setQueryData<BankData>(queryKeys.bank, (current) =>
-        current
-          ? {
-              ...current,
-              transactions: current.transactions.map((transaction) =>
-                transaction.id === payload.transactionId
-                  ? {
-                      ...transaction,
-                      excludedFromCalculation: payload.excludedFromCalculation,
-                    }
-                  : transaction,
-              ),
-            }
-          : current,
+      updateCalculationCache(
+        payload.transactionId,
+        payload.excludedFromCalculation,
       );
       qc.invalidateQueries({ queryKey: queryKeys.bank });
+    },
+  });
+  const calculationUpdateMutation = createMutation({
+    mutationFn: async (payload: CalculationUpdateInput) => {
+      await api.patch(
+        `/api/bank/transactions/${encodeURIComponent(payload.transactionId)}/calculation`,
+        { excludedFromCalculation: true },
+      );
+
+      if (payload.applyRule && payload.ruleId) {
+        await api.put(
+          `/api/classification/rules/${encodeURIComponent(payload.ruleId)}`,
+          {
+            categoryId: payload.categoryId,
+            excludedFromCalculation: true,
+          },
+        );
+        return;
+      }
+
+      if (payload.categoryId !== payload.originalCategoryId) {
+        await api.put(
+          `/api/classification/overrides/bank_transaction/${payload.transactionId}`,
+          { categoryId: payload.categoryId },
+        );
+      }
+
+      if (payload.applyRule) {
+        await api.post("/api/classification/rules", {
+          categoryId: payload.categoryId,
+          targetType: "bank_transaction",
+          field: "any_text",
+          operator: payload.operator,
+          pattern: payload.pattern.trim(),
+          priority: 200,
+          description: "由活動頁排除計算時建立",
+          excludedFromCalculation: true,
+        });
+      }
+    },
+    onSuccess: (_result, payload) => {
+      updateCalculationCache(payload.transactionId, true);
+      qc.invalidateQueries({ queryKey: queryKeys.bank });
+      if (payload.applyRule)
+        qc.invalidateQueries({ queryKey: queryKeys.classificationRules });
+      pendingCalculation = null;
+    },
+    onError: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.bank });
+      qc.invalidateQueries({ queryKey: queryKeys.classificationRules });
     },
   });
   const mappingMutation = createMutation({
@@ -445,10 +493,43 @@
   }
   function toggleCalculation(item: ActivityItem) {
     if (!item.transactionId) return;
+    if (!item.excludedFromCalculation) {
+      pendingCalculation = {
+        item,
+        categoryId: item.categoryId ?? "other",
+        applyRule: false,
+        pattern: item.classificationPattern ?? item.title,
+        operator: "contains",
+      };
+      return;
+    }
     $calculationMutation.mutate({
       transactionId: item.transactionId,
-      excludedFromCalculation: !item.excludedFromCalculation,
+      excludedFromCalculation: false,
     });
+  }
+  function handleCalculationChange(item: ActivityItem, event: Event) {
+    (event.currentTarget as HTMLInputElement).checked = Boolean(
+      item.excludedFromCalculation,
+    );
+    toggleCalculation(item);
+  }
+  function updateCalculationCache(
+    transactionId: string,
+    excludedFromCalculation: boolean,
+  ) {
+    qc.setQueryData<BankData>(queryKeys.bank, (current) =>
+      current
+        ? {
+            ...current,
+            transactions: current.transactions.map((transaction) =>
+              transaction.id === transactionId
+                ? { ...transaction, excludedFromCalculation }
+                : transaction,
+            ),
+          }
+        : current,
+    );
   }
   function updateMappingPreference(preference: InvoiceTransactionPreference) {
     qc.setQueryData<InvoiceTransactionPreference[]>(
@@ -511,12 +592,20 @@
     if (item.invoiceAmount == null || item.amount == null) return 0;
     return Math.abs(item.invoiceAmount - Math.abs(item.amount));
   }
-  function countMatches() {
-    if (!pending) return 0;
+  function countMatches(update: {
+    pattern: string;
+    operator: "contains" | "equals";
+  }) {
+    const pattern = update.pattern.trim().toLowerCase();
+    if (!pattern) return 0;
     return activityBankTransactions.filter((t) =>
-      `${t.description ?? ""} ${t.counterparty ?? ""}`
-        .toLowerCase()
-        .includes(pending!.pattern.toLowerCase()),
+      update.operator === "equals"
+        ? `${t.description ?? ""} ${t.counterparty ?? ""} ${t.sourceId}`
+            .trim()
+            .toLowerCase() === pattern
+        : `${t.description ?? ""} ${t.counterparty ?? ""} ${t.sourceId}`
+            .toLowerCase()
+            .includes(pattern),
     ).length;
   }
 </script>
@@ -1035,10 +1124,12 @@
                     <Checkbox
                       aria-label={`${detailItem.excludedFromCalculation ? "恢復" : "排除"} ${detailItem.title} 的統計計算`}
                       checked={detailItem.excludedFromCalculation}
-                      disabled={$calculationMutation.isPending &&
+                      disabled={($calculationMutation.isPending &&
                         $calculationMutation.variables?.transactionId ===
-                          detailItem.transactionId}
-                      onchange={() => toggleCalculation(detailItem)}
+                          detailItem.transactionId) ||
+                        $calculationUpdateMutation.isPending}
+                      onchange={(event: Event) =>
+                        handleCalculationChange(detailItem, event)}
                     />
                   </label>{/if}
 
@@ -1070,11 +1161,22 @@
       <CategoryUpdateDialog
         update={pending}
         {categories}
-        matchCount={countMatches()}
+        matchCount={countMatches(pending)}
         submitting={$categoryMutation.isPending}
         failed={$categoryMutation.isError}
         onCancel={() => (pending = null)}
         onSubmit={(input) => $categoryMutation.mutate(input)}
+      />
+    {/if}
+    {#if pendingCalculation}
+      <CalculationUpdateDialog
+        bind:update={pendingCalculation}
+        {categoryOptions}
+        matchCount={countMatches(pendingCalculation)}
+        submitting={$calculationUpdateMutation.isPending}
+        failed={$calculationUpdateMutation.isError}
+        onCancel={() => (pendingCalculation = null)}
+        onSubmit={(input) => $calculationUpdateMutation.mutate(input)}
       />
     {/if}
     {#if mappingDialog}<div

--- a/apps/web/src/features/activity/components/CalculationUpdateDialog.svelte
+++ b/apps/web/src/features/activity/components/CalculationUpdateDialog.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import Button from "@/shared/ui/Button.svelte";
+  import Checkbox from "@/shared/ui/Checkbox.svelte";
+  import Input from "@/shared/ui/Input.svelte";
+  import Select from "@/shared/ui/Select.svelte";
+  import type {
+    CalculationUpdateInput,
+    PendingCalculationUpdate,
+  } from "../model/types";
+
+  let {
+    update = $bindable(),
+    categoryOptions,
+    matchCount,
+    submitting,
+    failed,
+    onCancel,
+    onSubmit,
+  }: {
+    update: PendingCalculationUpdate;
+    categoryOptions: { id: string; label: string }[];
+    matchCount: number;
+    submitting: boolean;
+    failed: boolean;
+    onCancel: () => void;
+    onSubmit: (input: CalculationUpdateInput) => void;
+  } = $props();
+
+  const updatesExistingRule = $derived(
+    update.item.classificationSource === "user_rule" &&
+      Boolean(update.item.classificationRuleId),
+  );
+</script>
+
+<div
+  aria-labelledby="calculation-update-title"
+  aria-modal="true"
+  class="fixed inset-0 z-[75] flex items-end bg-ink/45 md:items-center md:justify-center md:p-6"
+  role="dialog"
+>
+  <div
+    class="max-h-[88vh] w-full overflow-y-auto rounded-t-2xl bg-white p-5 shadow-2xl md:max-w-lg md:rounded-2xl md:p-6"
+  >
+    <h2 class="text-xl font-semibold" id="calculation-update-title">
+      排除統計計算
+    </h2>
+    <p class="mt-1 text-sm text-ink/50">
+      將保留「{update.item.title}」，但不計入收支與圖表。
+    </p>
+
+    <label class="mt-5 grid gap-2 text-sm font-semibold">
+      分類
+      <Select bind:value={update.categoryId}>
+        {#each categoryOptions as category (category.id)}
+          <option value={category.id}>{category.label}</option>
+        {/each}
+      </Select>
+    </label>
+
+    <label
+      class="mt-4 flex cursor-pointer items-start gap-3 rounded-xl border border-ink/10 bg-paper p-4"
+    >
+      <Checkbox
+        class="mt-1"
+        checked={update.applyRule}
+        onchange={(event: Event) =>
+          (update.applyRule = (
+            event.currentTarget as HTMLInputElement
+          ).checked)}
+      />
+      <span>
+        <span class="block font-semibold">
+          {updatesExistingRule ? "同時修改目前分類規則" : "同時新增分類規則"}
+        </span>
+        <span class="mt-1 block text-xs text-ink/50">
+          {updatesExistingRule
+            ? "之後符合目前規則的活動也會使用所選分類並排除計算。"
+            : "之後符合新規則的活動也會使用所選分類並排除計算。"}
+        </span>
+      </span>
+    </label>
+
+    {#if update.applyRule && !updatesExistingRule}
+      <div
+        class="mt-4 grid gap-3 rounded-xl border border-steel/20 bg-steel/5 p-4"
+      >
+        <Select bind:value={update.operator}>
+          <option value="contains">交易文字包含</option>
+          <option value="equals">交易文字完全等於</option>
+        </Select>
+        <Input bind:value={update.pattern} />
+        <p class="text-xs font-semibold text-steel">
+          目前載入的活動中有 {matchCount} 筆符合
+        </p>
+      </div>
+    {:else if update.applyRule}
+      <p
+        class="mt-4 rounded-xl border border-steel/20 bg-steel/5 p-4 text-xs font-medium text-steel"
+      >
+        這會修改既有的使用者規則，並影響所有符合該規則的活動。
+      </p>
+    {/if}
+
+    <div class="mt-5 grid grid-cols-2 gap-3">
+      <Button variant="secondary" onclick={onCancel}>取消</Button>
+      <Button
+        disabled={submitting ||
+          (update.applyRule && !updatesExistingRule && !update.pattern.trim())}
+        onclick={() =>
+          onSubmit({
+            transactionId: update.item.transactionId!,
+            categoryId: update.categoryId,
+            originalCategoryId: update.item.categoryId ?? "other",
+            applyRule: update.applyRule,
+            ruleId: updatesExistingRule
+              ? update.item.classificationRuleId
+              : undefined,
+            pattern: update.pattern,
+            operator: update.operator,
+          })}
+      >
+        {submitting ? "更新中…" : "確認排除"}
+      </Button>
+    </div>
+
+    {#if failed}
+      <p class="mt-3 text-sm text-coral">
+        無法完成更新，請確認目前設定後再試一次。
+      </p>
+    {/if}
+  </div>
+</div>

--- a/apps/web/src/features/activity/model/types.ts
+++ b/apps/web/src/features/activity/model/types.ts
@@ -9,6 +9,8 @@ export interface ActivityItem {
   category: string;
   categoryId?: string;
   classificationPattern?: string;
+  classificationSource?: "override" | "user_rule" | "system_rule" | "fallback";
+  classificationRuleId?: string;
   transactionId?: string;
   excludedFromCalculation?: boolean;
   invoiceId?: string;
@@ -28,6 +30,24 @@ export interface CategoryUpdateInput {
   transactionId: string;
   categoryId: string;
   addRule: boolean;
+  pattern: string;
+  operator: "contains" | "equals";
+}
+
+export interface PendingCalculationUpdate {
+  item: ActivityItem;
+  categoryId: string;
+  applyRule: boolean;
+  pattern: string;
+  operator: "contains" | "equals";
+}
+
+export interface CalculationUpdateInput {
+  transactionId: string;
+  categoryId: string;
+  originalCategoryId: string;
+  applyRule: boolean;
+  ruleId?: string;
   pattern: string;
   operator: "contains" | "equals";
 }


### PR DESCRIPTION
## 變更內容

- 點擊「排除統計計算」時先顯示確認對話框，不再直接更新交易
- 允許在同一流程調整交易分類
- 若交易套用使用者分類規則，可選擇同步修改既有規則
- 若交易來自系統規則、手動覆寫或 fallback，可選擇新增使用者分類規則
- 取消對話框時維持原本的計算狀態；恢復列入計算仍只影響單筆交易

## 原因

原本排除計算只會 PATCH 單筆交易偏好，沒有經過分類規則確認流程，因此使用者無法在排除交易時同步建立或調整後續自動套用的規則。

## 使用者影響

使用者可明確選擇只排除目前交易，或讓相似交易之後自動使用同一分類並排除計算；系統內建規則仍不會被直接修改。

## 驗證

- `npm run verify:web`
- 47 個 unit tests 通過
- 12 個 Playwright E2E tests 通過
- Svelte typecheck、production build 通過
- Svelte autofixer 無問題
- 本次變更檔案 Prettier check 與 `git diff --check` 通過