### PR TITLE
調整資產清冊預設展開與投資文案

### DIFF
--- a/apps/web/e2e/assets.spec.ts
+++ b/apps/web/e2e/assets.spec.ts
@@ -189,7 +189,7 @@ test("uses the desktop asset ledger without losing detail workflows", async ({
   ).toBeVisible();
   await ledger.getByRole("button", { name: /^投資/ }).click();
   await expect(
-    page.getByRole("heading", { name: "投資工作區", exact: true }),
+    page.getByRole("heading", { name: "投資組合", exact: true }),
   ).toBeVisible();
   await page.getByRole("tab", { name: "交易紀錄", exact: true }).click();
   await expect(page.getByText("買進 · 2026/8/1")).toBeVisible();
@@ -231,10 +231,13 @@ test("keeps the mobile ledger readable and expandable", async ({ page }) => {
   await page.goto("/#/assets");
 
   const taishin = page.getByRole("button", { name: /^台 台新銀行/ });
-  await expect(taishin).toHaveAttribute("aria-expanded", "true");
+  await expect(taishin).toHaveAttribute("aria-expanded", "false");
   const ledger = page
     .locator('section[aria-label="資產清冊"]')
     .filter({ visible: true });
+  await expect(ledger.getByText("薪轉戶", { exact: true })).toBeHidden();
+  await taishin.click();
+  await expect(taishin).toHaveAttribute("aria-expanded", "true");
   await expect(ledger.getByText("薪轉戶", { exact: true })).toBeVisible();
   await expect(
     page.getByText("信用卡負債", { exact: true }).first(),

--- a/apps/web/src/features/assets/AssetsPage.svelte
+++ b/apps/web/src/features/assets/AssetsPage.svelte
@@ -81,7 +81,7 @@
   ]);
 
   let selectedKey = $state<string>();
-  let expandedKey = $state<string | null>();
+  let expandedKey = $state<string | null>(null);
   const activeKey = $derived(
     selectedKey && ledgerItems.some((item) => item.key === selectedKey)
       ? selectedKey
@@ -90,9 +90,7 @@
   const activeItem = $derived(
     ledgerItems.find((item) => item.key === activeKey),
   );
-  const mobileExpandedKey = $derived(
-    expandedKey === undefined ? (ledgerItems[0]?.key ?? null) : expandedKey,
-  );
+  const mobileExpandedKey = $derived(expandedKey);
 
   function toggleMobile(key: string) {
     expandedKey = mobileExpandedKey === key ? null : key;
@@ -411,7 +409,7 @@
               onclick={() => toggleMobile("investments")}
             >
               <span>
-                <strong class="block text-sm">投資工作區</strong>
+                <strong class="block text-sm">投資組合</strong>
                 <small class="mt-1 block text-xs text-ink/45">
                   {$investments.data?.length ?? 0} 個持倉 · 交易紀錄
                 </small>

--- a/apps/web/src/features/assets/components/InvestmentWorkspace.svelte
+++ b/apps/web/src/features/assets/components/InvestmentWorkspace.svelte
@@ -39,7 +39,7 @@
   {#if !compact}
     <header class="border-b border-border px-5 py-4">
       <p class="text-xs font-semibold text-muted-foreground">投資</p>
-      <h2 class="mt-1 text-xl font-semibold tracking-tight">投資工作區</h2>
+      <h2 class="mt-1 text-xl font-semibold tracking-tight">投資組合</h2>
       <p class="mt-1 text-xs text-muted-foreground">持倉與交易紀錄集中查看</p>
     </header>
     <div class="grid grid-cols-2 gap-2 border-b border-border p-4">
@@ -59,7 +59,7 @@
   <div
     class="flex gap-1 border-b border-border px-4 pt-2"
     role="tablist"
-    aria-label="投資工作區"
+    aria-label="投資組合"
   >
     <button
       class={`min-h-10 border-b-2 px-3 text-sm font-semibold ${tab === "holdings" ? "border-steel text-ink" : "border-transparent text-muted-foreground"}`}


### PR DESCRIPTION
## 變更內容

- 手機版進入資產清冊時，所有銀行預設保持收合。
- 使用者點擊銀行後才展開帳戶與信用卡明細，再次點擊可收合。
- 將使用者可見的「投資工作區」統一改為「投資組合」。
- 更新資產頁 E2E，涵蓋預設收合、點擊展開與新文案。

## 原因與影響

資產頁原本會自動展開第一家銀行，占用手機畫面並讓使用者誤以為該銀行被預先選取；「投資工作區」也偏向內部實作術語。調整後，資產清冊初始畫面更精簡，投資功能命名也更貼近日常使用語言。

## 驗證

- Mobile asset ledger E2E 通過
- Desktop asset ledger E2E 通過
- Svelte check：0 errors、0 warnings
- Svelte autofixer：無問題
- localhost 手機版初始收合、點擊展開及投資組合文案驗證
- `git diff --check`