### PR TITLE
feat(交易分類): 將「其他」改名為「未分類」

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -49,7 +49,7 @@ test.beforeEach(async ({ page }) => {
         { id: "fee", label: "手續費", sortOrder: 11, isSystem: true },
         { id: "insurance", label: "保險", sortOrder: 12, isSystem: true },
         { id: "tax", label: "稅務", sortOrder: 13, isSystem: true },
-        { id: "other", label: "其他", sortOrder: 14, isSystem: true },
+        { id: "other", label: "未分類", sortOrder: 14, isSystem: true },
       ];
     else if (path === "/api/classification/rules") body = [];
     else if (path.includes("/connectors/") && path.endsWith("/settings"))
@@ -289,7 +289,7 @@ test("excludes a bank transaction from activity calculations and restores it", a
             excludedFromCalculation,
             classification: {
               categoryId: "other",
-              label: "其他",
+              label: "未分類",
               source: "fallback",
             },
           },
@@ -315,7 +315,7 @@ test("excludes a bank transaction from activity calculations and restores it", a
   await page.goto("/#/activity");
   await expect(page.locator("html")).toHaveClass(/is-standalone/);
   const expenseSlice = page.getByRole("button", {
-    name: "其他 100.0% NT$8,318",
+    name: "未分類 100.0% NT$8,318",
   });
   await expect(expenseSlice).toBeVisible();
 
@@ -358,7 +358,7 @@ test("excludes a bank transaction from activity calculations and restores it", a
   await expect(expenseSlice).toBeHidden();
   await page.getByRole("button", { name: "返回活動列表" }).click();
   const excludedExpenseSlice = page.getByRole("button", {
-    name: "其他 0.0% NT$0",
+    name: "未分類 0.0% NT$0",
   });
   await expect(excludedExpenseSlice).toBeVisible();
   await excludedExpenseSlice.click();
@@ -493,7 +493,7 @@ test("can add a classification rule while excluding a transaction", async ({
             excludedFromCalculation: false,
             classification: {
               categoryId: "other",
-              label: "其他",
+              label: "未分類",
               source: "fallback",
             },
           },

--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -122,7 +122,7 @@
     { id: "insurance", label: "保險" },
     { id: "fee", label: "手續費" },
     { id: "tax", label: "稅務" },
-    { id: "other", label: "其他" },
+    { id: "other", label: "未分類" },
   ];
   const categoryOptions = $derived(
     $categoryRows.data?.length ? $categoryRows.data : fallbackCategories,
@@ -182,7 +182,7 @@
             .join(" · "),
           amount: t.amount,
           currency: t.currency,
-          category: t.classification?.label ?? "其他",
+          category: t.classification?.label ?? "未分類",
           categoryId: t.classification?.categoryId ?? "other",
           classificationPattern: t.counterparty ?? t.description,
           classificationSource: t.classification?.source ?? "fallback",

--- a/apps/web/src/features/activity/model/chart.test.ts
+++ b/apps/web/src/features/activity/model/chart.test.ts
@@ -16,7 +16,7 @@ function item(overrides: Partial<ActivityItem>): ActivityItem {
     subtitle: "",
     amount: 0,
     currency: "TWD",
-    category: "其他",
+    category: "未分類",
     status: "posted",
     ...overrides,
   };
@@ -88,7 +88,7 @@ describe("activity category chart", () => {
     expect(activityCashFlow(excluded)).toBe("expense");
     expect(buildActivityCategorySlices([excluded], "expense", {})).toEqual([
       {
-        category: "其他",
+        category: "未分類",
         amount: 0,
         percentage: 0,
         color: "#3e6f7c",
@@ -103,7 +103,7 @@ describe("activity category chart", () => {
         item({
           id: "2",
           amount: -300,
-          category: "其他",
+          category: "未分類",
           excludedFromCalculation: true,
         }),
       ],
@@ -119,7 +119,7 @@ describe("activity category chart", () => {
       })),
     ).toEqual([
       { category: "餐飲", amount: 500, percentage: 100 },
-      { category: "其他", amount: 0, percentage: 0 },
+      { category: "未分類", amount: 0, percentage: 0 },
     ]);
   });
 });

--- a/apps/web/src/features/assets/Bank.svelte
+++ b/apps/web/src/features/assets/Bank.svelte
@@ -136,7 +136,7 @@
     { id: "insurance", label: "保險" },
     { id: "fee", label: "手續費" },
     { id: "tax", label: "稅務" },
-    { id: "other", label: "其他" },
+    { id: "other", label: "未分類" },
   ];
   const categoryOptions = $derived(
     $categoryRows.data?.length ? $categoryRows.data : fallbackCategories,
@@ -238,7 +238,7 @@
                   <p class="mt-1 truncate text-xs text-ink/40">
                     {formatBankAccountName(t)} · {formatDate(
                       t.postedDate ?? t.authorizedAt,
-                    )} · {t.classification?.label ?? "其他"}
+                    )} · {t.classification?.label ?? "未分類"}
                   </p>
                 </div>
                 <p
@@ -271,7 +271,7 @@
                 {selected.description ?? selected.counterparty ?? "銀行交易"}
               </h2>
               <p class="mt-1 text-sm text-ink/50">
-                目前分類：{selected.classification?.label ?? "其他"}
+                目前分類：{selected.classification?.label ?? "未分類"}
               </p>
             </div>
             <Button

--- a/apps/worker/src/features/classification/service.ts
+++ b/apps/worker/src/features/classification/service.ts
@@ -101,7 +101,7 @@ export async function resolveClassifications(
     }
     result.set(
       transaction.id,
-      matched ?? { categoryId: "other", label: "其他", source: "fallback" },
+      matched ?? { categoryId: "other", label: "未分類", source: "fallback" },
     );
   }
 

--- a/apps/worker/tests/features/classification/service.test.ts
+++ b/apps/worker/tests/features/classification/service.test.ts
@@ -38,6 +38,29 @@ describe("matchesClassificationRule", () => {
 });
 
 describe("resolveClassifications", () => {
+  it("labels unmatched transactions as uncategorized", async () => {
+    const db = {
+      prepare() {
+        return {
+          bind() {
+            return this;
+          },
+          async all() {
+            return { results: [] };
+          },
+        };
+      },
+    } as unknown as D1Database;
+
+    const result = await resolveClassifications(db, [transaction]);
+
+    expect(result.get(transaction.id)).toEqual({
+      categoryId: "other",
+      label: "未分類",
+      source: "fallback",
+    });
+  });
+
   it("returns the calculation action from the first matching rule", async () => {
     const calls: Array<{ sql: string; values: unknown[] }> = [];
     const db = {

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -11,7 +11,7 @@
 - Tables：24
 - Explicit indexes：31
 - Other objects：0
-- Migrations：16
+- Migrations：18
 
 ## Tables
 
@@ -1192,6 +1192,8 @@ Migration 是 schema 演進的 source of truth；若要了解某欄位的變更�
 - [`0015_push_notifications.sql`](../packages/db/migrations/0015_push_notifications.sql)
 - [`0016_scheduled_sync_notification_batches.sql`](../packages/db/migrations/0016_scheduled_sync_notification_batches.sql)
 - [`0017_taishin_sync_job.sql`](../packages/db/migrations/0017_taishin_sync_job.sql)
+- [`0018_esun_credit_transaction_signs.sql`](../packages/db/migrations/0018_esun_credit_transaction_signs.sql)
+- [`0019_rename_other_classification.sql`](../packages/db/migrations/0019_rename_other_classification.sql)
 
 ## 程式碼導覽
 

--- a/packages/db/migrations/0019_rename_other_classification.sql
+++ b/packages/db/migrations/0019_rename_other_classification.sql
@@ -1,0 +1,4 @@
+UPDATE classification_categories
+SET label = '未分類',
+    updated_at = '2026-07-28T00:00:00.000Z'
+WHERE id = 'other';

--- a/packages/db/seeds/demo.sql
+++ b/packages/db/seeds/demo.sql
@@ -36,7 +36,7 @@ INSERT INTO classification_categories
   ('fee',           '手續費', 11, 1, '2026-06-22T00:00:00.000Z', '2026-06-22T00:00:00.000Z'),
   ('insurance',     '保險',   12, 1, '2026-06-22T00:00:00.000Z', '2026-06-22T00:00:00.000Z'),
   ('tax',           '稅務',   13, 1, '2026-06-22T00:00:00.000Z', '2026-06-22T00:00:00.000Z'),
-  ('other',         '其他',   14, 1, '2026-06-22T00:00:00.000Z', '2026-06-22T00:00:00.000Z');
+  ('other',         '未分類', 14, 1, '2026-06-22T00:00:00.000Z', '2026-07-28T00:00:00.000Z');
 
 INSERT INTO classification_rules
   (id, category_id, target_type, field, operator, pattern, priority, enabled, is_system, source, description, created_at, updated_at) VALUES


### PR DESCRIPTION
## Description

- 將交易分類中的系統分類「其他」改名為「未分類」，讓尚未完成歸類的交易語意更明確。
- 保留分類 ID `other`，避免影響既有分類規則、覆寫與資料關聯。
- 新增 D1 migration 更新既有資料庫，並同步 Demo seed、前後端 fallback 與測試案例。

## Architecture

- `0019_rename_other_classification.sql` 更新 `classification_categories.id = 'other'` 的顯示名稱。
- Worker classification service 在沒有命中規則時回傳 `label: "未分類"`。
- Activity 與 Bank 頁面的前端 fallback 同步使用「未分類」，API 正常回傳資料時仍以 API label 為準。
- 資料庫 schema 文件與相關單元、E2E 測試同步更新。

## Breaking Changes (optional)

無。分類 ID 仍為 `other`；僅顯示名稱與 API classification label 由「其他」調整為「未分類」。部署時需套用 D1 migration。

## Test & Risk

- `npm run typecheck`：通過，所有 workspace 型別檢查 0 errors / 0 warnings。
- `npm run build`：通過，所有 workspace 建置成功。
- Worker tests：23 個 test files、151 項測試通過。
- DB tests：1 個 test file、4 項測試通過。
- Connector self-check：TDCC、電子發票 v1/v2、台新皆通過。
- `npm run test:e2e -w @taiwan-fin-hub/web -- shell.spec.ts`：12 項瀏覽器測試通過。
- `npm run db:schema:docs`：成功在隔離 D1 套用 migrations 並更新 schema 文件。
- 本次修改的前端檔案通過 Prettier；repo-wide `format:check` 仍受既有 `SettingsPage.svelte` 格式問題影響。
- 既有 Vite build 警告：主 chunk 大於 500 kB，本次未新增依賴且不在此 PR 範圍。
- Regression scope：分類清單、未命中規則的交易、活動分類圖表、銀行交易列表與既有資料庫 migration。

## Checklist

- [ ] 代碼符合本專案風格 (Lint / Formatter 通過)
- [x] 自我 Review 並移除無用程式、除錯訊息
- [x] 文件 / Release Note 已更新
- [ ] 無新增 ESLint / Lint 警告
- [ ] 相依變更（API、DB、Config）已通知利害關係人
- [x] 拼字檢查通過
