### PR TITLE
修正活動分類篩選取消後仍保留支出篩選

### DIFF
--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -467,11 +467,14 @@
       selectedCategory?.flow === flow &&
       selectedCategory.category === category
     ) {
-      selectedCategory = null;
+      clearCategoryFilter();
       return;
     }
     selectedCategory = { flow, category };
     chooseFlow(flow, false);
+  }
+  function clearCategoryFilter() {
+    chooseFlow("all");
   }
   function chooseFlow(nextFlow: ActivityFlowFilter, clearCategory = true) {
     flow = nextFlow;
@@ -806,7 +809,7 @@
                 : "支出"}</span
             ><button
               class="min-h-8 px-2 text-xs font-semibold text-steel"
-              onclick={() => (selectedCategory = null)}>清除分類</button
+              onclick={clearCategoryFilter}>清除分類</button
             >
           </div>{/if}
         <div class="grid min-w-0 gap-1.5">


### PR DESCRIPTION
## 變更內容

- 修正活動頁分類篩選再次點擊後仍保留「支出」方向篩選的問題。
- 分類再次點擊與「清除分類」按鈕統一回到所有活動狀態。
- 保留月份、來源與搜尋條件，不改動後端或資料處理。

## 問題原因

分類選取原本會同時設定 `selectedCategory` 與 `flow`；取消分類時只清除了 `selectedCategory`，導致 `flow` 仍是 `expense`，列表因此顯示支出篩選而非無篩選狀態。

## 驗證

- Svelte autofixer
- `svelte-check`：0 errors / 0 warnings
- 前端單元測試：19 files、62 tests passed
- Prettier check
- `git diff --check`
- Web build passed
- 依需求未新增或執行 E2E 測試