### PR TITLE
新增外部匯率來源與手動更新介面

### DIFF
--- a/apps/web/src/app/navigation-config.ts
+++ b/apps/web/src/app/navigation-config.ts
@@ -81,7 +81,7 @@ export const mobileSettingsLabels: Record<
   },
   "exchange-rates": {
     label: "匯率",
-    description: "管理資產換算使用的參考匯率。",
+    description: "查看資產換算使用的參考匯率。",
   },
   "classification-rules": {
     label: "分類規則",

--- a/apps/web/src/features/settings/SettingsPage.svelte
+++ b/apps/web/src/features/settings/SettingsPage.svelte
@@ -94,7 +94,7 @@
   );
   const ratesSummary = $derived(
     ($rates.data ?? [])
-      .map((rate) => `${rate.currency} ${rate.rateTwd.toFixed(3)}`)
+      .map((rate) => `${rate.currency} ${rate.rateTwd.toFixed(2)}`)
       .join(" · ") || "尚未設定",
   );
   const notificationSummary = $derived(
@@ -324,12 +324,9 @@
         <div>
           <h2 class="text-2xl font-bold tracking-tight">匯率</h2>
           <p class="mt-1 text-sm text-muted-foreground">
-            管理資產與活動使用的換算基準。
+            查看資產與活動使用的換算基準，必要時手動更新。
           </p>
         </div>
-        <span class="rounded-lg bg-steel px-4 py-2 text-sm font-bold text-white"
-          >更新匯率</span
-        >
       </div>
 
       <section
@@ -343,18 +340,18 @@
         </div>
         <div class="rounded-xl border border-border bg-card p-4 shadow-xs">
           <p class="text-sm font-semibold text-muted-foreground">資料來源</p>
-          <p class="mt-2 text-lg font-bold">手動設定</p>
-          <p class="mt-1 text-sm text-muted-foreground">以設定值換算</p>
+          <p class="mt-2 text-lg font-bold">ExchangeRate-API</p>
+          <p class="mt-1 text-sm text-muted-foreground">手動點擊更新</p>
         </div>
         <div class="rounded-xl bg-muted p-4">
-          <p class="text-sm font-semibold text-muted-foreground">自訂匯率</p>
+          <p class="text-sm font-semibold text-muted-foreground">支援幣別</p>
           <p class="mt-2 text-lg font-bold">{$rates.data?.length ?? 0} 筆</p>
-          <p class="mt-1 text-sm font-semibold text-steel">可在下方編輯</p>
+          <p class="mt-1 text-sm font-semibold text-steel">USD · JPY · EUR</p>
         </div>
       </section>
 
       <div class="hidden md:block">
-        <ExchangeRatesPanel {api} variant="desktop" />
+        <ExchangeRatesPanel {api} {demoMode} variant="desktop" />
       </div>
       <aside
         class="hidden rounded-lg bg-muted p-3 text-sm text-muted-foreground md:block"
@@ -362,7 +359,7 @@
         匯率僅用於資產總覽與統計換算，不會變更原始交易幣別或金額。
       </aside>
       <div class="md:hidden">
-        <ExchangeRatesPanel {api} />
+        <ExchangeRatesPanel {api} {demoMode} />
       </div>
     </div>
   {:else if mobileView === "classification-rules"}
@@ -577,7 +574,7 @@
             {ratesSummary}
           </p>
           <span class="mt-4 block text-sm font-semibold text-steel"
-            >開啟設定 →</span
+            >查看匯率 →</span
           >
         </button>
         <button

--- a/apps/web/src/features/settings/components/ExchangeRatesPanel.svelte
+++ b/apps/web/src/features/settings/components/ExchangeRatesPanel.svelte
@@ -1,155 +1,185 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import {
     createMutation,
     createQuery,
     useQueryClient,
   } from "@tanstack/svelte-query";
-  import { Save } from "@lucide/svelte";
+  import { RefreshCw } from "@lucide/svelte";
   import Card from "@/shared/ui/Card.svelte";
   import CardHeader from "@/shared/ui/CardHeader.svelte";
   import CardContent from "@/shared/ui/CardContent.svelte";
   import Button from "@/shared/ui/Button.svelte";
-  import Input from "@/shared/ui/Input.svelte";
   import type { ApiClient } from "@/shared/api/client";
+  import { messageFromError } from "@/shared/api/client";
   import { queryKeys } from "@/shared/api/query-keys";
   import { exchangeRatesQuery } from "@/data/assets/queries";
-  import { bankQuery } from "@/data/bank/queries";
+  import type { ExchangeRateRow } from "@/data/assets/types";
   import { formatDateTime } from "@/shared/format/financial";
+
+  const EXCHANGE_RATE_SOURCE_URL = "https://www.exchangerate-api.com";
+  const currencies = ["USD", "JPY", "EUR"] as const;
+  const currencyLabels: Record<(typeof currencies)[number], string> = {
+    USD: "美元",
+    JPY: "日圓",
+    EUR: "歐元",
+  };
+
   let {
     api,
+    demoMode = false,
     variant = "default",
   }: {
     api: ApiClient;
+    demoMode?: boolean;
     variant?: "default" | "desktop";
   } = $props();
+
   const rates = createQuery(exchangeRatesQuery(() => api));
-  const bank = createQuery(bankQuery(() => api));
-  const qc = useQueryClient();
-  let values = $state<Record<string, string>>({});
-  const currencies = $derived([
-    ...new Set(
-      [
-        ...($bank.data?.accounts ?? []).map((account) => account.currency),
-        ...($rates.data ?? []).map((rate) => rate.currency),
-      ].filter(
-        (currency): currency is string =>
-          Boolean(currency) && currency !== "TWD",
-      ),
-    ),
-  ]);
-  const save = createMutation({
-    mutationFn: (payload: Record<string, number>) =>
-      api.put("/api/exchange-rates", { rates: payload }),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.exchangeRates }),
+  const queryClient = useQueryClient();
+  const refresh = createMutation({
+    mutationFn: () =>
+      api.post<ExchangeRateRow[]>("/api/exchange-rates/refresh"),
+    onSuccess: (data) =>
+      queryClient.setQueryData(queryKeys.exchangeRates, data),
   });
-  onMount(() =>
-    rates.subscribe((result) => {
-      for (const rate of result.data ?? []) {
-        if (values[rate.currency] === undefined)
-          values[rate.currency] = String(rate.rateTwd);
-      }
-    }),
+
+  const lastUpdatedAt = $derived(
+    ($rates.data ?? []).find((rate) => rate.updatedAt)?.updatedAt,
   );
+
+  function rateFor(currency: (typeof currencies)[number]) {
+    return ($rates.data ?? []).find((rate) => rate.currency === currency);
+  }
+
+  function displayRate(rate: ExchangeRateRow | undefined) {
+    return rate ? rate.rateTwd.toFixed(2) : "尚未取得";
+  }
 </script>
 
 {#if variant === "desktop"}
   <Card as="section" class="overflow-hidden border-border shadow-xs">
-    <CardHeader class="border-b border-border bg-muted/60">
-      <div>
-        <h2 class="text-base font-bold">匯率表格</h2>
+    <CardHeader
+      class="flex-row flex-wrap items-start justify-between gap-x-6 gap-y-3 border-b border-border bg-muted/60"
+    >
+      <div class="min-w-0">
+        <h2 class="text-base font-bold">匯率</h2>
         <p class="mt-1 text-sm text-muted-foreground">
-          可調整外幣換算使用的參考匯率。
+          目前支援美元、日圓與歐元，供資產與活動換算使用。
         </p>
+      </div>
+      <div class="flex flex-wrap items-start justify-end gap-x-4 gap-y-2">
+        <div class="text-right text-sm text-muted-foreground">
+          <p>
+            資料來源：<a
+              class="font-semibold text-steel underline underline-offset-2"
+              href={EXCHANGE_RATE_SOURCE_URL}
+              target="_blank"
+              rel="noreferrer">Rates By Exchange Rate API</a
+            >
+          </p>
+          <p>
+            最後更新：{lastUpdatedAt
+              ? formatDateTime(lastUpdatedAt)
+              : "尚未更新"}
+          </p>
+          {#if $refresh.error}
+            <p role="alert" class="text-coral">
+              {messageFromError($refresh.error)} 目前仍保留原有匯率。
+            </p>
+          {/if}
+        </div>
+        <Button
+          variant="primary"
+          disabled={demoMode || $refresh.isPending}
+          onclick={() => $refresh.mutate()}
+        >
+          <RefreshCw
+            class={$refresh.isPending ? "size-4 animate-spin" : "size-4"}
+          />{$refresh.isPending ? "更新中…" : "更新匯率"}
+        </Button>
       </div>
     </CardHeader>
     <CardContent class="p-0">
-      {#if currencies.length === 0}
-        <p class="p-5 text-sm text-muted-foreground">目前沒有外幣帳戶。</p>
-      {:else}
+      <div
+        class="hidden grid-cols-[minmax(0,1fr)_180px_1fr] bg-muted/60 text-sm font-semibold text-muted-foreground sm:grid"
+      >
+        <span class="px-4 py-3">幣別</span>
+        <span class="px-4 py-3">換算率</span>
+        <span class="px-4 py-3">說明</span>
+      </div>
+      {#each currencies as currency (currency)}
+        {@const rate = rateFor(currency)}
         <div
-          class="hidden grid-cols-[minmax(0,1fr)_180px_220px_220px] bg-muted/60 text-sm font-semibold text-muted-foreground sm:grid"
+          class="grid gap-1 border-t border-border px-4 py-3 text-sm sm:grid-cols-[minmax(0,1fr)_180px_1fr] sm:items-center sm:gap-0"
         >
-          <span class="px-4 py-3">幣別</span>
-          <span class="px-4 py-3">換算率</span>
-          <span class="px-4 py-3">來源</span>
-          <span class="px-4 py-3">更新時間</span>
-        </div>
-        {#each currencies as currency (currency)}
-          {@const rate = ($rates.data ?? []).find(
-            (item) => item.currency === currency,
-          )}
-          <label
-            class="grid gap-2 border-t border-border px-4 py-3 text-sm sm:grid-cols-[minmax(0,1fr)_180px_220px_220px] sm:items-center"
+          <span class="font-semibold"
+            >{currencyLabels[currency]}（{currency}）</span
           >
-            <span class="font-semibold">{currency}</span>
-            <Input
-              class="w-full text-right sm:w-32"
-              type="number"
-              step="0.0001"
-              bind:value={values[currency]}
-              aria-label={`${currency} 匯率`}
-            />
-            <span class="text-sm text-muted-foreground">手動設定</span>
-            <span class="text-sm text-muted-foreground"
-              >{rate?.updatedAt
-                ? formatDateTime(rate.updatedAt)
-                : "尚未更新"}</span
-            >
-          </label>
-        {/each}
-        <div class="border-t border-border p-4">
-          <Button
-            variant="primary"
-            disabled={$save.isPending}
-            onclick={() =>
-              $save.mutate(
-                Object.fromEntries(
-                  Object.entries(values).map(([k, v]) => [k, Number(v)]),
-                ),
-              )}
-            ><Save class="size-4" />{$save.isPending
-              ? "儲存中…"
-              : "儲存匯率"}</Button
+          <span class="font-mono text-right sm:text-left"
+            >1 {currency} = NT$ {displayRate(rate)}</span
+          >
+          <span class="text-sm text-muted-foreground"
+            >1 {currency} 換算為新台幣</span
           >
         </div>
-      {/if}
+      {/each}
     </CardContent>
   </Card>
 {:else}
-  <Card
-    ><CardHeader
-      ><h2 class="text-lg font-semibold">匯率</h2>
-      <p class="text-sm text-muted-foreground">
-        管理外幣換算使用的參考匯率
-      </p></CardHeader
-    ><CardContent
-      ><div class="grid gap-3">
-        {#if currencies.length === 0}<p class="text-sm text-muted-foreground">
-            目前沒有外幣帳戶。
-          </p>{:else}{#each currencies as currency (currency)}<label
-              class="flex items-center justify-between gap-3 text-sm"
-              ><span class="font-semibold">{currency}</span><Input
-                class="w-32 text-right"
-                type="number"
-                step="0.0001"
-                bind:value={values[currency]}
-              /></label
-            >{/each}<Button
-            variant="primary"
-            disabled={$save.isPending}
-            onclick={() =>
-              $save.mutate(
-                Object.fromEntries(
-                  Object.entries(values).map(([k, v]) => [k, Number(v)]),
-                ),
-              )}
-            ><Save class="size-4" />{$save.isPending
-              ? "儲存中…"
-              : "儲存匯率"}</Button
-          >{/if}
-      </div></CardContent
-    ></Card
-  >
+  <Card>
+    <CardHeader class="gap-4">
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <h2 class="text-lg font-semibold">匯率</h2>
+          <p class="mt-1 text-sm text-muted-foreground">
+            供資產與活動換算使用的參考匯率。
+          </p>
+        </div>
+        <Button
+          variant="primary"
+          size="sm"
+          disabled={demoMode || $refresh.isPending}
+          onclick={() => $refresh.mutate()}
+        >
+          <RefreshCw
+            class={$refresh.isPending ? "size-4 animate-spin" : "size-4"}
+          />{$refresh.isPending ? "更新中…" : "更新"}
+        </Button>
+      </div>
+    </CardHeader>
+    <CardContent>
+      <div class="grid gap-3">
+        {#each currencies as currency (currency)}
+          {@const rate = rateFor(currency)}
+          <div class="flex items-center justify-between gap-3 text-sm">
+            <span class="font-semibold"
+              >{currencyLabels[currency]}（{currency}）</span
+            >
+            <span class="font-mono">1 {currency} = NT$ {displayRate(rate)}</span
+            >
+          </div>
+        {/each}
+      </div>
+      <div
+        class="mt-4 grid gap-1 border-t border-border pt-3 text-sm text-muted-foreground"
+      >
+        <p>
+          資料來源：<a
+            class="font-semibold text-steel underline underline-offset-2"
+            href={EXCHANGE_RATE_SOURCE_URL}
+            target="_blank"
+            rel="noreferrer">Rates By Exchange Rate API</a
+          >
+        </p>
+        <p>
+          最後更新：{lastUpdatedAt ? formatDateTime(lastUpdatedAt) : "尚未更新"}
+        </p>
+        {#if $refresh.error}
+          <p role="alert" class="text-coral">
+            {messageFromError($refresh.error)} 目前仍保留原有匯率。
+          </p>
+        {/if}
+      </div>
+    </CardContent>
+  </Card>
 {/if}

--- a/apps/web/src/features/settings/components/MobileMore.svelte
+++ b/apps/web/src/features/settings/components/MobileMore.svelte
@@ -90,7 +90,7 @@
             ><WalletCards class="size-5" /></span
           ><span class="flex-1"
             ><span class="block font-semibold">匯率</span><span
-              class="block text-sm text-ink/45">管理外幣換算</span
+              class="block text-sm text-ink/45">查看外幣換算</span
             ></span
           ><span class="text-sm font-semibold text-steel">›</span></button
         >

--- a/apps/worker/src/features/exchange-rates/repository.ts
+++ b/apps/worker/src/features/exchange-rates/repository.ts
@@ -23,22 +23,26 @@ export async function listExchangeRates(db: D1Database) {
   return rows.results;
 }
 
-export async function upsertExchangeRates(
+export async function replaceExchangeRates(
   db: D1Database,
   rates: Array<{ currency: string; rate: number }>,
   now: string,
 ) {
-  if (rates.length === 0) return;
-  await db.batch(
-    rates.map(({ currency, rate }) =>
+  const statements = [db.prepare("DELETE FROM exchange_rates")];
+  if (rates.length === 0) {
+    await db.batch(statements);
+    return;
+  }
+
+  statements.push(
+    ...rates.map(({ currency, rate }) =>
       db
         .prepare(
-          `INSERT INTO exchange_rates (currency, rate_to_twd, updated_at) VALUES (?, ?, ?)
-       ON CONFLICT(currency) DO UPDATE SET
-         rate_to_twd = excluded.rate_to_twd,
-         updated_at = excluded.updated_at`,
+          `INSERT INTO exchange_rates (currency, rate_to_twd, updated_at) VALUES (?, ?, ?)`,
         )
         .bind(currency, rate, now),
     ),
   );
+
+  await db.batch(statements);
 }

--- a/apps/worker/src/features/exchange-rates/repository.ts
+++ b/apps/worker/src/features/exchange-rates/repository.ts
@@ -4,12 +4,20 @@ export type ExchangeRateRow = {
   updatedAt: string;
 };
 
+export const SUPPORTED_EXCHANGE_CURRENCIES = ["USD", "JPY", "EUR"] as const;
+
 export async function listExchangeRates(db: D1Database) {
   const rows = await db
     .prepare(
       `SELECT currency, rate_to_twd AS rateTwd, updated_at AS updatedAt
      FROM exchange_rates
-     ORDER BY currency ASC`,
+     WHERE currency IN ('USD', 'JPY', 'EUR')
+     ORDER BY CASE currency
+       WHEN 'USD' THEN 1
+       WHEN 'JPY' THEN 2
+       WHEN 'EUR' THEN 3
+       ELSE 4
+     END`,
     )
     .all<ExchangeRateRow>();
   return rows.results;

--- a/apps/worker/src/features/exchange-rates/route.ts
+++ b/apps/worker/src/features/exchange-rates/route.ts
@@ -1,14 +1,12 @@
 import type { Hono } from "hono";
-import { zValidator } from "@hono/zod-validator";
-import { z } from "zod";
 import type { AppBindings } from "../../platform/env";
 import { honoFactory } from "../../platform/hono";
-import { validationHook } from "../../platform/validation";
-import { getExchangeRates, updateExchangeRates } from "./service";
-
-const updateSchema = z.object({
-  rates: z.record(z.string().min(3).max(3), z.number().finite().positive()),
-});
+import { jsonError } from "../../platform/http";
+import {
+  ExchangeRateProviderError,
+  getExchangeRates,
+  refreshExchangeRates,
+} from "./service";
 
 export const exchangeRateRoutes = honoFactory.createApp();
 registerExchangeRateRoutes(exchangeRateRoutes);
@@ -18,16 +16,18 @@ function registerExchangeRateRoutes(api: Hono<AppBindings>) {
     c.json(await getExchangeRates(c.env.DB)),
   );
 
-  api.put(
-    "/exchange-rates",
-    zValidator(
-      "json",
-      updateSchema,
-      validationHook("INVALID_REQUEST", "Exchange rates are invalid."),
-    ),
-    async (c) => {
-      await updateExchangeRates(c.env.DB, c.req.valid("json").rates);
-      return c.json({ success: true });
-    },
-  );
+  api.post("/exchange-rates/refresh", async (c) => {
+    try {
+      return c.json(await refreshExchangeRates(c.env.DB));
+    } catch (error) {
+      if (error instanceof ExchangeRateProviderError) {
+        return jsonError(
+          "EXCHANGE_RATE_PROVIDER_UNAVAILABLE",
+          "匯率資料來源暫時無法取得，請稍後再試。",
+          502,
+        );
+      }
+      throw error;
+    }
+  });
 }

--- a/apps/worker/src/features/exchange-rates/service.ts
+++ b/apps/worker/src/features/exchange-rates/service.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import {
   listExchangeRates,
+  replaceExchangeRates,
   SUPPORTED_EXCHANGE_CURRENCIES,
-  upsertExchangeRates,
 } from "./repository";
 
 export const EXCHANGE_RATE_API_URL = "https://open.er-api.com/v6/latest/TWD";
@@ -47,7 +47,7 @@ export async function refreshExchangeRates(
     return { currency, rate: 1 / providerRate };
   });
 
-  await upsertExchangeRates(
+  await replaceExchangeRates(
     db,
     rates,
     new Date(provider.timeLastUpdateUnix * 1000).toISOString(),

--- a/apps/worker/src/features/exchange-rates/service.ts
+++ b/apps/worker/src/features/exchange-rates/service.ts
@@ -1,19 +1,101 @@
-import { listExchangeRates, upsertExchangeRates } from "./repository";
+import { z } from "zod";
+import {
+  listExchangeRates,
+  SUPPORTED_EXCHANGE_CURRENCIES,
+  upsertExchangeRates,
+} from "./repository";
+
+export const EXCHANGE_RATE_API_URL = "https://open.er-api.com/v6/latest/TWD";
+
+const PROVIDER_TIMEOUT_MS = 10_000;
+
+const providerResponseSchema = z.object({
+  result: z.literal("success"),
+  base_code: z.literal("TWD"),
+  time_last_update_unix: z.number().int().positive(),
+  rates: z.record(z.string(), z.number().finite()),
+});
+
+export class ExchangeRateProviderError extends Error {
+  constructor(message = "Exchange rate provider is unavailable.") {
+    super(message);
+    this.name = "ExchangeRateProviderError";
+  }
+}
 
 export function getExchangeRates(db: D1Database) {
   return listExchangeRates(db);
 }
 
-export async function updateExchangeRates(
+export async function refreshExchangeRates(
   db: D1Database,
-  rates: Record<string, number>,
+  fetcher: typeof fetch = fetch,
 ) {
+  const provider = await fetchProviderRates(fetcher);
+  const rates = SUPPORTED_EXCHANGE_CURRENCIES.map((currency) => {
+    const providerRate = provider.rates[currency];
+    if (typeof providerRate !== "number" || !Number.isFinite(providerRate)) {
+      throw new ExchangeRateProviderError(
+        `Exchange rate provider did not return ${currency}.`,
+      );
+    }
+    if (providerRate <= 0) {
+      throw new ExchangeRateProviderError(
+        `Exchange rate provider returned an invalid ${currency} rate.`,
+      );
+    }
+    return { currency, rate: 1 / providerRate };
+  });
+
   await upsertExchangeRates(
     db,
-    Object.entries(rates).map(([currency, rate]) => ({
-      currency: currency.toUpperCase(),
-      rate,
-    })),
-    new Date().toISOString(),
+    rates,
+    new Date(provider.timeLastUpdateUnix * 1000).toISOString(),
   );
+  return listExchangeRates(db);
+}
+
+async function fetchProviderRates(fetcher: typeof fetch) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PROVIDER_TIMEOUT_MS);
+  try {
+    let response: Response;
+    try {
+      response = await fetcher(EXCHANGE_RATE_API_URL, {
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      });
+    } catch {
+      throw new ExchangeRateProviderError();
+    }
+
+    if (!response.ok) {
+      throw new ExchangeRateProviderError(
+        `Exchange rate provider returned HTTP ${response.status}.`,
+      );
+    }
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      throw new ExchangeRateProviderError(
+        "Exchange rate provider returned invalid JSON.",
+      );
+    }
+
+    const parsed = providerResponseSchema.safeParse(payload);
+    if (!parsed.success) {
+      throw new ExchangeRateProviderError(
+        "Exchange rate provider returned an invalid response.",
+      );
+    }
+
+    return {
+      rates: parsed.data.rates,
+      timeLastUpdateUnix: parsed.data.time_last_update_unix,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
 }

--- a/apps/worker/tests/features/exchange-rates/route.test.ts
+++ b/apps/worker/tests/features/exchange-rates/route.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { exchangeRateRoutes } from "../../../src/features/exchange-rates/route";
+import type { Env } from "../../../src/platform/env";
+
+function envWithDb() {
+  const db = {
+    prepare() {
+      const statement = {
+        async all() {
+          return { results: [] };
+        },
+      };
+      return statement;
+    },
+  } as unknown as D1Database;
+  return { DB: db } as Env;
+}
+
+describe("exchange rate routes", () => {
+  it("returns the cached supported exchange rates", async () => {
+    const response = await exchangeRateRoutes.request(
+      "/exchange-rates",
+      {},
+      envWithDb(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual([]);
+  });
+
+  it("returns a provider error when a manual refresh cannot fetch rates", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("network unavailable")),
+    );
+
+    try {
+      const response = await exchangeRateRoutes.request(
+        "/exchange-rates/refresh",
+        { method: "POST" },
+        envWithDb(),
+      );
+
+      expect(response.status).toBe(502);
+      await expect(response.json()).resolves.toMatchObject({
+        error: { code: "EXCHANGE_RATE_PROVIDER_UNAVAILABLE" },
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/apps/worker/tests/features/exchange-rates/service.test.ts
+++ b/apps/worker/tests/features/exchange-rates/service.test.ts
@@ -8,8 +8,10 @@ import {
 function createDb(results: unknown[] = []) {
   const calls: Array<{ sql: string; values: unknown[] }> = [];
   const batches: unknown[][] = [];
+  const preparedSql: string[] = [];
   const db = {
     prepare(sql: string) {
+      preparedSql.push(sql);
       const statement = {
         bind(...values: unknown[]) {
           calls.push({ sql, values });
@@ -26,7 +28,7 @@ function createDb(results: unknown[] = []) {
       return [];
     },
   } as unknown as D1Database;
-  return { db, calls, batches };
+  return { db, calls, batches, preparedSql };
 }
 
 const providerPayload = {
@@ -42,7 +44,7 @@ const providerPayload = {
 
 describe("refreshExchangeRates", () => {
   it("converts the TWD-base response into the app's TWD rates", async () => {
-    const { db, calls, batches } = createDb([
+    const { db, calls, batches, preparedSql } = createDb([
       {
         currency: "USD",
         rateTwd: 32.3076,
@@ -76,6 +78,8 @@ describe("refreshExchangeRates", () => {
       }),
     );
     expect(batches).toHaveLength(1);
+    expect(preparedSql[0]).toBe("DELETE FROM exchange_rates");
+    expect(batches[0]).toHaveLength(4);
     expect(
       calls
         .filter(({ sql }) => sql.includes("INSERT INTO exchange_rates"))
@@ -89,7 +93,7 @@ describe("refreshExchangeRates", () => {
   });
 
   it("does not write partial data when a required currency is missing", async () => {
-    const { db, batches } = createDb();
+    const { db, batches, preparedSql } = createDb();
     const fetcher = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -107,6 +111,7 @@ describe("refreshExchangeRates", () => {
       ExchangeRateProviderError,
     );
     expect(batches).toHaveLength(0);
+    expect(preparedSql).not.toContain("DELETE FROM exchange_rates");
   });
 
   it("turns provider HTTP failures into a provider error", async () => {

--- a/apps/worker/tests/features/exchange-rates/service.test.ts
+++ b/apps/worker/tests/features/exchange-rates/service.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  EXCHANGE_RATE_API_URL,
+  ExchangeRateProviderError,
+  refreshExchangeRates,
+} from "../../../src/features/exchange-rates/service";
+
+function createDb(results: unknown[] = []) {
+  const calls: Array<{ sql: string; values: unknown[] }> = [];
+  const batches: unknown[][] = [];
+  const db = {
+    prepare(sql: string) {
+      const statement = {
+        bind(...values: unknown[]) {
+          calls.push({ sql, values });
+          return statement;
+        },
+        async all() {
+          return { results };
+        },
+      };
+      return statement;
+    },
+    async batch(statements: unknown[]) {
+      batches.push(statements);
+      return [];
+    },
+  } as unknown as D1Database;
+  return { db, calls, batches };
+}
+
+const providerPayload = {
+  result: "success",
+  base_code: "TWD",
+  time_last_update_unix: 1_785_628_951,
+  rates: {
+    USD: 0.030952,
+    JPY: 4.915215,
+    EUR: 0.026897,
+  },
+};
+
+describe("refreshExchangeRates", () => {
+  it("converts the TWD-base response into the app's TWD rates", async () => {
+    const { db, calls, batches } = createDb([
+      {
+        currency: "USD",
+        rateTwd: 32.3076,
+        updatedAt: "2026-08-02T00:02:31.000Z",
+      },
+      {
+        currency: "JPY",
+        rateTwd: 0.20345,
+        updatedAt: "2026-08-02T00:02:31.000Z",
+      },
+      {
+        currency: "EUR",
+        rateTwd: 37.1796,
+        updatedAt: "2026-08-02T00:02:31.000Z",
+      },
+    ]);
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(providerPayload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await refreshExchangeRates(db, fetcher);
+
+    expect(fetcher).toHaveBeenCalledWith(
+      EXCHANGE_RATE_API_URL,
+      expect.objectContaining({
+        headers: { Accept: "application/json" },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(batches).toHaveLength(1);
+    expect(
+      calls
+        .filter(({ sql }) => sql.includes("INSERT INTO exchange_rates"))
+        .map(({ values }) => values.slice(0, 2)),
+    ).toEqual([
+      ["USD", 1 / providerPayload.rates.USD],
+      ["JPY", 1 / providerPayload.rates.JPY],
+      ["EUR", 1 / providerPayload.rates.EUR],
+    ]);
+    expect(calls[0]?.values[2]).toBe("2026-08-02T00:02:31.000Z");
+  });
+
+  it("does not write partial data when a required currency is missing", async () => {
+    const { db, batches } = createDb();
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ...providerPayload,
+          rates: {
+            USD: providerPayload.rates.USD,
+            JPY: providerPayload.rates.JPY,
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(refreshExchangeRates(db, fetcher)).rejects.toBeInstanceOf(
+      ExchangeRateProviderError,
+    );
+    expect(batches).toHaveLength(0);
+  });
+
+  it("turns provider HTTP failures into a provider error", async () => {
+    const { db, batches } = createDb();
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(new Response("", { status: 429 }));
+
+    await expect(refreshExchangeRates(db, fetcher)).rejects.toBeInstanceOf(
+      ExchangeRateProviderError,
+    );
+    expect(batches).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## 摘要

- 將匯率更新來源改為 ExchangeRate-API 的 TWD base endpoint。
- 匯率頁固定顯示 USD、JPY、EUR，改為唯讀並支援手動更新。
- 顯示資料來源與最後更新時間，匯率畫面取到小數點後第二位。
- 避免髒幣別資料出現在匯率清單。

## 實作細節

- 新增 `POST /api/exchange-rates/refresh` 手動抓取並寫入三種匯率。
- 將外部回傳的「1 TWD = 外幣」反轉為系統使用的「1 外幣 = TWD」。
- 外部資料驗證失敗時不寫入部分資料，並回傳可辨識的 provider error。
- 移除匯率手動輸入與 PUT 更新流程；第一階段不加入 Cron 自動更新。
- 桌面版將資料來源與最後更新移到更新按鈕左側，手機版保留於卡片底部。

## 驗證

- Worker typecheck、194 個 Worker tests
- Web typecheck、62 個 Web unit tests
- 14 個 Playwright E2E tests
- Web build
- Svelte autofixer、format check、git diff check