### PR TITLE
排程同步加入 Queue 20 秒間隔

### DIFF
--- a/apps/worker/src/features/sync/scheduler-queue.ts
+++ b/apps/worker/src/features/sync/scheduler-queue.ts
@@ -5,8 +5,15 @@ const queueController = {
   cron: "queue:scheduled-sync",
 } as ScheduledController;
 
-export async function enqueueScheduledSync(env: Env) {
-  await env.SYNC_QUEUE.send({ type: "run-next-scheduled-sync" });
+export const SCHEDULED_SYNC_CHAIN_DELAY_SECONDS = 20;
+
+export async function enqueueScheduledSync(env: Env, delaySeconds = 0) {
+  const message = { type: "run-next-scheduled-sync" } as const;
+  if (delaySeconds > 0) {
+    await env.SYNC_QUEUE.send(message, { delaySeconds });
+    return;
+  }
+  await env.SYNC_QUEUE.send(message);
 }
 
 export async function consumeScheduledSyncQueue(
@@ -26,7 +33,9 @@ export async function consumeScheduledSyncQueue(
     }
 
     const processed = await runSchedulerTick(env, queueController);
-    if (processed) await enqueueScheduledSync(env);
+    if (processed) {
+      await enqueueScheduledSync(env, SCHEDULED_SYNC_CHAIN_DELAY_SECONDS);
+    }
     message.ack();
   }
 }

--- a/apps/worker/tests/features/sync/scheduler-queue.test.ts
+++ b/apps/worker/tests/features/sync/scheduler-queue.test.ts
@@ -53,7 +53,7 @@ describe("scheduled sync queue", () => {
     expect(send).toHaveBeenCalledWith({ type: "run-next-scheduled-sync" });
   });
 
-  it("immediately enqueues the next invocation after processing a job", async () => {
+  it("delays the next invocation after processing a job", async () => {
     const send = vi.fn().mockResolvedValue(undefined);
     const message = queueMessage({ type: "run-next-scheduled-sync" });
     mocks.runSchedulerTick.mockResolvedValue(true);
@@ -61,7 +61,10 @@ describe("scheduled sync queue", () => {
     await consumeScheduledSyncQueue(queueBatch(message), env(send));
 
     expect(mocks.runSchedulerTick).toHaveBeenCalledOnce();
-    expect(send).toHaveBeenCalledWith({ type: "run-next-scheduled-sync" });
+    expect(send).toHaveBeenCalledWith(
+      { type: "run-next-scheduled-sync" },
+      { delaySeconds: 20 },
+    );
     expect(message.ack).toHaveBeenCalledOnce();
   });
 

--- a/docs/001-cron-sync-design.md
+++ b/docs/001-cron-sync-design.md
@@ -1,7 +1,7 @@
 # Cron Job Design
 
 > 現況更新：Cron 目前只負責向 Cloudflare Queue 送出啟動訊息；每個 connector
-> 由獨立的 Queue consumer invocation 執行，完成後立即 enqueue 下一個工作。
+> 由獨立的 Queue consumer invocation 執行，完成後延遲 20 秒 enqueue 下一個工作。
 > 本文件後續內容保留最初 v1 設計背景；現行架構以
 > [`002-backend-architecture.md`](002-backend-architecture.md) 為準。
 

--- a/docs/002-backend-architecture.md
+++ b/docs/002-backend-architecture.md
@@ -415,11 +415,12 @@ sequenceDiagram
 - Lock acquisition 失敗時回傳或記錄「已有同步執行中」，不得平行執行同一 connector。
 
 Cron trigger 只負責向 `SYNC_QUEUE` 送出 scheduler 啟動訊息。Queue consumer
-每次 invocation 最多處理一個 connector，完成後若確實處理了工作便立即送出下一個訊息；
-下一次 consumer invocation 因此不必等待下一個 10 分鐘 Cron，且擁有獨立的 Worker
-CPU、subrequest 與執行時間額度。Queue consumer 使用 batch size 1 與 concurrency 1，
-維持 connector 逐一執行。是否到期仍由 D1 sync job 狀態判斷；沒有可執行工作時
-consumer 不再送出訊息，結束本次串接。
+每次 invocation 最多處理一個 connector，完成後若確實處理了工作便以 20 秒延遲送出下一個訊息，
+避免連續啟動 Browser session 時撞上 Browser Run 的 acquisition rate limit；下一次 consumer
+invocation 因此不必等待下一個 10 分鐘 Cron，且擁有獨立的 Worker CPU、subrequest 與執行時間額度。
+初始 Cron kick 不延遲。Queue consumer 使用 batch size 1 與 concurrency 1，維持 connector
+逐一執行。是否到期仍由 D1 sync job 狀態判斷；沒有可執行工作時 consumer 不再送出訊息，
+結束本次串接。
 
 ## 同步結果通知
 


### PR DESCRIPTION
## 變更內容

- 每次排程同步處理完成後，下一則 Queue scheduler 訊息固定延遲 20 秒。
- 初始 Cron kick 維持立即 enqueue。
- 保留送出下一則訊息後才 ack 目前 Queue message 的流程。
- 更新 Queue 測試與排程架構文件。

## 背景

Cloudflare Browser Run 對新 Browser session 有 acquisition rate limit。原本 Queue 完成一個 connector 後立即尋找下一個 connector，可能讓連續的 Browser session 啟動在 20 秒限制內，造成台新同步收到 HTTP 429 並被標記為失敗。

## 驗證

- `npm exec vitest -- run tests/features/sync/scheduler-queue.test.ts`
- `npm run test:backend`
- `npm run typecheck`
- `npm run build`
- `npm run format:check`
- `git diff --check`

## 影響

排程工作之間最多增加 20 秒間隔；初始排程啟動、同步 lock、batch、通知與前端行為維持不變。不涉及資料庫 migration、API 或金融資料格式變更。
