### PR TITLE
修正活動月份統計與連接器導覽

### DIFF
--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -63,6 +63,7 @@
     type ActivityFlowFilter,
     type ActivitySourceFilter,
   } from "./model/filter";
+  import { countPendingActivityItems } from "./model/pending";
   import {
     buildActivityCategorySlices,
     activityCashAmountTwd,
@@ -276,11 +277,7 @@
   const currentMonth = new Date().toISOString().slice(0, 7);
   const selectedMonthLabel = $derived(`${Number(selectedMonth.slice(5))} 月`);
   const pendingCount = $derived(
-    rawItems.filter(
-      (item) =>
-        (item.source === "bank" || item.source === "card") &&
-        (item.status === "pending" || item.categoryId === "other"),
-    ).length,
+    countPendingActivityItems(rawItems, selectedMonth),
   );
   const cashFlow = $derived(
     cashFlowMonths.map((month) => {

--- a/apps/web/src/features/activity/model/pending.test.ts
+++ b/apps/web/src/features/activity/model/pending.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { ActivityItem } from "./types";
+import { countPendingActivityItems } from "./pending";
+
+function item(overrides: Partial<ActivityItem>): ActivityItem {
+  return {
+    id: "1",
+    source: "bank",
+    date: "2026-08-01",
+    title: "交易",
+    subtitle: "",
+    amount: -100,
+    currency: "TWD",
+    category: "未分類",
+    categoryId: "other",
+    status: "posted",
+    ...overrides,
+  };
+}
+
+describe("countPendingActivityItems", () => {
+  it("只計算選定月份的銀行與信用卡待分類活動", () => {
+    expect(
+      countPendingActivityItems(
+        [
+          item({ id: "aug-unclassified" }),
+          item({
+            id: "aug-pending",
+            categoryId: "shopping",
+            category: "購物",
+            status: "pending",
+          }),
+          item({ id: "jul-unclassified", date: "2026-07-31" }),
+          item({
+            id: "aug-investment",
+            source: "investment",
+            status: "pending",
+          }),
+        ],
+        "2026-08",
+      ),
+    ).toBe(2);
+  });
+});

--- a/apps/web/src/features/activity/model/pending.ts
+++ b/apps/web/src/features/activity/model/pending.ts
@@ -1,0 +1,13 @@
+import type { ActivityItem } from "./types";
+
+export function countPendingActivityItems(
+  items: ActivityItem[],
+  month: string,
+) {
+  return items.filter(
+    (item) =>
+      item.date.startsWith(month) &&
+      (item.source === "bank" || item.source === "card") &&
+      (item.status === "pending" || item.categoryId === "other"),
+  ).length;
+}

--- a/apps/web/src/features/settings/SettingsPage.svelte
+++ b/apps/web/src/features/settings/SettingsPage.svelte
@@ -129,6 +129,11 @@
     selectedConnector = selectedConnector === id ? null : id;
   }
 
+  function openConnector(id: ConnectorId) {
+    selectedConnector = id;
+    navigate("data-sources");
+  }
+
   function isActiveTab(tabView: (typeof settingTabs)[number]["view"]) {
     return tabView === "settings"
       ? !mobileView || mobileView === "more"
@@ -158,6 +163,7 @@
       bank={$bank.data ?? { accounts: [], transactions: [] }}
       {navigate}
       {api}
+      {openConnector}
     />
   {:else if mobileView === "data-sources"}
     <div class="grid min-w-0 gap-4">
@@ -520,7 +526,7 @@
                 jobs={$jobs.data ?? []}
                 compact
                 selected={false}
-                onConfigure={() => navigate("data-sources")}
+                onConfigure={() => openConnector(source.id)}
               />
             {/each}
           </div>

--- a/apps/web/src/features/settings/components/MobileMore.svelte
+++ b/apps/web/src/features/settings/components/MobileMore.svelte
@@ -11,13 +11,14 @@
     getActionableSyncJobs,
     getSyncSourceStatus,
   } from "@/data/connectors/sync-status";
-  import type { SyncJobRow } from "@/data/connectors/types";
+  import type { ConnectorId, SyncJobRow } from "@/data/connectors/types";
   let {
     demoMode,
     jobs,
     rules,
     bank,
     navigate,
+    openConnector,
   }: {
     api: ApiClient;
     demoMode: boolean;
@@ -25,6 +26,7 @@
     rules: ClassificationRuleRow[];
     bank: BankData;
     navigate: (view: View) => void;
+    openConnector: (id: ConnectorId) => void;
   } = $props();
   const sources = connectorDefinitions;
   const configuredSources = $derived(
@@ -122,8 +124,11 @@
         {#each sources as source (source.id)}{@const job = jobs.find(
             (item) => item.connectorId === source.id,
           )}
-          <div
-            class="flex items-center justify-between gap-3 px-4 py-3 text-sm"
+          <button
+            type="button"
+            class="flex min-h-12 w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm transition hover:bg-paper focus-visible:outline-2 focus-visible:outline-steel"
+            aria-label={`管理${source.title}`}
+            onclick={() => openConnector(source.id)}
           >
             <span class="font-semibold">{source.title}</span><span
               class={getSyncSourceStatus(job) === "needs_action"
@@ -137,7 +142,7 @@
                     ? "尚未同步"
                     : "未設定"}</span
             >
-          </div>{/each}
+          </button>{/each}
       </div></Card
     >
   </section>

--- a/apps/web/src/features/settings/components/MobileMore.test.ts
+++ b/apps/web/src/features/settings/components/MobileMore.test.ts
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 import { describe, expect, it, vi } from "vitest";
 import { connectorDefinitions } from "@/data/connectors/definitions";
 import type { ApiClient } from "@/shared/api/client";
@@ -7,6 +7,7 @@ import MobileMore from "./MobileMore.svelte";
 describe("MobileMore", () => {
   it("shows unconfigured connectors without counting them as healthy or actionable", () => {
     const api = {} as ApiClient;
+    const openConnector = vi.fn();
     const { getAllByText, getByText } = render(MobileMore, {
       props: {
         api,
@@ -15,6 +16,7 @@ describe("MobileMore", () => {
         rules: [],
         bank: { accounts: [], transactions: [] },
         navigate: vi.fn(),
+        openConnector,
       },
     });
 
@@ -26,5 +28,24 @@ describe("MobileMore", () => {
     expect(getByText("同步與通知")).toBeInTheDocument();
     expect(getByText("中國信託銀行")).toBeInTheDocument();
     expect(getAllByText("未設定")).toHaveLength(connectorCount);
+  });
+
+  it("opens the selected connector from the source summary", async () => {
+    const openConnector = vi.fn();
+    const { getByRole } = render(MobileMore, {
+      props: {
+        api: {} as ApiClient,
+        demoMode: false,
+        jobs: [],
+        rules: [],
+        bank: { accounts: [], transactions: [] },
+        navigate: vi.fn(),
+        openConnector,
+      },
+    });
+
+    await fireEvent.click(getByRole("button", { name: "管理電子發票" }));
+
+    expect(openConnector).toHaveBeenCalledWith("einvoice");
   });
 });


### PR DESCRIPTION
## 變更內容

- 修正活動頁「待分類」數量，改為依目前選定月份計算。
- 將手機「更多」頁的資料來源摘要列改為可點擊，直接開啟指定連接器設定。
- 讓桌面設定總覽點擊來源卡片後，直接選取並展開對應連接器。
- 補上手機來源列互動測試。

## 問題原因

- 待分類統計原本掃描整個活動資料範圍，沒有套用選定月份。
- `MobileMore` 的來源列只是非互動的摘要 `<div>`。
- 設定總覽原本只導向 `data-sources`，沒有傳遞使用者點選的連接器。

## 驗證

- Svelte autofixer、Prettier、typecheck
- Web 單元測試：65 passed
- E2E：14 passed
- Production build
- 410px 手機與 1266px 桌面瀏覽器驗證

此 PR 為 Draft，未包含工作區其他未相關修改。