### PR TITLE
fix(其他資產): 修正編輯估值未更新

### DIFF
--- a/apps/web/src/features/assets/ManualAssets.svelte
+++ b/apps/web/src/features/assets/ManualAssets.svelte
@@ -88,7 +88,9 @@
         name: form.name,
         category: form.category,
         currency: form.currency,
-        note: form.note || undefined,
+        note: form.note || null,
+        value: Number(form.value),
+        date: form.date,
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.manualAssets });

--- a/apps/worker/src/features/manual-assets/repository.ts
+++ b/apps/worker/src/features/manual-assets/repository.ts
@@ -81,7 +81,10 @@ export async function updateManualAsset(
     category?: string;
     note?: string | null;
     currency?: string;
+    value?: number;
+    date?: string;
   },
+  now: string,
 ) {
   const sets: string[] = [];
   const values: unknown[] = [];
@@ -101,10 +104,20 @@ export async function updateManualAsset(
     sets.push("currency = ?");
     values.push(input.currency);
   }
-  await db
-    .prepare(`UPDATE manual_assets SET ${sets.join(", ")} WHERE id = ?`)
-    .bind(...values, id)
-    .run();
+  const statements: D1PreparedStatement[] = [];
+  if (sets.length > 0) {
+    statements.push(
+      db
+        .prepare(`UPDATE manual_assets SET ${sets.join(", ")} WHERE id = ?`)
+        .bind(...values, id),
+    );
+  }
+  if (input.value !== undefined && input.date !== undefined) {
+    statements.push(
+      manualAssetHistoryUpsertStatement(db, id, input.date, input.value, now),
+    );
+  }
+  if (statements.length > 0) await db.batch(statements);
 }
 
 export async function deleteManualAsset(db: D1Database, id: string) {

--- a/apps/worker/src/features/manual-assets/route.ts
+++ b/apps/worker/src/features/manual-assets/route.ts
@@ -31,8 +31,16 @@ const updateSchema = z
     category: z.string().trim().min(1).max(64).optional(),
     note: z.string().max(1_000).nullable().optional(),
     currency: currencySchema.optional(),
+    value: z.number().finite().optional(),
+    date: isoDateSchema.optional(),
   })
-  .refine((body) => Object.keys(body).length > 0);
+  .refine((body) => Object.keys(body).length > 0)
+  .refine(
+    (body) =>
+      (body.value === undefined && body.date === undefined) ||
+      (body.value !== undefined && body.date !== undefined),
+    "value and date must be provided together.",
+  );
 const historySchema = z.object({
   value: z.number().finite(),
   date: isoDateSchema,

--- a/apps/worker/src/features/manual-assets/service.ts
+++ b/apps/worker/src/features/manual-assets/service.ts
@@ -49,9 +49,11 @@ export function editManualAsset(
     category?: string;
     note?: string | null;
     currency?: string;
+    value?: number;
+    date?: string;
   },
 ) {
-  return updateManualAssetRecord(db, id, input);
+  return updateManualAssetRecord(db, id, input, new Date().toISOString());
 }
 
 export function removeManualAsset(db: D1Database, id: string) {

--- a/apps/worker/tests/features/manual-assets/repository.test.ts
+++ b/apps/worker/tests/features/manual-assets/repository.test.ts
@@ -1,0 +1,98 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { updateManualAsset } from "../../../src/features/manual-assets/repository";
+
+class SqliteQueryStatement {
+  private values: unknown[] = [];
+
+  constructor(
+    private readonly database: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: unknown[]) {
+    this.values = values;
+    return this;
+  }
+
+  async run() {
+    this.database.prepare(this.sql).run(...(this.values as never[]));
+  }
+}
+
+const databases: DatabaseSync[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+describe("manual asset repository", () => {
+  it("updates asset metadata and its current valuation atomically", async () => {
+    const database = new DatabaseSync(":memory:");
+    databases.push(database);
+    database.exec(`
+      CREATE TABLE manual_assets (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        category TEXT NOT NULL,
+        note TEXT,
+        currency TEXT NOT NULL
+      );
+      CREATE TABLE net_worth_history (
+        id TEXT PRIMARY KEY,
+        date TEXT NOT NULL,
+        net_worth REAL NOT NULL,
+        asset_type TEXT NOT NULL,
+        source TEXT NOT NULL,
+        snapshotted_at TEXT NOT NULL,
+        UNIQUE(source, asset_type, date)
+      );
+      INSERT INTO manual_assets (id, name, category, note, currency)
+      VALUES ('manual:home', '舊名稱', 'real_estate', '舊備註', 'TWD');
+      INSERT INTO net_worth_history
+        (id, date, net_worth, asset_type, source, snapshotted_at)
+      VALUES
+        ('manual:manual:home:2026-08-01', '2026-08-01', 100, 'manual:home', 'manual', '2026-08-01T00:00:00.000Z');
+    `);
+    const db = {
+      prepare(sql: string) {
+        return new SqliteQueryStatement(database, sql);
+      },
+      async batch(statements: SqliteQueryStatement[]) {
+        for (const statement of statements) await statement.run();
+      },
+    } as unknown as D1Database;
+
+    await updateManualAsset(
+      db,
+      "manual:home",
+      {
+        name: "新名稱",
+        note: null,
+        currency: "USD",
+        value: 125,
+        date: "2026-08-03",
+      },
+      "2026-08-03T12:00:00.000Z",
+    );
+
+    expect(database.prepare("SELECT * FROM manual_assets").get()).toMatchObject(
+      {
+        name: "新名稱",
+        note: null,
+        currency: "USD",
+      },
+    );
+    expect(
+      database
+        .prepare(
+          "SELECT date, net_worth, snapshotted_at FROM net_worth_history WHERE date = '2026-08-03'",
+        )
+        .get(),
+    ).toEqual({
+      date: "2026-08-03",
+      net_worth: 125,
+      snapshotted_at: "2026-08-03T12:00:00.000Z",
+    });
+  });
+});


### PR DESCRIPTION
## Description

- 修正編輯其他資產時，估值與估值日期未送到 API 的問題。
- 更新 API 接受 `value` 與 `date`，並要求兩者成對提供。
- 以單一 D1 batch 同步更新資產欄位與 `net_worth_history`，確保編輯後清單與歷史一致。

## Architecture

- `ManualAssets.svelte` 將編輯表單的估值與日期送至 `PUT /api/manual-assets/:id`。
- `manual-assets/route.ts` 以 Zod 驗證 `value`/`date`；`service.ts` 提供更新時間；`repository.ts` 組合 metadata update 與 history upsert statements 後以 D1 batch 執行。

## Breaking Changes (optional)

更新 API 若只提供 `value` 或只提供 `date` 會回傳驗證錯誤；既有只更新名稱、類別、備註或幣別的 request 仍可使用。

## Test & Risk

- `npm run format:check`：通過。
- `npm run typecheck -w @taiwan-fin-hub/web`、`npm run typecheck -w @taiwan-fin-hub/worker`：通過。
- `npm run test:unit -w @taiwan-fin-hub/web`：19 個 test files、62 tests 通過。
- `npm test -w @taiwan-fin-hub/worker`：34 個 test files、196 tests 通過，包含估值更新 regression test。
- Regression scope：其他資產編輯、估值歷史、資產總覽與淨值圖表。
- 待手動確認：編輯既有資產後，清單目前估值、幣別與估值歷史均同步更新。

## Checklist

- [x] 代碼符合本專案風格 (Lint / Formatter 通過)
- [x] 自我 Review 並移除無用程式、除錯訊息
- [ ] 文件 / Release Note 已更新
- [ ] 無新增 ESLint / Lint 警告
- [ ] 相依變更（API、DB、Config）已通知利害關係人
- [ ] 拼字檢查通過