### PR TITLE
fix(活動): 合併發票後沿用銀行／信用卡名稱

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -897,11 +897,12 @@ test("merges a matching invoice and counts an unmatched invoice as expense", asy
   const activityRows = page.locator("tbody tr");
   await expect(activityRows).toHaveCount(2);
   const matchedActivityRow = activityRows.filter({
-    hasText: "好食餐飲有限公司",
+    hasText: "信用卡消費",
   });
   await expect(matchedActivityRow).toContainText("測試銀行");
   await expect(matchedActivityRow).toContainText("測試信用卡");
   await expect(matchedActivityRow).toContainText("已配對發票");
+  await expect(matchedActivityRow).not.toContainText("好食餐飲有限公司");
   await expect(
     activityRows.filter({ hasText: "未支援銀行商店" }),
   ).toContainText("−NT$1,490");
@@ -1063,7 +1064,7 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
 
   await expect(page.getByText("已完成配對，活動只顯示一筆")).toBeVisible();
   const mappedActivityRow = page.getByRole("button", {
-    name: "查看 菲尖極道商行 活動詳情",
+    name: "查看 全支付﹘樂法 台中漢口店 活動詳情",
   });
   await expect(mappedActivityRow).toContainText("玉山銀行");
   await expect(mappedActivityRow).toContainText("信用卡 · 餐飲");

--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -961,7 +961,7 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
             id: "card-1",
             connectorId: "sinopac",
             sourceId: "card-source-1",
-            institutionName: "玉山銀行",
+            institutionName: "測試銀行",
             accountName: "信用卡",
             accountType: "credit",
             currency: "TWD",
@@ -969,15 +969,15 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
         ],
         transactions: [
           {
-            id: "pxpay-tea",
+            id: "synthetic-drink",
             connectorId: "sinopac",
             accountId: "card-1",
             sourceId: "transaction-source-1",
             postedDate: `${month}-06`,
-            amount: 37,
+            amount: 100,
             currency: "TWD",
-            description: "全支付﹘樂法 台中漢口店",
-            counterparty: "全支付﹘樂法 台中漢口店",
+            description: "測試飲料店",
+            counterparty: "測試飲料店",
             status: "posted",
             excludedFromCalculation: false,
             classification: {
@@ -987,15 +987,15 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
             },
           },
           {
-            id: "dinner",
+            id: "synthetic-meal",
             connectorId: "sinopac",
             accountId: "card-1",
             sourceId: "transaction-source-2",
             postedDate: `${month}-06`,
-            amount: -265,
+            amount: -250,
             currency: "TWD",
-            description: "連支＊萬川雞飯．肉骨茶",
-            counterparty: "連支＊萬川雞飯．肉骨茶",
+            description: "測試餐飲店",
+            counterparty: "測試餐飲店",
             status: "posted",
             excludedFromCalculation: false,
             classification: {
@@ -1014,10 +1014,10 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
       id: "invoice-1",
       connectorId: "einvoice",
       sourceId: "invoice-source-1",
-      invoiceDate: `${month}-06T04:39:18.000Z`,
-      invoiceNumber: "DR95850239",
-      sellerName: "菲尖極道商行",
-      amount: 50,
+      invoiceDate: `${month}-06T12:00:00.000Z`,
+      invoiceNumber: "TEST-0001",
+      sellerName: "合成發票商店",
+      amount: 120,
     };
     await route.fulfill({
       json:
@@ -1029,10 +1029,10 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
                   id: "invoice-line-1",
                   sourceId: "invoice-line-source-1",
                   lineNumber: 1,
-                  description: "瓶裝飲料",
+                  description: "測試品項",
                   quantity: 1,
-                  unitPrice: 50,
-                  amount: 50,
+                  unitPrice: 120,
+                  amount: 120,
                 },
               ],
             }
@@ -1042,9 +1042,9 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
 
   await page.goto("/#/activity");
   await page
-    .getByRole("button", { name: "查看 菲尖極道商行 活動詳情" })
+    .getByRole("button", { name: "查看 合成發票商店 活動詳情" })
     .click();
-  await expect(page.getByText("瓶裝飲料", { exact: true })).toBeVisible();
+  await expect(page.getByText("測試品項", { exact: true })).toBeVisible();
   await expect(page.getByText("尚未找到銀行／信用卡交易")).toBeVisible();
   await page.getByRole("button", { name: "配對交易" }).click();
   await expect(
@@ -1052,21 +1052,21 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
   ).toBeVisible();
   await page
     .getByRole("button", {
-      name: /^全支付﹘樂法 台中漢口店 玉山銀行/,
+      name: /^測試飲料店 測試銀行/,
     })
     .click();
   await page.getByRole("button", { name: "下一步" }).click();
   await expect(
     page.getByRole("heading", { name: "確認合併這兩筆？" }),
   ).toBeVisible();
-  await expect(page.getByText("差額 NT$13", { exact: true })).toBeVisible();
+  await expect(page.getByText("差額 NT$20", { exact: true })).toBeVisible();
   await page.getByRole("button", { name: "確認配對" }).click();
 
   await expect(page.getByText("已完成配對，活動只顯示一筆")).toBeVisible();
   const mappedActivityRow = page.getByRole("button", {
-    name: "查看 全支付﹘樂法 台中漢口店 活動詳情",
+    name: "查看 測試飲料店 活動詳情",
   });
-  await expect(mappedActivityRow).toContainText("玉山銀行");
+  await expect(mappedActivityRow).toContainText("測試銀行");
   await expect(mappedActivityRow).toContainText("信用卡 · 餐飲");
   await expect(mappedActivityRow).toContainText("已配對發票");
   await mappedActivityRow.click();
@@ -1075,19 +1075,19 @@ test("manually maps, manages, and separates a same-day invoice transaction on mo
     detail
       .getByText("銀行／信用卡原始名稱")
       .locator("..")
-      .getByText("全支付﹘樂法 台中漢口店", { exact: true }),
+      .getByText("測試飲料店", { exact: true }),
   ).toBeVisible();
   await expect(
     detail
       .getByText("發票商家名稱")
       .locator("..")
-      .getByText("菲尖極道商行", { exact: true }),
+      .getByText("合成發票商店", { exact: true }),
   ).toBeVisible();
   await page.getByRole("button", { name: "管理配對" }).click();
   await page.getByRole("button", { name: "解除並保持分開" }).click();
   await expect(page.getByText("已解除配對，兩筆活動將保持分開")).toBeVisible();
-  await expect(page.getByText("菲尖極道商行").first()).toBeVisible();
-  await expect(page.getByText("全支付﹘樂法 台中漢口店").first()).toBeVisible();
+  await expect(page.getByText("合成發票商店").first()).toBeVisible();
+  await expect(page.getByText("測試飲料店").first()).toBeVisible();
 });
 
 test("loads invoice line items only after expanding an invoice", async ({

--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -179,11 +179,7 @@
           id: t.id,
           source: isCard ? ("card" as const) : ("bank" as const),
           date: t.authorizedAt ?? t.postedDate ?? "",
-          title:
-            matchedInvoice?.sellerName ??
-            t.description ??
-            t.counterparty ??
-            "銀行交易",
+          title: t.description ?? t.counterparty ?? "銀行交易",
           subtitle: [
             institutionName,
             accountName,


### PR DESCRIPTION
## Description
- 修正活動頁在銀行／信用卡交易與發票合併後的活動名稱，改用銀行／信用卡交易原始名稱。
- 保留發票商家名稱、發票號碼與合併關聯，仍可於活動詳情查看。
- 更新自動合併與手機手動合併的回歸測試。

## Architecture
活動頁的 `rawItems` 由銀行交易、發票配對結果與投資交易組合而成；本次只調整銀行／信用卡 activity item 的 `title` 映射，配對服務、API、資料庫與詳情資料來源維持不變。

## Breaking Changes (optional)
無。

## Test & Risk
- `npm run typecheck -w @taiwan-fin-hub/web`：通過，0 errors / 0 warnings。
- `../../node_modules/.bin/vitest run src/features/activity/model/matching.test.ts --pool=threads --maxWorkers=1`：通過，14 tests passed。
- `npm run test:e2e -w @taiwan-fin-hub/web -- --grep "merges a matching invoice|manually maps, manages"`：通過，2 tests passed。
- `npm run format:check -w @taiwan-fin-hub/web`：通過。
- `npm run build -w @taiwan-fin-hub/web`：通過；只有既有的 chunk size warning。
- Regression scope：活動列表（桌面／手機）與活動詳情的合併名稱顯示；未涉及 API、DB、Config 或配對演算法。

## Checklist
- [x] 代碼符合本專案風格 (Formatter 通過)
- [x] 自我 Review 並移除無用程式、除錯訊息
- [ ] 文件 / Release Note 已更新
- [ ] 無新增 ESLint / Lint 警告（本次未執行 ESLint）
- [x] 無 API、DB、Config 相依變更
- [ ] 拼字檢查通過
