### PR TITLE
修正未設定連接器誤顯示需要處理

### DIFF
--- a/apps/web/src/data/connectors/sync-status.test.ts
+++ b/apps/web/src/data/connectors/sync-status.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  getActionableSyncJobs,
+  getConfiguredSyncJobs,
+  getSyncSourceStatus,
+  isActionableSyncJob,
+} from "./sync-status";
+import type { SyncJobRow } from "./types";
+
+function job(overrides: Partial<SyncJobRow>): SyncJobRow {
+  return {
+    id: "esun:all",
+    connectorId: "esun",
+    configured: false,
+    scope: "all",
+    enabled: false,
+    intervalMinutes: 1440,
+    nextRunAt: "2026-08-02T00:00:00.000Z",
+    scheduleMode: "inherit",
+    preferredTime: "06:00",
+    preferredWeekday: 1,
+    lockedUntil: null,
+    lockedBy: null,
+    lockTrigger: null,
+    lockScope: null,
+    lastRunAt: null,
+    lastSuccessAt: null,
+    lastStatus: null,
+    lastError: null,
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    running: false,
+    ...overrides,
+  };
+}
+
+describe("sync source status", () => {
+  it("keeps legacy failures on unconfigured connectors in the unconfigured state", () => {
+    const unconfigured = job({ lastStatus: "needs_user_action" });
+
+    expect(getSyncSourceStatus(unconfigured)).toBe("unconfigured");
+    expect(isActionableSyncJob(unconfigured)).toBe(false);
+  });
+
+  it("keeps manual failures on configured connectors actionable", () => {
+    const configured = job({ configured: true, lastStatus: "failed" });
+
+    expect(getSyncSourceStatus(configured)).toBe("needs_action");
+    expect(isActionableSyncJob(configured)).toBe(true);
+  });
+
+  it("separates configured healthy sources from connectors that have not been set up", () => {
+    const configured = job({
+      configured: true,
+      lastSuccessAt: "2026-08-01T00:00:00.000Z",
+    });
+    const unconfigured = job({ id: "tdcc:all", connectorId: "tdcc" });
+
+    expect(getConfiguredSyncJobs([configured, unconfigured])).toEqual([
+      configured,
+    ]);
+    expect(getSyncSourceStatus(configured)).toBe("healthy");
+    expect(getSyncSourceStatus(unconfigured)).toBe("unconfigured");
+  });
+
+  it("counts at most the all-scope job for each configured source", () => {
+    const source = job({ configured: true, lastStatus: "failed" });
+    const nestedScope = job({
+      configured: true,
+      id: "esun:bank",
+      scope: "bank",
+      lastStatus: "failed",
+    });
+
+    expect(getActionableSyncJobs([source, nestedScope])).toEqual([source]);
+  });
+});

--- a/apps/web/src/data/connectors/sync-status.ts
+++ b/apps/web/src/data/connectors/sync-status.ts
@@ -1,0 +1,33 @@
+import type { SyncJobRow } from "./types";
+
+export type SyncSourceStatus =
+  "unconfigured" | "needs_action" | "healthy" | "not_synced";
+
+type SyncJobStatusInput = Pick<
+  SyncJobRow,
+  "configured" | "lastStatus" | "lastSuccessAt"
+>;
+
+export function getSyncSourceStatus(
+  job: SyncJobStatusInput | undefined,
+  configured = job?.configured ?? false,
+): SyncSourceStatus {
+  if (!configured) return "unconfigured";
+  if (job?.lastStatus === "failed" || job?.lastStatus === "needs_user_action")
+    return "needs_action";
+  return job?.lastSuccessAt ? "healthy" : "not_synced";
+}
+
+export function isActionableSyncJob(
+  job: SyncJobStatusInput | undefined,
+): boolean {
+  return getSyncSourceStatus(job) === "needs_action";
+}
+
+export function getConfiguredSyncJobs(jobs: SyncJobRow[]) {
+  return jobs.filter((job) => job.configured && job.scope === "all");
+}
+
+export function getActionableSyncJobs(jobs: SyncJobRow[]) {
+  return getConfiguredSyncJobs(jobs).filter(isActionableSyncJob);
+}

--- a/apps/web/src/data/connectors/types.ts
+++ b/apps/web/src/data/connectors/types.ts
@@ -16,6 +16,7 @@ export interface ConnectorSettings {
 export interface SyncJobRow {
   id: string;
   connectorId: ConnectorId;
+  configured: boolean;
   scope: string;
   enabled: boolean;
   intervalMinutes: number;

--- a/apps/web/src/features/overview/OverviewPage.svelte
+++ b/apps/web/src/features/overview/OverviewPage.svelte
@@ -19,6 +19,10 @@
   } from "@/data/assets/queries";
   import { bankQuery, bankRangeQuery } from "@/data/bank/queries";
   import { syncJobsQuery } from "@/data/connectors/queries";
+  import {
+    getActionableSyncJobs,
+    getConfiguredSyncJobs,
+  } from "@/data/connectors/sync-status";
   import { investmentsQuery } from "@/data/investments/queries";
   import {
     invoiceTransactionMappingsQuery,
@@ -139,14 +143,10 @@
   const monthlyIncome = $derived(monthlyTotals.income);
   const monthlyExpense = $derived(monthlyTotals.expense);
   const monthlyNet = $derived(monthlyIncome - monthlyExpense);
-  const unhealthy = $derived(
-    ($jobs.data ?? []).filter(
-      (job) =>
-        job.lastStatus === "failed" || job.lastStatus === "needs_user_action",
-    ),
-  );
+  const unhealthy = $derived(getActionableSyncJobs($jobs.data ?? []));
+  const configuredSyncJobs = $derived(getConfiguredSyncJobs($jobs.data ?? []));
   const staleJobs = $derived(
-    ($jobs.data ?? []).filter(
+    configuredSyncJobs.filter(
       (job) =>
         job.enabled &&
         !job.running &&
@@ -156,7 +156,7 @@
             48 * 60 * 60 * 1000),
     ),
   );
-  const sourceCount = $derived(Math.max(($jobs.data ?? []).length, 4));
+  const sourceCount = $derived(configuredSyncJobs.length);
   const healthyCount = $derived(Math.max(sourceCount - unhealthy.length, 0));
   const insights = $derived.by(() => {
     const items: OverviewInsight[] = [];

--- a/apps/web/src/features/settings/SettingsPage.svelte
+++ b/apps/web/src/features/settings/SettingsPage.svelte
@@ -10,6 +10,10 @@
     connectorFields,
   } from "@/data/connectors/definitions";
   import { syncJobsQuery } from "@/data/connectors/queries";
+  import {
+    getActionableSyncJobs,
+    getConfiguredSyncJobs,
+  } from "@/data/connectors/sync-status";
   import { notificationConfigQuery } from "@/data/notifications/queries";
   import type { ConnectorId } from "@/data/connectors/types";
   import { formatDateTime } from "@/shared/format/financial";
@@ -54,18 +58,12 @@
   const rates = createQuery(exchangeRatesQuery(() => api));
   const notifications = createQuery(notificationConfigQuery(() => api));
   let selectedConnector = $state<ConnectorId | null>(null);
-  const needsAction = $derived(
-    ($jobs.data ?? []).filter(
-      (j) => j.lastStatus === "failed" || j.lastStatus === "needs_user_action",
-    ).length,
+  const needsAction = $derived(getActionableSyncJobs($jobs.data ?? []).length);
+  const configuredSources = $derived(getConfiguredSyncJobs($jobs.data ?? []));
+  const healthySources = $derived(
+    Math.max(configuredSources.length - needsAction, 0),
   );
-  const healthySources = $derived(Math.max(sources.length - needsAction, 0));
-  const actionJob = $derived(
-    ($jobs.data ?? []).find(
-      (job) =>
-        job.lastStatus === "failed" || job.lastStatus === "needs_user_action",
-    ),
-  );
+  const actionJob = $derived(getActionableSyncJobs($jobs.data ?? []).at(0));
   const actionSource = $derived(
     sources.find((source) => source.id === actionJob?.connectorId),
   );
@@ -76,12 +74,14 @@
     }, undefined),
   );
   const inheritedJob = $derived(
-    ($jobs.data ?? []).find(
-      (job) => job.scope === "all" && job.scheduleMode === "inherit",
+    configuredSources.find(
+      (job) => job.enabled && job.scheduleMode === "inherit",
     ),
   );
   const inheritedJobCount = $derived(
-    ($jobs.data ?? []).filter((job) => job.scheduleMode === "inherit").length,
+    configuredSources.filter(
+      (job) => job.enabled && job.scheduleMode === "inherit",
+    ).length,
   );
   const scheduleSummary = $derived(
     !inheritedJob
@@ -115,9 +115,7 @@
   const enabledRuleCount = $derived(
     ($rules.data ?? []).filter((rule) => rule.enabled).length,
   );
-  const recentJobs = $derived(
-    ($jobs.data ?? []).filter((job) => job.scope === "all"),
-  );
+  const recentJobs = $derived(getConfiguredSyncJobs($jobs.data ?? []));
   const recentSuccessCount = $derived(
     recentJobs.filter((job) => job.lastStatus === "success").length,
   );
@@ -453,13 +451,20 @@
             </span>
           </div>
           <h2 class="mt-2 text-xl font-bold">
-            {actionSource?.title ??
-              `${healthySources} / ${sources.length} 來源正常`}
+            {#if needsAction}
+              {actionSource?.title ?? "資料來源需要處理"}
+            {:else if configuredSources.length}
+              {healthySources} / {configuredSources.length} 已設定來源正常
+            {:else}
+              尚未設定資料來源
+            {/if}
           </h2>
           <p class="mt-1 text-sm text-muted-foreground">
             {needsAction
               ? "完成重新驗證後即可恢復自動同步。"
-              : "所有連接器都能正常同步。"}
+              : configuredSources.length
+                ? "所有已設定連接器都能正常同步。"
+                : "設定資料來源後即可開始同步。"}
           </p>
           <button
             class="mt-4 rounded-lg bg-steel px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-steel/90"
@@ -482,7 +487,7 @@
             >
           </div>
           <p class="mt-2 text-3xl font-bold">
-            {healthySources} / {sources.length}
+            {healthySources} / {configuredSources.length}
           </p>
           <p class="mt-1 text-sm text-muted-foreground">
             {inheritedJobCount} 個排程啟用 · {latestSuccessAt

--- a/apps/web/src/features/settings/components/MobileMore.svelte
+++ b/apps/web/src/features/settings/components/MobileMore.svelte
@@ -7,6 +7,10 @@
   import type { BankData } from "@/data/bank/types";
   import type { ClassificationRuleRow } from "@/data/classification/types";
   import { connectorDefinitions } from "@/data/connectors/definitions";
+  import {
+    getActionableSyncJobs,
+    getSyncSourceStatus,
+  } from "@/data/connectors/sync-status";
   import type { SyncJobRow } from "@/data/connectors/types";
   let {
     demoMode,
@@ -23,12 +27,10 @@
     navigate: (view: View) => void;
   } = $props();
   const sources = connectorDefinitions;
-  const unhealthy = $derived(
-    jobs.filter(
-      (job) =>
-        job.lastStatus === "failed" || job.lastStatus === "needs_user_action",
-    ),
+  const configuredSources = $derived(
+    jobs.filter((job) => job.configured && job.scope === "all"),
   );
+  const unhealthy = $derived(getActionableSyncJobs(jobs));
 </script>
 
 <div class="grid gap-4">
@@ -40,7 +42,8 @@
     ><CardContent class="pt-5"
       ><p class="text-sm font-semibold text-ink/45">資料健康度</p>
       <p class="mt-2 text-2xl font-bold">
-        {Math.max(sources.length - unhealthy.length, 0)} / {sources.length} 來源正常
+        {Math.max(configuredSources.length - unhealthy.length, 0)} / {configuredSources.length}
+        已設定來源正常
       </p>
       {#if unhealthy.length}<p class="mt-2 text-sm font-semibold text-coral">
           {unhealthy.length} 個來源需要處理
@@ -123,16 +126,16 @@
             class="flex items-center justify-between gap-3 px-4 py-3 text-sm"
           >
             <span class="font-semibold">{source.title}</span><span
-              class={job?.lastStatus === "failed" ||
-              job?.lastStatus === "needs_user_action"
+              class={getSyncSourceStatus(job) === "needs_action"
                 ? "text-coral"
                 : "text-moss"}
-              >{job?.lastStatus === "failed" ||
-              job?.lastStatus === "needs_user_action"
+              >{getSyncSourceStatus(job) === "needs_action"
                 ? "需要處理"
-                : job?.lastSuccessAt
+                : getSyncSourceStatus(job) === "healthy"
                   ? "正常"
-                  : "尚未同步"}</span
+                  : getSyncSourceStatus(job) === "not_synced"
+                    ? "尚未同步"
+                    : "未設定"}</span
             >
           </div>{/each}
       </div></Card

--- a/apps/web/src/features/settings/components/MobileMore.test.ts
+++ b/apps/web/src/features/settings/components/MobileMore.test.ts
@@ -5,9 +5,9 @@ import type { ApiClient } from "@/shared/api/client";
 import MobileMore from "./MobileMore.svelte";
 
 describe("MobileMore", () => {
-  it("uses the shared connector definitions in its health summary", () => {
+  it("shows unconfigured connectors without counting them as healthy or actionable", () => {
     const api = {} as ApiClient;
-    const { getByText } = render(MobileMore, {
+    const { getAllByText, getByText } = render(MobileMore, {
       props: {
         api,
         demoMode: false,
@@ -19,13 +19,12 @@ describe("MobileMore", () => {
     });
 
     const connectorCount = connectorDefinitions.length;
-    expect(
-      getByText(`${connectorCount} / ${connectorCount} 來源正常`),
-    ).toBeInTheDocument();
+    expect(getByText("0 / 0 已設定來源正常")).toBeInTheDocument();
     expect(
       getByText(new RegExp(`${connectorCount} 個\\s*›`)),
     ).toBeInTheDocument();
     expect(getByText("同步與通知")).toBeInTheDocument();
     expect(getByText("中國信託銀行")).toBeInTheDocument();
+    expect(getAllByText("未設定")).toHaveLength(connectorCount);
   });
 });

--- a/apps/web/src/features/settings/components/SourceCard.svelte
+++ b/apps/web/src/features/settings/components/SourceCard.svelte
@@ -10,6 +10,7 @@
   import type { ApiClient } from "@/shared/api/client";
   import { connectorSettingsQuery } from "@/data/connectors/queries";
   import type { ConnectorId, SyncJobRow } from "@/data/connectors/types";
+  import { getSyncSourceStatus } from "@/data/connectors/sync-status";
   import { formatDateTime } from "@/shared/format/financial";
   let {
     api,
@@ -42,9 +43,10 @@
       (item) => item.connectorId === id && item.scope === "all",
     ),
   );
-  const needsAction = $derived(
-    job?.lastStatus === "failed" || job?.lastStatus === "needs_user_action",
+  const sourceStatus = $derived(
+    getSyncSourceStatus(job, $settings.data?.configured ?? job?.configured),
   );
+  const needsAction = $derived(sourceStatus === "needs_action");
   const weekdays = ["週日", "週一", "週二", "週三", "週四", "週五", "週六"];
   const scheduleLabel = $derived(
     !job?.enabled
@@ -83,25 +85,25 @@
         >{title}</span
       >
       <span class="block truncate text-sm text-muted-foreground">
-        {job?.lastSuccessAt
+        {sourceStatus === "healthy" && job?.lastSuccessAt
           ? `最近同步 ${formatDateTime(job.lastSuccessAt)}`
-          : $settings.data?.configured
-            ? "尚未成功同步"
-            : "尚未設定"}
+          : sourceStatus === "unconfigured"
+            ? "尚未設定"
+            : "尚未成功同步"}
       </span>
     </span>
     <Badge
       class="shrink-0 whitespace-nowrap text-sm"
       variant={needsAction
         ? "destructive"
-        : $settings.data?.configured && job?.lastSuccessAt
+        : sourceStatus === "healthy"
           ? "success"
           : "secondary"}
       >{needsAction
         ? "需要處理"
-        : $settings.data?.configured && job?.lastSuccessAt
+        : sourceStatus === "healthy"
           ? "正常"
-          : $settings.data?.configured
+          : sourceStatus === "not_synced"
             ? "尚未同步"
             : "未設定"}</Badge
     >
@@ -130,12 +132,12 @@
           class="shrink-0 whitespace-nowrap text-sm"
           variant={needsAction
             ? "destructive"
-            : $settings.data?.configured
+            : sourceStatus !== "unconfigured"
               ? "success"
               : "secondary"}
           >{needsAction
             ? "需要處理"
-            : $settings.data?.configured
+            : sourceStatus !== "unconfigured"
               ? "已設定"
               : "未設定"}</Badge
         >

--- a/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
+++ b/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
@@ -130,6 +130,7 @@
       qc.invalidateQueries({
         queryKey: queryKeys.connectorSettings(connectorId),
       });
+      qc.invalidateQueries({ queryKey: queryKeys.syncJobs });
     },
     onError: (e) => (error = e instanceof Error ? e.message : "儲存失敗"),
   });

--- a/apps/worker/src/features/sync/notification-batch-repository.ts
+++ b/apps/worker/src/features/sync/notification-batch-repository.ts
@@ -13,6 +13,7 @@ type BatchMemberRow = {
   last_status: SyncNotificationStatus | null;
   locked_until: string | null;
   lock_trigger: "manual" | "scheduled" | null;
+  configured_connector_id: string | null;
 };
 
 type BatchResultRow = {
@@ -33,6 +34,11 @@ export async function ensureDefaultScheduleBatch(db: D1Database) {
       `SELECT id, connector_id
        FROM sync_jobs
        WHERE enabled = 1
+         AND EXISTS (
+           SELECT 1
+           FROM connector_settings
+           WHERE connector_settings.connector_id = sync_jobs.connector_id
+         )
          AND schedule_mode = 'inherit'
          AND (last_status IS NULL OR last_status != 'needs_user_action')
        ORDER BY id ASC`,
@@ -95,6 +101,11 @@ export async function findNextDefaultScheduleBatchJob(
          WHERE r.batch_id = ?
            AND r.completed_at IS NULL
            AND j.enabled = 1
+           AND EXISTS (
+             SELECT 1
+             FROM connector_settings
+             WHERE connector_settings.connector_id = j.connector_id
+           )
            AND j.schedule_mode = 'inherit'
            AND (j.last_status IS NULL OR j.last_status != 'needs_user_action')
            AND (j.locked_until IS NULL OR j.locked_until < ?)
@@ -192,9 +203,12 @@ async function reconcileDefaultScheduleBatchMembers(
          j.schedule_mode,
          j.last_status,
          j.locked_until,
-         j.lock_trigger
+         j.lock_trigger,
+         connector_settings.connector_id AS configured_connector_id
        FROM scheduled_sync_batch_results r
        LEFT JOIN sync_jobs j ON j.id = r.job_id
+       LEFT JOIN connector_settings
+         ON connector_settings.connector_id = j.connector_id
        WHERE r.batch_id = ? AND r.completed_at IS NULL`,
     )
     .bind(batchId)
@@ -206,7 +220,8 @@ async function reconcileDefaultScheduleBatchMembers(
       row.enabled === null ||
       row.enabled !== 1 ||
       row.schedule_mode === null ||
-      row.schedule_mode !== "inherit";
+      row.schedule_mode !== "inherit" ||
+      row.configured_connector_id === null;
     const needsUserAction = row.last_status === "needs_user_action";
     const scheduledRunIsActive =
       row.lock_trigger === "scheduled" &&

--- a/apps/worker/src/features/sync/schedule-repository.ts
+++ b/apps/worker/src/features/sync/schedule-repository.ts
@@ -94,6 +94,11 @@ export async function listSyncJobs(db: D1Database) {
       `SELECT
        id,
        connector_id AS connectorId,
+       EXISTS (
+         SELECT 1
+         FROM connector_settings
+         WHERE connector_settings.connector_id = sync_jobs.connector_id
+       ) AS configured,
        scope,
        enabled,
        interval_minutes AS intervalMinutes,
@@ -116,6 +121,7 @@ export async function listSyncJobs(db: D1Database) {
     .all<{
       id: string;
       connectorId: ConnectorId;
+      configured: number;
       scope: string;
       enabled: number;
       intervalMinutes: number;

--- a/apps/worker/src/features/sync/schedule-service.ts
+++ b/apps/worker/src/features/sync/schedule-service.ts
@@ -54,6 +54,7 @@ export async function getSyncJobs(db: D1Database) {
   const now = new Date();
   return rows.map((row) => ({
     ...row,
+    configured: Boolean(row.configured),
     enabled: Boolean(row.enabled),
     running: Boolean(row.lockedUntil && new Date(row.lockedUntil) > now),
   }));

--- a/apps/worker/tests/features/sync/notification-batch-repository.test.ts
+++ b/apps/worker/tests/features/sync/notification-batch-repository.test.ts
@@ -2,7 +2,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { DatabaseSync } from "node:sqlite";
 import type { ConnectorId } from "@taiwan-fin-hub/core";
-import type { SyncJobRow } from "@taiwan-fin-hub/db";
+import { findNextDueSyncJob, type SyncJobRow } from "@taiwan-fin-hub/db";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   claimCompletedDefaultScheduleBatch,
@@ -11,6 +11,7 @@ import {
   findOpenDefaultScheduleBatchId,
   recordDefaultScheduleBatchResult,
 } from "../../../src/features/sync/notification-batch-repository";
+import { getSyncJobs } from "../../../src/features/sync/schedule-service";
 
 class SqliteStatement {
   private values: unknown[] = [];
@@ -54,7 +55,9 @@ class SqliteStatement {
   }
 }
 
-function createDb(options: { failBatchAt?: number } = {}) {
+function createDb(
+  options: { failBatchAt?: number; skipMigration?: string } = {},
+) {
   const database = new DatabaseSync(":memory:");
   database.exec("PRAGMA foreign_keys = ON");
   const migrationsDirectory = fileURLToPath(
@@ -62,6 +65,7 @@ function createDb(options: { failBatchAt?: number } = {}) {
   );
   for (const file of readdirSync(migrationsDirectory)
     .filter((name) => name.endsWith(".sql"))
+    .filter((name) => name !== options.skipMigration)
     .sort()) {
     database.exec(readFileSync(`${migrationsDirectory}/${file}`, "utf8"));
   }
@@ -108,6 +112,22 @@ function enableInheritedJobs(
     .run(nextRunAt);
 }
 
+function configureJobs(
+  database: DatabaseSync,
+  jobs: SyncJobRow<ConnectorId>[],
+) {
+  const now = "2026-07-23T00:00:00.000Z";
+  for (const job of jobs) {
+    database
+      .prepare(
+        `INSERT INTO connector_settings (
+           id, connector_id, encrypted_config, created_at, updated_at
+         ) VALUES (?, ?, '{}', ?, ?)`,
+      )
+      .run(`${job.connector_id}:settings`, job.connector_id, now, now);
+  }
+}
+
 function listJobs(database: DatabaseSync) {
   return database
     .prepare("SELECT * FROM sync_jobs ORDER BY id")
@@ -140,10 +160,105 @@ afterEach(() => {
 });
 
 describe("default schedule notification rounds", () => {
+  it("leaves every fresh-install connector unconfigured, disabled, and on the default schedule", async () => {
+    const { database, db } = createDb();
+    databases.push(database);
+
+    expect(
+      database
+        .prepare(
+          `SELECT COUNT(*) AS count
+           FROM sync_jobs
+           WHERE enabled != 0
+              OR last_status IS NOT NULL
+              OR last_error IS NOT NULL`,
+        )
+        .get(),
+    ).toEqual({ count: 0 });
+    expect(
+      database
+        .prepare(
+          `SELECT COUNT(*) AS count
+           FROM sync_jobs
+           WHERE schedule_mode != 'inherit'
+              OR preferred_time != '06:00'
+              OR preferred_weekday != 1
+              OR interval_minutes != 1440`,
+        )
+        .get(),
+    ).toEqual({ count: 0 });
+    expect((await getSyncJobs(db)).every((job) => !job.configured)).toBe(true);
+  });
+
+  it("restores unconfigured jobs to an existing user's default schedule", () => {
+    const { database } = createDb({
+      skipMigration: "0023_disable_unconfigured_sync_jobs.sql",
+    });
+    databases.push(database);
+    database
+      .prepare(
+        `UPDATE sync_schedule_settings
+         SET interval_minutes = 10080, preferred_time = '20:30', preferred_weekday = 5
+         WHERE id = 'default'`,
+      )
+      .run();
+    const migrationsDirectory = fileURLToPath(
+      new URL("../../../../../packages/db/migrations/", import.meta.url),
+    );
+    database.exec(
+      readFileSync(
+        `${migrationsDirectory}/0023_disable_unconfigured_sync_jobs.sql`,
+        "utf8",
+      ),
+    );
+
+    expect(
+      database
+        .prepare(
+          `SELECT COUNT(*) AS count
+           FROM sync_jobs
+           WHERE schedule_mode != 'inherit'
+              OR interval_minutes != 10080
+              OR preferred_time != '20:30'
+              OR preferred_weekday != 5`,
+        )
+        .get(),
+    ).toEqual({ count: 0 });
+  });
+
+  it("does not select an enabled unconfigured job for a due run or default batch", async () => {
+    const { database, db } = createDb();
+    databases.push(database);
+    database
+      .prepare(
+        `UPDATE sync_jobs
+         SET enabled = 1, next_run_at = '2020-01-01T00:00:00.000Z'
+         WHERE id = 'esun:all'`,
+      )
+      .run();
+
+    await expect(
+      findNextDueSyncJob(db, new Date("2026-08-01T00:00:00.000Z")),
+    ).resolves.toBeNull();
+    await expect(ensureDefaultScheduleBatch(db)).resolves.toBeNull();
+
+    configureJobs(database, [
+      database
+        .prepare("SELECT * FROM sync_jobs WHERE id = 'esun:all'")
+        .get() as unknown as SyncJobRow<ConnectorId>,
+    ]);
+    const jobs = await getSyncJobs(db);
+    expect(jobs.find((job) => job.id === "esun:all")?.configured).toBe(true);
+    await expect(
+      findNextDueSyncJob(db, new Date("2026-08-01T00:00:00.000Z")),
+    ).resolves.toMatchObject({ id: "esun:all" });
+  });
+
   it("creates the round header and fixed membership atomically", async () => {
     const { database, db } = createDb({ failBatchAt: 1 });
     databases.push(database);
     enableInheritedJobs(database);
+    configureJobs(database, listJobs(database));
 
     await expect(ensureDefaultScheduleBatch(db)).rejects.toThrow(
       "simulated D1 batch failure",
@@ -164,6 +279,7 @@ describe("default schedule notification rounds", () => {
     const { database, db } = createDb();
     databases.push(database);
     enableInheritedJobs(database);
+    configureJobs(database, listJobs(database));
     const jobs = listJobs(database);
     const batchId = await createBatch(db);
 
@@ -193,6 +309,7 @@ describe("default schedule notification rounds", () => {
     const { database, db } = createDb();
     databases.push(database);
     enableInheritedJobs(database);
+    configureJobs(database, listJobs(database));
     const jobs = listJobs(database);
     const batchId = await createBatch(db);
     const first = await findNextDefaultScheduleBatchJob(db, batchId);
@@ -212,6 +329,7 @@ describe("default schedule notification rounds", () => {
     const { database, db } = createDb();
     databases.push(database);
     enableInheritedJobs(database);
+    configureJobs(database, listJobs(database));
     const jobs = listJobs(database);
     const addedLater = jobs.at(-1)!;
     database
@@ -241,6 +359,7 @@ describe("default schedule notification rounds", () => {
     const { database, db } = createDb();
     databases.push(database);
     enableInheritedJobs(database);
+    configureJobs(database, listJobs(database));
     const jobs = listJobs(database);
     const pending = jobs[0]!;
     const batchId = await createBatch(db);
@@ -270,6 +389,7 @@ describe("default schedule notification rounds", () => {
     const { database, db } = createDb();
     databases.push(database);
     enableInheritedJobs(database);
+    configureJobs(database, listJobs(database));
     const jobs = listJobs(database);
     const paused = jobs[0]!;
     const batchId = await createBatch(db);
@@ -294,6 +414,7 @@ describe("default schedule notification rounds", () => {
     const { database, db } = createDb();
     databases.push(database);
     enableInheritedJobs(database);
+    configureJobs(database, listJobs(database));
     const jobs = listJobs(database);
     const skipped = jobs[0]!;
     const batchId = await createBatch(db);
@@ -317,6 +438,7 @@ describe("default schedule notification rounds", () => {
     const { database, db } = createDb();
     databases.push(database);
     enableInheritedJobs(database);
+    configureJobs(database, listJobs(database));
     const jobs = listJobs(database);
     const running = jobs[0]!;
     const batchId = await createBatch(db);
@@ -350,6 +472,7 @@ describe("default schedule notification rounds", () => {
     const { database, db } = createDb();
     databases.push(database);
     enableInheritedJobs(database);
+    configureJobs(database, listJobs(database));
     const jobs = listJobs(database);
     const firstBatchId = await createBatch(db);
     await expect(ensureDefaultScheduleBatch(db)).resolves.toBe(firstBatchId);
@@ -368,6 +491,7 @@ describe("default schedule notification rounds", () => {
     const { database, db } = createDb();
     databases.push(database);
     enableInheritedJobs(database);
+    configureJobs(database, listJobs(database));
     const jobs = listJobs(database);
     const oldBatchId = await createBatch(db);
     for (const job of jobs) await completeMember(db, oldBatchId, job);

--- a/apps/worker/tests/features/sync/schedule-state.test.ts
+++ b/apps/worker/tests/features/sync/schedule-state.test.ts
@@ -20,6 +20,7 @@ describe("sync job user-action pause", () => {
 
     await findNextDueSyncJob(db, new Date("2026-07-15T00:00:00.000Z"));
     expect(sql).toContain("last_status != 'needs_user_action'");
+    expect(sql).toContain("FROM connector_settings");
   });
 
   it("records required user action without disabling the user's schedule", async () => {

--- a/packages/db/migrations/0023_disable_unconfigured_sync_jobs.sql
+++ b/packages/db/migrations/0023_disable_unconfigured_sync_jobs.sql
@@ -1,0 +1,33 @@
+-- Before 0004, the initial sync jobs for several connectors were enabled.
+-- A fresh installation therefore ran them without credentials and persisted a
+-- misleading needs_user_action status. A connector without settings is not
+-- eligible for scheduled sync and should not retain a sync result.
+UPDATE sync_jobs
+SET enabled = 0,
+    interval_minutes = COALESCE(
+      (SELECT interval_minutes FROM sync_schedule_settings WHERE id = 'default'),
+      1440
+    ),
+    schedule_mode = 'inherit',
+    preferred_time = COALESCE(
+      (SELECT preferred_time FROM sync_schedule_settings WHERE id = 'default'),
+      '06:00'
+    ),
+    preferred_weekday = COALESCE(
+      (SELECT preferred_weekday FROM sync_schedule_settings WHERE id = 'default'),
+      1
+    ),
+    last_run_at = NULL,
+    last_success_at = NULL,
+    last_status = NULL,
+    last_error = NULL,
+    locked_until = NULL,
+    locked_by = NULL,
+    lock_trigger = NULL,
+    lock_scope = NULL,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM connector_settings
+  WHERE connector_settings.connector_id = sync_jobs.connector_id
+);

--- a/packages/db/src/sync-jobs.ts
+++ b/packages/db/src/sync-jobs.ts
@@ -80,6 +80,11 @@ export async function findNextDueSyncJob<TConnectorId extends string>(
         `SELECT *
      FROM sync_jobs
      WHERE enabled = 1
+       AND EXISTS (
+         SELECT 1
+         FROM connector_settings
+         WHERE connector_settings.connector_id = sync_jobs.connector_id
+       )
        AND (last_status IS NULL OR last_status != 'needs_user_action')
        AND next_run_at <= ?
        AND (locked_until IS NULL OR locked_until < ?)


### PR DESCRIPTION
## 變更內容

- 新增 migration，停用並清理未設定連接器的既有同步工作。
- Scheduler 與預設同步通知批次跳過沒有 `connector_settings` 的連接器。
- `/api/sync-jobs` 回傳 `configured`，前端統一區分未設定、需要處理、正常與尚未同步。
- 修正資料來源卡片、設定總覽、行動版設定與 Overview 的健康度計算。
- 已設定連接器的手動同步失敗仍會顯示需要處理。

## 根因

早期 migration 先建立了啟用中的同步工作，後續使用 `INSERT OR IGNORE` 無法將既有資料改為停用。首次排程因此在沒有憑證時執行，將工作寫成 `needs_user_action`；前端又優先依同步工作狀態顯示徽章，造成「尚未設定」與「需要處理」同時出現。

## 驗證

- `npm run typecheck`
- `npm run test:backend`
- `npm run verify:web`
- Svelte autofixer（5 個相關元件）
- `git diff --check`

以上本地驗證均通過。