### PR TITLE
重新設計活動列表並顯示銀行與帳戶資訊

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -734,9 +734,12 @@ test("merges a matching invoice and counts an unmatched invoice as expense", asy
 
   const activityRows = page.locator("tbody tr");
   await expect(activityRows).toHaveCount(2);
-  await expect(
-    activityRows.filter({ hasText: "好食餐飲有限公司" }),
-  ).toContainText("信用卡＋發票");
+  const matchedActivityRow = activityRows.filter({
+    hasText: "好食餐飲有限公司",
+  });
+  await expect(matchedActivityRow).toContainText("測試銀行");
+  await expect(matchedActivityRow).toContainText("測試信用卡");
+  await expect(matchedActivityRow).toContainText("已配對發票");
   await expect(
     activityRows.filter({ hasText: "未支援銀行商店" }),
   ).toContainText("−NT$1,490");
@@ -897,12 +900,13 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
   await page.getByRole("button", { name: "確認配對" }).click();
 
   await expect(page.getByText("已完成配對，活動只顯示一筆")).toBeVisible();
-  await expect(
-    page.getByText("信用卡＋發票 · 2026/7/6", { exact: true }),
-  ).toBeVisible();
-  await page
-    .getByRole("button", { name: "查看 菲尖極道商行 活動詳情" })
-    .click();
+  const mappedActivityRow = page.getByRole("button", {
+    name: "查看 菲尖極道商行 活動詳情",
+  });
+  await expect(mappedActivityRow).toContainText("玉山銀行");
+  await expect(mappedActivityRow).toContainText("信用卡 · 餐飲");
+  await expect(mappedActivityRow).toContainText("已配對發票");
+  await mappedActivityRow.click();
   const detail = page.getByRole("dialog", { name: "活動明細" });
   await expect(
     detail

--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -7,10 +7,6 @@
   } from "@tanstack/svelte-query";
   import {
     Search,
-    Building2,
-    CreditCard,
-    FileText,
-    TrendingUp,
     ArrowDown,
     Check,
     Link2,
@@ -56,6 +52,11 @@
     PendingCalculationUpdate,
     PendingCategoryUpdate,
   } from "./model/types";
+  import {
+    activityStatusLabel,
+    formatActivityDateGroup,
+    groupActivitiesByDate,
+  } from "./model/list";
   import {
     buildActivityCategorySlices,
     activityCashAmountTwd,
@@ -162,12 +163,15 @@
         const matchedInvoice = invoiceMatches.transactionToInvoice.get(t.id);
         const isCard =
           account?.accountType === "credit" || t.accountType === "credit";
-        const accountLabel =
+        const institutionName =
           t.institutionName ??
           account?.institutionName ??
+          (isCard ? "信用卡" : "銀行");
+        const accountLast4 = t.accountLast4 ?? account?.accountLast4;
+        const accountName =
           t.accountName ??
           account?.accountName ??
-          "";
+          (accountLast4 ? `末四碼 ${accountLast4}` : "");
         return {
           id: t.id,
           source: isCard ? ("card" as const) : ("bank" as const),
@@ -177,9 +181,15 @@
             t.description ??
             t.counterparty ??
             "銀行交易",
-          subtitle: [accountLabel, matchedInvoice?.invoiceNumber]
+          subtitle: [
+            institutionName,
+            accountName,
+            matchedInvoice?.invoiceNumber,
+          ]
             .filter(Boolean)
             .join(" · "),
+          institutionName,
+          accountName,
           amount: t.amount,
           currency: t.currency,
           category: t.classification?.label ?? "未分類",
@@ -202,6 +212,8 @@
           date: i.invoiceDate,
           title: i.sellerName ?? "電子發票",
           subtitle: i.invoiceNumber ?? "",
+          institutionName: "電子發票",
+          accountName: i.invoiceNumber ?? "",
           amount: i.amount,
           currency: "TWD",
           category: "發票",
@@ -209,22 +221,27 @@
           invoiceAmount: i.amount,
           status: "已開立",
         })),
-      ...($trades.data ?? []).map((t) => ({
-        id: t.id,
-        source: "investment" as const,
-        date: normalizeFinancialDate(t.tradeDate ?? t.postedDate),
-        title: t.name ?? t.symbol ?? "投資交易",
-        subtitle: [
+      ...($trades.data ?? []).map((t) => {
+        const accountName = [
           t.transactionName ?? t.transactionCode,
           t.quantity != null ? `${formatNumber(t.quantity)} 股` : undefined,
         ]
           .filter(Boolean)
-          .join(" · "),
-        amount: t.price === 1 ? undefined : t.amount,
-        currency: t.currency,
-        category: "投資",
-        status: "已完成",
-      })),
+          .join(" · ");
+        return {
+          id: t.id,
+          source: "investment" as const,
+          date: normalizeFinancialDate(t.tradeDate ?? t.postedDate),
+          title: t.name ?? t.symbol ?? "投資交易",
+          subtitle: accountName,
+          institutionName: "投資",
+          accountName,
+          amount: t.price === 1 ? undefined : t.amount,
+          currency: t.currency,
+          category: "投資",
+          status: "已完成",
+        };
+      }),
     ].sort((a, b) => b.date.localeCompare(a.date)),
   );
   const detailItem = $derived(
@@ -307,7 +324,7 @@
         matchesSource &&
         item.date.startsWith(selectedMonth) &&
         (!search.trim() ||
-          `${item.title} ${item.subtitle} ${item.category}`
+          `${item.title} ${item.subtitle} ${item.institutionName ?? ""} ${item.accountName ?? ""} ${item.category}`
             .toLowerCase()
             .includes(search.toLowerCase())) &&
         (!selectedCategory ||
@@ -315,6 +332,7 @@
       );
     }),
   );
+  const filteredGroups = $derived(groupActivitiesByDate(filtered));
   const mappingCandidates = $derived.by(() => {
     if (!mappingDialog) return [];
     const unavailableTransactionIds = new Set(
@@ -759,16 +777,16 @@
             <h2 class="truncate text-lg font-semibold">
               {selectedCategory
                 ? `${selectedMonthLabel} · ${selectedCategory.category}`
-                : `${selectedMonthLabel}所有活動`}
+                : "所有活動"}
             </h2>
-            <p class="text-xs text-ink/45">銀行、信用卡、投資與發票</p>
+            <p class="text-xs text-ink/45">銀行與帳戶資訊直接顯示於每筆活動</p>
           </div>
           <div class="relative md:w-80">
             <Search
               class="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-muted-foreground"
             /><Input
               class="h-11 pl-9"
-              placeholder="搜尋商家、帳戶、品項或分類"
+              placeholder="搜尋商家、銀行或分類"
               bind:value={search}
             />
           </div>
@@ -788,7 +806,7 @@
           </div>{/if}
         <TabsList class="grid h-auto w-full grid-cols-4"
           >{#each [{ key: "all", label: "全部" }, { key: "bank", label: "銀行" }, { key: "card", label: "信用卡" }, { key: "invoice", label: "發票" }] as filter (filter.key)}<TabsTrigger
-              class={`min-h-9 min-w-0 px-1 text-xs md:text-sm ${source === filter.key ? "bg-ink text-white" : ""}`}
+              class="min-h-9 min-w-0 px-1 text-xs md:text-sm"
               active={source === filter.key}
               onclick={() => {
                 source = filter.key as typeof source;
@@ -803,106 +821,147 @@
           </p>{/if}
       </CardHeader>
       <CardContent class="min-w-0 p-0">
-        <div class="min-w-0 divide-y divide-ink/8 md:hidden">
-          {#if filtered.length === 0}<p
+        <div class="min-w-0 md:hidden">
+          {#if filteredGroups.length === 0}<p
               class="p-8 text-center text-sm text-ink/50"
             >
               沒有符合條件的活動。
-            </p>{:else}{#each filtered as item (item.source + "-" + item.id)}{@const amount =
-                activityDisplayAmount(item)}
-              <button
-                aria-label={`查看 ${item.title} 活動詳情`}
-                class={`flex w-full min-w-0 items-center gap-3 px-4 py-3 text-left transition hover:bg-paper ${item.excludedFromCalculation ? "bg-ink/[0.025]" : ""}`}
-                onclick={() => openDetail(item)}
+            </p>{:else}{#each filteredGroups as group (group.dateKey)}<div
+                class="flex items-center justify-between bg-paper px-4 py-2.5 text-xs"
               >
-                <span
-                  class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-steel/10 text-steel"
-                  >{#if item.source === "bank"}<Building2
-                      class="size-5"
-                    />{:else if item.source === "card"}<CreditCard
-                      class="size-5"
-                    />{:else if item.source === "invoice"}<FileText
-                      class="size-5"
-                    />{:else}<TrendingUp class="size-5" />{/if}</span
-                >
-                <div class="min-w-0 flex-1">
-                  <p class="truncate text-sm font-semibold">{item.title}</p>
-                  <p class="mt-0.5 truncate text-xs text-ink/45">
-                    {sourceLabel(item)} · {formatDate(item.date)}
-                  </p>
-                  <Badge variant="secondary" class="mt-1.5"
-                    >{item.category}</Badge
+                <span class="font-semibold text-ink/80"
+                  >{formatActivityDateGroup(group.dateKey)}</span
+                ><span class="text-ink/45">{group.items.length} 筆</span>
+              </div>
+              <div class="divide-y divide-ink/8">
+                {#each group.items as item (item.source + "-" + item.id)}{@const amount =
+                    activityDisplayAmount(item)}
+                  <button
+                    aria-label={`查看 ${item.title} 活動詳情`}
+                    class={`flex w-full min-w-0 items-center gap-3 px-4 py-3.5 text-left transition hover:bg-paper ${item.excludedFromCalculation ? "bg-ink/[0.025]" : ""}`}
+                    onclick={() => openDetail(item)}
                   >
-                </div>
-                <span class="flex shrink-0 items-center gap-1">
-                  <span
-                    class={`max-w-[38vw] truncate text-sm font-semibold tabular-nums ${item.excludedFromCalculation ? "text-ink/35 line-through" : (amount ?? 0) < 0 ? "text-coral" : item.source !== "invoice" ? "text-moss" : ""}`}
-                  >
-                    {amount == null
-                      ? "—"
-                      : `${amount >= 0 && item.source !== "invoice" ? "+" : ""}${formatCurrency(amount, item.currency)}`}
-                  </span>
-                  <ChevronRight class="size-4 text-ink/30" />
-                </span>
-              </button>{/each}{/if}
+                    <div class="min-w-0 flex-1">
+                      <p class="truncate text-sm font-semibold">{item.title}</p>
+                      <p
+                        class="mt-1 truncate text-xs font-semibold text-ink/75"
+                      >
+                        {item.institutionName ?? sourceLabel(item)}
+                      </p>
+                      <p class="mt-0.5 truncate text-[11px] text-ink/45">
+                        {[item.accountName, item.category]
+                          .filter(Boolean)
+                          .join(" · ")}
+                      </p>
+                    </div>
+                    <div class="flex shrink-0 items-center gap-1.5">
+                      <div class="max-w-[40vw] text-right">
+                        <p
+                          class={`truncate text-sm font-semibold tabular-nums ${item.excludedFromCalculation ? "text-ink/35 line-through" : (amount ?? 0) < 0 ? "text-coral" : item.source !== "invoice" ? "text-moss" : ""}`}
+                        >
+                          {amount == null
+                            ? "—"
+                            : `${amount >= 0 && item.source !== "invoice" ? "+" : ""}${formatCurrency(amount, item.currency)}`}
+                        </p>
+                        <p class="mt-1 text-[11px] text-ink/40">
+                          {activityStatusLabel(item)}
+                        </p>
+                      </div>
+                      <ChevronRight class="size-4 text-ink/30" />
+                    </div>
+                  </button>{/each}
+              </div>{/each}{/if}
         </div>
         <div class="hidden overflow-x-auto md:block">
-          <table class="w-full min-w-[760px] text-left text-sm">
-            <thead class="bg-paper text-xs font-semibold text-ink/45"
-              ><tr
-                ><th class="px-5 py-3">日期</th><th class="px-4 py-3">來源</th
-                ><th class="px-4 py-3">說明／商家</th><th class="px-4 py-3"
-                  >分類</th
-                ><th class="px-5 py-3 text-right">金額</th></tr
-              ></thead
-            ><tbody class="divide-y divide-ink/8"
-              >{#if filtered.length === 0}<tr
-                  ><td class="px-5 py-8 text-center text-ink/50" colspan="5"
-                    >沒有符合條件的活動。</td
-                  ></tr
-                >{:else}{#each filtered as item (item.source + "-" + item.id)}{@const amount =
-                    activityDisplayAmount(item)}<tr
-                    aria-label={`查看 ${item.title} 活動詳情`}
-                    class={`cursor-pointer transition hover:bg-paper focus-visible:outline-2 focus-visible:outline-steel ${item.excludedFromCalculation ? "bg-ink/[0.025]" : ""}`}
-                    onclick={() => openDetail(item)}
-                    onkeydown={(event) => {
-                      if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        openDetail(item);
-                      }
-                    }}
-                    role="button"
-                    tabindex="0"
-                    ><td class="whitespace-nowrap px-5 py-3 text-ink/55"
-                      >{formatDate(item.date)}</td
-                    ><td class="px-4 py-3">{sourceLabel(item)}</td><td
-                      class="max-w-xs px-4 py-3"
-                      ><p class="truncate font-semibold">{item.title}</p>
-                      <p class="truncate text-xs text-ink/40">
-                        {item.subtitle}
-                      </p>
-                      {#if item.transactionId && item.invoiceId && itemMappingDifference(item) > 0}<Badge
-                          variant="secondary"
-                          class="mt-1 bg-amber-50 text-amber-800"
-                          >點數折抵 {formatCurrency(
-                            itemMappingDifference(item),
-                          )}</Badge
-                        >{/if}</td
-                    ><td class="px-4 py-3"
-                      ><Badge variant="secondary">{item.category}</Badge></td
-                    ><td
-                      class={`whitespace-nowrap px-5 py-3 text-right font-semibold tabular-nums ${item.excludedFromCalculation ? "text-ink/35 line-through" : (amount ?? 0) < 0 ? "text-coral" : item.source !== "invoice" ? "text-moss" : ""}`}
-                      ><span class="inline-flex items-center gap-2"
-                        >{amount == null
-                          ? "—"
-                          : formatCurrency(amount, item.currency)}<ChevronRight
-                          class="size-4 text-ink/30"
-                        /></span
-                      ></td
-                    ></tr
-                  >{/each}{/if}</tbody
+          {#if filteredGroups.length === 0}<p
+              class="p-8 text-center text-sm text-ink/50"
             >
-          </table>
+              沒有符合條件的活動。
+            </p>{:else}<table
+              class="w-full min-w-[760px] table-fixed text-left text-sm"
+            >
+              <colgroup
+                ><col /><col class="w-56" /><col class="w-36" /><col
+                  class="w-44"
+                /></colgroup
+              >
+              <thead class="text-xs font-semibold text-ink/45"
+                ><tr
+                  ><th class="px-5 py-2.5">商家／說明</th><th
+                    class="px-4 py-2.5">銀行／帳戶</th
+                  ><th class="px-4 py-2.5">分類</th><th
+                    class="px-5 py-2.5 text-right">金額</th
+                  ></tr
+                ></thead
+              >
+            </table>
+            {#each filteredGroups as group (group.dateKey)}<div
+                class="flex min-w-[760px] items-center justify-between bg-paper px-5 py-2.5 text-xs"
+              >
+                <span class="font-semibold text-ink/80"
+                  >{formatActivityDateGroup(group.dateKey)}</span
+                ><span class="text-ink/45">{group.items.length} 筆</span>
+              </div>
+              <table class="w-full min-w-[760px] table-fixed text-left text-sm">
+                <colgroup
+                  ><col /><col class="w-56" /><col class="w-36" /><col
+                    class="w-44"
+                  /></colgroup
+                >
+                <tbody class="divide-y divide-ink/8"
+                  >{#each group.items as item (item.source + "-" + item.id)}{@const amount =
+                      activityDisplayAmount(item)}<tr
+                      aria-label={`查看 ${item.title} 活動詳情`}
+                      class={`cursor-pointer transition hover:bg-paper focus-visible:outline-2 focus-visible:outline-steel ${item.excludedFromCalculation ? "bg-ink/[0.025]" : ""}`}
+                      onclick={() => openDetail(item)}
+                      onkeydown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          openDetail(item);
+                        }
+                      }}
+                      role="button"
+                      tabindex="0"
+                      ><td class="min-w-0 px-5 py-3.5"
+                        ><p class="truncate font-semibold">{item.title}</p>
+                        {#if item.transactionId && item.invoiceId && itemMappingDifference(item) > 0}<Badge
+                            variant="secondary"
+                            class="mt-1 bg-amber-50 text-amber-800"
+                            >點數折抵 {formatCurrency(
+                              itemMappingDifference(item),
+                            )}</Badge
+                          >{/if}</td
+                      ><td class="px-4 py-3.5"
+                        ><p class="truncate font-semibold text-ink/80">
+                          {item.institutionName ?? sourceLabel(item)}
+                        </p>
+                        {#if item.accountName}<p
+                            class="mt-1 truncate text-xs text-ink/40"
+                          >
+                            {item.accountName}
+                          </p>{/if}</td
+                      ><td class="px-4 py-3.5"
+                        ><Badge variant="secondary">{item.category}</Badge></td
+                      ><td class="px-5 py-3.5"
+                        ><div class="flex items-center justify-end gap-2">
+                          <div class="min-w-0 text-right">
+                            <p
+                              class={`truncate whitespace-nowrap font-semibold tabular-nums ${item.excludedFromCalculation ? "text-ink/35 line-through" : (amount ?? 0) < 0 ? "text-coral" : item.source !== "invoice" ? "text-moss" : ""}`}
+                            >
+                              {amount == null
+                                ? "—"
+                                : `${amount >= 0 && item.source !== "invoice" ? "+" : ""}${formatCurrency(amount, item.currency)}`}
+                            </p>
+                            <p class="mt-1 text-xs text-ink/40">
+                              {activityStatusLabel(item)}
+                            </p>
+                          </div>
+                          <ChevronRight class="size-4 shrink-0 text-ink/30" />
+                        </div></td
+                      ></tr
+                    >{/each}</tbody
+                >
+              </table>{/each}{/if}
         </div>
       </CardContent>
     </Card>

--- a/apps/web/src/features/activity/model/list.test.ts
+++ b/apps/web/src/features/activity/model/list.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  activityStatusLabel,
+  formatActivityDateGroup,
+  groupActivitiesByDate,
+} from "./list";
+import type { ActivityItem } from "./types";
+
+function item(id: string, date: string): ActivityItem {
+  return {
+    id,
+    source: "bank",
+    date,
+    title: id,
+    subtitle: "",
+    currency: "TWD",
+    category: "未分類",
+    status: "posted",
+  };
+}
+
+describe("activity list", () => {
+  it("groups sorted activities by their financial date", () => {
+    const groups = groupActivitiesByDate([
+      item("a", "2026-07-28T12:00:00+08:00"),
+      item("b", "2026-07-28"),
+      item("c", "2026-07-27"),
+    ]);
+
+    expect(groups.map((group) => [group.dateKey, group.items.length])).toEqual([
+      ["2026-07-28", 2],
+      ["2026-07-27", 1],
+    ]);
+  });
+
+  it("formats date groups and transaction statuses for display", () => {
+    expect(formatActivityDateGroup("2026-07-28")).toBe("7 月 28 日・週二");
+    expect(formatActivityDateGroup("")).toBe("日期未提供");
+    expect(activityStatusLabel(item("pending", "2026-07-28"))).toBe("已入帳");
+    expect(
+      activityStatusLabel({
+        ...item("matched", "2026-07-28"),
+        source: "card",
+        invoiceId: "invoice-1",
+      }),
+    ).toBe("已配對發票");
+    expect(
+      activityStatusLabel({
+        ...item("pending", "2026-07-28"),
+        status: "pending",
+      }),
+    ).toBe("待入帳");
+    expect(
+      activityStatusLabel({
+        ...item("complete", "2026-07-28"),
+        status: "已完成",
+      }),
+    ).toBe("已完成");
+  });
+});

--- a/apps/web/src/features/activity/model/list.ts
+++ b/apps/web/src/features/activity/model/list.ts
@@ -1,0 +1,42 @@
+import type { ActivityItem } from "./types";
+
+export interface ActivityDateGroup {
+  dateKey: string;
+  items: ActivityItem[];
+}
+
+export function groupActivitiesByDate(
+  items: ActivityItem[],
+): ActivityDateGroup[] {
+  const groups = new Map<string, ActivityItem[]>();
+  for (const item of items) {
+    const dateKey = item.date.match(/^\d{4}-\d{2}-\d{2}/)?.[0] ?? "";
+    const group = groups.get(dateKey);
+    if (group) group.push(item);
+    else groups.set(dateKey, [item]);
+  }
+  return Array.from(groups, ([dateKey, groupedItems]) => ({
+    dateKey,
+    items: groupedItems,
+  }));
+}
+
+export function formatActivityDateGroup(dateKey: string) {
+  const match = dateKey.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return "日期未提供";
+  const [, year, month, day] = match;
+  const weekday = ["週日", "週一", "週二", "週三", "週四", "週五", "週六"];
+  const dayOfWeek = new Date(
+    Date.UTC(Number(year), Number(month) - 1, Number(day)),
+  ).getUTCDay();
+  return `${Number(month)} 月 ${Number(day)} 日・${weekday[dayOfWeek]}`;
+}
+
+export function activityStatusLabel(
+  item: Pick<ActivityItem, "invoiceId" | "source" | "status">,
+) {
+  if (item.invoiceId && item.source !== "invoice") return "已配對發票";
+  if (item.status === "pending") return "待入帳";
+  if (item.status === "posted") return "已入帳";
+  return item.status;
+}

--- a/apps/web/src/features/activity/model/types.ts
+++ b/apps/web/src/features/activity/model/types.ts
@@ -4,6 +4,8 @@ export interface ActivityItem {
   date: string;
   title: string;
   subtitle: string;
+  institutionName?: string;
+  accountName?: string;
   amount?: number;
   currency: string;
   category: string;

--- a/design/activity.pen
+++ b/design/activity.pen
@@ -1,0 +1,3001 @@
+{
+  "version": "2.14",
+  "children": [
+    {
+      "type": "frame",
+      "id": "Ufflg",
+      "x": 920,
+      "y": 0,
+      "name": "活動列表｜shadcn｜桌面版 1440",
+      "clip": true,
+      "width": 1440,
+      "height": 1120,
+      "fill": "$bg",
+      "children": [
+        {
+          "type": "frame",
+          "id": "NSfqH",
+          "name": "側邊導覽",
+          "width": 236,
+          "height": "fill_container",
+          "fill": "$surface",
+          "layout": "vertical",
+          "gap": 28,
+          "padding": [
+            28,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "qQCVn",
+              "name": "品牌",
+              "width": "fill_container",
+              "gap": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dacJB",
+                  "name": "品牌標誌",
+                  "width": 34,
+                  "height": 34,
+                  "fill": "$steel",
+                  "cornerRadius": 10,
+                  "layout": "vertical",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "MSsNF",
+                      "name": "品牌字母",
+                      "fill": "#FFFFFF",
+                      "content": "T",
+                      "fontFamily": "$font",
+                      "fontSize": 17,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "vw2z2",
+                  "name": "品牌名稱",
+                  "fill": "$ink",
+                  "content": "Taiwan Fin Hub",
+                  "fontFamily": "$font",
+                  "fontSize": 16,
+                  "fontWeight": "700"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "lRsAG",
+              "name": "主選單",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 6,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "B4c8ol",
+                  "name": "選單｜總覽",
+                  "width": "fill_container",
+                  "height": 42,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 10,
+                  "gap": 11,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "DsEqk",
+                      "name": "總覽圖示",
+                      "fill": "$muted",
+                      "content": "◫",
+                      "fontFamily": "$font",
+                      "fontSize": 17,
+                      "fontWeight": "650"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xj2xA",
+                      "name": "總覽文字",
+                      "fill": "$muted",
+                      "content": "總覽",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "LpKFi",
+                  "name": "選單｜活動",
+                  "width": "fill_container",
+                  "height": 42,
+                  "fill": "$steel-soft",
+                  "cornerRadius": 10,
+                  "gap": 11,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "iOwES",
+                      "name": "活動圖示",
+                      "fill": "$steel",
+                      "content": "≡",
+                      "fontFamily": "$font",
+                      "fontSize": 17,
+                      "fontWeight": "650"
+                    },
+                    {
+                      "type": "text",
+                      "id": "hXneS",
+                      "name": "活動文字",
+                      "fill": "$steel",
+                      "content": "活動",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "650"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "qsfUu",
+                  "name": "選單｜帳戶",
+                  "width": "fill_container",
+                  "height": 42,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 10,
+                  "gap": 11,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "zqSoZ",
+                      "name": "帳戶圖示",
+                      "fill": "$muted",
+                      "content": "□",
+                      "fontFamily": "$font",
+                      "fontSize": 17,
+                      "fontWeight": "650"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ReQ7F",
+                      "name": "帳戶文字",
+                      "fill": "$muted",
+                      "content": "帳戶",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Yrh9i",
+                  "name": "選單｜發票",
+                  "width": "fill_container",
+                  "height": 42,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 10,
+                  "gap": 11,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "hgZYe",
+                      "name": "發票圖示",
+                      "fill": "$muted",
+                      "content": "▧",
+                      "fontFamily": "$font",
+                      "fontSize": 17,
+                      "fontWeight": "650"
+                    },
+                    {
+                      "type": "text",
+                      "id": "MuxOT",
+                      "name": "發票文字",
+                      "fill": "$muted",
+                      "content": "發票",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dgaR1",
+                  "name": "選單｜投資",
+                  "width": "fill_container",
+                  "height": 42,
+                  "fill": "#FFFFFF00",
+                  "cornerRadius": 10,
+                  "gap": 11,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "fn3b3",
+                      "name": "投資圖示",
+                      "fill": "$muted",
+                      "content": "⌁",
+                      "fontFamily": "$font",
+                      "fontSize": 17,
+                      "fontWeight": "650"
+                    },
+                    {
+                      "type": "text",
+                      "id": "V5h2PD",
+                      "name": "投資文字",
+                      "fill": "$muted",
+                      "content": "投資",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "hbQ4r",
+              "name": "導覽留白",
+              "width": "fill_container",
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "V537T",
+              "name": "設定",
+              "width": "fill_container",
+              "height": 42,
+              "gap": 11,
+              "padding": [
+                0,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Ei0RL",
+                  "name": "設定圖示",
+                  "fill": "$muted",
+                  "content": "⚙",
+                  "fontFamily": "$font",
+                  "fontSize": 16,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "Eyr8e",
+                  "name": "設定文字",
+                  "fill": "$muted",
+                  "content": "設定",
+                  "fontFamily": "$font",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "nNSHc",
+          "name": "活動內容",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            36,
+            44,
+            44,
+            44
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "hp2Kb",
+              "name": "頁面標題列",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "asyjG",
+                  "name": "標題區",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "dU76d",
+                      "name": "頁面標題",
+                      "fill": "$ink",
+                      "content": "活動",
+                      "fontFamily": "$font",
+                      "fontSize": 30,
+                      "fontWeight": "720"
+                    },
+                    {
+                      "type": "text",
+                      "id": "QSZcW",
+                      "name": "頁面說明",
+                      "fill": "$muted",
+                      "content": "掌握所有帳戶的收入、支出與消費紀錄",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rPrCr",
+                  "name": "shadcn/Button outline｜月份",
+                  "height": 42,
+                  "fill": "$surface",
+                  "cornerRadius": 6,
+                  "stroke": "$line",
+                  "strokeWidth": 1,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000D",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 2
+                  },
+                  "gap": 10,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "VVX60",
+                      "name": "月份圖示",
+                      "fill": "$steel",
+                      "content": "月",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "zAJOd",
+                      "name": "月份文字",
+                      "fill": "$ink",
+                      "content": "2026 年 7 月",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "650"
+                    },
+                    {
+                      "type": "text",
+                      "id": "eUn2m",
+                      "name": "月份展開",
+                      "fill": "$muted",
+                      "content": "⌄",
+                      "fontFamily": "$font",
+                      "fontSize": 16,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ZMO5p",
+              "name": "月份摘要",
+              "width": "fill_container",
+              "gap": 14,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "IXkF7",
+                  "name": "摘要｜本月收入",
+                  "width": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": 12,
+                  "stroke": "$line",
+                  "strokeWidth": 1,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000D",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 2
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 18,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "mZlXt",
+                      "name": "本月收入標籤",
+                      "fill": "$muted",
+                      "content": "本月收入",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "fMQyT",
+                      "name": "本月收入數值",
+                      "fill": "$moss",
+                      "content": "NT$ 126,800",
+                      "fontFamily": "$font",
+                      "fontSize": 23,
+                      "fontWeight": "720"
+                    },
+                    {
+                      "type": "text",
+                      "id": "mg6MH",
+                      "name": "本月收入補充",
+                      "fill": "$muted",
+                      "content": "較上月 +8.2%",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "e34TnY",
+                  "name": "摘要｜本月支出",
+                  "width": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": 12,
+                  "stroke": "$line",
+                  "strokeWidth": 1,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000D",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 2
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 18,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "qRiB6",
+                      "name": "本月支出標籤",
+                      "fill": "$muted",
+                      "content": "本月支出",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "FsxlU",
+                      "name": "本月支出數值",
+                      "fill": "$coral",
+                      "content": "NT$ 47,236",
+                      "fontFamily": "$font",
+                      "fontSize": 23,
+                      "fontWeight": "720"
+                    },
+                    {
+                      "type": "text",
+                      "id": "LxMMU",
+                      "name": "本月支出補充",
+                      "fill": "$muted",
+                      "content": "較上月 -3.1%",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "DSvoC",
+                  "name": "摘要｜活動筆數",
+                  "width": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": 12,
+                  "stroke": "$line",
+                  "strokeWidth": 1,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000D",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 2
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 18,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "voz3t",
+                      "name": "活動筆數標籤",
+                      "fill": "$muted",
+                      "content": "活動筆數",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "cDkRz",
+                      "name": "活動筆數數值",
+                      "fill": "$steel",
+                      "content": "128 筆",
+                      "fontFamily": "$font",
+                      "fontSize": 23,
+                      "fontWeight": "720"
+                    },
+                    {
+                      "type": "text",
+                      "id": "eyoLC",
+                      "name": "活動筆數補充",
+                      "fill": "$muted",
+                      "content": "來自 5 個金融帳戶",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "a4FkB",
+              "name": "活動清單卡片",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": 12,
+              "stroke": "$line",
+              "strokeWidth": 1,
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000D",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "blur": 2
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "xzl1S",
+                  "name": "清單工具列",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 16,
+                  "padding": [
+                    22,
+                    24,
+                    18,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "XyExj",
+                      "name": "清單標題與搜尋",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "qdvG7",
+                          "name": "清單標題",
+                          "layout": "vertical",
+                          "gap": 5,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "W0Clpd",
+                              "name": "所有活動標題",
+                              "fill": "$ink",
+                              "content": "所有活動",
+                              "fontFamily": "$font",
+                              "fontSize": 19,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "CiNf5",
+                              "name": "所有活動說明",
+                              "fill": "$muted",
+                              "content": "銀行資訊直接顯示在每筆活動下方",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "eHsTe",
+                          "name": "清單操作",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ywB42",
+                              "name": "shadcn/Input｜搜尋",
+                              "width": 300,
+                              "height": 40,
+                              "fill": "$surface",
+                              "cornerRadius": 6,
+                              "stroke": "$line",
+                              "strokeWidth": 1,
+                              "effect": {
+                                "type": "shadow",
+                                "shadowType": "outer",
+                                "color": "#0000000D",
+                                "offset": {
+                                  "x": 0,
+                                  "y": 1
+                                },
+                                "blur": 2
+                              },
+                              "gap": 9,
+                              "padding": [
+                                0,
+                                13
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "d34ve",
+                                  "name": "搜尋圖示",
+                                  "fill": "$muted",
+                                  "content": "⌕",
+                                  "fontFamily": "$font",
+                                  "fontSize": 18,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "zE3RR",
+                                  "name": "搜尋提示",
+                                  "fill": "$muted",
+                                  "content": "搜尋商家、銀行或分類",
+                                  "fontFamily": "$font",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Q5ymGD",
+                              "name": "shadcn/Button outline｜篩選",
+                              "height": 40,
+                              "fill": "$surface",
+                              "cornerRadius": 6,
+                              "stroke": "$line",
+                              "strokeWidth": 1,
+                              "effect": {
+                                "type": "shadow",
+                                "shadowType": "outer",
+                                "color": "#0000000D",
+                                "offset": {
+                                  "x": 0,
+                                  "y": 1
+                                },
+                                "blur": 2
+                              },
+                              "gap": 7,
+                              "padding": [
+                                0,
+                                13
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "fYjdt",
+                                  "name": "篩選圖示",
+                                  "fill": "$muted",
+                                  "content": "≛",
+                                  "fontFamily": "$font",
+                                  "fontSize": 16,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "BXgw1",
+                                  "name": "篩選文字",
+                                  "fill": "$ink",
+                                  "content": "篩選",
+                                  "fontFamily": "$font",
+                                  "fontSize": 13,
+                                  "fontWeight": "650"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "P4c5qE",
+                      "name": "shadcn/TabsList｜活動來源",
+                      "width": "fill_container",
+                      "height": 40,
+                      "fill": "$bg",
+                      "cornerRadius": 6,
+                      "padding": 4,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "tSj17",
+                          "name": "shadcn/TabsTrigger active｜全部",
+                          "height": "fill_container",
+                          "fill": "$surface",
+                          "cornerRadius": 4,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#00000012",
+                            "offset": {
+                              "x": 0,
+                              "y": 1
+                            },
+                            "blur": 2
+                          },
+                          "padding": [
+                            0,
+                            13
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "CpVI8",
+                              "name": "全部 128文字",
+                              "fill": "$ink",
+                              "content": "全部 128",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "650"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "EIsKO",
+                          "name": "來源｜銀行 64",
+                          "height": "fill_container",
+                          "fill": "#FFFFFF00",
+                          "cornerRadius": 4,
+                          "padding": [
+                            0,
+                            13
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "qHgLJ",
+                              "name": "銀行 64文字",
+                              "fill": "$muted",
+                              "content": "銀行 64",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "650"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "jEmzC",
+                          "name": "來源｜信用卡 41",
+                          "height": "fill_container",
+                          "fill": "#FFFFFF00",
+                          "cornerRadius": 4,
+                          "padding": [
+                            0,
+                            13
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "G5hB6",
+                              "name": "信用卡 41文字",
+                              "fill": "$muted",
+                              "content": "信用卡 41",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "650"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "NVGYI",
+                          "name": "來源｜發票 23",
+                          "height": "fill_container",
+                          "fill": "#FFFFFF00",
+                          "cornerRadius": 4,
+                          "padding": [
+                            0,
+                            13
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "hETWO",
+                              "name": "發票 23文字",
+                              "fill": "$muted",
+                              "content": "發票 23",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "650"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "J53Hg",
+                  "name": "工具列分隔線",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "$line"
+                },
+                {
+                  "type": "frame",
+                  "id": "m8DBD",
+                  "name": "依日期分組的活動",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "xlWCB",
+                      "name": "活動欄位標題",
+                      "width": "fill_container",
+                      "height": 34,
+                      "fill": "$surface",
+                      "gap": 14,
+                      "padding": [
+                        0,
+                        24
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "durRe",
+                          "name": "商家說明欄標題",
+                          "fill": "$muted",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "商家／說明",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "650"
+                        },
+                        {
+                          "type": "text",
+                          "id": "CA8Rf",
+                          "name": "銀行帳戶欄標題",
+                          "fill": "$muted",
+                          "textGrowth": "fixed-width",
+                          "width": 210,
+                          "content": "銀行／帳戶",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "650"
+                        },
+                        {
+                          "type": "text",
+                          "id": "zE7mJ",
+                          "name": "分類欄標題",
+                          "fill": "$muted",
+                          "textGrowth": "fixed-width",
+                          "width": 100,
+                          "content": "分類",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "650"
+                        },
+                        {
+                          "type": "text",
+                          "id": "djNkd",
+                          "name": "金額欄標題",
+                          "fill": "$muted",
+                          "textGrowth": "fixed-width",
+                          "width": 138,
+                          "content": "金額",
+                          "textAlign": "right",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "650"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ohGua",
+                          "name": "展開欄",
+                          "width": 10,
+                          "height": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ik8Vj",
+                      "name": "日期群組｜7月28日",
+                      "width": "fill_container",
+                      "height": 40,
+                      "fill": "$bg",
+                      "padding": [
+                        0,
+                        24
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Y6AyxG",
+                          "name": "7月28日日期",
+                          "fill": "$ink",
+                          "content": "7 月 28 日・週一",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "bJD9c",
+                          "name": "7月28日摘要",
+                          "fill": "$muted",
+                          "content": "3 筆 · 淨收入 NT$ 61,088",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HWQxB",
+                      "name": "活動｜Uber Eats",
+                      "width": "fill_container",
+                      "height": 76,
+                      "gap": 18,
+                      "padding": [
+                        0,
+                        24
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "frAYX",
+                          "name": "Uber Eats資訊",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "rerN5",
+                              "name": "Uber Eats名稱",
+                              "fill": "$ink",
+                              "content": "Uber Eats",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "keiJu",
+                          "name": "銀行帳戶｜永豐銀行",
+                          "width": 210,
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Jn89M",
+                              "name": "永豐銀行名稱",
+                              "fill": "$ink",
+                              "content": "永豐銀行",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "jOSx9",
+                              "name": "DAWHO 信用卡帳戶",
+                              "fill": "$muted",
+                              "content": "DAWHO 信用卡",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "B7wUvG",
+                          "name": "shadcn/Badge secondary｜分類",
+                          "width": 100,
+                          "height": 24,
+                          "fill": "$bg",
+                          "cornerRadius": 999,
+                          "padding": [
+                            0,
+                            10
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "pCrVB",
+                              "name": "餐飲分類文字",
+                              "fill": "$muted",
+                              "content": "餐飲",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qeCqb",
+                          "name": "Uber Eats金額",
+                          "width": 138,
+                          "layout": "vertical",
+                          "gap": 5,
+                          "alignItems": "end",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "n3ZmzS",
+                              "name": "Uber Eats金額文字",
+                              "fill": "$coral",
+                              "content": "-NT$ 486",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "720"
+                            },
+                            {
+                              "type": "text",
+                              "id": "z9Ipun",
+                              "name": "Uber Eats狀態",
+                              "fill": "$muted",
+                              "content": "已入帳",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "I9FaKC",
+                          "name": "Uber Eats展開",
+                          "fill": "$muted",
+                          "content": "›",
+                          "fontFamily": "$font",
+                          "fontSize": 20,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "IDv86",
+                      "name": "Uber Eats分隔線",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "$line"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "K9blBp",
+                      "name": "活動｜全聯福利中心",
+                      "width": "fill_container",
+                      "height": 76,
+                      "gap": 18,
+                      "padding": [
+                        0,
+                        24
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "jSMRC",
+                          "name": "全聯福利中心資訊",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "C03Sfs",
+                              "name": "全聯福利中心名稱",
+                              "fill": "$ink",
+                              "content": "全聯福利中心",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "h2Fhg",
+                          "name": "銀行帳戶｜台新銀行",
+                          "width": 210,
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "mqKxZ",
+                              "name": "台新銀行名稱",
+                              "fill": "$ink",
+                              "content": "台新銀行",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "fE3yH",
+                              "name": "Richart 帳戶帳戶",
+                              "fill": "$muted",
+                              "content": "Richart 帳戶",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Rfs6S",
+                          "name": "shadcn/Badge secondary｜分類",
+                          "width": 100,
+                          "height": 24,
+                          "fill": "$bg",
+                          "cornerRadius": 999,
+                          "padding": [
+                            0,
+                            10
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "NTNzi",
+                              "name": "日常採買分類文字",
+                              "fill": "$muted",
+                              "content": "日常採買",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "f5QUuR",
+                          "name": "全聯福利中心金額",
+                          "width": 138,
+                          "layout": "vertical",
+                          "gap": 5,
+                          "alignItems": "end",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "A4r2z",
+                              "name": "全聯福利中心金額文字",
+                              "fill": "$coral",
+                              "content": "-NT$ 826",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "720"
+                            },
+                            {
+                              "type": "text",
+                              "id": "NNOv9",
+                              "name": "全聯福利中心狀態",
+                              "fill": "$muted",
+                              "content": "已入帳",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "mt7vp",
+                          "name": "全聯福利中心展開",
+                          "fill": "$muted",
+                          "content": "›",
+                          "fontFamily": "$font",
+                          "fontSize": 20,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "XLDHP",
+                      "name": "全聯福利中心分隔線",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "$line"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "w0WpmR",
+                      "name": "活動｜薪資入帳",
+                      "width": "fill_container",
+                      "height": 76,
+                      "gap": 18,
+                      "padding": [
+                        0,
+                        24
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Q9F0v",
+                          "name": "薪資入帳資訊",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "MfOmb",
+                              "name": "薪資入帳名稱",
+                              "fill": "$ink",
+                              "content": "薪資入帳",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "FgH1z",
+                          "name": "銀行帳戶｜中國信託",
+                          "width": 210,
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "zioQB",
+                              "name": "中國信託名稱",
+                              "fill": "$ink",
+                              "content": "中國信託",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "AnjGT",
+                              "name": "數位帳戶帳戶",
+                              "fill": "$muted",
+                              "content": "數位帳戶",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "fIUpk",
+                          "name": "shadcn/Badge secondary｜分類",
+                          "width": 100,
+                          "height": 24,
+                          "fill": "$bg",
+                          "cornerRadius": 999,
+                          "padding": [
+                            0,
+                            10
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Jdpj9",
+                              "name": "薪資分類文字",
+                              "fill": "$muted",
+                              "content": "薪資",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "RrKrv",
+                          "name": "薪資入帳金額",
+                          "width": 138,
+                          "layout": "vertical",
+                          "gap": 5,
+                          "alignItems": "end",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Au1DF",
+                              "name": "薪資入帳金額文字",
+                              "fill": "$moss",
+                              "content": "＋NT$ 62,400",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "720"
+                            },
+                            {
+                              "type": "text",
+                              "id": "v0XEw",
+                              "name": "薪資入帳狀態",
+                              "fill": "$muted",
+                              "content": "已入帳",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "W4Qai",
+                          "name": "薪資入帳展開",
+                          "fill": "$muted",
+                          "content": "›",
+                          "fontFamily": "$font",
+                          "fontSize": 20,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "AdSMe",
+                      "name": "薪資入帳分隔線",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "$line"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dUfws",
+                      "name": "日期群組｜7月27日",
+                      "width": "fill_container",
+                      "height": 40,
+                      "fill": "$bg",
+                      "padding": [
+                        0,
+                        24
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "PV5cZ",
+                          "name": "7月27日日期",
+                          "fill": "$ink",
+                          "content": "7 月 27 日・週日",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "PmEmX",
+                          "name": "7月27日摘要",
+                          "fill": "$muted",
+                          "content": "3 筆 · 支出 NT$ 1,185",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HXC9x",
+                      "name": "活動｜統一超商",
+                      "width": "fill_container",
+                      "height": 76,
+                      "gap": 18,
+                      "padding": [
+                        0,
+                        24
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "j4pIdF",
+                          "name": "統一超商資訊",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "LqONQ",
+                              "name": "統一超商名稱",
+                              "fill": "$ink",
+                              "content": "統一超商",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "i3X19",
+                          "name": "銀行帳戶｜台新銀行",
+                          "width": 210,
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "mP9S8",
+                              "name": "台新銀行名稱",
+                              "fill": "$ink",
+                              "content": "台新銀行",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "m7iKs",
+                              "name": "@GoGo 信用卡帳戶",
+                              "fill": "$muted",
+                              "content": "@GoGo 信用卡",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vWpSc",
+                          "name": "shadcn/Badge secondary｜分類",
+                          "width": 100,
+                          "height": 24,
+                          "fill": "$bg",
+                          "cornerRadius": 999,
+                          "padding": [
+                            0,
+                            10
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "hXwJb",
+                              "name": "日常採買分類文字",
+                              "fill": "$muted",
+                              "content": "日常採買",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Zxl8G",
+                          "name": "統一超商金額",
+                          "width": 138,
+                          "layout": "vertical",
+                          "gap": 5,
+                          "alignItems": "end",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "VHF8m",
+                              "name": "統一超商金額文字",
+                              "fill": "$coral",
+                              "content": "-NT$ 135",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "720"
+                            },
+                            {
+                              "type": "text",
+                              "id": "ZWkOV",
+                              "name": "統一超商狀態",
+                              "fill": "$amber",
+                              "content": "已配對發票",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "IZMPE",
+                          "name": "統一超商展開",
+                          "fill": "$muted",
+                          "content": "›",
+                          "fontFamily": "$font",
+                          "fontSize": 20,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "oiX4W",
+                      "name": "統一超商分隔線",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "$line"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "N8Q9fl",
+                      "name": "活動｜街口支付",
+                      "width": "fill_container",
+                      "height": 76,
+                      "gap": 18,
+                      "padding": [
+                        0,
+                        24
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "B0sJjO",
+                          "name": "街口支付資訊",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "GAkDF",
+                              "name": "街口支付名稱",
+                              "fill": "$ink",
+                              "content": "街口支付",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ldRDP",
+                          "name": "銀行帳戶｜第一銀行",
+                          "width": 210,
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "SktBp",
+                              "name": "第一銀行名稱",
+                              "fill": "$ink",
+                              "content": "第一銀行",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "l9vOP",
+                              "name": "iLEO 帳戶帳戶",
+                              "fill": "$muted",
+                              "content": "iLEO 帳戶",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "mKel1",
+                          "name": "shadcn/Badge secondary｜分類",
+                          "width": 100,
+                          "height": 24,
+                          "fill": "$bg",
+                          "cornerRadius": 999,
+                          "padding": [
+                            0,
+                            10
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "D0rSv",
+                              "name": "轉帳支付分類文字",
+                              "fill": "$muted",
+                              "content": "轉帳支付",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "cwNWk",
+                          "name": "街口支付金額",
+                          "width": 138,
+                          "layout": "vertical",
+                          "gap": 5,
+                          "alignItems": "end",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "CDDnF",
+                              "name": "街口支付金額文字",
+                              "fill": "$coral",
+                              "content": "-NT$ 250",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "720"
+                            },
+                            {
+                              "type": "text",
+                              "id": "IXuj3",
+                              "name": "街口支付狀態",
+                              "fill": "$muted",
+                              "content": "已入帳",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "hlc09",
+                          "name": "街口支付展開",
+                          "fill": "$muted",
+                          "content": "›",
+                          "fontFamily": "$font",
+                          "fontSize": 20,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "M0gGGT",
+                      "name": "街口支付分隔線",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "$line"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "A8HXm",
+                      "name": "活動｜App Store",
+                      "width": "fill_container",
+                      "height": 76,
+                      "gap": 18,
+                      "padding": [
+                        0,
+                        24
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "y8bodI",
+                          "name": "App Store資訊",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "pl184",
+                              "name": "App Store名稱",
+                              "fill": "$ink",
+                              "content": "App Store",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "HLcTT",
+                          "name": "銀行帳戶｜玉山銀行",
+                          "width": 210,
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "jkYk2",
+                              "name": "玉山銀行名稱",
+                              "fill": "$ink",
+                              "content": "玉山銀行",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "vK8Ty",
+                              "name": "U Bear 信用卡帳戶",
+                              "fill": "$muted",
+                              "content": "U Bear 信用卡",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "FOSQb",
+                          "name": "shadcn/Badge secondary｜分類",
+                          "width": 100,
+                          "height": 24,
+                          "fill": "$bg",
+                          "cornerRadius": 999,
+                          "padding": [
+                            0,
+                            10
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "B21Jc6",
+                              "name": "數位服務分類文字",
+                              "fill": "$muted",
+                              "content": "數位服務",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "cKKql",
+                          "name": "App Store金額",
+                          "width": 138,
+                          "layout": "vertical",
+                          "gap": 5,
+                          "alignItems": "end",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "bV18c",
+                              "name": "App Store金額文字",
+                              "fill": "$coral",
+                              "content": "-NT$ 800",
+                              "fontFamily": "$font",
+                              "fontSize": 14,
+                              "fontWeight": "720"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Q9CvB3",
+                              "name": "App Store狀態",
+                              "fill": "$muted",
+                              "content": "已入帳",
+                              "fontFamily": "$font",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "RuWZt",
+                          "name": "App Store展開",
+                          "fill": "$muted",
+                          "content": "›",
+                          "fontFamily": "$font",
+                          "fontSize": 20,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "elM8B",
+                      "name": "App Store分隔線",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "$line"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "VAOaI",
+      "x": 2480,
+      "y": 0,
+      "name": "活動列表｜shadcn｜手機版 390",
+      "clip": true,
+      "width": 390,
+      "height": 980,
+      "fill": "$bg",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "DDr90",
+          "name": "手機活動內容",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "padding": [
+            22,
+            16,
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "HAaYc",
+              "name": "手機標題列",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "myVrR",
+                  "name": "手機標題",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "FsH2U",
+                      "name": "手機頁面標題",
+                      "fill": "$ink",
+                      "content": "活動",
+                      "fontFamily": "$font",
+                      "fontSize": 26,
+                      "fontWeight": "730"
+                    },
+                    {
+                      "type": "text",
+                      "id": "qYh1P",
+                      "name": "手機頁面說明",
+                      "fill": "$muted",
+                      "content": "2026 年 7 月",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "D41j9q",
+                  "name": "shadcn/Button outline｜手機月份",
+                  "height": 38,
+                  "fill": "$surface",
+                  "cornerRadius": 6,
+                  "stroke": "$line",
+                  "strokeWidth": 1,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000D",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 2
+                  },
+                  "gap": 8,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "uoHub",
+                      "name": "手機月份文字",
+                      "fill": "$steel",
+                      "content": "7 月",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "nXrXy",
+                      "name": "手機月份展開",
+                      "fill": "$muted",
+                      "content": "⌄",
+                      "fontFamily": "$font",
+                      "fontSize": 15,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "llVHt",
+              "name": "手機月份摘要",
+              "width": "fill_container",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Nd78F",
+                  "name": "手機本月支出",
+                  "width": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": 12,
+                  "stroke": "$line",
+                  "strokeWidth": 1,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000D",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 2
+                  },
+                  "layout": "vertical",
+                  "gap": 5,
+                  "padding": 14,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "xnqqT",
+                      "name": "手機支出標籤",
+                      "fill": "$coral",
+                      "content": "本月支出",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "650"
+                    },
+                    {
+                      "type": "text",
+                      "id": "yFD7Y",
+                      "name": "手機支出數值",
+                      "fill": "$coral",
+                      "content": "NT$ 47,236",
+                      "fontFamily": "$font",
+                      "fontSize": 18,
+                      "fontWeight": "730"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "QzLzW",
+                  "name": "手機活動筆數",
+                  "width": 112,
+                  "fill": "$surface",
+                  "cornerRadius": 12,
+                  "stroke": "$line",
+                  "strokeWidth": 1,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000000D",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "blur": 2
+                  },
+                  "layout": "vertical",
+                  "gap": 5,
+                  "padding": 14,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "S1tJk",
+                      "name": "手機筆數標籤",
+                      "fill": "$steel",
+                      "content": "活動筆數",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "650"
+                    },
+                    {
+                      "type": "text",
+                      "id": "hg0rO",
+                      "name": "手機筆數數值",
+                      "fill": "$steel",
+                      "content": "128 筆",
+                      "fontFamily": "$font",
+                      "fontSize": 18,
+                      "fontWeight": "730"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "CP8oJ",
+              "name": "手機活動清單",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": 12,
+              "stroke": "$line",
+              "strokeWidth": 1,
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#0000000D",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "blur": 2
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dubC1",
+                  "name": "手機清單工具",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": [
+                    16,
+                    14,
+                    14,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "a5gqg",
+                      "name": "shadcn/Input｜手機搜尋",
+                      "width": "fill_container",
+                      "height": 39,
+                      "fill": "$surface",
+                      "cornerRadius": 6,
+                      "stroke": "$line",
+                      "strokeWidth": 1,
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#0000000D",
+                        "offset": {
+                          "x": 0,
+                          "y": 1
+                        },
+                        "blur": 2
+                      },
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QsfK7",
+                          "name": "手機搜尋圖示",
+                          "fill": "$muted",
+                          "content": "⌕",
+                          "fontFamily": "$font",
+                          "fontSize": 18,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ENrbn",
+                          "name": "手機搜尋提示",
+                          "fill": "$muted",
+                          "content": "搜尋商家、銀行或分類",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "twcRh",
+                      "name": "shadcn/TabsList｜手機來源",
+                      "width": "fill_container",
+                      "height": 39,
+                      "fill": "$bg",
+                      "cornerRadius": 6,
+                      "padding": 4,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "JL34r",
+                          "name": "shadcn/TabsTrigger active｜手機全部",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "fill": "$surface",
+                          "cornerRadius": 4,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#00000012",
+                            "offset": {
+                              "x": 0,
+                              "y": 1
+                            },
+                            "blur": 2
+                          },
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "jZjbL",
+                              "name": "手機全部文字",
+                              "fill": "$ink",
+                              "content": "全部",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "650"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "nR0Ee",
+                          "name": "手機來源｜銀行",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "fill": "#FFFFFF00",
+                          "cornerRadius": 4,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "vns5c",
+                              "name": "手機銀行文字",
+                              "fill": "$muted",
+                              "content": "銀行",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "650"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Kod7c",
+                          "name": "手機來源｜信用卡",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "fill": "#FFFFFF00",
+                          "cornerRadius": 4,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "GELzu",
+                              "name": "手機信用卡文字",
+                              "fill": "$muted",
+                              "content": "信用卡",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "650"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "J9ULz",
+                          "name": "手機來源｜發票",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "fill": "#FFFFFF00",
+                          "cornerRadius": 4,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "xNQzO",
+                              "name": "手機發票文字",
+                              "fill": "$muted",
+                              "content": "發票",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "650"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "X7OlT",
+                  "name": "手機工具分隔線",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "$line"
+                },
+                {
+                  "type": "frame",
+                  "id": "wVe9d",
+                  "name": "手機日期活動",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Ds2Pg",
+                      "name": "手機日期群組｜7月28日",
+                      "width": "fill_container",
+                      "height": 38,
+                      "fill": "$bg",
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "xt5SP",
+                          "name": "手機7月28日日期",
+                          "fill": "$ink",
+                          "content": "7 月 28 日・週一",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "plMSc",
+                          "name": "手機7月28日摘要",
+                          "fill": "$muted",
+                          "content": "3 筆",
+                          "fontFamily": "$font",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dIQpY",
+                      "name": "手機活動｜Uber Eats",
+                      "width": "fill_container",
+                      "height": 76,
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "h5uZr",
+                          "name": "手機Uber Eats資訊",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 5,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "C2jXkF",
+                              "name": "手機Uber Eats名稱",
+                              "fill": "$ink",
+                              "content": "Uber Eats",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "kXycy",
+                              "name": "手機銀行帳戶｜永豐銀行",
+                              "layout": "vertical",
+                              "gap": 2,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Xynk5",
+                                  "name": "手機永豐銀行名稱",
+                                  "fill": "$ink",
+                                  "content": "永豐銀行",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "hxWtA",
+                                  "name": "手機DAWHO 卡帳戶",
+                                  "fill": "$muted",
+                                  "content": "DAWHO 卡 · 餐飲",
+                                  "fontFamily": "$font",
+                                  "fontSize": 9,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "mRJg7",
+                          "name": "手機Uber Eats金額",
+                          "width": 88,
+                          "layout": "vertical",
+                          "gap": 5,
+                          "alignItems": "end",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Jun8q",
+                              "name": "手機Uber Eats金額文字",
+                              "fill": "$coral",
+                              "content": "-NT$ 486",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "720"
+                            },
+                            {
+                              "type": "text",
+                              "id": "oNNzu",
+                              "name": "手機Uber Eats狀態",
+                              "fill": "$muted",
+                              "content": "已入帳  ›",
+                              "fontFamily": "$font",
+                              "fontSize": 9,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "zU60g",
+                      "name": "手機Uber Eats分隔線",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "$line"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uzaRT",
+                      "name": "手機活動｜全聯福利中心",
+                      "width": "fill_container",
+                      "height": 76,
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "CaGxA",
+                          "name": "手機全聯福利中心資訊",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 5,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "npXvT",
+                              "name": "手機全聯福利中心名稱",
+                              "fill": "$ink",
+                              "content": "全聯福利中心",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "gbavO",
+                              "name": "手機銀行帳戶｜台新銀行",
+                              "layout": "vertical",
+                              "gap": 2,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "E6jDvh",
+                                  "name": "手機台新銀行名稱",
+                                  "fill": "$ink",
+                                  "content": "台新銀行",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "udqt1",
+                                  "name": "手機Richart帳戶",
+                                  "fill": "$muted",
+                                  "content": "Richart · 日常",
+                                  "fontFamily": "$font",
+                                  "fontSize": 9,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "L8fGbO",
+                          "name": "手機全聯福利中心金額",
+                          "width": 88,
+                          "layout": "vertical",
+                          "gap": 5,
+                          "alignItems": "end",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "HFupn",
+                              "name": "手機全聯福利中心金額文字",
+                              "fill": "$coral",
+                              "content": "-NT$ 826",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "720"
+                            },
+                            {
+                              "type": "text",
+                              "id": "hrXe3",
+                              "name": "手機全聯福利中心狀態",
+                              "fill": "$muted",
+                              "content": "已入帳  ›",
+                              "fontFamily": "$font",
+                              "fontSize": 9,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "tZj5y",
+                      "name": "手機全聯福利中心分隔線",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "$line"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "d1yFA2",
+                      "name": "手機活動｜薪資入帳",
+                      "width": "fill_container",
+                      "height": 76,
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "mEwae",
+                          "name": "手機薪資入帳資訊",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 5,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "ls2hB",
+                              "name": "手機薪資入帳名稱",
+                              "fill": "$ink",
+                              "content": "薪資入帳",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "TOttU",
+                              "name": "手機銀行帳戶｜中國信託",
+                              "layout": "vertical",
+                              "gap": 2,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "zSRsT",
+                                  "name": "手機中國信託名稱",
+                                  "fill": "$ink",
+                                  "content": "中國信託",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "S7n4wi",
+                                  "name": "手機數位帳戶帳戶",
+                                  "fill": "$muted",
+                                  "content": "數位帳戶 · 薪資",
+                                  "fontFamily": "$font",
+                                  "fontSize": 9,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ZXBHa",
+                          "name": "手機薪資入帳金額",
+                          "width": 88,
+                          "layout": "vertical",
+                          "gap": 5,
+                          "alignItems": "end",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "w7vtRx",
+                              "name": "手機薪資入帳金額文字",
+                              "fill": "$moss",
+                              "content": "＋NT$ 62,400",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "720"
+                            },
+                            {
+                              "type": "text",
+                              "id": "V43kcv",
+                              "name": "手機薪資入帳狀態",
+                              "fill": "$muted",
+                              "content": "已入帳  ›",
+                              "fontFamily": "$font",
+                              "fontSize": 9,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Wk9XJ",
+                      "name": "手機薪資入帳分隔線",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "$line"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GQTwS",
+                      "name": "手機活動｜統一超商",
+                      "width": "fill_container",
+                      "height": 76,
+                      "gap": 12,
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "unTsR",
+                          "name": "手機統一超商資訊",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 5,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Y8AY6n",
+                              "name": "手機統一超商名稱",
+                              "fill": "$ink",
+                              "content": "統一超商",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "IFlVJ",
+                              "name": "手機銀行帳戶｜台新銀行",
+                              "layout": "vertical",
+                              "gap": 2,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "bbFxe",
+                                  "name": "手機台新銀行名稱",
+                                  "fill": "$ink",
+                                  "content": "台新銀行",
+                                  "fontFamily": "$font",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "QO9VE",
+                                  "name": "手機@GoGo 卡帳戶",
+                                  "fill": "$muted",
+                                  "content": "@GoGo 卡 · 日常",
+                                  "fontFamily": "$font",
+                                  "fontSize": 9,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "iLT6z",
+                          "name": "手機統一超商金額",
+                          "width": 88,
+                          "layout": "vertical",
+                          "gap": 5,
+                          "alignItems": "end",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "a6SK2b",
+                              "name": "手機統一超商金額文字",
+                              "fill": "$coral",
+                              "content": "-NT$ 135",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "720"
+                            },
+                            {
+                              "type": "text",
+                              "id": "MnM7s",
+                              "name": "手機統一超商狀態",
+                              "fill": "$muted",
+                              "content": "已入帳  ›",
+                              "fontFamily": "$font",
+                              "fontSize": 9,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "evUEX",
+                      "name": "手機統一超商分隔線",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "$line"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "b11bb",
+          "name": "手機底部導覽",
+          "width": "fill_container",
+          "height": 68,
+          "fill": "$surface",
+          "padding": [
+            6,
+            10,
+            8,
+            10
+          ],
+          "justifyContent": "space_around",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "HXau7",
+              "name": "手機導覽｜總覽",
+              "width": 72,
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "U1g4G",
+                  "name": "手機總覽圖示",
+                  "fill": "$muted",
+                  "content": "◫",
+                  "fontFamily": "$font",
+                  "fontSize": 16,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "bYs1r",
+                  "name": "手機總覽文字",
+                  "fill": "$muted",
+                  "content": "總覽",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "550"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "AcVHl",
+              "name": "手機導覽｜活動",
+              "width": 72,
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "n0Mud",
+                  "name": "手機活動圖示",
+                  "fill": "$steel",
+                  "content": "≡",
+                  "fontFamily": "$font",
+                  "fontSize": 16,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "fisWq",
+                  "name": "手機活動文字",
+                  "fill": "$steel",
+                  "content": "活動",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "700"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "CMghj",
+              "name": "手機導覽｜帳戶",
+              "width": 72,
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "RyMuJ",
+                  "name": "手機帳戶圖示",
+                  "fill": "$muted",
+                  "content": "□",
+                  "fontFamily": "$font",
+                  "fontSize": 16,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "k1ZQYi",
+                  "name": "手機帳戶文字",
+                  "fill": "$muted",
+                  "content": "帳戶",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "550"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "I3SIgi",
+              "name": "手機導覽｜更多",
+              "width": 72,
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "OMNSr",
+                  "name": "手機更多圖示",
+                  "fill": "$muted",
+                  "content": "•••",
+                  "fontFamily": "$font",
+                  "fontSize": 16,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "c9bIa",
+                  "name": "手機更多文字",
+                  "fill": "$muted",
+                  "content": "更多",
+                  "fontFamily": "$font",
+                  "fontSize": 10,
+                  "fontWeight": "550"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "bg": {
+      "type": "color",
+      "value": "#F7F7F2"
+    },
+    "surface": {
+      "type": "color",
+      "value": "#FFFFFF"
+    },
+    "ink": {
+      "type": "color",
+      "value": "#1F2933"
+    },
+    "muted": {
+      "type": "color",
+      "value": "#6E7881"
+    },
+    "line": {
+      "type": "color",
+      "value": "#E3E6E2"
+    },
+    "steel": {
+      "type": "color",
+      "value": "#3E6F7C"
+    },
+    "steel-soft": {
+      "type": "color",
+      "value": "#E7F0F1"
+    },
+    "moss": {
+      "type": "color",
+      "value": "#556B2F"
+    },
+    "moss-soft": {
+      "type": "color",
+      "value": "#EEF2E8"
+    },
+    "coral": {
+      "type": "color",
+      "value": "#B75B45"
+    },
+    "coral-soft": {
+      "type": "color",
+      "value": "#F8ECE8"
+    },
+    "amber": {
+      "type": "color",
+      "value": "#8C641F"
+    },
+    "amber-soft": {
+      "type": "color",
+      "value": "#FBF3DE"
+    },
+    "font": {
+      "type": "string",
+      "value": "Inter"
+    }
+  },
+  "fileToken": "39985e99-3243-488c-908e-00762c5e73c0"
+}


### PR DESCRIPTION
## 變更內容

- 依照 pen.dev 設計重整活動頁下方列表，並納入 `design/activity.pen`
- 桌面版改用日期分組，以及「商家／說明、銀行／帳戶、分類、金額」欄位
- 手機版將銀行名稱獨立顯示，帳戶與分類置於次行，並移除重複的來源圖示
- 搜尋範圍加入銀行與帳戶名稱
- 配對發票的交易在列表狀態顯示「已配對發票」
- 新增日期分組與狀態顯示的單元測試，並更新相關 E2E 契約

## 調整原因

原本活動列表的銀行資訊層級較弱，使用者不容易快速辨識每筆活動來自哪家銀行；若同時使用銀行簡稱圖示與 Badge，又會造成資訊重複。這次改為獨立的銀行／帳戶資訊區，讓桌面與手機都能直接掃讀。

## 使用者影響

- 可直接從活動列表辨識銀行與帳戶
- 日期分組降低重複資訊，提升大量活動的掃讀效率
- 發票配對狀態更明確
- 保留既有活動詳情、分類、發票配對與排除計算流程

## 驗證

- `npm run verify:web`
  - Svelte typecheck：通過
  - Unit tests：49 passed
  - Playwright E2E：12 passed
  - Production build：通過
- Svelte autofixer：無問題
- 1440px 與 390px localhost 實際版面檢查
- 390px `scrollWidth === clientWidth`
- `git diff --check`：通過