### PR TITLE
重構資產清冊並修正信用卡帳戶狀態

### DIFF
--- a/apps/web/e2e/assets.spec.ts
+++ b/apps/web/e2e/assets.spec.ts
@@ -1,0 +1,268 @@
+import { expect, test } from "@playwright/test";
+
+const bankData = {
+  accounts: [
+    {
+      id: "taishin-deposit",
+      connectorId: "taishin",
+      sourceId: "deposit-812",
+      institutionName: "台新銀行",
+      bankCode: "812",
+      accountName: "薪轉戶",
+      accountType: "savings",
+      balance: 742_880,
+      currency: "TWD",
+      asOfAt: "2026-08-08T14:30:00+08:00",
+    },
+    {
+      id: "taishin-card",
+      connectorId: "taishin",
+      sourceId: "card-812",
+      institutionName: "台新銀行",
+      bankCode: "812",
+      accountName: "台新信用卡",
+      accountType: "credit",
+      balance: -10_060,
+      currency: "TWD",
+      paymentDueDate: "2026-08-20",
+    },
+    {
+      id: "obank-usd",
+      connectorId: "obank",
+      sourceId: "deposit-048",
+      institutionName: "王道銀行",
+      bankCode: "048",
+      accountName: "美元活存",
+      accountType: "savings",
+      balance: 1_000,
+      currency: "USD",
+      asOfAt: "2026-08-08T12:00:00+08:00",
+    },
+  ],
+  transactions: [],
+};
+
+test.beforeEach(async ({ page }) => {
+  const manualAssets = [
+    {
+      id: "home",
+      name: "自住房屋",
+      category: "real_estate",
+      note: null,
+      currency: "TWD",
+      createdAt: "2026-01-01",
+      value: 1_600_000,
+      date: "2026-08-03",
+    },
+  ];
+  const manualAssetHistory = new Map([
+    ["home", [{ date: "2026-08-03", value: 1_600_000 }]],
+  ]);
+  await page.route("**/api/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const method = route.request().method();
+    if (!path.startsWith("/api/")) {
+      await route.continue();
+      return;
+    }
+    let body: unknown;
+    if (path === "/api/runtime") body = { demoMode: true };
+    else if (path === "/api/bank") body = bankData;
+    else if (path === "/api/bank/bills")
+      body = [
+        {
+          id: "bill-1",
+          connectorId: "taishin",
+          accountId: "taishin-card",
+          sourceId: "bill-1",
+          billingPeriod: "2026-08",
+          statementAmount: 10_060,
+          isPaid: 0,
+          paymentDueDate: "2026-08-20",
+          currency: "TWD",
+        },
+        {
+          id: "bill-2",
+          connectorId: "taishin",
+          accountId: "taishin-card",
+          sourceId: "bill-2",
+          billingPeriod: "2026-07",
+          statementAmount: 8_000,
+          isPaid: null,
+          paymentDueDate: "2026-07-20",
+          currency: "TWD",
+        },
+      ];
+    else if (path === "/api/investments")
+      body = [
+        {
+          id: "0050",
+          assetType: "etf",
+          symbol: "0050",
+          name: "元大台灣50",
+          quantity: 1_000,
+          marketValue: 925_000,
+          currency: "TWD",
+          asOfDate: "2026-08-08",
+        },
+        {
+          id: "00878",
+          assetType: "etf",
+          symbol: "00878",
+          name: "國泰永續高股息",
+          quantity: 10_000,
+          marketValue: 268_800,
+          currency: "TWD",
+          asOfDate: "2026-08-08",
+        },
+      ];
+    else if (path === "/api/investment-transactions")
+      body = [
+        {
+          id: "trade-1",
+          connectorId: "tdcc",
+          accountId: "tdcc",
+          sourceId: "trade-1",
+          name: "元大台灣50",
+          assetType: "etf",
+          transactionName: "買進",
+          tradeDate: "2026-08-01",
+          quantity: 100,
+          currency: "TWD",
+        },
+      ];
+    else if (path === "/api/manual-assets" && method === "GET")
+      body = manualAssets;
+    else if (path === "/api/manual-assets" && method === "POST") {
+      const input = route.request().postDataJSON();
+      const id = `manual-${manualAssets.length + 1}`;
+      manualAssets.push({
+        id,
+        name: input.name,
+        category: input.category,
+        note: input.note || null,
+        currency: input.currency,
+        createdAt: "2026-08-09",
+        value: input.value,
+        date: input.date,
+      });
+      manualAssetHistory.set(id, [{ date: input.date, value: input.value }]);
+      body = { id };
+    } else if (
+      path.match(/^\/api\/manual-assets\/[^/]+\/history$/) &&
+      method === "GET"
+    ) {
+      const assetId = path.split("/")[3]!;
+      body = manualAssetHistory.get(assetId) ?? [];
+    } else if (path === "/api/exchange-rates")
+      body = [{ currency: "USD", rateTwd: 32, updatedAt: "2026-08-08" }];
+    else throw new Error(`Unexpected assets E2E request: ${path}`);
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+  });
+});
+
+test("uses the desktop asset ledger without losing detail workflows", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/#/assets");
+
+  await expect(
+    page.getByRole("heading", { name: "資產清冊", exact: true }),
+  ).toBeVisible();
+
+  const ledger = page
+    .locator('section[aria-label="資產清冊"]')
+    .filter({ visible: true });
+  await expect(ledger.getByText("薪轉戶", { exact: true })).toBeVisible();
+  await ledger.locator("summary").filter({ hasText: "查看信用卡帳單" }).click();
+  await expect(
+    ledger.getByText("2026-08 · 期限 2026/8/20 · 待繳"),
+  ).toBeVisible();
+  await expect(
+    ledger.getByText("2026-07 · 期限 2026/7/20 · 狀態未提供"),
+  ).toBeVisible();
+  await ledger.getByRole("button", { name: /^投資/ }).click();
+  await expect(
+    page.getByRole("heading", { name: "投資工作區", exact: true }),
+  ).toBeVisible();
+  await page.getByRole("tab", { name: "交易紀錄", exact: true }).click();
+  await expect(page.getByText("買進 · 2026/8/1")).toBeVisible();
+
+  await ledger.getByRole("button", { name: /^其他資產/ }).click();
+  await expect(page.getByText("自住房屋", { exact: true })).toBeVisible();
+  const manageHistory = ledger.getByRole("button", {
+    name: "管理估值歷史",
+    exact: true,
+  });
+  await manageHistory.click();
+  await expect(
+    ledger.getByRole("heading", { name: "估值歷史", exact: true }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/#\/assets$/);
+
+  const addAsset = ledger.getByRole("button", {
+    name: "新增資產",
+    exact: true,
+  });
+  await addAsset.click();
+  const editor = page.getByRole("dialog", { name: "新增資產" });
+  await expect(editor).toBeVisible();
+  await expect(editor.getByLabel("名稱")).toBeFocused();
+  await editor.getByLabel("名稱").fill("緊急預備金");
+  await editor.getByLabel("目前估值").fill("300000");
+  await editor.getByRole("button", { name: "儲存", exact: true }).click();
+  await expect(ledger.getByText("緊急預備金", { exact: true })).toBeVisible();
+  await expect(page).toHaveURL(/#\/assets$/);
+
+  await addAsset.click();
+  await page.keyboard.press("Escape");
+  await expect(editor).toBeHidden();
+  await expect(addAsset).toBeFocused();
+});
+
+test("keeps the mobile ledger readable and expandable", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/#/assets");
+
+  const taishin = page.getByRole("button", { name: /^台 台新銀行/ });
+  await expect(taishin).toHaveAttribute("aria-expanded", "true");
+  const ledger = page
+    .locator('section[aria-label="資產清冊"]')
+    .filter({ visible: true });
+  await expect(ledger.getByText("薪轉戶", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("信用卡負債", { exact: true }).first(),
+  ).toBeVisible();
+  await ledger.getByRole("button", { name: /^其他資產/ }).click();
+  await expect(
+    ledger.getByRole("button", { name: "管理估值歷史", exact: true }),
+  ).toBeHidden();
+  const homeAsset = ledger.getByRole("button", {
+    name: /^自住房屋/,
+  });
+  await homeAsset.click();
+  await expect(
+    ledger.getByRole("heading", { name: "估值歷史", exact: true }),
+  ).toBeVisible();
+  await homeAsset.click();
+  await expect(
+    ledger.getByRole("heading", { name: "估值歷史", exact: true }),
+  ).toBeHidden();
+  const addAsset = ledger.getByRole("button", {
+    name: "新增資產",
+    exact: true,
+  });
+  await addAsset.click();
+  await expect(page.getByRole("dialog", { name: "新增資產" })).toBeVisible();
+  await expect(page).toHaveURL(/#\/assets$/);
+  await page.keyboard.press("Escape");
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(
+    390,
+  );
+});

--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -78,7 +78,7 @@ test("loads the responsive shell and changes primary views", async ({
     .first()
     .click();
   await expect(
-    page.getByRole("heading", { name: "資產", exact: true }),
+    page.getByRole("heading", { name: "資產清冊", exact: true }),
   ).toBeVisible();
   await expect(page).toHaveURL(/#\/assets$/);
 
@@ -400,7 +400,7 @@ test("uses app-like scrolling and history only in standalone display mode", asyn
   await page.getByRole("button", { name: "資產", exact: true }).last().click();
   await expect(page).toHaveURL(/#\/assets$/);
   await expect(
-    page.getByRole("heading", { name: "資產", exact: true }),
+    page.getByRole("heading", { name: "資產清冊", exact: true }),
   ).toBeVisible();
   expect(await page.evaluate(() => window.history.length)).toBe(historyLength);
 });

--- a/apps/web/src/app/App.svelte
+++ b/apps/web/src/app/App.svelte
@@ -199,9 +199,11 @@
                         ? "資產總覽"
                         : primaryView === "activity"
                           ? "所有活動"
-                          : currentView.label}</span
+                          : (currentView.pageTitle ?? currentView.label)}</span
                   ><span class="hidden md:inline"
-                    >{detail?.label ?? currentView.label}</span
+                    >{detail?.label ??
+                      currentView.pageTitle ??
+                      currentView.label}</span
                   >
                 </h1>
               {/if}
@@ -234,7 +236,7 @@
         class="mx-auto max-w-[1440px] px-4 pb-5 pt-0 sm:px-6 md:py-5 xl:px-8 xl:py-6"
       >
         {#if view === "overview"}<Overview {api} {navigate} />
-        {:else if view === "assets"}<Assets {api} {navigate} />
+        {:else if view === "assets"}<Assets {api} />
         {:else if view === "activity"}<Activity {api} {navigate} />
         {:else if view === "invoices"}<Invoices {api} />
         {:else if view === "investments"}<Investments {api} />

--- a/apps/web/src/app/navigation-config.ts
+++ b/apps/web/src/app/navigation-config.ts
@@ -5,6 +5,7 @@ import type { DetailView, MobileSettingsView, PrimaryView } from "./types";
 export interface NavigationItem {
   view: PrimaryView;
   label: string;
+  pageTitle?: string;
   shortLabel: string;
   description: string;
   icon: Component;
@@ -21,6 +22,7 @@ export const navItems: NavigationItem[] = [
   {
     view: "assets",
     label: "資產",
+    pageTitle: "資產清冊",
     shortLabel: "資產",
     description: "銀行、信用卡、投資與其他資產集中管理。",
     icon: Wallet,

--- a/apps/web/src/features/assets/AssetsPage.svelte
+++ b/apps/web/src/features/assets/AssetsPage.svelte
@@ -1,39 +1,47 @@
 <script lang="ts">
   import { createQuery } from "@tanstack/svelte-query";
-  import { Building2, CreditCard, Search } from "@lucide/svelte";
-  import Button from "@/shared/ui/Button.svelte";
-  import Card from "@/shared/ui/Card.svelte";
-  import CardHeader from "@/shared/ui/CardHeader.svelte";
-  import CardContent from "@/shared/ui/CardContent.svelte";
-  import EmptyState from "@/shared/ui/EmptyState.svelte";
-  import Input from "@/shared/ui/Input.svelte";
-  import TabsList from "@/shared/ui/TabsList.svelte";
-  import TabsTrigger from "@/shared/ui/TabsTrigger.svelte";
-  import type { ApiClient } from "@/shared/api/client";
+  import {
+    Building2,
+    ChevronRight,
+    Landmark,
+    WalletCards,
+  } from "@lucide/svelte";
   import { exchangeRatesQuery, manualAssetsQuery } from "@/data/assets/queries";
   import { bankQuery, creditCardBillsQuery } from "@/data/bank/queries";
-  import type { CreditCardBillRow } from "@/data/bank/types";
-  import { investmentsQuery } from "@/data/investments/queries";
-  import type { View } from "@/app/types";
-  import { calculateAssetSummary } from "./model/summary";
-  import type { AssetSection } from "./model/types";
   import {
-    formatBankAccountName,
-    formatCurrency,
-    formatDate,
-    formatNumber,
-  } from "@/shared/format/financial";
+    investmentsQuery,
+    investmentTransactionsQuery,
+  } from "@/data/investments/queries";
+  import type { ApiClient } from "@/shared/api/client";
+  import { formatCurrency } from "@/shared/format/financial";
+  import Card from "@/shared/ui/Card.svelte";
+  import CardContent from "@/shared/ui/CardContent.svelte";
+  import EmptyState from "@/shared/ui/EmptyState.svelte";
+  import InstitutionDetails from "./components/InstitutionDetails.svelte";
+  import InvestmentWorkspace from "./components/InvestmentWorkspace.svelte";
+  import ManualAssets from "./ManualAssets.svelte";
+  import { calculateAssetSummary } from "./model/summary";
+  import type { InstitutionAssetGroup } from "./model/summary";
 
-  let { api, navigate }: { api: ApiClient; navigate: (view: View) => void } =
-    $props();
+  type LedgerItem =
+    | {
+        key: string;
+        kind: "institution";
+        label: string;
+        group: InstitutionAssetGroup;
+      }
+    | { key: "investments"; kind: "investments"; label: "投資" }
+    | { key: "manual-assets"; kind: "manual-assets"; label: "其他資產" };
+
+  let { api }: { api: ApiClient } = $props();
+
   const bank = createQuery(bankQuery(() => api));
   const bills = createQuery(creditCardBillsQuery(() => api));
   const investments = createQuery(investmentsQuery(() => api));
+  const trades = createQuery(investmentTransactionsQuery(() => api));
   const manual = createQuery(manualAssetsQuery(() => api));
   const rates = createQuery(exchangeRatesQuery(() => api));
 
-  let section = $state<AssetSection>("all");
-  let billSearch = $state("");
   const summary = $derived(
     calculateAssetSummary({
       bank: $bank.data ?? { accounts: [], transactions: [] },
@@ -42,529 +50,425 @@
       rates: $rates.data,
     }),
   );
-  const deposits = $derived(summary.deposits);
-  const cards = $derived(summary.cards);
-  const cardsById = $derived(new Map(cards.map((card) => [card.id, card])));
-  const filteredBills = $derived(
-    ($bills.data ?? []).filter((bill) =>
-      `${bill.accountSourceId ?? ""} ${bill.billingPeriod}`
-        .toLowerCase()
-        .includes(billSearch.toLowerCase()),
-    ),
-  );
-  const bankTotal = $derived(summary.bankTotal);
-  const investmentTotal = $derived(summary.investmentTotal);
-  const manualTotal = $derived(summary.manualTotal);
-  const cardDebt = $derived(summary.cardDebt);
-  const grossAssets = $derived(summary.grossAssets);
-  const netWorth = $derived(summary.netWorth);
-  const groupedBanks = $derived(summary.groupedBanks);
-  const tabs: { key: AssetSection; label: string }[] = [
-    { key: "all", label: "全部" },
-    { key: "bank", label: "銀行" },
-    { key: "cards", label: "信用卡" },
-    { key: "investments", label: "投資" },
-    { key: "manual-assets", label: "其他資產" },
-  ];
   const loading = $derived(
-    $bank.isPending || $investments.isPending || $manual.isPending,
+    $bank.isPending ||
+      $investments.isPending ||
+      $manual.isPending ||
+      $rates.isPending,
   );
   const failed = $derived(
-    $bank.isError || $investments.isError || $manual.isError,
+    $bank.isError || $investments.isError || $manual.isError || $rates.isError,
   );
-  const mobileSummary = $derived(
-    section === "bank"
-      ? {
-          label: "銀行與現金",
-          value: bankTotal,
-          detail: `${deposits.length} 個帳戶`,
-        }
-      : section === "cards"
-        ? {
-            label: "信用卡負債",
-            value: cardDebt,
-            detail: `${cards.length} 張卡片 · 目前未繳`,
-          }
-        : section === "investments"
-          ? {
-              label: "投資市值",
-              value: investmentTotal,
-              detail: `${$investments.data?.length ?? 0} 個持倉 · TDCC`,
-            }
-          : section === "manual-assets"
-            ? {
-                label: "其他資產",
-                value: manualTotal,
-                detail: "房產、保險與交通工具",
-              }
-            : {
-                label: "全部資產",
-                value: netWorth,
-                detail: "淨資產 · 已扣除信用卡負債",
-              },
+  const ledgerItems = $derived<LedgerItem[]>([
+    ...summary.institutionGroups.map((group): LedgerItem => ({
+      key: group.key,
+      kind: "institution",
+      label: group.institution,
+      group,
+    })),
+    ...(($investments.data?.length ?? 0) > 0
+      ? ([{ key: "investments", kind: "investments", label: "投資" }] as const)
+      : []),
+    ...(($manual.data?.length ?? 0) > 0
+      ? ([
+          {
+            key: "manual-assets",
+            kind: "manual-assets",
+            label: "其他資產",
+          },
+        ] as const)
+      : []),
+  ]);
+
+  let selectedKey = $state<string>();
+  let expandedKey = $state<string | null>();
+  const activeKey = $derived(
+    selectedKey && ledgerItems.some((item) => item.key === selectedKey)
+      ? selectedKey
+      : ledgerItems[0]?.key,
   );
-  function billAccountName(bill: CreditCardBillRow) {
-    const card = cardsById.get(bill.accountId);
-    return card?.accountName ?? card?.institutionName ?? "信用卡帳戶";
+  const activeItem = $derived(
+    ledgerItems.find((item) => item.key === activeKey),
+  );
+  const mobileExpandedKey = $derived(
+    expandedKey === undefined ? (ledgerItems[0]?.key ?? null) : expandedKey,
+  );
+
+  function toggleMobile(key: string) {
+    expandedKey = mobileExpandedKey === key ? null : key;
   }
 </script>
 
 {#if loading}
   <EmptyState
-    title="載入資產中"
+    title="載入資產清冊中"
     body="正在彙整銀行、信用卡、投資與其他資產。"
   />
 {:else if failed}
   <EmptyState
-    title="無法載入資產"
-    body="請稍後再試，或確認 Worker API 是否可用。"
+    title="無法載入資產清冊"
+    body="部分必要資料目前無法取得，請稍後再試。"
   />
 {:else}
-  <div class="grid min-w-0 max-w-full gap-5">
-    <section class="rounded-2xl bg-ink p-5 text-white shadow-xs md:hidden">
-      <p class="text-xs font-semibold tracking-wide text-white/60">
-        {mobileSummary.label}
-      </p>
-      <p
-        class="mt-2 break-words text-3xl font-bold tracking-tight tabular-nums"
+  <div class="grid min-w-0 max-w-full gap-4">
+    {#if summary.missingCurrencies.length > 0}
+      <div
+        class="rounded-xl border border-coral/25 bg-coral/5 px-4 py-3 text-sm text-ink"
+        role="status"
       >
-        {formatCurrency(mobileSummary.value)}
-      </p>
-      <p class="mt-2 text-xs text-white/60">{mobileSummary.detail}</p>
+        <p class="font-semibold">部分外幣資產尚未納入新台幣總額</p>
+        <p class="mt-1 text-xs text-ink/55">
+          缺少 {summary.missingCurrencies.join("、")} 匯率；原始幣別金額仍會顯示在清冊中。
+        </p>
+      </div>
+    {/if}
+
+    <section
+      class="grid grid-cols-2 gap-3 xl:grid-cols-[1.2fr_1fr_1fr_1fr]"
+      aria-label="資產摘要"
+    >
+      <Card>
+        <CardContent class="p-4">
+          <p class="text-xs font-semibold text-ink/50">
+            總資產｜不含信用卡負債
+          </p>
+          <p class="mt-2 text-xl font-bold tracking-tight tabular-nums">
+            {formatCurrency(summary.grossAssets)}
+          </p>
+          <p class="mt-1 hidden text-xs text-ink/45 sm:block">
+            銀行、投資與其他資產合計
+          </p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent class="p-4">
+          <p class="text-xs font-semibold text-ink/50">銀行與現金</p>
+          <p
+            class="mt-2 text-xl font-bold tracking-tight tabular-nums text-steel"
+          >
+            {formatCurrency(summary.bankTotal)}
+          </p>
+          <p class="mt-1 text-xs text-ink/45">
+            {summary.deposits.length} 個帳戶
+          </p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent class="p-4">
+          <p class="text-xs font-semibold text-ink/50">投資</p>
+          <p
+            class="mt-2 text-xl font-bold tracking-tight tabular-nums text-steel"
+          >
+            {formatCurrency(summary.investmentTotal)}
+          </p>
+          <p class="mt-1 text-xs text-ink/45">
+            {$investments.data?.length ?? 0} 個持倉
+          </p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent class="p-4">
+          <p class="text-xs font-semibold text-ink/50">信用卡負債</p>
+          <p
+            class="mt-2 text-xl font-bold tracking-tight tabular-nums text-coral"
+          >
+            {formatCurrency(-summary.cardDebt)}
+          </p>
+          <p class="mt-1 text-xs text-ink/45">
+            {summary.cards.length} 張卡片
+          </p>
+        </CardContent>
+      </Card>
     </section>
 
-    <div class="hidden gap-4 md:grid md:grid-cols-2 xl:grid-cols-4">
-      {#each [{ label: "資產總額", value: grossAssets, detail: "不含信用卡負債", tone: "" }, { label: "銀行與現金", value: bankTotal, detail: `${deposits.length} 個帳戶`, tone: "text-moss" }, { label: "投資", value: investmentTotal, detail: `${$investments.data?.length ?? 0} 個持倉`, tone: "text-steel" }, { label: "信用卡負債", value: -cardDebt, detail: `${cards.length} 張卡片`, tone: "text-coral" }] as item (item.label)}
-        <Card
-          ><CardContent class="p-5"
-            ><p class="text-xs font-semibold text-ink/50">{item.label}</p>
-            <p
-              class={`mt-2 text-2xl font-bold tracking-tight tabular-nums ${item.tone}`}
-            >
-              {formatCurrency(item.value)}
-            </p>
-            <p class="mt-1 text-xs text-ink/45">{item.detail}</p></CardContent
-          ></Card
-        >
-      {/each}
-    </div>
-
-    <TabsList class="grid h-auto w-full grid-cols-5 bg-card shadow-xs">
-      {#each tabs as tab (tab.key)}
-        <TabsTrigger
-          class={`min-h-10 min-w-0 px-1 text-xs sm:text-sm ${section === tab.key ? "bg-ink text-white" : ""}`}
-          active={section === tab.key}
-          onclick={() => (section = tab.key)}>{tab.label}</TabsTrigger
-        >
-      {/each}
-    </TabsList>
-
-    {#if section === "all"}
-      <div class="grid gap-3 xl:hidden">
-        <Card>
-          <CardHeader class="flex-row items-center justify-between py-4"
-            ><div>
-              <h2 class="text-lg font-semibold">銀行與現金</h2>
-              <p class="mt-1 text-xs text-ink/45">各銀行彙整，外幣換算為 TWD</p>
-            </div>
-            <button
-              class="shrink-0 text-right text-steel"
-              onclick={() => (section = "bank")}
-              ><span class="block text-xs font-medium text-ink/45">總額</span
-              ><span
-                class="mt-0.5 block text-xl font-bold tabular-nums sm:text-2xl"
-                >{formatCurrency(bankTotal)}</span
-              ></button
-            ></CardHeader
+    {#if ledgerItems.length === 0}
+      <EmptyState
+        title="尚無資產資料"
+        body="完成資料來源同步，或新增一筆其他資產後即可在此查看。"
+      />
+    {:else}
+      <section
+        class="hidden h-[620px] min-w-0 grid-cols-[minmax(320px,0.9fr)_minmax(360px,1.1fr)] gap-4 xl:grid"
+        aria-label="資產清冊"
+      >
+        <Card class="flex min-h-0 flex-col overflow-hidden">
+          <header
+            class="flex items-center justify-between gap-3 border-b border-border px-4 py-3"
           >
-          <CardContent class="pt-0">
-            <div class="divide-y divide-ink/8">
-              {#each groupedBanks as group (group.institution)}
+            <div>
+              <h2 class="font-semibold">帳戶與資產</h2>
+              <p class="mt-1 text-xs text-muted-foreground">
+                同一金融機構的帳戶與信用卡合併顯示
+              </p>
+            </div>
+            <span class="text-xs text-muted-foreground">
+              {ledgerItems.length} 項
+            </span>
+          </header>
+          <div class="min-h-0 flex-1 overflow-y-auto">
+            {#if summary.institutionGroups.length > 0}
+              <p
+                class="bg-muted px-4 py-2 text-xs font-semibold text-muted-foreground"
+              >
+                金融機構
+              </p>
+              {#each summary.institutionGroups as group (group.key)}
                 <button
-                  class="flex min-h-16 w-full items-center justify-between gap-3 py-3 text-left"
-                  onclick={() => (section = "bank")}
+                  class={`grid min-h-[68px] w-full grid-cols-[36px_minmax(0,1fr)_auto] items-center gap-3 border-b border-border px-3 py-2 text-left transition hover:bg-muted ${activeKey === group.key ? "bg-accent shadow-[inset_3px_0_0_hsl(var(--primary))]" : "bg-white"}`}
+                  type="button"
+                  aria-pressed={activeKey === group.key}
+                  onclick={() => (selectedKey = group.key)}
                 >
-                  <div class="flex min-w-0 items-center gap-3">
-                    <span
-                      class="flex size-9 shrink-0 items-center justify-center rounded-xl bg-steel/10 text-steel"
-                      ><Building2 class="size-4" /></span
+                  <span
+                    class="flex size-9 items-center justify-center rounded-lg border border-border bg-paper text-xs font-bold text-steel"
+                  >
+                    {group.institution.slice(0, 1)}
+                  </span>
+                  <span class="min-w-0">
+                    <strong class="block truncate text-sm">
+                      {group.institution}
+                    </strong>
+                    <small class="mt-1 block truncate text-xs text-ink/45">
+                      {group.accounts.length} 帳戶 · {group.cards.length} 卡片{group
+                        .foreignCurrencies.length
+                        ? ` · 含 ${group.foreignCurrencies.join("、")}`
+                        : ""}
+                    </small>
+                  </span>
+                  <span class="text-right">
+                    <strong class="block text-sm tabular-nums text-steel">
+                      {group.accounts.length
+                        ? formatCurrency(group.assetTotalTwd)
+                        : "—"}
+                    </strong>
+                    <small
+                      class={`mt-1 block text-xs tabular-nums ${group.cards.length ? "text-coral" : "text-ink/40"}`}
                     >
-                    <div class="min-w-0">
-                      <h3 class="truncate font-semibold">
-                        {group.institution}
-                      </h3>
-                      <p class="mt-1 truncate text-xs text-ink/45">
-                        {group.accounts.length} 個帳戶{group.foreignCurrencies
-                          .length
-                          ? ` · 含 ${group.foreignCurrencies.join("、")}`
-                          : ""}
-                      </p>
-                    </div>
-                  </div>
-                  <p class="shrink-0 text-lg font-bold tabular-nums text-steel">
-                    {formatCurrency(group.totalTwd)}
-                  </p>
+                      {group.cards.length
+                        ? `負債 ${formatCurrency(-group.debtTotalTwd)}`
+                        : "無信用卡"}
+                    </small>
+                  </span>
                 </button>
               {/each}
-            </div>
-          </CardContent>
-        </Card>
-        <Card
-          ><CardHeader class="flex-row items-center justify-between"
-            ><h2 class="text-lg font-semibold">投資</h2>
-            <span class="text-sm font-bold tabular-nums text-steel"
-              >{formatCurrency(investmentTotal)}</span
-            ></CardHeader
-          ><CardContent
-            ><button
-              class="flex w-full items-center justify-between gap-4 text-left"
-              onclick={() => (section = "investments")}
-              ><div>
-                <p class="font-semibold">主要投資帳戶</p>
-                <p class="text-xs text-ink/45">
-                  {$investments.data?.length ?? 0} 個持倉 · TDCC
-                </p>
-              </div>
-              <span class="text-xs font-semibold text-steel">查看持倉 →</span
-              ></button
-            ></CardContent
-          ></Card
-        >
-        <Card
-          ><CardHeader class="flex-row items-center justify-between"
-            ><h2 class="text-lg font-semibold">其他資產</h2>
-            <span class="font-bold tabular-nums text-moss"
-              >{formatCurrency(manualTotal)}</span
-            ></CardHeader
-          ><CardContent class="pt-0"
-            ><button
-              class="text-left text-xs text-ink/45"
-              onclick={() => (section = "manual-assets")}
-              >保險、房產、交通工具 · 更新估值 →</button
-            ></CardContent
-          ></Card
-        >
-      </div>
+            {/if}
 
-      <div
-        class="hidden gap-5 xl:grid xl:grid-cols-[minmax(0,2fr)_minmax(300px,0.8fr)]"
-      >
-        <div class="grid content-start gap-5">
-          <Card>
-            <CardHeader
-              class="flex-row items-center justify-between border-b border-ink/8"
-              ><div>
-                <h2 class="text-lg font-semibold">銀行帳戶</h2>
-                <p class="text-xs text-ink/45">{deposits.length} 個帳戶</p>
-              </div></CardHeader
-            >
-            <div class="divide-y divide-ink/8">
-              {#each groupedBanks as group (group.institution)}
-                <div class="p-4">
-                  <div class="mb-2 flex items-center justify-between gap-3">
-                    <h3 class="font-semibold">{group.institution}</h3>
-                    <div class="flex items-center gap-3">
-                      <span class="text-lg font-bold tabular-nums text-steel">
-                        {formatCurrency(group.totalTwd)}
-                      </span>
-                    </div>
-                  </div>
-                  <div class="grid gap-2">
-                    {#each group.accounts as account (account.id)}
-                      <div
-                        class="flex items-center justify-between gap-4 text-sm"
-                      >
-                        <span class="min-w-0 truncate text-ink/60"
-                          >{account.accountName ??
-                            formatBankAccountName(account)}</span
-                        ><span class="shrink-0 font-semibold tabular-nums"
-                          >{formatCurrency(
-                            account.balance ?? 0,
-                            account.currency,
-                          )}</span
-                        >
-                      </div>
-                    {/each}
-                  </div>
-                </div>
-              {/each}
-            </div>
-          </Card>
-          <Card>
-            <CardHeader
-              class="flex-row items-center justify-between border-b border-ink/8"
-              ><div>
-                <h2 class="text-lg font-semibold">投資持倉</h2>
-                <p class="text-xs text-ink/45">
-                  市值 {formatCurrency(investmentTotal)}
-                </p>
-              </div>
-              <Button
-                size="sm"
-                variant="ghost"
-                onclick={() => navigate("investments")}>查看全部 →</Button
-              ></CardHeader
-            >
-            <div class="divide-y divide-ink/8">
-              {#each ($investments.data ?? []).slice(0, 5) as item (item.id)}
-                <div
-                  class="grid grid-cols-[64px_minmax(0,1fr)_auto] items-center gap-3 px-5 py-3 text-sm"
-                >
-                  <span class="font-semibold text-steel"
-                    >{item.symbol ?? item.assetType.toUpperCase()}</span
-                  ><span class="min-w-0 truncate font-medium">{item.name}</span
-                  ><span class="font-semibold tabular-nums"
-                    >{formatCurrency(
-                      (item.marketValue ?? 0) + (item.cashBalance ?? 0),
-                      item.currency,
-                    )}</span
-                  >
-                </div>
-              {/each}
-            </div>
-          </Card>
-        </div>
-        <div class="grid content-start gap-5">
-          <Card
-            ><CardHeader
-              ><h2 class="text-lg font-semibold">信用卡</h2></CardHeader
-            ><CardContent
-              ><div class="rounded-xl bg-ink p-4 text-white">
-                <p class="text-xs text-white/60">目前負債</p>
-                <p class="mt-2 text-2xl font-bold tabular-nums">
-                  {formatCurrency(cardDebt)}
-                </p>
-                <p class="mt-2 text-xs text-white/55">{cards.length} 張卡片</p>
-              </div></CardContent
-            ></Card
-          >
-          <Card
-            ><CardHeader class="flex-row items-center justify-between"
-              ><h2 class="text-lg font-semibold">其他資產</h2>
-              <Button
-                size="sm"
-                variant="ghost"
-                onclick={() => navigate("manual-assets")}>更新估值</Button
-              ></CardHeader
-            ><CardContent
-              ><p class="text-2xl font-bold tabular-nums text-moss">
-                {formatCurrency(manualTotal)}
-              </p>
-              <p class="mt-2 text-xs text-ink/45">
-                保險、不動產、交通工具與其他
-              </p></CardContent
-            ></Card
-          >
-        </div>
-      </div>
-    {:else if section === "bank"}
-      <Card>
-        <CardHeader
-          ><div>
-            <h2 class="flex items-center gap-2 text-lg font-semibold">
-              <Building2 class="size-5 text-steel" />銀行帳戶
-            </h2>
-            <p class="mt-1 text-xs text-ink/45">依銀行分組，總額由大到小排列</p>
-          </div></CardHeader
-        >
-        <div class="divide-y divide-ink/8">
-          {#each groupedBanks as group (group.institution)}
-            <section class="px-5 py-4">
-              <div class="flex items-center justify-between gap-3">
-                <div>
-                  <h3 class="font-semibold">{group.institution}</h3>
-                  <p class="mt-1 text-xs text-ink/45">
-                    {group.accounts.length} 個帳戶
-                  </p>
-                </div>
-                <p class="text-lg font-bold tabular-nums text-steel sm:text-xl">
-                  {formatCurrency(group.totalTwd)}
-                </p>
-              </div>
-              <div class="mt-3 grid gap-2 md:grid-cols-2">
-                {#each group.accounts as account (account.id)}<div
-                    class="rounded-xl border border-ink/8 p-3"
-                  >
-                    <div
-                      class="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-end gap-x-3 gap-y-1"
-                    >
-                      <p
-                        class="col-span-2 min-w-0 break-words text-sm font-semibold"
-                      >
-                        {account.accountName ?? formatBankAccountName(account)}
-                      </p>
-                      <p class="min-w-0 text-xs text-ink/45">
-                        {account.currency} · {account.asOfAt
-                          ? `更新 ${formatDate(account.asOfAt)}`
-                          : "尚未同步"}
-                      </p>
-                      <p class="shrink-0 text-right font-bold tabular-nums">
-                        {formatCurrency(account.balance ?? 0, account.currency)}
-                      </p>
-                    </div>
-                  </div>{/each}
-              </div>
-            </section>
-          {/each}
-        </div>
-      </Card>
-    {:else if section === "cards"}
-      <Card
-        ><CardHeader
-          ><div>
-            <h2 class="text-lg font-semibold">信用卡帳戶</h2>
-            <p class="mt-1 text-xs text-ink/45">
-              目前負債 {formatCurrency(cardDebt)}
-            </p>
-          </div></CardHeader
-        ><CardContent
-          >{#if cards.length === 0}<p
-              class="py-8 text-center text-sm text-ink/45"
-            >
-              尚無信用卡資料。
-            </p>{:else}<div class="grid gap-3 md:grid-cols-2">
-              {#each cards as card, index (card.id)}<div
-                  class={`w-full rounded-2xl p-4 text-left text-white ${index % 2 === 0 ? "bg-ink" : "bg-steel"}`}
-                >
-                  <div class="flex items-start justify-between">
-                    <div>
-                      <p class="font-semibold">
-                        {card.institutionName ?? card.connectorId}
-                      </p>
-                      <p class="mt-2 text-xs text-white/65">
-                        {card.accountName ?? formatBankAccountName(card)}
-                      </p>
-                    </div>
-                    <CreditCard class="size-5 text-white/70" />
-                  </div>
-                  <p class="mt-5 text-2xl font-bold tabular-nums">
-                    {formatCurrency(Math.abs(card.balance ?? 0), card.currency)}
-                  </p>
-                </div>{/each}
-            </div>{/if}</CardContent
-        ></Card
-      ><Card class="min-w-0 max-w-full overflow-hidden"
-        ><CardHeader class="flex-wrap items-center justify-between gap-3"
-          ><div>
-            <h2 class="text-lg font-semibold">信用卡帳單</h2>
-            <p class="mt-1 text-xs text-ink/45">
-              共 {filteredBills.length} 筆帳單
-            </p>
-          </div>
-          <div class="relative w-full sm:w-44">
-            <Search
-              class="pointer-events-none absolute left-3 top-1/2 z-10 size-4 -translate-y-1/2 text-muted-foreground"
-            /><Input
-              class="pl-9"
-              placeholder="搜尋帳單"
-              bind:value={billSearch}
-            />
-          </div></CardHeader
-        ><CardContent class="min-w-0 p-0"
-          ><div class="max-w-full overflow-x-auto">
-            <table class="w-full min-w-[680px] text-left text-sm">
-              <thead class="border-y border-ink/8 bg-paper text-xs text-ink/50"
-                ><tr
-                  ><th class="px-5 py-3">帳戶</th><th class="px-5 py-3">帳期</th
-                  ><th class="px-5 py-3 text-right">帳單金額</th><th
-                    class="px-5 py-3">繳款期限</th
-                  ><th class="px-5 py-3">狀態</th></tr
-                ></thead
-              ><tbody class="divide-y divide-ink/8"
-                >{#each filteredBills as bill (bill.id)}<tr
-                    ><td class="px-5 py-3 font-medium"
-                      >{billAccountName(bill)}</td
-                    ><td class="px-5 py-3">{bill.billingPeriod}</td><td
-                      class="px-5 py-3 text-right font-semibold"
-                      >{bill.statementAmount == null
-                        ? "-"
-                        : formatCurrency(
-                            bill.statementAmount,
-                            bill.currency,
-                          )}</td
-                    ><td class="px-5 py-3"
-                      >{bill.paymentDueDate
-                        ? formatDate(bill.paymentDueDate)
-                        : "—"}</td
-                    ><td class="px-5 py-3">{bill.isPaid ? "已繳" : "待繳"}</td
-                    ></tr
-                  >{/each}</tbody
+            {#if ($investments.data?.length ?? 0) > 0}
+              <p
+                class="bg-muted px-4 py-2 text-xs font-semibold text-muted-foreground"
               >
-            </table>
-          </div></CardContent
-        ></Card
-      >
-    {:else if section === "investments"}
-      <Card
-        ><CardHeader class="flex-row items-center justify-between"
-          ><div>
-            <h2 class="text-lg font-semibold">投資持倉</h2>
-            <p class="mt-1 text-xs text-ink/45">
-              市值 {formatCurrency(investmentTotal)}
-            </p>
+                投資
+              </p>
+              <button
+                class={`grid min-h-[68px] w-full grid-cols-[36px_minmax(0,1fr)_auto] items-center gap-3 border-b border-border px-3 py-2 text-left transition hover:bg-muted ${activeKey === "investments" ? "bg-accent shadow-[inset_3px_0_0_hsl(var(--primary))]" : "bg-white"}`}
+                type="button"
+                aria-pressed={activeKey === "investments"}
+                onclick={() => (selectedKey = "investments")}
+              >
+                <span
+                  class="flex size-9 items-center justify-center rounded-lg border border-border bg-paper text-steel"
+                  ><Landmark class="size-4" /></span
+                >
+                <span class="min-w-0">
+                  <strong class="block text-sm">投資</strong>
+                  <small class="mt-1 block text-xs text-ink/45">
+                    {$investments.data?.length ?? 0} 個持倉 · 持倉與交易紀錄
+                  </small>
+                </span>
+                <strong class="text-sm tabular-nums text-steel">
+                  {formatCurrency(summary.investmentTotal)}
+                </strong>
+              </button>
+            {/if}
+
+            {#if ($manual.data?.length ?? 0) > 0}
+              <p
+                class="bg-muted px-4 py-2 text-xs font-semibold text-muted-foreground"
+              >
+                其他資產
+              </p>
+              <button
+                class={`grid min-h-[68px] w-full grid-cols-[36px_minmax(0,1fr)_auto] items-center gap-3 border-b border-border px-3 py-2 text-left transition hover:bg-muted ${activeKey === "manual-assets" ? "bg-accent shadow-[inset_3px_0_0_hsl(var(--primary))]" : "bg-white"}`}
+                type="button"
+                aria-pressed={activeKey === "manual-assets"}
+                onclick={() => (selectedKey = "manual-assets")}
+              >
+                <span
+                  class="flex size-9 items-center justify-center rounded-lg border border-border bg-paper text-moss"
+                  ><WalletCards class="size-4" /></span
+                >
+                <span class="min-w-0">
+                  <strong class="block text-sm">其他資產</strong>
+                  <small class="mt-1 block text-xs text-ink/45">
+                    {$manual.data?.length ?? 0} 筆 · 手動維護估值
+                  </small>
+                </span>
+                <strong class="text-sm tabular-nums text-moss">
+                  {formatCurrency(summary.manualTotal)}
+                </strong>
+              </button>
+            {/if}
           </div>
-          <Button
-            size="sm"
-            variant="ghost"
-            onclick={() => navigate("investments")}>交易紀錄 →</Button
-          ></CardHeader
-        ><CardContent
-          ><div class="divide-y divide-ink/8">
-            {#each $investments.data ?? [] as item (item.id)}<button
-                class="flex min-h-16 w-full items-center justify-between gap-3 py-3 text-left"
-                onclick={() => navigate("investments")}
-                ><div class="min-w-0">
-                  <p class="truncate font-semibold">
-                    {item.symbol ? `${item.symbol} ` : ""}{item.name}
-                  </p>
-                  <p class="mt-1 text-xs text-ink/45">
-                    {formatNumber(item.quantity ?? 0)} 單位 · {item.assetType.toUpperCase()}
-                  </p>
-                </div>
-                <p class="shrink-0 font-bold tabular-nums text-steel">
-                  {formatCurrency(
-                    (item.marketValue ?? 0) + (item.cashBalance ?? 0),
-                    item.currency,
-                  )}
-                </p></button
-              >{/each}
-          </div></CardContent
-        ></Card
-      >
-    {:else}
-      <Card
-        ><CardHeader class="flex-row items-center justify-between"
-          ><div>
-            <h2 class="text-lg font-semibold">其他資產</h2>
-            <p class="mt-1 text-xs text-ink/45">
-              合計 {formatCurrency(manualTotal)}
-            </p>
+        </Card>
+
+        <Card class="min-h-0 overflow-y-auto">
+          {#if activeItem?.kind === "institution"}
+            <InstitutionDetails
+              group={activeItem.group}
+              bills={$bills.data ?? []}
+              billsPending={$bills.isPending}
+              billsError={$bills.isError}
+            />
+          {:else if activeItem?.kind === "investments"}
+            <InvestmentWorkspace
+              positions={$investments.data ?? []}
+              trades={$trades.data ?? []}
+              total={summary.investmentTotal}
+              tradesPending={$trades.isPending}
+              tradesError={$trades.isError}
+            />
+          {:else if activeItem?.kind === "manual-assets"}
+            <ManualAssets {api} variant="embedded" />
+          {/if}
+        </Card>
+      </section>
+
+      <section class="grid gap-3 xl:hidden" aria-label="資產清冊">
+        {#if summary.institutionGroups.length > 0}
+          <div class="flex items-center justify-between px-1 pt-1">
+            <h2 class="text-base font-semibold">金融機構</h2>
+            <span class="text-xs text-muted-foreground">
+              {summary.institutionGroups.length} 個機構
+            </span>
           </div>
-          <Button
-            size="sm"
-            variant="ghost"
-            onclick={() => navigate("manual-assets")}>＋ 新增資產</Button
-          ></CardHeader
-        ><CardContent
-          ><div class="divide-y divide-ink/8">
-            {#each $manual.data ?? [] as item (item.id)}<button
-                class="flex min-h-16 w-full items-center justify-between gap-3 py-3 text-left"
-                onclick={() => navigate("manual-assets")}
-                ><div class="min-w-0">
-                  <p class="truncate font-semibold">{item.name}</p>
-                  <p class="mt-1 truncate text-xs text-ink/45">
-                    {item.category} · {item.date
-                      ? `${formatDate(item.date)} 更新`
-                      : "查看估值歷史"}
-                  </p>
+          {#each summary.institutionGroups as group (group.key)}
+            <Card class="overflow-hidden">
+              <button
+                class="grid min-h-[72px] w-full grid-cols-[36px_minmax(0,1fr)_auto_16px] items-center gap-3 px-3 py-2 text-left"
+                type="button"
+                aria-expanded={mobileExpandedKey === group.key}
+                onclick={() => toggleMobile(group.key)}
+              >
+                <span
+                  class="flex size-9 items-center justify-center rounded-lg border border-border bg-paper text-xs font-bold text-steel"
+                >
+                  {group.institution.slice(0, 1)}
+                </span>
+                <span class="min-w-0">
+                  <strong class="block truncate text-sm">
+                    {group.institution}
+                  </strong>
+                  <small class="mt-1 block truncate text-xs text-ink/45">
+                    {group.accounts.length} 帳戶 · {group.cards.length} 卡片{group
+                      .foreignCurrencies.length
+                      ? ` · 含 ${group.foreignCurrencies.join("、")}`
+                      : ""}
+                  </small>
+                </span>
+                <span class="text-right">
+                  <strong class="block text-sm tabular-nums text-steel">
+                    {group.accounts.length
+                      ? formatCurrency(group.assetTotalTwd)
+                      : "—"}
+                  </strong>
+                  <small
+                    class={`mt-1 block text-xs tabular-nums ${group.cards.length ? "text-coral" : "text-ink/40"}`}
+                  >
+                    {group.cards.length
+                      ? `負債 ${formatCurrency(-group.debtTotalTwd)}`
+                      : "無信用卡"}
+                  </small>
+                </span>
+                <ChevronRight
+                  class={`size-4 text-ink/40 transition ${mobileExpandedKey === group.key ? "rotate-90" : ""}`}
+                />
+              </button>
+              {#if mobileExpandedKey === group.key}
+                <div class="border-t border-border bg-paper/60 p-3">
+                  <InstitutionDetails
+                    {group}
+                    bills={$bills.data ?? []}
+                    billsPending={$bills.isPending}
+                    billsError={$bills.isError}
+                    compact
+                  />
                 </div>
-                <p class="shrink-0 font-bold tabular-nums text-moss">
-                  {formatCurrency(item.value ?? 0, item.currency)}
-                </p></button
-              >{/each}
-          </div></CardContent
-        ></Card
-      >
+              {/if}
+            </Card>
+          {/each}
+        {/if}
+
+        {#if ($investments.data?.length ?? 0) > 0}
+          <div class="flex items-center justify-between px-1 pt-2">
+            <h2 class="text-base font-semibold">投資</h2>
+            <span class="text-xs text-muted-foreground">持倉與交易</span>
+          </div>
+          <Card class="overflow-hidden">
+            <button
+              class="grid min-h-[68px] w-full grid-cols-[minmax(0,1fr)_auto_16px] items-center gap-3 px-4 text-left"
+              type="button"
+              aria-expanded={mobileExpandedKey === "investments"}
+              onclick={() => toggleMobile("investments")}
+            >
+              <span>
+                <strong class="block text-sm">投資工作區</strong>
+                <small class="mt-1 block text-xs text-ink/45">
+                  {$investments.data?.length ?? 0} 個持倉 · 交易紀錄
+                </small>
+              </span>
+              <strong class="text-sm tabular-nums text-steel">
+                {formatCurrency(summary.investmentTotal)}
+              </strong>
+              <ChevronRight
+                class={`size-4 text-ink/40 transition ${mobileExpandedKey === "investments" ? "rotate-90" : ""}`}
+              />
+            </button>
+            {#if mobileExpandedKey === "investments"}
+              <div class="border-t border-border p-3">
+                <InvestmentWorkspace
+                  positions={$investments.data ?? []}
+                  trades={$trades.data ?? []}
+                  total={summary.investmentTotal}
+                  tradesPending={$trades.isPending}
+                  tradesError={$trades.isError}
+                  compact
+                />
+              </div>
+            {/if}
+          </Card>
+        {/if}
+
+        <div class="flex items-center justify-between px-1 pt-2">
+          <h2 class="text-base font-semibold">其他資產</h2>
+          <span class="text-xs text-muted-foreground">手動維護</span>
+        </div>
+        <Card class="overflow-hidden">
+          <button
+            class="grid min-h-[68px] w-full grid-cols-[minmax(0,1fr)_auto_16px] items-center gap-3 px-4 text-left"
+            type="button"
+            aria-expanded={mobileExpandedKey === "manual-assets"}
+            onclick={() => toggleMobile("manual-assets")}
+          >
+            <span>
+              <strong class="block text-sm">其他資產</strong>
+              <small class="mt-1 block text-xs text-ink/45">
+                {$manual.data?.length ?? 0} 筆 · 估值歷史
+              </small>
+            </span>
+            <strong class="text-sm tabular-nums text-moss">
+              {formatCurrency(summary.manualTotal)}
+            </strong>
+            <ChevronRight
+              class={`size-4 text-ink/40 transition ${mobileExpandedKey === "manual-assets" ? "rotate-90" : ""}`}
+            />
+          </button>
+          {#if mobileExpandedKey === "manual-assets"}
+            <div class="border-t border-border p-3">
+              <ManualAssets {api} variant="embedded" />
+            </div>
+          {/if}
+        </Card>
+      </section>
     {/if}
   </div>
 {/if}

--- a/apps/web/src/features/assets/ManualAssets.svelte
+++ b/apps/web/src/features/assets/ManualAssets.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount, tick } from "svelte";
   import { toStore } from "svelte/store";
   import {
     createMutation,
@@ -28,7 +29,13 @@
     todayStr,
   } from "@/shared/format/financial";
 
-  let { api }: { api: ApiClient } = $props();
+  let {
+    api,
+    variant = "page",
+  }: {
+    api: ApiClient;
+    variant?: "page" | "embedded";
+  } = $props();
   const qc = useQueryClient();
   const assets = createQuery(manualAssetsQuery(() => api));
   const rates = createQuery(exchangeRatesQuery(() => api));
@@ -46,6 +53,9 @@
     date: string;
   } | null>(null);
   let formError = $state("");
+  let editorDialog = $state<HTMLDivElement>();
+  let deleteDialog = $state<HTMLDivElement>();
+  let returnFocus: HTMLElement | null = null;
   let form = $state({
     name: "",
     category: "real_estate",
@@ -84,8 +94,7 @@
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.manualAssets });
       qc.invalidateQueries({ queryKey: queryKeys.netWorthHistory });
-      adding = false;
-      reset();
+      closeEditor();
     },
   });
   const update = createMutation({
@@ -101,8 +110,7 @@
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.manualAssets });
       qc.invalidateQueries({ queryKey: queryKeys.netWorthHistory });
-      editing = null;
-      reset();
+      closeEditor();
     },
   });
   const remove = createMutation({
@@ -110,7 +118,7 @@
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.manualAssets });
       qc.invalidateQueries({ queryKey: queryKeys.netWorthHistory });
-      deletingAsset = null;
+      closeDeleteConfirmation();
     },
   });
   const history = createQuery(
@@ -153,7 +161,7 @@
       api.delete(`/api/manual-assets/${assetId}/history/${date}`),
     onSuccess: () => {
       invalidateHistory();
-      deletingHistory = null;
+      closeDeleteConfirmation();
     },
   });
 
@@ -168,7 +176,43 @@
       note: "",
     };
   }
+  function rememberFocus() {
+    returnFocus =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+  }
+  async function focusFirstControl(dialog: "editor" | "delete") {
+    await tick();
+    const element = dialog === "editor" ? editorDialog : deleteDialog;
+    element
+      ?.querySelector<HTMLElement>(
+        dialog === "editor"
+          ? "input:not([type='hidden']), select, textarea"
+          : "button",
+      )
+      ?.focus();
+  }
+  function restoreFocus() {
+    const target = returnFocus;
+    returnFocus = null;
+    void tick().then(() => target?.focus());
+  }
+  function openAdd() {
+    rememberFocus();
+    adding = true;
+    editing = null;
+    reset();
+    void focusFirstControl("editor");
+  }
+  function closeEditor() {
+    adding = false;
+    editing = null;
+    reset();
+    restoreFocus();
+  }
   function startEdit(asset: ManualAssetRow) {
+    rememberFocus();
     formError = "";
     editing = asset;
     form = {
@@ -179,6 +223,26 @@
       date: asset.date ?? todayStr(),
       note: asset.note ?? "",
     };
+    void focusFirstControl("editor");
+  }
+  function requestDeleteAsset(asset: ManualAssetRow) {
+    rememberFocus();
+    deletingAsset = asset;
+    void focusFirstControl("delete");
+  }
+  function requestDeleteHistory(
+    assetId: string,
+    assetName: string,
+    date: string,
+  ) {
+    rememberFocus();
+    deletingHistory = { assetId, assetName, date };
+    void focusFirstControl("delete");
+  }
+  function closeDeleteConfirmation() {
+    deletingAsset = null;
+    deletingHistory = null;
+    restoreFocus();
   }
   function submit() {
     if (!form.name.trim() || !form.value) {
@@ -202,28 +266,72 @@
     historyDate = todayStr();
     editingHistoryDate = null;
   }
+  function toggleHistoryManagement() {
+    if (expandedAssetId) {
+      expandedAssetId = null;
+      return;
+    }
+    const firstAsset = $assets.data?.[0];
+    if (firstAsset) toggleHistory(firstAsset.id);
+  }
+
+  onMount(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (deletingAsset || deletingHistory) closeDeleteConfirmation();
+      else if (adding || editing) closeEditor();
+    };
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  });
+
+  $effect(() => {
+    if (!adding && !editing && !deletingAsset && !deletingHistory) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  });
 </script>
 
 {#if $assets.isPending}
   <EmptyState title="載入其他資產中" body="正在讀取估值紀錄。" />
 {:else}
-  <div class="grid gap-5">
-    <div class="flex items-end justify-between">
+  <div class={variant === "embedded" ? "grid gap-3" : "grid gap-5"}>
+    <div
+      class={`flex flex-wrap items-end justify-between gap-3 ${variant === "embedded" ? "px-4 pt-4" : ""}`}
+    >
       <div>
         <p class="text-sm text-ink/50">其他資產總額</p>
-        <p class="mt-1 text-3xl font-bold">{formatCurrency(total)}</p>
+        <p
+          class={`mt-1 font-bold tabular-nums ${variant === "embedded" ? "text-xl" : "text-3xl"}`}
+        >
+          {formatCurrency(total)}
+        </p>
       </div>
-      <Button
-        variant="primary"
-        onclick={() => {
-          adding = true;
-          editing = null;
-          reset();
-        }}><Plus class="size-4" />新增資產</Button
-      >
+      <div class="flex flex-wrap gap-2">
+        {#if variant === "embedded"}
+          <Button
+            class="hidden md:inline-flex"
+            variant="secondary"
+            disabled={($assets.data ?? []).length === 0}
+            onclick={toggleHistoryManagement}
+          >
+            {expandedAssetId ? "收起估值歷史" : "管理估值歷史"}
+          </Button>
+        {/if}
+        <Button variant="primary" onclick={openAdd}
+          ><Plus class="size-4" />新增資產</Button
+        >
+      </div>
     </div>
-    <Card>
-      <CardHeader><h2 class="text-lg font-semibold">資產清單</h2></CardHeader>
+    <Card class={variant === "embedded" ? "border-0 shadow-none" : ""}>
+      <CardHeader class={variant === "embedded" ? "px-4" : ""}
+        ><h2 class="text-lg font-semibold">
+          {variant === "embedded" ? "資產與估值" : "資產清單"}
+        </h2></CardHeader
+      >
       <CardContent class="p-0">
         <div class="divide-y divide-ink/8">
           {#if ($assets.data ?? []).length === 0}
@@ -257,7 +365,7 @@
                     ><button
                       class="rounded-sm p-1 text-ink/40 hover:text-coral"
                       aria-label="刪除資產"
-                      onclick={() => (deletingAsset = asset)}
+                      onclick={() => requestDeleteAsset(asset)}
                       ><Trash2 class="size-4" /></button
                     >
                   </div>
@@ -323,11 +431,11 @@
                                   size="sm"
                                   variant="ghost"
                                   onclick={() =>
-                                    (deletingHistory = {
-                                      assetId: asset.id,
-                                      assetName: asset.name,
-                                      date: entry.date,
-                                    })}>刪除</Button
+                                    requestDeleteHistory(
+                                      asset.id,
+                                      asset.name,
+                                      entry.date,
+                                    )}>刪除</Button
                                 >
                               </div>{/if}
                           </div>
@@ -371,10 +479,15 @@
         class="fixed inset-0 z-[70] flex items-end bg-ink/45 md:items-center md:justify-center md:p-6"
       >
         <div
+          aria-labelledby="manual-asset-editor-title"
+          aria-modal="true"
+          bind:this={editorDialog}
           class="w-full rounded-t-2xl bg-white p-5 shadow-2xl md:max-w-lg md:rounded-2xl"
+          role="dialog"
+          tabindex="-1"
         >
           <div class="flex items-center justify-between">
-            <h2 class="text-xl font-semibold">
+            <h2 id="manual-asset-editor-title" class="text-xl font-semibold">
               {editing ? "編輯資產" : "新增資產"}
             </h2>
             <Button
@@ -382,10 +495,7 @@
               class="rounded-full text-xl"
               size="icon"
               variant="ghost"
-              onclick={() => {
-                adding = false;
-                editing = null;
-              }}>×</Button
+              onclick={closeEditor}>×</Button
             >
           </div>
           <div class="mt-5 grid gap-3">
@@ -422,12 +532,7 @@
               </p>{/if}
           </div>
           <div class="mt-5 grid grid-cols-2 gap-3">
-            <Button
-              variant="secondary"
-              onclick={() => {
-                adding = false;
-                editing = null;
-              }}>取消</Button
+            <Button variant="secondary" onclick={closeEditor}>取消</Button
             ><Button
               disabled={$add.isPending || $update.isPending}
               onclick={submit}
@@ -444,8 +549,10 @@
         <div
           aria-labelledby="delete-confirmation-title"
           aria-modal="true"
+          bind:this={deleteDialog}
           class="w-full max-w-sm rounded-2xl bg-white p-5 shadow-2xl"
           role="dialog"
+          tabindex="-1"
         >
           <h2 id="delete-confirmation-title" class="text-lg font-semibold">
             {deletingAsset ? "確定刪除資產？" : "確定刪除估值？"}
@@ -463,10 +570,7 @@
             <Button
               variant="secondary"
               disabled={$remove.isPending || $deleteHistory.isPending}
-              onclick={() => {
-                deletingAsset = null;
-                deletingHistory = null;
-              }}>取消</Button
+              onclick={closeDeleteConfirmation}>取消</Button
             ><Button
               class="bg-coral text-white hover:bg-coral/90"
               disabled={$remove.isPending || $deleteHistory.isPending}

--- a/apps/web/src/features/assets/components/InstitutionDetails.svelte
+++ b/apps/web/src/features/assets/components/InstitutionDetails.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+  import type { CreditCardBillRow } from "@/data/bank/types";
+  import {
+    formatBankAccountName,
+    formatCurrency,
+    formatDate,
+  } from "@/shared/format/financial";
+  import type { InstitutionAssetGroup } from "../model/summary";
+
+  let {
+    group,
+    bills,
+    billsPending = false,
+    billsError = false,
+    compact = false,
+  }: {
+    group: InstitutionAssetGroup;
+    bills: CreditCardBillRow[];
+    billsPending?: boolean;
+    billsError?: boolean;
+    compact?: boolean;
+  } = $props();
+
+  const cardsById = $derived(
+    new Map(group.cards.map((card) => [card.id, card])),
+  );
+  const institutionBills = $derived(
+    bills
+      .filter((bill) => cardsById.has(bill.accountId))
+      .sort((a, b) => b.billingPeriod.localeCompare(a.billingPeriod)),
+  );
+
+  function billAccountName(bill: CreditCardBillRow) {
+    const card = cardsById.get(bill.accountId);
+    return card?.accountName ?? card?.institutionName ?? "信用卡帳戶";
+  }
+
+  function paymentStatusLabel(isPaid?: number) {
+    if (isPaid === 1) return "已繳";
+    if (isPaid === 0) return "待繳";
+    return "狀態未提供";
+  }
+</script>
+
+<div class={compact ? "grid gap-3" : "flex min-h-full flex-col"}>
+  {#if !compact}
+    <header class="border-b border-border px-5 py-4">
+      <p class="text-xs font-semibold text-muted-foreground">金融機構</p>
+      <h2 class="mt-1 text-xl font-semibold tracking-tight">
+        {group.institution}
+      </h2>
+      <p class="mt-1 text-xs text-muted-foreground">
+        帳戶與信用卡依各自資料來源顯示
+      </p>
+    </header>
+    <div class="grid grid-cols-2 gap-2 border-b border-border p-4">
+      <div class="rounded-lg border border-border bg-paper p-3">
+        <p class="text-xs text-muted-foreground">銀行資產</p>
+        <p class="mt-1 text-lg font-bold tabular-nums text-steel">
+          {group.accounts.length ? formatCurrency(group.assetTotalTwd) : "—"}
+        </p>
+      </div>
+      <div class="rounded-lg border border-border bg-paper p-3">
+        <p class="text-xs text-muted-foreground">信用卡負債</p>
+        <p class="mt-1 text-lg font-bold tabular-nums text-coral">
+          {group.cards.length ? formatCurrency(-group.debtTotalTwd) : "—"}
+        </p>
+      </div>
+    </div>
+  {/if}
+
+  <section class={compact ? "" : "border-b border-border px-5 py-4"}>
+    <div class="flex items-center justify-between gap-3">
+      <h3 class="text-sm font-semibold">銀行帳戶</h3>
+      <span class="text-xs text-muted-foreground">
+        {group.accounts.length} 個帳戶
+      </span>
+    </div>
+    {#if group.accounts.length === 0}
+      <p class="py-3 text-sm text-muted-foreground">此機構沒有銀行帳戶。</p>
+    {:else}
+      <div class="mt-2 divide-y divide-border">
+        {#each group.accounts as account (account.id)}
+          <div
+            class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 py-3"
+          >
+            <div class="min-w-0">
+              <p class="break-words text-sm font-semibold">
+                {account.accountName ?? formatBankAccountName(account)}
+              </p>
+              <p class="mt-1 text-xs text-muted-foreground">
+                {account.currency}{account.asOfAt
+                  ? ` · 更新 ${formatDate(account.asOfAt)}`
+                  : " · 尚未取得更新時間"}
+              </p>
+            </div>
+            <p class="text-right text-sm font-bold tabular-nums text-steel">
+              {formatCurrency(account.balance ?? 0, account.currency)}
+            </p>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </section>
+
+  <section class={compact ? "" : "border-b border-border px-5 py-4"}>
+    <div class="flex items-center justify-between gap-3">
+      <h3 class="text-sm font-semibold">信用卡帳戶</h3>
+      <span class="text-xs text-muted-foreground">
+        {group.cards.length} 張卡片
+      </span>
+    </div>
+    {#if group.cards.length === 0}
+      <p class="py-3 text-sm text-muted-foreground">此機構沒有信用卡。</p>
+    {:else}
+      <div class="mt-2 divide-y divide-border">
+        {#each group.cards as card (card.id)}
+          <div
+            class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 py-3"
+          >
+            <div class="min-w-0">
+              <p class="break-words text-sm font-semibold">
+                {card.accountName ?? formatBankAccountName(card)}
+              </p>
+              <p class="mt-1 text-xs text-muted-foreground">
+                {card.paymentDueDate
+                  ? `繳款期限 ${formatDate(card.paymentDueDate)}`
+                  : "繳款期限待同步"}
+              </p>
+            </div>
+            <p class="text-right text-sm font-bold tabular-nums text-coral">
+              {formatCurrency(-Math.abs(card.balance ?? 0), card.currency)}
+            </p>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </section>
+
+  {#if group.cards.length > 0}
+    <details class={compact ? "rounded-lg border border-border" : "m-4"}>
+      <summary
+        class="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 rounded-lg border border-border bg-white px-3 text-sm font-semibold hover:bg-muted"
+      >
+        查看信用卡帳單
+        <span class="text-xs font-normal text-muted-foreground">
+          {institutionBills.length} 筆
+        </span>
+      </summary>
+      <div class="divide-y divide-border px-3">
+        {#if billsPending}
+          <p class="py-4 text-sm text-muted-foreground">正在載入帳單。</p>
+        {:else if billsError}
+          <p class="py-4 text-sm text-coral">信用卡帳單暫時無法載入。</p>
+        {:else if institutionBills.length === 0}
+          <p class="py-4 text-sm text-muted-foreground">尚無信用卡帳單。</p>
+        {:else}
+          {#each institutionBills as bill (bill.id)}
+            <div class="grid gap-1 py-3 sm:grid-cols-[1fr_auto] sm:gap-3">
+              <div>
+                <p class="text-sm font-semibold">{billAccountName(bill)}</p>
+                <p class="mt-1 text-xs text-muted-foreground">
+                  {bill.billingPeriod} · {bill.paymentDueDate
+                    ? `期限 ${formatDate(bill.paymentDueDate)}`
+                    : "期限未提供"} · {paymentStatusLabel(bill.isPaid)}
+                </p>
+              </div>
+              <p class="text-sm font-bold tabular-nums">
+                {bill.statementAmount == null
+                  ? "—"
+                  : formatCurrency(bill.statementAmount, bill.currency)}
+              </p>
+            </div>
+          {/each}
+        {/if}
+      </div>
+    </details>
+  {/if}
+</div>

--- a/apps/web/src/features/assets/components/InvestmentWorkspace.svelte
+++ b/apps/web/src/features/assets/components/InvestmentWorkspace.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import type {
+    InvestmentRow,
+    InvestmentTransactionRow,
+  } from "@/data/investments/types";
+  import {
+    formatCurrency,
+    formatDate,
+    formatNumber,
+  } from "@/shared/format/financial";
+
+  let {
+    positions,
+    trades,
+    total,
+    tradesPending = false,
+    tradesError = false,
+    compact = false,
+  }: {
+    positions: InvestmentRow[];
+    trades: InvestmentTransactionRow[];
+    total: number;
+    tradesPending?: boolean;
+    tradesError?: boolean;
+    compact?: boolean;
+  } = $props();
+
+  let tab = $state<"holdings" | "transactions">("holdings");
+
+  function tradeDisplay(trade: InvestmentTransactionRow) {
+    if (trade.amount != null && trade.price != null && trade.price !== 1)
+      return formatCurrency(trade.amount, trade.currency);
+    if (trade.quantity != null) return `${formatNumber(trade.quantity)} 股`;
+    return "金額未提供";
+  }
+</script>
+
+<div class={compact ? "grid gap-3" : "flex min-h-full flex-col"}>
+  {#if !compact}
+    <header class="border-b border-border px-5 py-4">
+      <p class="text-xs font-semibold text-muted-foreground">投資</p>
+      <h2 class="mt-1 text-xl font-semibold tracking-tight">投資工作區</h2>
+      <p class="mt-1 text-xs text-muted-foreground">持倉與交易紀錄集中查看</p>
+    </header>
+    <div class="grid grid-cols-2 gap-2 border-b border-border p-4">
+      <div class="rounded-lg border border-border bg-paper p-3">
+        <p class="text-xs text-muted-foreground">投資市值</p>
+        <p class="mt-1 text-lg font-bold tabular-nums text-steel">
+          {formatCurrency(total)}
+        </p>
+      </div>
+      <div class="rounded-lg border border-border bg-paper p-3">
+        <p class="text-xs text-muted-foreground">持倉</p>
+        <p class="mt-1 text-lg font-bold tabular-nums">{positions.length} 筆</p>
+      </div>
+    </div>
+  {/if}
+
+  <div
+    class="flex gap-1 border-b border-border px-4 pt-2"
+    role="tablist"
+    aria-label="投資工作區"
+  >
+    <button
+      class={`min-h-10 border-b-2 px-3 text-sm font-semibold ${tab === "holdings" ? "border-steel text-ink" : "border-transparent text-muted-foreground"}`}
+      type="button"
+      role="tab"
+      aria-selected={tab === "holdings"}
+      onclick={() => (tab = "holdings")}>持倉</button
+    >
+    <button
+      class={`min-h-10 border-b-2 px-3 text-sm font-semibold ${tab === "transactions" ? "border-steel text-ink" : "border-transparent text-muted-foreground"}`}
+      type="button"
+      role="tab"
+      aria-selected={tab === "transactions"}
+      onclick={() => (tab = "transactions")}>交易紀錄</button
+    >
+  </div>
+
+  <div class={compact ? "" : "min-h-0 flex-1 overflow-y-auto px-5 pb-4"}>
+    {#if tab === "holdings"}
+      {#if positions.length === 0}
+        <p class="py-8 text-center text-sm text-muted-foreground">
+          尚無投資持倉。
+        </p>
+      {:else}
+        <div class="divide-y divide-border">
+          {#each positions as position (position.id)}
+            <div
+              class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 py-3"
+            >
+              <div class="min-w-0">
+                <p class="break-words text-sm font-semibold">
+                  {position.symbol ? `${position.symbol} ` : ""}{position.name}
+                </p>
+                <p class="mt-1 text-xs text-muted-foreground">
+                  {position.assetType.toUpperCase()} · {position.currency} ·
+                  {formatNumber(position.quantity ?? 0)} 單位
+                </p>
+              </div>
+              <p class="text-right text-sm font-bold tabular-nums text-steel">
+                {formatCurrency(
+                  (position.marketValue ?? 0) + (position.cashBalance ?? 0),
+                  position.currency,
+                )}
+              </p>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    {:else if tradesPending}
+      <p class="py-8 text-center text-sm text-muted-foreground">
+        正在載入交易紀錄。
+      </p>
+    {:else if tradesError}
+      <p class="py-8 text-center text-sm text-coral">交易紀錄暫時無法載入。</p>
+    {:else if trades.length === 0}
+      <p class="py-8 text-center text-sm text-muted-foreground">
+        尚無交易紀錄。
+      </p>
+    {:else}
+      <div class="divide-y divide-border">
+        {#each trades.slice(0, 100) as trade (trade.id)}
+          <div
+            class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 py-3"
+          >
+            <div class="min-w-0">
+              <p class="break-words text-sm font-semibold">
+                {trade.name ?? trade.symbol ?? "投資交易"}
+              </p>
+              <p class="mt-1 text-xs text-muted-foreground">
+                {trade.transactionName ?? trade.transactionCode ?? "交易"} ·
+                {formatDate(trade.tradeDate ?? trade.postedDate)}
+              </p>
+            </div>
+            <p class="text-right text-sm font-semibold">
+              {tradeDisplay(trade)}
+            </p>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</div>

--- a/apps/web/src/features/assets/model/summary.test.ts
+++ b/apps/web/src/features/assets/model/summary.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { calculateAssetSummary } from "./summary";
 
 describe("calculateAssetSummary", () => {
-  it("converts balances, subtracts card debt, and groups deposit accounts", () => {
+  it("converts balances and groups accounts and cards by institution", () => {
     const summary = calculateAssetSummary({
       bank: {
         accounts: [
@@ -11,14 +11,17 @@ describe("calculateAssetSummary", () => {
             connectorId: "esun",
             sourceId: "deposit",
             institutionName: "玉山銀行",
+            bankCode: "808",
             accountType: "savings",
             balance: 100,
             currency: "USD",
           },
           {
             id: "card",
-            connectorId: "sinopac",
+            connectorId: "esun",
             sourceId: "card",
+            institutionName: "玉山銀行",
+            bankCode: "808",
             accountType: "credit",
             balance: -2_000,
             currency: "TWD",
@@ -53,6 +56,49 @@ describe("calculateAssetSummary", () => {
     expect(summary.bankTotal).toBe(3_000);
     expect(summary.cardDebt).toBe(2_000);
     expect(summary.netWorth).toBe(17_000);
-    expect(summary.groupedBanks[0]?.institution).toBe("玉山銀行");
+    expect(summary.institutionGroups).toHaveLength(1);
+    expect(summary.institutionGroups[0]).toMatchObject({
+      key: "bank:808",
+      institution: "玉山銀行",
+      assetTotalTwd: 3_000,
+      debtTotalTwd: 2_000,
+    });
+    expect(summary.institutionGroups[0]?.accounts).toHaveLength(1);
+    expect(summary.institutionGroups[0]?.cards).toHaveLength(1);
+    expect(summary.missingCurrencies).toEqual([]);
+  });
+
+  it("reports currencies omitted from TWD totals when exchange rates are missing", () => {
+    const summary = calculateAssetSummary({
+      bank: {
+        accounts: [
+          {
+            id: "foreign",
+            connectorId: "obank",
+            sourceId: "foreign",
+            accountType: "savings",
+            balance: 100,
+            currency: "USD",
+          },
+        ],
+        transactions: [],
+      },
+      investments: [],
+      manualAssets: [
+        {
+          id: "yen",
+          name: "日圓資產",
+          category: "other",
+          note: null,
+          currency: "JPY",
+          createdAt: "2026-08-09",
+          value: 10_000,
+        },
+      ],
+      rates: [],
+    });
+
+    expect(summary.grossAssets).toBe(0);
+    expect(summary.missingCurrencies).toEqual(["JPY", "USD"]);
   });
 });

--- a/apps/web/src/features/assets/model/summary.ts
+++ b/apps/web/src/features/assets/model/summary.ts
@@ -2,10 +2,22 @@ import type { ExchangeRateRow, ManualAssetRow } from "@/data/assets/types";
 import type { BankAccountRow, BankData } from "@/data/bank/types";
 import type { InvestmentRow } from "@/data/investments/types";
 
-export interface BankAccountGroup {
+const CONNECTOR_BANK_CODES: Record<string, string> = {
+  cathaybk: "013",
+  obank: "048",
+  sinopac: "807",
+  esun: "808",
+  taishin: "812",
+  ctbc: "822",
+};
+
+export interface InstitutionAssetGroup {
+  key: string;
   institution: string;
   accounts: BankAccountRow[];
-  totalTwd: number;
+  cards: BankAccountRow[];
+  assetTotalTwd: number;
+  debtTotalTwd: number;
   foreignCurrencies: string[];
 }
 
@@ -18,7 +30,14 @@ export interface AssetSummary {
   cardDebt: number;
   grossAssets: number;
   netWorth: number;
-  groupedBanks: BankAccountGroup[];
+  institutionGroups: InstitutionAssetGroup[];
+  missingCurrencies: string[];
+}
+
+function institutionKey(account: BankAccountRow) {
+  const bankCode =
+    account.bankCode ?? CONNECTOR_BANK_CODES[account.connectorId];
+  return bankCode ? `bank:${bankCode}` : `connector:${account.connectorId}`;
 }
 
 export function calculateAssetSummary({
@@ -37,6 +56,23 @@ export function calculateAssetSummary({
   );
   const toTwd = (value: number, currency: string) =>
     currency === "TWD" ? value : value * (rateValues[currency] ?? 0);
+  const missingCurrencies = new Set<string>();
+  const recordMissingRate = (value: number, currency: string) => {
+    if (value !== 0 && currency !== "TWD" && rateValues[currency] == null)
+      missingCurrencies.add(currency);
+  };
+  bank.accounts.forEach((account) =>
+    recordMissingRate(account.balance ?? 0, account.currency),
+  );
+  investments.forEach((item) =>
+    recordMissingRate(
+      (item.marketValue ?? 0) + (item.cashBalance ?? 0),
+      item.currency,
+    ),
+  );
+  manualAssets.forEach((item) =>
+    recordMissingRate(item.value ?? 0, item.currency),
+  );
   const deposits = bank.accounts.filter(
     (account) => account.accountType !== "credit",
   );
@@ -64,36 +100,60 @@ export function calculateAssetSummary({
   );
   const grossAssets = bankTotal + investmentTotal + manualTotal;
 
-  const groups = deposits.reduce<Record<string, BankAccountRow[]>>(
+  const groups = bank.accounts.reduce<Record<string, BankAccountRow[]>>(
     (result, account) => {
-      const institution = account.institutionName ?? account.connectorId;
-      (result[institution] ??= []).push(account);
+      (result[institutionKey(account)] ??= []).push(account);
       return result;
     },
     {},
   );
-  const groupedBanks = Object.entries(groups)
-    .map(([institution, accounts]) => ({
-      institution,
-      accounts: [...accounts].sort(
-        (a, b) =>
-          toTwd(b.balance ?? 0, b.currency) - toTwd(a.balance ?? 0, a.currency),
-      ),
-      totalTwd: accounts.reduce(
-        (sum, account) => sum + toTwd(account.balance ?? 0, account.currency),
-        0,
-      ),
-      foreignCurrencies: [
-        ...new Set(
-          accounts
-            .map((account) => account.currency)
-            .filter((currency) => currency !== "TWD"),
+  const institutionGroups = Object.entries(groups)
+    .map(([key, groupedAccounts]) => {
+      const accounts = groupedAccounts.filter(
+        (account) => account.accountType !== "credit",
+      );
+      const cards = groupedAccounts.filter(
+        (account) => account.accountType === "credit",
+      );
+      return {
+        key,
+        institution:
+          groupedAccounts.find((account) => account.institutionName)
+            ?.institutionName ??
+          groupedAccounts[0]?.connectorId ??
+          "金融機構",
+        accounts: [...accounts].sort(
+          (a, b) =>
+            toTwd(b.balance ?? 0, b.currency) -
+            toTwd(a.balance ?? 0, a.currency),
         ),
-      ],
-    }))
+        cards: [...cards].sort(
+          (a, b) =>
+            Math.abs(toTwd(b.balance ?? 0, b.currency)) -
+            Math.abs(toTwd(a.balance ?? 0, a.currency)),
+        ),
+        assetTotalTwd: accounts.reduce(
+          (sum, account) => sum + toTwd(account.balance ?? 0, account.currency),
+          0,
+        ),
+        debtTotalTwd: cards.reduce(
+          (sum, account) =>
+            sum + Math.abs(toTwd(account.balance ?? 0, account.currency)),
+          0,
+        ),
+        foreignCurrencies: [
+          ...new Set(
+            groupedAccounts
+              .map((account) => account.currency)
+              .filter((currency) => currency !== "TWD"),
+          ),
+        ],
+      };
+    })
     .sort(
       (a, b) =>
-        b.totalTwd - a.totalTwd ||
+        b.assetTotalTwd - a.assetTotalTwd ||
+        b.debtTotalTwd - a.debtTotalTwd ||
         a.institution.localeCompare(b.institution, "zh-TW"),
     );
 
@@ -106,6 +166,7 @@ export function calculateAssetSummary({
     cardDebt,
     grossAssets,
     netWorth: grossAssets - cardDebt,
-    groupedBanks,
+    institutionGroups,
+    missingCurrencies: [...missingCurrencies].sort(),
   };
 }

--- a/apps/worker/src/connectors/esun.ts
+++ b/apps/worker/src/connectors/esun.ts
@@ -384,15 +384,26 @@ async function scrapeCreditCards(client: EsunHttpClient): Promise<Scraped> {
   const cards = getCreditCards(detail);
   const cutoffDate = new Date();
   cutoffDate.setMonth(cutoffDate.getMonth() - BANK_SYNC_MONTHS);
-  const bankTransactions = await scrapeTransactions(client, cutoffDate);
-  const accountIds = new Set<string>([
+  const scrapedTransactions = await scrapeTransactions(client, cutoffDate);
+  const mainSourceId = "credit:esun:main";
+  const physicalCardSourceIds = new Set([
     ...cards.map((card) => creditCardSourceId(card.cardNo)),
+    ...scrapedTransactions
+      .map((transaction) => transaction.accountId)
+      .filter((accountId) => accountId !== mainSourceId),
+  ]);
+  const balanceAccountId = esunCreditBalanceAccountId(physicalCardSourceIds);
+  const bankTransactions = scrapedTransactions.map((transaction) =>
+    transaction.accountId === mainSourceId && balanceAccountId !== mainSourceId
+      ? { ...transaction, accountId: balanceAccountId }
+      : transaction,
+  );
+  const accountIds = new Set<string>([
+    ...physicalCardSourceIds,
     ...bankTransactions.map((transaction) => transaction.accountId),
   ]);
   accountIds.delete("");
-
-  const mainSourceId = "credit:esun:main";
-  accountIds.add(mainSourceId);
+  accountIds.add(balanceAccountId);
 
   // overview fields:
   //   trsam = total credit limit (永久信用額度)
@@ -449,8 +460,8 @@ async function scrapeCreditCards(client: EsunHttpClient): Promise<Scraped> {
 
   const bankBalanceSnapshots: Scraped["bankBalanceSnapshots"] = [
     {
-      accountId: mainSourceId,
-      sourceId: `${mainSourceId}:${asOfAt}`,
+      accountId: balanceAccountId,
+      sourceId: `${balanceAccountId}:${asOfAt}`,
       balance: -outstanding,
       availableBalance: availableCredit,
       statementBalance,
@@ -475,8 +486,8 @@ async function scrapeCreditCards(client: EsunHttpClient): Promise<Scraped> {
       const payam = bill.payam ?? 0;
       const isCurrentPeriod = bym6 === (overview.lstym ?? 0);
       return {
-        accountId: mainSourceId,
-        sourceId: `${mainSourceId}:bill:${billingPeriod}`,
+        accountId: balanceAccountId,
+        sourceId: `${balanceAccountId}:bill:${billingPeriod}`,
         billingPeriod,
         statementAmount: tamt || undefined,
         minimumPayment: bill.mimpy ?? undefined,
@@ -1045,6 +1056,19 @@ function readOutstandingBalance(detail: EsunCardDetailData) {
 function creditCardSourceId(cardNo: string | null | undefined) {
   const last4 = cardNo?.match(/(\d{4})$/)?.[1];
   return last4 ? `credit:esun:${last4}` : "credit:esun:main";
+}
+
+export function esunCreditBalanceAccountId(
+  physicalCardSourceIds: Iterable<string>,
+) {
+  const accountIds = [
+    ...new Set(
+      [...physicalCardSourceIds].filter(
+        (accountId) => accountId !== "credit:esun:main",
+      ),
+    ),
+  ];
+  return accountIds.length === 1 ? accountIds[0]! : "credit:esun:main";
 }
 
 function normalizeEsunMonthDay(year: string, monthDay: string) {

--- a/apps/worker/src/connectors/sinopac.ts
+++ b/apps/worker/src/connectors/sinopac.ts
@@ -870,6 +870,19 @@ export function parseSinopacCardData(
     summary.paymentDueDate ?? latestTwdBill?.paymentDueDate;
   const statementClosingDate =
     summary.statementClosingDate ?? latestTwdBill?.statementClosingDate;
+  const latestBillMatchesStatement =
+    latestTwdBill?.statementAmount != null &&
+    statementAmount != null &&
+    Math.abs(latestTwdBill.statementAmount) === Math.abs(statementAmount) &&
+    (!latestTwdBill.paymentDueDate ||
+      !paymentDueDate ||
+      latestTwdBill.paymentDueDate === paymentDueDate) &&
+    (!latestTwdBill.statementClosingDate ||
+      !statementClosingDate ||
+      latestTwdBill.statementClosingDate === statementClosingDate);
+  const noOutstandingStatement =
+    summary.noPaymentNeeded ||
+    (latestBillMatchesStatement && latestTwdBill?.isPaid === true);
   const bankBalanceSnapshots: Scraped["bankBalanceSnapshots"] = [];
   if (
     statementAmount != null ||
@@ -881,7 +894,7 @@ export function parseSinopacCardData(
     bankBalanceSnapshots.push({
       accountId,
       sourceId: `${accountId}:${now.toISOString().slice(0, 10)}`,
-      balance: summary.noPaymentNeeded
+      balance: noOutstandingStatement
         ? 0
         : statementAmount == null
           ? 0
@@ -891,7 +904,7 @@ export function parseSinopacCardData(
         statementAmount == null ? undefined : Math.abs(statementAmount),
       paymentDueDate,
       statementClosingDate,
-      noPaymentNeeded: summary.noPaymentNeeded,
+      noPaymentNeeded: noOutstandingStatement,
       currency: "TWD",
       asOfAt: now.toISOString(),
       raw: {

--- a/apps/worker/src/features/sync/persistence.ts
+++ b/apps/worker/src/features/sync/persistence.ts
@@ -385,6 +385,15 @@ function promotionStatement(
     .join(", ");
   const updates = config.updateColumns
     .map((column) => {
+      if (entityType === "credit_card_bill") {
+        if (column === "paid_amount")
+          return "paid_amount = COALESCE(excluded.paid_amount, credit_card_bills.paid_amount)";
+        if (column === "is_paid")
+          return `is_paid = CASE
+            WHEN credit_card_bills.is_paid = 1 OR excluded.is_paid = 1 THEN 1
+            ELSE COALESCE(excluded.is_paid, credit_card_bills.is_paid)
+          END`;
+      }
       if (entityType !== "bank_transaction")
         return `${column} = excluded.${column}`;
       if (column === "status")

--- a/apps/worker/src/features/sync/repository.ts
+++ b/apps/worker/src/features/sync/repository.ts
@@ -132,6 +132,60 @@ export function reconcileEsunLifecycleShadowStatements(db: D1Database) {
   ];
 }
 
+export function reconcileEsunSingleCardSummaryAccountStatements(
+  db: D1Database,
+) {
+  const mainAccountId = `(SELECT id FROM bank_accounts
+    WHERE connector_id = 'esun' AND source_id = 'credit:esun:main')`;
+  const physicalAccountFilter = `connector_id = 'esun'
+    AND account_type = 'credit'
+    AND source_id LIKE 'credit:esun:%'
+    AND source_id <> 'credit:esun:main'
+    AND canonical_account_id IS NULL`;
+  const physicalAccountId = `(SELECT id FROM bank_accounts
+    WHERE ${physicalAccountFilter}
+    ORDER BY id
+    LIMIT 1)`;
+  const hasSinglePhysicalCard = `(SELECT COUNT(*) FROM bank_accounts
+    WHERE ${physicalAccountFilter}) = 1`;
+
+  return [
+    db.prepare(
+      `DELETE FROM credit_card_bills
+       WHERE account_id = ${mainAccountId}
+         AND ${hasSinglePhysicalCard}
+         AND EXISTS (
+           SELECT 1 FROM credit_card_bills current
+           WHERE current.account_id = ${physicalAccountId}
+             AND current.billing_period = credit_card_bills.billing_period
+         )`,
+    ),
+    db.prepare(
+      `UPDATE credit_card_bills
+       SET account_id = ${physicalAccountId}
+       WHERE account_id = ${mainAccountId}
+         AND ${hasSinglePhysicalCard}`,
+    ),
+    db.prepare(
+      `UPDATE bank_balance_snapshots
+       SET account_id = ${physicalAccountId}
+       WHERE account_id = ${mainAccountId}
+         AND ${hasSinglePhysicalCard}`,
+    ),
+    db.prepare(
+      `UPDATE bank_transactions
+       SET account_id = ${physicalAccountId}
+       WHERE account_id = ${mainAccountId}
+         AND ${hasSinglePhysicalCard}`,
+    ),
+    db.prepare(
+      `DELETE FROM bank_accounts
+       WHERE id = ${mainAccountId}
+         AND ${hasSinglePhysicalCard}`,
+    ),
+  ];
+}
+
 export function reconcileSinopacLegacyTransactionStatements(db: D1Database) {
   const match = `canonical.connector_id = legacy.connector_id
       AND canonical.account_id = legacy.account_id

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -64,6 +64,7 @@ import {
   connectorStateStatement,
   linkCanonicalBankAccountsStatement,
   reconcileEsunLifecycleShadowStatements,
+  reconcileEsunSingleCardSummaryAccountStatements,
   reconcileSinopacLegacyTransactionStatements,
   updateConnectorEncryptedConfig,
 } from "./repository";
@@ -442,8 +443,12 @@ export async function syncEsun(
         ? [
             linkCanonicalBankAccountsStatement(env.DB),
             ...reconcileEsunLifecycleShadowStatements(env.DB),
+            ...reconcileEsunSingleCardSummaryAccountStatements(env.DB),
           ]
-        : reconcileEsunLifecycleShadowStatements(env.DB),
+        : [
+            ...reconcileEsunLifecycleShadowStatements(env.DB),
+            ...reconcileEsunSingleCardSummaryAccountStatements(env.DB),
+          ],
     finalizeStatements,
   });
 

--- a/apps/worker/tests/connectors/esun.test.ts
+++ b/apps/worker/tests/connectors/esun.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  esunCreditBalanceAccountId,
   normalizeEsunTimelineTransactions,
   type EsunTimelinePage,
   type EsunTimelineTransaction,
@@ -33,6 +34,16 @@ function transaction(
 }
 
 describe("E.SUN credit card timeline normalization", () => {
+  it("uses the physical card for a single card and keeps an aggregate for multiple cards", () => {
+    expect(esunCreditBalanceAccountId(["credit:esun:1204"])).toBe(
+      "credit:esun:1204",
+    );
+    expect(
+      esunCreditBalanceAccountId(["credit:esun:1204", "credit:esun:9876"]),
+    ).toBe("credit:esun:main");
+    expect(esunCreditBalanceAccountId([])).toBe("credit:esun:main");
+  });
+
   it("collapses pending and posted lifecycle copies into one stable transaction", () => {
     const rows = normalizeEsunTimelineTransactions([
       page([transaction("未入帳"), transaction("已入帳")]),

--- a/apps/worker/tests/connectors/sinopac.test.ts
+++ b/apps/worker/tests/connectors/sinopac.test.ts
@@ -328,6 +328,11 @@ describe("sinopac App JSON parser", () => {
       isPaid: true,
       currency: "TWD",
     });
+    expect(result.bankBalanceSnapshots[0]).toMatchObject({
+      balance: 0,
+      statementBalance: 5541,
+      noPaymentNeeded: true,
+    });
     expect(result.bankTransactions).toEqual([
       expect.objectContaining({
         postedDate: "2026-07-09",
@@ -342,6 +347,37 @@ describe("sinopac App JSON parser", () => {
         currency: "TWD",
       }),
     ]);
+  });
+
+  it("does not clear a newer statement when only the previous bill is paid", () => {
+    const newerSummaryPayload = structuredClone(mobileSummaryPayload);
+    newerSummaryPayload[0]!.SubInfo[0] = [
+      ...newerSummaryPayload[0]!.SubInfo[0]!.filter(
+        (item) => !["本期應繳", "繳款截止日", "結帳日"].includes(item.DataText),
+      ),
+      { DataText: "本期應繳", DataValue: "7,000" },
+      { DataText: "繳款截止日", DataValue: "2026/08/07" },
+      { DataText: "結帳日", DataValue: "2026/07/23" },
+    ];
+
+    const result = parseSinopacCardData(
+      {
+        summary: newerSummaryPayload,
+        bills: mobileBillPayload,
+        unbilled: mobileUnbilledPayload,
+      },
+      new Date("2026-07-24T12:00:00.000Z"),
+    );
+
+    expect(result.creditCardBills[0]).toMatchObject({
+      statementAmount: 5541,
+      isPaid: true,
+    });
+    expect(result.bankBalanceSnapshots[0]).toMatchObject({
+      balance: -7000,
+      statementBalance: 7000,
+      noPaymentNeeded: false,
+    });
   });
 
   it("maps latest authorizations to pending and upgrades matching card transactions to posted", () => {

--- a/apps/worker/tests/features/sync/persistence.test.ts
+++ b/apps/worker/tests/features/sync/persistence.test.ts
@@ -153,6 +153,33 @@ function bankTransactionRecord(
   };
 }
 
+function creditCardBillRecord(
+  paidAmount: number | null,
+  isPaid: 0 | 1 | null,
+): SyncWriteRecord {
+  return {
+    entityType: "credit_card_bill",
+    recordKey: "tdcc:account-0:2026-07",
+    payload: {
+      id: "tdcc:account-0:2026-07",
+      connector_id: "tdcc",
+      account_id: "tdcc:account-0",
+      source_id: "statement-2026-07",
+      billing_period: "2026-07",
+      statement_amount: 1000,
+      minimum_payment: 100,
+      paid_amount: paidAmount,
+      is_paid: isPaid,
+      payment_due_date: "2026-08-08",
+      statement_closing_date: "2026-07-23",
+      currency: "TWD",
+      raw_payload: "{}",
+      created_at: "2026-07-23T00:00:00.000Z",
+      updated_at: "2026-08-08T00:00:00.000Z",
+    },
+  };
+}
+
 describe("staged sync persistence", () => {
   it("seeds a disabled CTBC all-scope sync job", () => {
     const db = createDb();
@@ -428,6 +455,26 @@ describe("staged sync persistence", () => {
         .prepare("SELECT COUNT(*) AS count FROM bank_transactions")
         .get(),
     ).toEqual({ count: 2 });
+  });
+
+  it("preserves confirmed credit card payment data when a later sync omits it", async () => {
+    const db = createDb();
+
+    await persistStagedSyncWrite(db as unknown as D1Database, {
+      records: [bankAccountRecord(0), creditCardBillRecord(1000, 1)],
+    });
+    await persistStagedSyncWrite(db as unknown as D1Database, {
+      records: [creditCardBillRecord(null, null)],
+    });
+
+    expect(
+      db.database
+        .prepare(
+          `SELECT paid_amount AS paidAmount, is_paid AS isPaid
+           FROM credit_card_bills WHERE billing_period = '2026-07'`,
+        )
+        .get(),
+    ).toEqual({ paidAmount: 1000, isPaid: 1 });
   });
 
   it("rolls back promotion and leaves the cursor unchanged when a staged record is invalid", async () => {

--- a/apps/worker/tests/features/sync/persistence.test.ts
+++ b/apps/worker/tests/features/sync/persistence.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   linkCanonicalBankAccountsStatement,
   reconcileEsunLifecycleShadowStatements,
+  reconcileEsunSingleCardSummaryAccountStatements,
   reconcileSinopacLegacyTransactionStatements,
 } from "../../../src/features/sync/repository";
 
@@ -274,6 +275,127 @@ describe("staged sync persistence", () => {
         .prepare("SELECT target_id, category_id FROM classification_overrides")
         .get(),
     ).toEqual({ target_id: "canonical", category_id: "shopping" });
+  });
+
+  it("merges the E.SUN single-card summary account into the physical card", async () => {
+    const db = createDb();
+    db.database.exec(`
+      INSERT INTO bank_accounts
+        (id, connector_id, source_id, institution_name, account_name, account_type,
+         currency, raw_payload, created_at, updated_at)
+      VALUES
+        ('esun-main', 'esun', 'credit:esun:main', '玉山銀行', '玉山信用卡',
+         'credit', 'TWD', '{}', '2026-07-01', '2026-08-09'),
+        ('esun-1204', 'esun', 'credit:esun:1204', '玉山銀行', '玉山 Unicard',
+         'credit', 'TWD', '{}', '2026-07-01', '2026-08-09');
+
+      INSERT INTO bank_balance_snapshots
+        (id, connector_id, account_id, source_id, balance, currency, as_of_at,
+         raw_payload, created_at, updated_at)
+      VALUES
+        ('old-balance', 'esun', 'esun-main', 'credit:esun:main:2026-08-08',
+         -14510, 'TWD', '2026-08-08', '{}', '2026-08-08', '2026-08-08'),
+        ('new-balance', 'esun', 'esun-1204', 'credit:esun:1204:2026-08-09',
+         -14510, 'TWD', '2026-08-09', '{}', '2026-08-09', '2026-08-09');
+
+      INSERT INTO bank_transactions
+        (id, connector_id, account_id, source_id, posted_date, amount, currency,
+         description, status, raw_payload, created_at, updated_at)
+      VALUES
+        ('main-transaction', 'esun', 'esun-main', 'fallback-transaction',
+         '2026-07-20', -500, 'TWD', '測試交易', 'posted', '{}',
+         '2026-07-20', '2026-07-20');
+
+      INSERT INTO credit_card_bills
+        (id, connector_id, account_id, source_id, billing_period,
+         statement_amount, currency, raw_payload, created_at, updated_at)
+      VALUES
+        ('old-june', 'esun', 'esun-main', 'main:bill:2026-06', '2026-06',
+         5000, 'TWD', '{}', '2026-06-23', '2026-06-23'),
+        ('old-july', 'esun', 'esun-main', 'main:bill:2026-07', '2026-07',
+         14000, 'TWD', '{}', '2026-07-23', '2026-07-23'),
+        ('new-july', 'esun', 'esun-1204', '1204:bill:2026-07', '2026-07',
+         14510, 'TWD', '{}', '2026-08-09', '2026-08-09');
+    `);
+
+    await db.batch(
+      reconcileEsunSingleCardSummaryAccountStatements(
+        db as unknown as D1Database,
+      ),
+    );
+
+    expect(
+      db.database
+        .prepare(
+          "SELECT source_id AS sourceId FROM bank_accounts WHERE connector_id = 'esun'",
+        )
+        .all(),
+    ).toEqual([{ sourceId: "credit:esun:1204" }]);
+    expect(
+      db.database
+        .prepare(
+          "SELECT DISTINCT account_id AS accountId FROM bank_balance_snapshots WHERE connector_id = 'esun'",
+        )
+        .all(),
+    ).toEqual([{ accountId: "esun-1204" }]);
+    expect(
+      db.database
+        .prepare(
+          "SELECT account_id AS accountId FROM bank_transactions WHERE connector_id = 'esun'",
+        )
+        .get(),
+    ).toEqual({ accountId: "esun-1204" });
+    expect(
+      db.database
+        .prepare(
+          `SELECT billing_period AS billingPeriod, statement_amount AS statementAmount,
+                  account_id AS accountId
+           FROM credit_card_bills WHERE connector_id = 'esun'
+           ORDER BY billing_period`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        billingPeriod: "2026-06",
+        statementAmount: 5000,
+        accountId: "esun-1204",
+      },
+      {
+        billingPeriod: "2026-07",
+        statementAmount: 14510,
+        accountId: "esun-1204",
+      },
+    ]);
+  });
+
+  it("keeps the E.SUN summary account when multiple physical cards exist", async () => {
+    const db = createDb();
+    db.database.exec(`
+      INSERT INTO bank_accounts
+        (id, connector_id, source_id, account_type, currency, raw_payload,
+         created_at, updated_at)
+      VALUES
+        ('esun-main', 'esun', 'credit:esun:main', 'credit', 'TWD', '{}',
+         '2026-07-01', '2026-08-09'),
+        ('esun-1204', 'esun', 'credit:esun:1204', 'credit', 'TWD', '{}',
+         '2026-07-01', '2026-08-09'),
+        ('esun-9876', 'esun', 'credit:esun:9876', 'credit', 'TWD', '{}',
+         '2026-07-01', '2026-08-09');
+    `);
+
+    await db.batch(
+      reconcileEsunSingleCardSummaryAccountStatements(
+        db as unknown as D1Database,
+      ),
+    );
+
+    expect(
+      db.database
+        .prepare(
+          "SELECT COUNT(*) AS count FROM bank_accounts WHERE connector_id = 'esun'",
+        )
+        .get(),
+    ).toEqual({ count: 3 });
   });
 
   it("migrates preferences and removes matching legacy Sinopac transaction ids", async () => {


### PR DESCRIPTION
## 變更內容

- 將資產頁重構為資產清冊，依金融機構、投資與其他資產分組。
- 桌面版採主從明細，手機版採可展開卡片，手動資產新增、編輯、刪除與估值歷史皆可在同頁完成。
- 補上 dialog 的 Escape 關閉、焦點回復與背景捲動鎖定。
- 修正永豐已繳帳單仍被計入信用卡負債，並保留已確認的繳款狀態，避免後續同步以空值覆蓋。
- 信用卡帳單改為「已繳／待繳／狀態未提供」三態顯示。
- 修正玉山單一卡片同時建立實體卡與彙總帳戶，造成卡片數重複；同步時會將既有彙總帳戶的餘額、交易與帳單安全遷移到實體卡，多卡情境則保留彙總帳戶。

## 原因與影響

原本資產資訊分散於多個頁面，手機版操作需要跳轉；信用卡同步資料也存在帳單狀態與 balance snapshot 語意不一致，以及玉山單卡被建模成兩個 credit account 的問題。

完成後，資產管理流程集中在資產清冊，已繳帳單不會再增加負債，未知繳款狀態不會誤標為待繳，玉山單卡也只會顯示一張卡。

## 驗證

- `npm run verify:web`
  - 66 個前端單元測試通過
  - 16 個 E2E 通過
  - Svelte check 與 production build 通過
- `npm run test:backend`
  - Worker 211 個測試通過
  - DB、connector self-check 與部署測試通過
- `npm run typecheck`
- `git diff --check`
- localhost desktop/mobile 資產頁視覺與互動驗證