### PR TITLE
啟用 Cloudflare Workers Logs

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -29,3 +29,11 @@ database_name = "taiwan-fin-hub"
 # database_id is intentionally omitted from this public configuration.
 # Cloudflare automatically provisions or resolves the D1 binding on deploy.
 migrations_dir = "packages/db/migrations"
+
+[observability]
+enabled = true
+head_sampling_rate = 1
+
+[observability.logs]
+enabled = true
+invocation_logs = true


### PR DESCRIPTION
## 變更內容

- 在 `wrangler.toml` 啟用 Workers Observability
- 將 log head sampling rate 設為 100%
- 明確啟用 logs 與 invocation logs

## 原因

先前只在 Cloudflare Dashboard 開啟 logs，但 Wrangler 部署會以專案設定檔作為 source of truth。由於 `wrangler.toml` 沒有保存 Observability 設定，後續部署可能使 Dashboard 設定再次消失。

## 影響

後續部署會持續保存 Worker invocation logs 與程式輸出的 custom logs，方便追查 Cron、Queue 與連接器同步失敗。

## 驗證

- `git diff --check`
- `wrangler deploy --dry-run -c wrangler.toml`
- `wrangler deploy --dry-run -c wrangler.private.toml`
- `npm run deploy -w @taiwan-fin-hub/worker`
  - Svelte check：0 errors、0 warnings
  - Vite build：通過
  - 遠端 D1 migration：無待套用 migration
  - Worker 部署成功，D1、Browser、AI、Queue、Assets bindings 均保留