### PR TITLE
feat(其他資產): 支援多幣別估值

### DIFF
--- a/apps/web/src/data/assets/types.ts
+++ b/apps/web/src/data/assets/types.ts
@@ -16,6 +16,7 @@ export interface ManualAssetRow {
   name: string;
   category: string;
   note: string | null;
+  currency: string;
   createdAt: string;
   value?: number;
   date?: string;

--- a/apps/web/src/features/assets/AssetsPage.svelte
+++ b/apps/web/src/features/assets/AssetsPage.svelte
@@ -502,7 +502,7 @@
                   </p>
                 </div>
                 <p class="shrink-0 font-bold tabular-nums text-moss">
-                  {formatCurrency(item.value ?? 0)}
+                  {formatCurrency(item.value ?? 0, item.currency)}
                 </p></button
               >{/each}
           </div></CardContent

--- a/apps/web/src/features/assets/ManualAssets.svelte
+++ b/apps/web/src/features/assets/ManualAssets.svelte
@@ -17,6 +17,7 @@
   import type { ApiClient } from "@/shared/api/client";
   import { queryKeys } from "@/shared/api/query-keys";
   import {
+    exchangeRatesQuery,
     manualAssetHistoryQuery,
     manualAssetsQuery,
   } from "@/data/assets/queries";
@@ -30,6 +31,7 @@
   let { api }: { api: ApiClient } = $props();
   const qc = useQueryClient();
   const assets = createQuery(manualAssetsQuery(() => api));
+  const rates = createQuery(exchangeRatesQuery(() => api));
   let adding = $state(false);
   let editing = $state<ManualAssetRow | null>(null);
   let expandedAssetId = $state<string | null>(null);
@@ -37,9 +39,11 @@
   let historyDate = $state(todayStr());
   let editingHistoryDate = $state<string | null>(null);
   let editingHistoryValue = $state("");
+  let formError = $state("");
   let form = $state({
     name: "",
     category: "real_estate",
+    currency: "TWD",
     value: "",
     date: todayStr(),
     note: "",
@@ -50,8 +54,19 @@
     vehicle: "交通工具",
     other: "其他",
   };
+  const currencies = ["TWD", "USD", "JPY", "EUR"] as const;
+  const rateValues = $derived(
+    Object.fromEntries(
+      ($rates.data ?? []).map((rate) => [rate.currency, rate.rateTwd]),
+    ),
+  );
+  const toTwd = (value: number, currency: string) =>
+    currency === "TWD" ? value : value * (rateValues[currency] ?? 0);
   const total = $derived(
-    ($assets.data ?? []).reduce((s, a) => s + (a.value ?? 0), 0),
+    ($assets.data ?? []).reduce(
+      (sum, asset) => sum + toTwd(asset.value ?? 0, asset.currency),
+      0,
+    ),
   );
 
   const add = createMutation({
@@ -72,10 +87,12 @@
       api.put(`/api/manual-assets/${editing!.id}`, {
         name: form.name,
         category: form.category,
+        currency: form.currency,
         note: form.note || undefined,
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.manualAssets });
+      qc.invalidateQueries({ queryKey: queryKeys.netWorthHistory });
       editing = null;
       reset();
     },
@@ -129,26 +146,34 @@
   });
 
   function reset() {
+    formError = "";
     form = {
       name: "",
       category: "real_estate",
+      currency: "TWD",
       value: "",
       date: todayStr(),
       note: "",
     };
   }
   function startEdit(asset: ManualAssetRow) {
+    formError = "";
     editing = asset;
     form = {
       name: asset.name,
       category: asset.category,
+      currency: asset.currency,
       value: String(asset.value ?? ""),
       date: asset.date ?? todayStr(),
       note: asset.note ?? "",
     };
   }
   function submit() {
-    if (!form.name.trim() || !form.value) return;
+    if (!form.name.trim() || !form.value) {
+      formError = "請輸入資產名稱與目前估值。";
+      return;
+    }
+    formError = "";
     editing ? $update.mutate() : $add.mutate();
   }
   function invalidateHistory() {
@@ -203,14 +228,14 @@
                     <p class="truncate font-semibold">{asset.name}</p>
                     <p class="mt-1 text-xs text-ink/45">
                       {categories[asset.category as keyof typeof categories] ??
-                        asset.category} · {asset.date
+                        asset.category} · {asset.currency} · {asset.date
                         ? formatDate(asset.date)
                         : "尚未估值"}{asset.note ? ` · ${asset.note}` : ""}
                     </p>
                   </button>
                   <div class="flex items-center gap-3">
                     <p class="font-bold tabular-nums">
-                      {formatCurrency(asset.value ?? 0)}
+                      {formatCurrency(asset.value ?? 0, asset.currency)}
                     </p>
                     <button
                       class="rounded-sm p-1 text-ink/40 hover:text-steel"
@@ -270,7 +295,10 @@
                                 >
                               </div>{:else}<div class="flex items-center gap-2">
                                 <span class="font-medium"
-                                  >{formatCurrency(entry.value)}</span
+                                  >{formatCurrency(
+                                    entry.value,
+                                    asset.currency,
+                                  )}</span
                                 ><Button
                                   size="sm"
                                   variant="ghost"
@@ -297,7 +325,7 @@
                       class="mt-3 flex flex-wrap items-end gap-2 border-t border-ink/8 pt-3"
                     >
                       <label class="grid gap-1 text-xs text-ink/55"
-                        >估值<Input
+                        >估值（{asset.currency}）<Input
                           class="w-32"
                           type="number"
                           bind:value={historyValue}
@@ -349,7 +377,7 @@
           </div>
           <div class="mt-5 grid gap-3">
             <label class="grid gap-1 text-sm"
-              >名稱<Input bind:value={form.name} /></label
+              >名稱<Input required bind:value={form.name} /></label
             ><label class="grid gap-1 text-sm"
               >類別<Select bind:value={form.category}
                 >{#each Object.entries(categories) as [key, label] (key)}<option
@@ -357,12 +385,28 @@
                   >{/each}</Select
               ></label
             ><label class="grid gap-1 text-sm"
-              >目前估值<Input type="number" bind:value={form.value} /></label
+              >幣別<Select bind:value={form.currency}
+                >{#each currencies as currency (currency)}<option
+                    value={currency}>{currency}</option
+                  >{/each}</Select
+              ></label
+            ><label class="grid gap-1 text-sm"
+              >目前估值<Input
+                required
+                type="number"
+                bind:value={form.value}
+              /></label
             ><label class="grid gap-1 text-sm"
               >估值日期<Input type="date" bind:value={form.date} /></label
             ><label class="grid gap-1 text-sm"
               >備註<Textarea rows="2" bind:value={form.note} /></label
             >
+            {#if formError}<p
+                class="text-sm font-medium text-coral"
+                role="alert"
+              >
+                {formError}
+              </p>{/if}
           </div>
           <div class="mt-5 grid grid-cols-2 gap-3">
             <Button

--- a/apps/web/src/features/assets/model/summary.test.ts
+++ b/apps/web/src/features/assets/model/summary.test.ts
@@ -42,8 +42,9 @@ describe("calculateAssetSummary", () => {
           name: "房屋",
           category: "real_estate",
           note: null,
+          currency: "USD",
           createdAt: "2026-07-22",
-          value: 20_000,
+          value: 200,
         },
       ],
       rates: [{ currency: "USD", rateTwd: 30, updatedAt: "2026-07-22" }],
@@ -51,7 +52,7 @@ describe("calculateAssetSummary", () => {
 
     expect(summary.bankTotal).toBe(3_000);
     expect(summary.cardDebt).toBe(2_000);
-    expect(summary.netWorth).toBe(31_000);
+    expect(summary.netWorth).toBe(17_000);
     expect(summary.groupedBanks[0]?.institution).toBe("玉山銀行");
   });
 });

--- a/apps/web/src/features/assets/model/summary.ts
+++ b/apps/web/src/features/assets/model/summary.ts
@@ -54,7 +54,7 @@ export function calculateAssetSummary({
     0,
   );
   const manualTotal = manualAssets.reduce(
-    (sum, item) => sum + (item.value ?? 0),
+    (sum, item) => sum + toTwd(item.value ?? 0, item.currency),
     0,
   );
   const cardDebt = cards.reduce(

--- a/apps/web/src/features/overview/OverviewPage.svelte
+++ b/apps/web/src/features/overview/OverviewPage.svelte
@@ -101,7 +101,7 @@
   );
   const manualTotal = $derived(
     ($manualAssets.data ?? []).reduce(
-      (sum, item) => sum + (item.value ?? 0),
+      (sum, item) => sum + toTwd(item.value ?? 0, item.currency),
       0,
     ),
   );
@@ -218,9 +218,11 @@
   });
   const missingRates = $derived([
     ...new Set(
-      bankData.accounts
-        .map((account) => account.currency)
-        .filter((currency) => currency !== "TWD" && !rateValues[currency]),
+      [
+        ...bankData.accounts.map((account) => account.currency),
+        ...($investments.data ?? []).map((item) => item.currency),
+        ...($manualAssets.data ?? []).map((item) => item.currency),
+      ].filter((currency) => currency !== "TWD" && !rateValues[currency]),
     ),
   ]);
   const loading = $derived(
@@ -255,7 +257,7 @@
         class="flex items-center justify-between gap-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
       >
         <span
-          >帳戶含外幣（{missingRates.join("、")}）尚未設定匯率，TWD
+          >資產含外幣（{missingRates.join("、")}）尚未設定匯率，TWD
           總額可能不準確。</span
         >
         <button

--- a/apps/worker/src/features/manual-assets/repository.ts
+++ b/apps/worker/src/features/manual-assets/repository.ts
@@ -3,6 +3,7 @@ export type ManualAssetRow = {
   name: string;
   category: string;
   note: string | null;
+  currency: string;
   createdAt: string;
 };
 
@@ -15,7 +16,7 @@ export type ManualAssetHistoryRow = {
 export async function listManualAssets(db: D1Database) {
   const assets = await db
     .prepare(
-      `SELECT id, name, category, note, created_at AS createdAt
+      `SELECT id, name, category, note, currency, created_at AS createdAt
      FROM manual_assets
      ORDER BY created_at ASC`,
     )
@@ -43,6 +44,7 @@ export async function createManualAsset(
     name: string;
     category: string;
     note: string | null;
+    currency: string;
     value: number;
     date: string;
     now: string;
@@ -51,9 +53,16 @@ export async function createManualAsset(
   await db.batch([
     db
       .prepare(
-        `INSERT INTO manual_assets (id, name, category, note, created_at) VALUES (?, ?, ?, ?, ?)`,
+        `INSERT INTO manual_assets (id, name, category, note, currency, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
       )
-      .bind(input.id, input.name, input.category, input.note, input.now),
+      .bind(
+        input.id,
+        input.name,
+        input.category,
+        input.note,
+        input.currency,
+        input.now,
+      ),
     manualAssetHistoryUpsertStatement(
       db,
       input.id,
@@ -67,7 +76,12 @@ export async function createManualAsset(
 export async function updateManualAsset(
   db: D1Database,
   id: string,
-  input: { name?: string; category?: string; note?: string | null },
+  input: {
+    name?: string;
+    category?: string;
+    note?: string | null;
+    currency?: string;
+  },
 ) {
   const sets: string[] = [];
   const values: unknown[] = [];
@@ -82,6 +96,10 @@ export async function updateManualAsset(
   if ("note" in input) {
     sets.push("note = ?");
     values.push(input.note ?? null);
+  }
+  if (input.currency) {
+    sets.push("currency = ?");
+    values.push(input.currency);
   }
   await db
     .prepare(`UPDATE manual_assets SET ${sets.join(", ")} WHERE id = ?`)

--- a/apps/worker/src/features/manual-assets/route.ts
+++ b/apps/worker/src/features/manual-assets/route.ts
@@ -16,10 +16,12 @@ import {
 } from "./service";
 
 const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+const currencySchema = z.enum(["TWD", "USD", "JPY", "EUR"]);
 const createSchema = z.object({
   name: z.string().trim().min(1).max(120),
   category: z.string().trim().min(1).max(64),
   note: z.string().max(1_000).optional(),
+  currency: currencySchema.default("TWD"),
   value: z.number().finite(),
   date: isoDateSchema,
 });
@@ -28,6 +30,7 @@ const updateSchema = z
     name: z.string().trim().min(1).max(120).optional(),
     category: z.string().trim().min(1).max(64).optional(),
     note: z.string().max(1_000).nullable().optional(),
+    currency: currencySchema.optional(),
   })
   .refine((body) => Object.keys(body).length > 0);
 const historySchema = z.object({

--- a/apps/worker/src/features/manual-assets/service.ts
+++ b/apps/worker/src/features/manual-assets/service.ts
@@ -26,6 +26,7 @@ export async function addManualAsset(
     name: string;
     category: string;
     note?: string;
+    currency: string;
     value: number;
     date: string;
   },
@@ -43,7 +44,12 @@ export async function addManualAsset(
 export function editManualAsset(
   db: D1Database,
   id: string,
-  input: { name?: string; category?: string; note?: string | null },
+  input: {
+    name?: string;
+    category?: string;
+    note?: string | null;
+    currency?: string;
+  },
 ) {
   return updateManualAssetRecord(db, id, input);
 }

--- a/apps/worker/src/features/net-worth/repository.ts
+++ b/apps/worker/src/features/net-worth/repository.ts
@@ -8,12 +8,29 @@ export type NetWorthPageCursor = {
 export async function listNetWorthChartHistory(db: D1Database) {
   const result = await db
     .prepare(
-      `SELECT date, net_worth AS netWorth, asset_type AS assetType, source
-       FROM net_worth_history
-       WHERE source = 'manual'
-          OR (source = 'bank' AND asset_type = 'deposit')
-          OR asset_type IN ('stock', 'fund')
-       ORDER BY date ASC, source ASC, asset_type ASC, id ASC`,
+      `SELECT
+         history.date,
+         CASE
+           WHEN history.source != 'manual' OR asset.currency = 'TWD'
+             THEN history.net_worth
+           WHEN rate.rate_to_twd IS NOT NULL
+             THEN history.net_worth * rate.rate_to_twd
+           ELSE 0
+         END AS netWorth,
+         history.asset_type AS assetType,
+         history.source
+       FROM net_worth_history history
+       LEFT JOIN manual_assets asset
+         ON history.source = 'manual' AND asset.id = history.asset_type
+       LEFT JOIN exchange_rates rate ON rate.currency = asset.currency
+       WHERE history.source = 'manual'
+          OR (history.source = 'bank' AND history.asset_type = 'deposit')
+          OR history.asset_type IN ('stock', 'fund')
+       ORDER BY
+         history.date ASC,
+         history.source ASC,
+         history.asset_type ASC,
+         history.id ASC`,
     )
     .all<{
       date: string;

--- a/apps/worker/tests/features/net-worth/repository.test.ts
+++ b/apps/worker/tests/features/net-worth/repository.test.ts
@@ -1,0 +1,72 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { listNetWorthChartHistory } from "../../../src/features/net-worth/repository";
+
+class SqliteQueryStatement {
+  constructor(
+    private readonly database: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  async all<T>() {
+    return { results: this.database.prepare(this.sql).all() as T[] };
+  }
+}
+
+const databases: DatabaseSync[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+describe("net worth repository", () => {
+  it("converts manual asset history from its original currency to TWD", async () => {
+    const database = new DatabaseSync(":memory:");
+    databases.push(database);
+    database.exec(`
+      CREATE TABLE manual_assets (
+        id TEXT PRIMARY KEY,
+        currency TEXT NOT NULL
+      );
+      CREATE TABLE exchange_rates (
+        currency TEXT PRIMARY KEY,
+        rate_to_twd REAL NOT NULL
+      );
+      CREATE TABLE net_worth_history (
+        id TEXT PRIMARY KEY,
+        date TEXT NOT NULL,
+        net_worth REAL NOT NULL,
+        asset_type TEXT NOT NULL,
+        source TEXT NOT NULL
+      );
+      INSERT INTO manual_assets (id, currency)
+      VALUES ('manual:usd-policy', 'USD'), ('manual:home', 'TWD');
+      INSERT INTO exchange_rates (currency, rate_to_twd) VALUES ('USD', 32);
+      INSERT INTO net_worth_history
+        (id, date, net_worth, asset_type, source)
+      VALUES
+        ('usd', '2026-08-01', 100, 'manual:usd-policy', 'manual'),
+        ('twd', '2026-08-01', 5000, 'manual:home', 'manual');
+    `);
+    const db = {
+      prepare(sql: string) {
+        return new SqliteQueryStatement(database, sql);
+      },
+    } as unknown as D1Database;
+
+    await expect(listNetWorthChartHistory(db)).resolves.toEqual([
+      {
+        date: "2026-08-01",
+        netWorth: 5000,
+        assetType: "manual:home",
+        source: "manual",
+      },
+      {
+        date: "2026-08-01",
+        netWorth: 3200,
+        assetType: "manual:usd-policy",
+        source: "manual",
+      },
+    ]);
+  });
+});

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -11,7 +11,7 @@
 - Tables：24
 - Explicit indexes：31
 - Other objects：0
-- Migrations：19
+- Migrations：22
 
 ## Tables
 
@@ -32,7 +32,7 @@
 | [`invoice_line_items`](#invoice_line_items) | 電子發票底下的商品或服務明細。 | 13 | 1 | 2 |
 | [`invoice_transaction_preferences`](#invoice_transaction_preferences) | 使用者對電子發票與銀行交易是否關聯的決策。 | 5 | 0 | 1 |
 | [`invoices`](#invoices) | 電子發票的抬頭與總額主檔。 | 10 | 0 | 2 |
-| [`manual_assets`](#manual_assets) | 使用者手動登錄、無法由銀行或投資連接器同步的資產。 | 5 | 0 | 0 |
+| [`manual_assets`](#manual_assets) | 使用者手動登錄、無法由銀行或投資連接器同步的資產。 | 6 | 0 | 0 |
 | [`net_worth_history`](#net_worth_history) | 按日期保存的淨資產或資產類別歷史數值，用於圖表與歷史查詢。 | 6 | 0 | 2 |
 | [`notification_preferences`](#notification_preferences) | 此單一部署的同步推播偏好設定。 | 5 | 0 | 0 |
 | [`push_subscriptions`](#push_subscriptions) | 瀏覽器 Web Push 裝置訂閱資料。 | 6 | 0 | 0 |
@@ -820,6 +820,7 @@ CREATE TABLE invoices (
 | 3 | `category` | 資產分類，例如房產、現金或其他。 | TEXT | NO | — | — | — |
 | 4 | `note` | 使用者補充的備註。 | TEXT | YES | — | — | — |
 | 5 | `created_at` | 手動資產建立的時間。 | TEXT | NO | — | — | — |
+| 6 | `currency` | 資產估值使用的幣別，預設為 TWD。 | TEXT | NO | 'TWD' | — | — |
 
 #### Foreign keys
 
@@ -838,7 +839,7 @@ CREATE TABLE manual_assets (
   category TEXT NOT NULL,
   note TEXT,
   created_at TEXT NOT NULL
-)
+, currency TEXT NOT NULL DEFAULT 'TWD')
 ```
 
 ### `net_worth_history`
@@ -852,7 +853,7 @@ CREATE TABLE manual_assets (
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
 | 1 | `id` | 歷史點的系統識別碼。 | TEXT | YES | — | 1 | — |
 | 2 | `date` | 此數值所代表的日期。 | TEXT | NO | — | — | — |
-| 3 | `net_worth` | 該日期與資產類型的金額，通常以 TWD 表示。 | INTEGER | NO | — | — | — |
+| 3 | `net_worth` | 該日期與資產類型的金額；手動資產保留其設定幣別，其餘讀模型通常以 TWD 表示。 | INTEGER | NO | — | — | — |
 | 4 | `asset_type` | 資產類型，例如 total、deposit、stock、fund 或手動資產 id。 | TEXT | NO | 'total' | — | — |
 | 5 | `source` | 數值來源，例如 bank 或 manual。 | TEXT | NO | — | — | — |
 | 6 | `snapshotted_at` | 此歷史點實際建立或重算的時間。 | TEXT | NO | — | — | — |
@@ -1195,6 +1196,9 @@ Migration 是 schema 演進的 source of truth；若要了解某欄位的變更�
 - [`0018_esun_credit_transaction_signs.sql`](../packages/db/migrations/0018_esun_credit_transaction_signs.sql)
 - [`0019_rename_other_classification.sql`](../packages/db/migrations/0019_rename_other_classification.sql)
 - [`0020_connector_cursor_secret_cleanup.sql`](../packages/db/migrations/0020_connector_cursor_secret_cleanup.sql)
+- [`0021_ctbc_sync_job.sql`](../packages/db/migrations/0021_ctbc_sync_job.sql)
+- [`0023_disable_unconfigured_sync_jobs.sql`](../packages/db/migrations/0023_disable_unconfigured_sync_jobs.sql)
+- [`0024_manual_asset_currency.sql`](../packages/db/migrations/0024_manual_asset_currency.sql)
 
 ## 程式碼導覽
 

--- a/packages/db/migrations/0024_manual_asset_currency.sql
+++ b/packages/db/migrations/0024_manual_asset_currency.sql
@@ -1,0 +1,1 @@
+ALTER TABLE manual_assets ADD COLUMN currency TEXT NOT NULL DEFAULT 'TWD';

--- a/packages/db/schema-metadata.json
+++ b/packages/db/schema-metadata.json
@@ -259,6 +259,7 @@
         "name": "前端顯示的資產名稱。",
         "category": "資產分類，例如房產、現金或其他。",
         "note": "使用者補充的備註。",
+        "currency": "資產估值使用的幣別，預設為 TWD。",
         "created_at": "手動資產建立的時間。"
       }
     },
@@ -268,7 +269,7 @@
       "columns": {
         "id": "歷史點的系統識別碼。",
         "date": "此數值所代表的日期。",
-        "net_worth": "該日期與資產類型的金額，通常以 TWD 表示。",
+        "net_worth": "該日期與資產類型的金額；手動資產保留其設定幣別，其餘讀模型通常以 TWD 表示。",
         "asset_type": "資產類型，例如 total、deposit、stock、fund 或手動資產 id。",
         "source": "數值來源，例如 bank 或 manual。",
         "snapshotted_at": "此歷史點實際建立或重算的時間。"


### PR DESCRIPTION
## Description

- 其他資產新增 TWD、USD、JPY、EUR 幣別選擇，既有資料預設為 TWD。
- 清單與估值歷史保留原幣顯示，資產總額、總覽與淨值圖表依匯率換算為 TWD。
- 新增 `manual_assets.currency` migration、API 驗證與外幣換算測試。
- 修正估值未填寫時儲存按鈕無回饋的表單提示。
- 修正編輯其他資產時估值與估值日期未送出，現在會同步更新估值歷史。

## Architecture

- 前端 `ManualAssets.svelte` 送出幣別、估值與日期，`data/assets` 型別承載 API 回應。
- Worker `manual-assets/route.ts` 驗證更新資料，`service.ts` 傳遞 use case 與時間，`repository.ts` 以 batch 同步更新 `manual_assets` 與 `net_worth_history`。
- 資產摘要與總覽沿用匯率 map 換算；淨值圖表 repository 讀取手動資產幣別與 `exchange_rates` 後輸出 TWD 值。
- DB 以 `0024_manual_asset_currency.sql` 對既有資料套用 `TWD` default。

## Breaking Changes (optional)

無。既有其他資產會自動視為 TWD；新增 API request 未提供幣別時也預設為 TWD。更新估值時 `value` 與 `date` 必須一併提供。

## Test & Risk

- `npm run format:check`：通過。
- `npm run typecheck -w @taiwan-fin-hub/web`、`npm run typecheck -w @taiwan-fin-hub/worker`：通過。
- `npm run test:unit -w @taiwan-fin-hub/web`：19 個 test files、62 tests 通過。
- `npm test -w @taiwan-fin-hub/worker`：34 個 test files、196 tests 通過，包含編輯估值歷史的 regression test。
- `npm test -w @taiwan-fin-hub/db`：4 tests 通過。
- `npm run verify:web`：前端型別檢查、62 tests、14 項 Playwright E2E 與 production build 通過。
- Regression scope：其他資產 CRUD、估值歷史、資產總覽/摘要、淨值圖表、資料庫 migration；外幣匯率缺失時沿用既有換算策略。
- 待手動確認：編輯既有資產後，清單目前估值、幣別與估值歷史均同步更新。

## Checklist

- [x] 代碼符合本專案風格 (Lint / Formatter 通過)
- [x] 自我 Review 並移除無用程式、除錯訊息
- [x] 文件 / Release Note 已更新
- [ ] 無新增 ESLint / Lint 警告
- [ ] 相依變更（API、DB、Config）已通知利害關係人
- [ ] 拼字檢查通過