### PR TITLE
feat(活動): 新增收支方向篩選與圓餅圖入口

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -197,6 +197,108 @@ test("shows this month's cash flow on the overview and opens activity", async ({
   await expect(page).toHaveURL(/#\/activity$/);
 });
 
+test("filters activity by cash flow and keeps source filters composable", async ({
+  page,
+}) => {
+  const month = new Date().toISOString().slice(0, 7);
+  await page.route("**/api/bank**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        accounts: [
+          {
+            id: "deposit-account",
+            connectorId: "cathaybk",
+            sourceId: "deposit-account",
+            accountType: "deposit",
+            currency: "TWD",
+          },
+          {
+            id: "card-account",
+            connectorId: "cathaybk",
+            sourceId: "card-account",
+            accountType: "credit",
+            currency: "TWD",
+          },
+        ],
+        transactions: [
+          {
+            id: "bank-income",
+            connectorId: "cathaybk",
+            accountId: "deposit-account",
+            sourceId: "bank-income",
+            postedDate: `${month}-02`,
+            amount: 50_000,
+            currency: "TWD",
+            description: "薪資入帳",
+            status: "posted",
+          },
+          {
+            id: "bank-expense",
+            connectorId: "cathaybk",
+            accountId: "deposit-account",
+            sourceId: "bank-expense",
+            postedDate: `${month}-03`,
+            amount: -18_000,
+            currency: "TWD",
+            description: "房租支出",
+            status: "posted",
+          },
+          {
+            id: "card-income",
+            connectorId: "cathaybk",
+            accountId: "card-account",
+            sourceId: "card-income",
+            postedDate: `${month}-04`,
+            amount: 300,
+            currency: "TWD",
+            description: "信用卡退款",
+            status: "posted",
+          },
+          {
+            id: "card-expense",
+            connectorId: "cathaybk",
+            accountId: "card-account",
+            sourceId: "card-expense",
+            postedDate: `${month}-05`,
+            amount: -600,
+            currency: "TWD",
+            description: "信用卡消費",
+            status: "posted",
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto("/#/activity");
+
+  const activityRows = page.locator("tbody tr");
+  const sourceFilters = page.getByRole("tablist", { name: "活動來源" });
+
+  await expect(activityRows).toHaveCount(4);
+  await page.getByRole("button", { name: "查看收入活動" }).click();
+  await expect(activityRows).toHaveCount(2);
+  await expect(activityRows.filter({ hasText: "薪資入帳" })).toBeVisible();
+  await expect(activityRows.filter({ hasText: "信用卡退款" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "顯示全部活動" }),
+  ).toHaveAttribute("aria-pressed", "true");
+
+  await sourceFilters.getByRole("tab", { name: "銀行" }).click();
+  await expect(activityRows).toHaveCount(1);
+  await expect(activityRows).toContainText("薪資入帳");
+
+  await page.getByRole("button", { name: "查看支出活動" }).click();
+  await expect(activityRows).toHaveCount(1);
+  await expect(activityRows).toContainText("房租支出");
+
+  await sourceFilters.getByRole("tab", { name: "信用卡" }).click();
+  await expect(activityRows).toHaveCount(1);
+  await expect(activityRows).toContainText("信用卡消費");
+});
+
 test("uses app-like scrolling and history only in standalone display mode", async ({
   page,
 }) => {

--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -58,9 +58,14 @@
     groupActivitiesByDate,
   } from "./model/list";
   import {
+    filterActivities,
+    type ActivityCategoryFilter,
+    type ActivityFlowFilter,
+    type ActivitySourceFilter,
+  } from "./model/filter";
+  import {
     buildActivityCategorySlices,
     activityCashAmountTwd,
-    activityCashFlow,
     activityDisplayAmount,
   } from "./model/chart";
   import {
@@ -94,12 +99,10 @@
   const rates = createQuery(exchangeRatesQuery(() => api));
   const categoryRows = createQuery(classificationCategoriesQuery(() => api));
   const qc = useQueryClient();
-  let source = $state<"all" | "bank" | "card" | "invoice">("all");
+  let flow = $state<ActivityFlowFilter>("all");
+  let source = $state<ActivitySourceFilter>("all");
   let search = $state("");
-  let selectedCategory = $state<{
-    flow: "income" | "expense";
-    category: string;
-  } | null>(null);
+  let selectedCategory = $state<ActivityCategoryFilter | null>(null);
   let pending = $state<PendingCategoryUpdate | null>(null);
   let pendingCalculation = $state<PendingCalculationUpdate | null>(null);
   let mappingDialog = $state<{
@@ -313,23 +316,12 @@
     Math.max(...cashFlow.flatMap((point) => [point.income, point.expense]), 1),
   );
   const filtered = $derived(
-    rawItems.filter((item) => {
-      const matchesFlow =
-        !selectedCategory || activityCashFlow(item) === selectedCategory.flow;
-      const matchesSource =
-        source === "all" ||
-        item.source === source ||
-        (source === "invoice" && Boolean(item.invoiceId));
-      return (
-        matchesSource &&
-        item.date.startsWith(selectedMonth) &&
-        (!search.trim() ||
-          `${item.title} ${item.subtitle} ${item.institutionName ?? ""} ${item.accountName ?? ""} ${item.category}`
-            .toLowerCase()
-            .includes(search.toLowerCase())) &&
-        (!selectedCategory ||
-          (item.category === selectedCategory.category && matchesFlow))
-      );
+    filterActivities(rawItems, {
+      month: selectedMonth,
+      flow,
+      source,
+      search,
+      category: selectedCategory,
     }),
   );
   const filteredGroups = $derived(groupActivitiesByDate(filtered));
@@ -478,10 +470,22 @@
       };
   }
   function chooseCategory(flow: "income" | "expense", category: string) {
-    selectedCategory =
-      selectedCategory?.flow === flow && selectedCategory.category === category
-        ? null
-        : { flow, category };
+    if (
+      selectedCategory?.flow === flow &&
+      selectedCategory.category === category
+    ) {
+      selectedCategory = null;
+      return;
+    }
+    selectedCategory = { flow, category };
+    chooseFlow(flow, false);
+  }
+  function chooseFlow(nextFlow: ActivityFlowFilter, clearCategory = true) {
+    flow = nextFlow;
+    if (clearCategory) selectedCategory = null;
+  }
+  function chooseChartFlow(nextFlow: Exclude<ActivityFlowFilter, "all">) {
+    chooseFlow(flow === nextFlow && !selectedCategory ? "all" : nextFlow);
   }
   function chooseMonth(month: string) {
     selectedMonth = month;
@@ -710,7 +714,9 @@
           selectedCategory={selectedCategory?.flow === "income"
             ? selectedCategory.category
             : undefined}
+          flowSelected={flow === "income" && !selectedCategory}
           onSelect={(category) => chooseCategory("income", category)}
+          onSelectFlow={() => chooseChartFlow("income")}
         />
         <ActivityCategoryChart
           flow="expense"
@@ -718,7 +724,9 @@
           selectedCategory={selectedCategory?.flow === "expense"
             ? selectedCategory.category
             : undefined}
+          flowSelected={flow === "expense" && !selectedCategory}
           onSelect={(category) => chooseCategory("expense", category)}
+          onSelectFlow={() => chooseChartFlow("expense")}
         />
       </div>
     </section>
@@ -776,8 +784,12 @@
           <div class="min-w-0">
             <h2 class="truncate text-lg font-semibold">
               {selectedCategory
-                ? `${selectedMonthLabel} · ${selectedCategory.category}`
-                : "所有活動"}
+                ? `${selectedMonthLabel} · ${selectedCategory.flow === "income" ? "收入" : "支出"} · ${selectedCategory.category}`
+                : flow === "income"
+                  ? `${selectedMonthLabel} · 收入`
+                  : flow === "expense"
+                    ? `${selectedMonthLabel} · 支出`
+                    : "所有活動"}
             </h2>
             <p class="text-xs text-ink/45">銀行與帳戶資訊直接顯示於每筆活動</p>
           </div>
@@ -801,19 +813,20 @@
                 : "支出"}</span
             ><button
               class="min-h-8 px-2 text-xs font-semibold text-steel"
-              onclick={() => (selectedCategory = null)}>顯示全部</button
+              onclick={() => (selectedCategory = null)}>清除分類</button
             >
           </div>{/if}
-        <TabsList class="grid h-auto w-full grid-cols-4"
-          >{#each [{ key: "all", label: "全部" }, { key: "bank", label: "銀行" }, { key: "card", label: "信用卡" }, { key: "invoice", label: "發票" }] as filter (filter.key)}<TabsTrigger
-              class="min-h-9 min-w-0 px-1 text-xs md:text-sm"
-              active={source === filter.key}
-              onclick={() => {
-                source = filter.key as typeof source;
-                selectedCategory = null;
-              }}>{filter.label}</TabsTrigger
-            >{/each}</TabsList
-        >
+        <div class="grid min-w-0 gap-1.5">
+          <span class="text-xs font-semibold text-ink/50">來源</span>
+          <TabsList aria-label="活動來源" class="grid h-auto w-full grid-cols-4"
+            >{#each [{ key: "all", label: "全部" }, { key: "bank", label: "銀行" }, { key: "card", label: "信用卡" }, { key: "invoice", label: "發票" }] as filter (filter.key)}<TabsTrigger
+                class="min-h-9 min-w-0 px-1 text-xs md:text-sm"
+                active={source === filter.key}
+                onclick={() => (source = filter.key as ActivitySourceFilter)}
+                >{filter.label}</TabsTrigger
+              >{/each}</TabsList
+          >
+        </div>
         {#if $calculationMutation.isError}<p
             class="text-sm font-medium text-coral"
           >

--- a/apps/web/src/features/activity/components/ActivityCategoryChart.svelte
+++ b/apps/web/src/features/activity/components/ActivityCategoryChart.svelte
@@ -15,15 +15,20 @@
     flow,
     slices,
     selectedCategory,
+    flowSelected,
     onSelect,
+    onSelectFlow,
   }: {
     flow: ActivityFlow;
     slices: ActivityCategorySlice[];
     selectedCategory?: string;
+    flowSelected: boolean;
     onSelect: (category: string) => void;
+    onSelectFlow: () => void;
   } = $props();
 
   const title = $derived(flow === "income" ? "收入分類" : "支出分類");
+  const flowLabel = $derived(flow === "income" ? "收入" : "支出");
   const total = $derived(slices.reduce((sum, slice) => sum + slice.amount, 0));
   const chartConfig: ChartConfig = {
     default: { label: "金額", color: "#3e6f7c" },
@@ -87,14 +92,20 @@
               props={{ arc: { stroke: "white", strokeWidth: 2 } }}
             />
           </ChartContainer>
-          <div
-            class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center"
+          <button
+            type="button"
+            aria-label={flowSelected ? "顯示全部活動" : `查看${flowLabel}活動`}
+            aria-pressed={flowSelected}
+            class={`absolute left-1/2 top-1/2 z-10 flex size-20 -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center rounded-full transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-steel focus-visible:ring-offset-2 ${flowSelected ? "bg-steel/10 ring-2 ring-steel/25" : "hover:bg-paper"}`}
+            onclick={onSelectFlow}
           >
-            <span class="text-[11px] text-ink/40">合計</span>
+            <span class="text-[11px] font-semibold text-steel">
+              {flowSelected ? "顯示全部" : `查看${flowLabel}`}
+            </span>
             <span class="mt-0.5 text-sm font-bold tabular-nums"
               >{formatCompactTwd(total)}</span
             >
-          </div>
+          </button>
         </div>
         <div class="grid min-w-0 gap-1.5">
           {#each slices as slice (slice.category)}

--- a/apps/web/src/features/activity/model/filter.test.ts
+++ b/apps/web/src/features/activity/model/filter.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { filterActivities, type ActivityListFilters } from "./filter";
+import type { ActivityItem } from "./types";
+
+function item(id: string, overrides: Partial<ActivityItem> = {}): ActivityItem {
+  return {
+    id,
+    source: "bank",
+    date: "2026-07-15",
+    title: id,
+    subtitle: "",
+    amount: 0,
+    currency: "TWD",
+    category: "未分類",
+    status: "posted",
+    ...overrides,
+  };
+}
+
+const defaultFilters: ActivityListFilters = {
+  month: "2026-07",
+  flow: "all",
+  source: "all",
+  search: "",
+  category: null,
+};
+
+describe("activity filters", () => {
+  it("filters normalized income and expense flows", () => {
+    const items = [
+      item("salary", { amount: 50_000, category: "薪資" }),
+      item("rent", { amount: -18_000, category: "居住" }),
+      item("invoice", {
+        source: "invoice",
+        amount: 600,
+        category: "發票",
+      }),
+      item("investment", {
+        source: "investment",
+        amount: -10_000,
+        category: "投資",
+      }),
+      item("zero", { amount: 0 }),
+    ];
+
+    expect(
+      filterActivities(items, { ...defaultFilters, flow: "income" }).map(
+        ({ id }) => id,
+      ),
+    ).toEqual(["salary"]);
+    expect(
+      filterActivities(items, { ...defaultFilters, flow: "expense" }).map(
+        ({ id }) => id,
+      ),
+    ).toEqual(["rent", "invoice"]);
+    expect(filterActivities(items, defaultFilters)).toHaveLength(5);
+  });
+
+  it("keeps excluded activities in their flow without counting semantics", () => {
+    const excludedRefund = item("refund", {
+      source: "card",
+      amount: 300,
+      excludedFromCalculation: true,
+    });
+
+    expect(
+      filterActivities([excludedRefund], {
+        ...defaultFilters,
+        flow: "income",
+      }),
+    ).toEqual([excludedRefund]);
+  });
+
+  it("combines month, source, search, and category filters", () => {
+    const matchedCardInvoice = item("matched", {
+      source: "card",
+      title: "Good Food 好食餐廳",
+      institutionName: "測試銀行",
+      amount: -860,
+      category: "餐飲",
+      invoiceId: "invoice-1",
+    });
+    const standaloneInvoice = item("standalone", {
+      source: "invoice",
+      title: "便利商店",
+      amount: 100,
+      category: "發票",
+    });
+    const previousMonth = item("old", {
+      date: "2026-06-15",
+      title: "Good Food 好食餐廳",
+      amount: -500,
+      category: "餐飲",
+      invoiceId: "invoice-old",
+    });
+
+    expect(
+      filterActivities([matchedCardInvoice, standaloneInvoice, previousMonth], {
+        ...defaultFilters,
+        flow: "expense",
+        source: "invoice",
+        search: "  GOOD FOOD  ",
+        category: { flow: "expense", category: "餐飲" },
+      }),
+    ).toEqual([matchedCardInvoice]);
+  });
+});

--- a/apps/web/src/features/activity/model/filter.ts
+++ b/apps/web/src/features/activity/model/filter.ts
@@ -1,0 +1,51 @@
+import { activityCashFlow, type ActivityFlow } from "./chart";
+import type { ActivityItem } from "./types";
+
+export type ActivityFlowFilter = "all" | ActivityFlow;
+export type ActivitySourceFilter = "all" | "bank" | "card" | "invoice";
+
+export interface ActivityCategoryFilter {
+  flow: ActivityFlow;
+  category: string;
+}
+
+export interface ActivityListFilters {
+  month: string;
+  flow: ActivityFlowFilter;
+  source: ActivitySourceFilter;
+  search: string;
+  category: ActivityCategoryFilter | null;
+}
+
+export function filterActivities(
+  items: ActivityItem[],
+  filters: ActivityListFilters,
+) {
+  const normalizedSearch = filters.search.trim().toLowerCase();
+
+  return items.filter((item) => {
+    const itemFlow = activityCashFlow(item);
+    const matchesFlow = filters.flow === "all" || itemFlow === filters.flow;
+    const matchesSource =
+      filters.source === "all" ||
+      item.source === filters.source ||
+      (filters.source === "invoice" && Boolean(item.invoiceId));
+    const matchesSearch =
+      !normalizedSearch ||
+      `${item.title} ${item.subtitle} ${item.institutionName ?? ""} ${item.accountName ?? ""} ${item.category}`
+        .toLowerCase()
+        .includes(normalizedSearch);
+    const matchesCategory =
+      !filters.category ||
+      (item.category === filters.category.category &&
+        itemFlow === filters.category.flow);
+
+    return (
+      item.date.startsWith(filters.month) &&
+      matchesFlow &&
+      matchesSource &&
+      matchesSearch &&
+      matchesCategory
+    );
+  });
+}

--- a/apps/web/src/shared/ui/TabsList.svelte
+++ b/apps/web/src/shared/ui/TabsList.svelte
@@ -4,10 +4,16 @@
   let {
     children,
     class: className = "",
-  }: { children?: Snippet; class?: string } = $props();
+    ...rest
+  }: {
+    children?: Snippet;
+    class?: string;
+    [key: string]: unknown;
+  } = $props();
 </script>
 
 <div
+  {...rest}
   role="tablist"
   class={cn(
     "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",


### PR DESCRIPTION
## Description
- 活動頁新增收入／支出方向篩選，可與月份、來源、搜尋及分類條件組合。
- 收入與支出圓餅圖中央新增「查看收入／查看支出」入口，啟用後可顯示全部活動。
- 發票、信用卡退款、零金額、投資及排除計算活動沿用既有收支語意，避免改變統計結果。

## Architecture
- `ActivityPage.svelte` 負責月份、收支方向、來源、搜尋與分類的 UI state 組合。
- `model/filter.ts` 提供純函式篩選，重用既有 `activityCashFlow` 作為唯一收支判定。
- `ActivityCategoryChart.svelte` 透過 callback 切換整體收支方向，圓餅切片仍只負責分類篩選。
- `TabsList.svelte` 轉送 ARIA 屬性，讓來源 tablist 具有可辨識名稱。

## Breaking Changes (optional)
無。

## Test & Risk
- `npm run typecheck -w @taiwan-fin-hub/web`：通過，0 errors / 0 warnings。
- `npm run test:unit -w @taiwan-fin-hub/web -- --reporter=verbose`：17 個 test files、54 個 tests 全數通過。
- `npm run test:e2e -w @taiwan-fin-hub/web -- --workers=1`：13 個 tests 全數通過。
- `npm run build -w @taiwan-fin-hub/web`：production build 通過；仍有既有的單一 chunk 超過 500 kB 警告。
- Regression scope：活動清單月份／來源／搜尋／分類組合、圓餅中央收支切換、分類切片切換、發票與排除計算活動顯示。

## Checklist
- [x] 代碼符合本專案風格 (Lint / Formatter 通過)
- [x] 自我 Review 並移除無用程式、除錯訊息
- [ ] 文件 / Release Note 已更新
- [x] 無新增 ESLint / Lint 警告
- [x] 相依變更（API、DB、Config）已通知利害關係人
- [ ] 拼字檢查通過