### PR TITLE
調整估值歷史排序並新增刪除防呆

### DIFF
--- a/apps/web/src/features/assets/ManualAssets.svelte
+++ b/apps/web/src/features/assets/ManualAssets.svelte
@@ -39,6 +39,12 @@
   let historyDate = $state(todayStr());
   let editingHistoryDate = $state<string | null>(null);
   let editingHistoryValue = $state("");
+  let deletingAsset = $state<ManualAssetRow | null>(null);
+  let deletingHistory = $state<{
+    assetId: string;
+    assetName: string;
+    date: string;
+  } | null>(null);
   let formError = $state("");
   let form = $state({
     name: "",
@@ -104,6 +110,7 @@
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.manualAssets });
       qc.invalidateQueries({ queryKey: queryKeys.netWorthHistory });
+      deletingAsset = null;
     },
   });
   const history = createQuery(
@@ -144,7 +151,10 @@
   const deleteHistory = createMutation({
     mutationFn: ({ assetId, date }: { assetId: string; date: string }) =>
       api.delete(`/api/manual-assets/${assetId}/history/${date}`),
-    onSuccess: invalidateHistory,
+    onSuccess: () => {
+      invalidateHistory();
+      deletingHistory = null;
+    },
   });
 
   function reset() {
@@ -247,7 +257,7 @@
                     ><button
                       class="rounded-sm p-1 text-ink/40 hover:text-coral"
                       aria-label="刪除資產"
-                      onclick={() => $remove.mutate(asset.id)}
+                      onclick={() => (deletingAsset = asset)}
                       ><Trash2 class="size-4" /></button
                     >
                   </div>
@@ -313,8 +323,9 @@
                                   size="sm"
                                   variant="ghost"
                                   onclick={() =>
-                                    $deleteHistory.mutate({
+                                    (deletingHistory = {
                                       assetId: asset.id,
+                                      assetName: asset.name,
                                       date: entry.date,
                                     })}>刪除</Button
                                 >
@@ -423,6 +434,53 @@
               >{$add.isPending || $update.isPending
                 ? "儲存中…"
                 : "儲存"}</Button
+            >
+          </div>
+        </div>
+      </div>{/if}
+    {#if deletingAsset || deletingHistory}<div
+        class="fixed inset-0 z-[80] flex items-center justify-center bg-ink/45 p-5"
+      >
+        <div
+          aria-labelledby="delete-confirmation-title"
+          aria-modal="true"
+          class="w-full max-w-sm rounded-2xl bg-white p-5 shadow-2xl"
+          role="dialog"
+        >
+          <h2 id="delete-confirmation-title" class="text-lg font-semibold">
+            {deletingAsset ? "確定刪除資產？" : "確定刪除估值？"}
+          </h2>
+          <p class="mt-2 text-sm leading-6 text-ink/60">
+            {#if deletingAsset}
+              「{deletingAsset.name}」與全部估值歷史將永久刪除，無法復原。
+            {:else if deletingHistory}
+              「{deletingHistory.assetName}」在 {formatDate(
+                deletingHistory.date,
+              )} 的估值將永久刪除，無法復原。
+            {/if}
+          </p>
+          <div class="mt-5 grid grid-cols-2 gap-3">
+            <Button
+              variant="secondary"
+              disabled={$remove.isPending || $deleteHistory.isPending}
+              onclick={() => {
+                deletingAsset = null;
+                deletingHistory = null;
+              }}>取消</Button
+            ><Button
+              class="bg-coral text-white hover:bg-coral/90"
+              disabled={$remove.isPending || $deleteHistory.isPending}
+              onclick={() => {
+                if (deletingAsset) $remove.mutate(deletingAsset.id);
+                else if (deletingHistory)
+                  $deleteHistory.mutate({
+                    assetId: deletingHistory.assetId,
+                    date: deletingHistory.date,
+                  });
+              }}
+              >{$remove.isPending || $deleteHistory.isPending
+                ? "刪除中…"
+                : "確認刪除"}</Button
             >
           </div>
         </div>

--- a/apps/worker/src/features/manual-assets/repository.ts
+++ b/apps/worker/src/features/manual-assets/repository.ts
@@ -137,7 +137,7 @@ export async function listManualAssetHistory(db: D1Database, id: string) {
       `SELECT date, net_worth AS value
      FROM net_worth_history
      WHERE source = 'manual' AND asset_type = ?
-     ORDER BY date DESC`,
+     ORDER BY date ASC`,
     )
     .bind(id)
     .all<{ date: string; value: number }>();

--- a/apps/worker/tests/features/manual-assets/repository.test.ts
+++ b/apps/worker/tests/features/manual-assets/repository.test.ts
@@ -1,6 +1,9 @@
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
-import { updateManualAsset } from "../../../src/features/manual-assets/repository";
+import {
+  listManualAssetHistory,
+  updateManualAsset,
+} from "../../../src/features/manual-assets/repository";
 
 class SqliteQueryStatement {
   private values: unknown[] = [];
@@ -18,6 +21,14 @@ class SqliteQueryStatement {
   async run() {
     this.database.prepare(this.sql).run(...(this.values as never[]));
   }
+
+  async all<T>() {
+    return {
+      results: this.database
+        .prepare(this.sql)
+        .all(...(this.values as never[])) as T[],
+    };
+  }
 }
 
 const databases: DatabaseSync[] = [];
@@ -27,6 +38,36 @@ afterEach(() => {
 });
 
 describe("manual asset repository", () => {
+  it("lists valuation history from oldest to newest", async () => {
+    const database = new DatabaseSync(":memory:");
+    databases.push(database);
+    database.exec(`
+      CREATE TABLE net_worth_history (
+        id TEXT PRIMARY KEY,
+        date TEXT NOT NULL,
+        net_worth REAL NOT NULL,
+        asset_type TEXT NOT NULL,
+        source TEXT NOT NULL,
+        snapshotted_at TEXT NOT NULL
+      );
+      INSERT INTO net_worth_history
+        (id, date, net_worth, asset_type, source, snapshotted_at)
+      VALUES
+        ('new', '2026-08-03', 4790, 'manual:stock', 'manual', '2026-08-03T00:00:00.000Z'),
+        ('old', '2025-03-03', 3031, 'manual:stock', 'manual', '2025-03-03T00:00:00.000Z');
+    `);
+    const db = {
+      prepare(sql: string) {
+        return new SqliteQueryStatement(database, sql);
+      },
+    } as unknown as D1Database;
+
+    await expect(listManualAssetHistory(db, "manual:stock")).resolves.toEqual([
+      { date: "2025-03-03", value: 3031 },
+      { date: "2026-08-03", value: 4790 },
+    ]);
+  });
+
   it("updates asset metadata and its current valuation atomically", async () => {
     const database = new DatabaseSync(":memory:");
     databases.push(database);


### PR DESCRIPTION
## 變更內容

- 將其他資產的估值歷史查詢改為日期升冪排序
- 新增 repository 回歸測試，確認資料一律由舊到新回傳
- 刪除資產前顯示二次確認，明確提醒資產與全部估值歷史將永久刪除
- 刪除單筆估值前顯示資產名稱與估值日期
- 刪除進行中停用操作按鈕，避免重複送出

## 原因

估值歷史 API 原本使用 `ORDER BY date DESC`，導致畫面顯示為新到舊。同時，資產及估值的刪除按鈕原本會立即呼叫 API，容易因誤觸造成不可復原的資料刪除。

## 影響

- 估值歷史會從最舊日期依序顯示到最新日期
- 新增、編輯或重新載入後仍維持相同排序
- 資產與單筆估值必須經過明確確認才會刪除
- 取消確認不會送出刪除請求

## 驗證

- Worker 測試：35 個測試檔案、206 個測試全數通過
- Worker typecheck 通過
- Web typecheck：0 errors、0 warnings
- Web 單元測試：19 個測試檔案、65 個測試全數通過
- Svelte autofixer：無問題或建議
- localhost 手機版實測：
  - 資產刪除確認提示內容正確
  - 單筆估值刪除確認提示內容正確
  - 取消後資產及兩筆估值皆完整保留