### PR TITLE
新增每日同步結果報告

### DIFF
--- a/apps/web/src/data/sync-reports/queries.ts
+++ b/apps/web/src/data/sync-reports/queries.ts
@@ -1,0 +1,13 @@
+import type { ScheduledSyncReport } from "@taiwan-fin-hub/core";
+import { queryOptions } from "@tanstack/svelte-query";
+import type { ApiClient } from "@/shared/api/client";
+import { queryKeys } from "@/shared/api/query-keys";
+
+type ApiProvider = () => ApiClient;
+
+export const latestSyncReportQuery = (getApi: ApiProvider) =>
+  queryOptions({
+    queryKey: queryKeys.latestSyncReport,
+    queryFn: () =>
+      getApi().get<ScheduledSyncReport | null>("/api/sync-reports/latest"),
+  });

--- a/apps/web/src/data/sync-reports/types.ts
+++ b/apps/web/src/data/sync-reports/types.ts
@@ -1,0 +1,1 @@
+export type { ScheduledSyncReport } from "@taiwan-fin-hub/core";

--- a/apps/web/src/features/overview/OverviewPage.svelte
+++ b/apps/web/src/features/overview/OverviewPage.svelte
@@ -19,6 +19,7 @@
   } from "@/data/assets/queries";
   import { bankQuery, bankRangeQuery } from "@/data/bank/queries";
   import { syncJobsQuery } from "@/data/connectors/queries";
+  import { latestSyncReportQuery } from "@/data/sync-reports/queries";
   import {
     getActionableSyncJobs,
     getConfiguredSyncJobs,
@@ -36,6 +37,7 @@
     rateMap,
   } from "@/shared/format/financial";
   import NetWorthHistoryChart from "./components/NetWorthHistoryChart.svelte";
+  import LatestSyncReportCard from "./components/LatestSyncReportCard.svelte";
 
   type InsightTone = "coral" | "amber" | "moss" | "steel";
   type InsightIcon = "sync" | "card" | "cashflow";
@@ -66,6 +68,7 @@
   const manualAssets = createQuery(manualAssetsQuery(() => api));
   const rates = createQuery(exchangeRatesQuery(() => api));
   const jobs = createQuery(syncJobsQuery(() => api));
+  const latestSyncReport = createQuery(latestSyncReportQuery(() => api));
   const history = createQuery(netWorthHistoryQuery(() => api));
 
   const bankData = $derived($bank.data ?? { accounts: [], transactions: [] });
@@ -379,6 +382,11 @@
         {/each}
       </CardContent>
     </Card>
+
+    <LatestSyncReportCard
+      report={$latestSyncReport.data}
+      loading={$latestSyncReport.isPending}
+    />
 
     <div class="grid gap-4 xl:grid-cols-[minmax(0,1.8fr)_340px]">
       <div class="min-w-0">

--- a/apps/web/src/features/overview/components/LatestSyncReportCard.svelte
+++ b/apps/web/src/features/overview/components/LatestSyncReportCard.svelte
@@ -1,0 +1,229 @@
+<script lang="ts">
+  import { CircleCheckBig, RefreshCw, TriangleAlert } from "@lucide/svelte";
+  import {
+    connectorCatalog,
+    type ScheduledSyncReport,
+  } from "@taiwan-fin-hub/core";
+  import Card from "@/shared/ui/Card.svelte";
+  import CardContent from "@/shared/ui/CardContent.svelte";
+  import { formatCurrency, formatDateTime } from "@/shared/format/financial";
+  import {
+    financialChangeUnavailableMessage,
+    signedFinancialChange,
+    syncReportStatusPresentation,
+    zeroRateCurrenciesMessage,
+  } from "../model/sync-report";
+
+  let {
+    report,
+    loading = false,
+  }: { report: ScheduledSyncReport | null | undefined; loading?: boolean } =
+    $props();
+
+  const presentation = $derived(
+    report ? syncReportStatusPresentation(report) : null,
+  );
+  const unavailableMessage = $derived(
+    report
+      ? financialChangeUnavailableMessage(
+          report.financialChangeUnavailableReason,
+        )
+      : null,
+  );
+  const zeroRateMessage = $derived(
+    report ? zeroRateCurrenciesMessage(report.missingCurrencies) : null,
+  );
+  const newRecordItems = $derived(
+    report
+      ? [
+          { label: "交易", value: report.newRecords.bankTransactions },
+          { label: "發票", value: report.newRecords.invoices },
+          {
+            label: "投資交易",
+            value: report.newRecords.investmentTransactions,
+          },
+        ]
+      : [],
+  );
+  const financialItems = $derived(
+    report?.financialChange
+      ? [
+          {
+            label: "資產",
+            value: report.financialChange.assets,
+            positiveChangeIsFavorable: true,
+          },
+          {
+            label: "信用卡負債",
+            value: report.financialChange.creditCardDebt,
+            positiveChangeIsFavorable: false,
+          },
+          {
+            label: "淨資產",
+            value: report.financialChange.netWorth,
+            positiveChangeIsFavorable: true,
+          },
+        ]
+      : [],
+  );
+
+  function formatFinancialChange(value: number) {
+    const amount = formatCurrency(Math.abs(value));
+    if (amount.includes("•")) return amount;
+    return `${signedFinancialChange(value).sign}${amount}`;
+  }
+
+  function sourceStatusLabel(status: ScheduledSyncReport["status"]) {
+    if (status === "success") return "完成";
+    if (status === "needs_user_action") return "需要處理";
+    return "失敗";
+  }
+
+  function sourceNewRecordSummary(
+    source: ScheduledSyncReport["sources"][number],
+  ) {
+    const counts = [
+      source.newRecords.bankTransactions > 0
+        ? `交易 ${source.newRecords.bankTransactions}`
+        : null,
+      source.newRecords.invoices > 0
+        ? `發票 ${source.newRecords.invoices}`
+        : null,
+      source.newRecords.investmentTransactions > 0
+        ? `投資交易 ${source.newRecords.investmentTransactions}`
+        : null,
+    ].filter((item): item is string => item !== null);
+    return counts.length > 0 ? `新增 ${counts.join("、")}` : "沒有新增資料";
+  }
+</script>
+
+{#if loading}
+  <div aria-busy="true">
+    <Card>
+      <CardContent class="flex min-h-32 items-center gap-3 p-5 text-ink/50">
+        <RefreshCw class="size-5 animate-spin" />
+        <p class="text-sm font-medium">讀取最近同步結果中</p>
+      </CardContent>
+    </Card>
+  </div>
+{:else if report && presentation}
+  <Card as="section" class="overflow-hidden">
+    <CardContent class="grid gap-5 p-5 md:p-6">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="flex min-w-0 items-start gap-3">
+          <span
+            class={`mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-full ${presentation.tone === "success" ? "bg-emerald-50 text-moss" : "bg-amber-50 text-amber-700"}`}
+          >
+            {#if presentation.tone === "success"}
+              <CircleCheckBig class="size-5" />
+            {:else}
+              <TriangleAlert class="size-5" />
+            {/if}
+          </span>
+          <div class="min-w-0">
+            <p class="text-xs font-semibold text-ink/45">最近一次同步</p>
+            <h2 class="mt-1 text-lg font-semibold">{presentation.label}</h2>
+            <p class="mt-1 text-xs text-ink/50">
+              {presentation.description}
+            </p>
+          </div>
+        </div>
+        <time
+          class="text-xs font-medium text-ink/45"
+          datetime={report.completedAt}
+          >{formatDateTime(report.completedAt)}</time
+        >
+      </div>
+
+      <div class="grid gap-3 md:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
+        <div class="rounded-xl bg-paper p-4">
+          <p class="text-xs font-semibold text-ink/50">新增資料</p>
+          <div class="mt-3 grid grid-cols-3 gap-2">
+            {#each newRecordItems as item (item.label)}
+              <div class="min-w-0">
+                <p class="text-xl font-bold tabular-nums">{item.value}</p>
+                <p class="mt-1 truncate text-[11px] text-ink/45">
+                  {item.label}
+                </p>
+              </div>
+            {/each}
+          </div>
+        </div>
+
+        {#if report.financialChange}
+          <div class="rounded-xl border border-border/80 p-4">
+            <p class="text-xs font-semibold text-ink/50">同步後變化</p>
+            <div class="mt-3 grid grid-cols-3 gap-2">
+              {#each financialItems as item (item.label)}
+                {@const change = signedFinancialChange(
+                  item.value,
+                  item.positiveChangeIsFavorable,
+                )}
+                <div class="min-w-0">
+                  <p
+                    class={`truncate text-base font-bold tabular-nums sm:text-lg ${change.tone === "positive" ? "text-moss" : change.tone === "negative" ? "text-coral" : "text-ink"}`}
+                  >
+                    {formatFinancialChange(item.value)}
+                  </p>
+                  <p class="mt-1 truncate text-[11px] text-ink/45">
+                    {item.label}
+                  </p>
+                </div>
+              {/each}
+            </div>
+          </div>
+        {:else if unavailableMessage}
+          <div
+            class="flex items-center gap-3 rounded-xl border border-amber-200 bg-amber-50/70 p-4 text-amber-900"
+          >
+            <TriangleAlert class="size-5 shrink-0" />
+            <p class="text-xs font-medium leading-relaxed">
+              {unavailableMessage}
+            </p>
+          </div>
+        {/if}
+      </div>
+
+      {#if zeroRateMessage}
+        <div
+          class="flex items-start gap-2 rounded-lg bg-amber-50/70 px-3 py-2.5 text-amber-900"
+        >
+          <TriangleAlert class="mt-0.5 size-4 shrink-0" />
+          <p class="text-xs font-medium leading-relaxed">{zeroRateMessage}</p>
+        </div>
+      {/if}
+
+      {#if report.sources.length > 0}
+        <details class="group border-t border-border/70 pt-4">
+          <summary
+            class="cursor-pointer list-none text-xs font-semibold text-steel marker:content-none"
+          >
+            <span class="group-open:hidden">查看各資料來源</span>
+            <span class="hidden group-open:inline">收合各資料來源</span>
+          </summary>
+          <div class="mt-3 grid gap-2">
+            {#each report.sources as source (source.connectorId)}
+              <div
+                class="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 rounded-lg bg-paper px-3 py-2.5"
+              >
+                <div class="min-w-0">
+                  <p class="truncate text-xs font-semibold">
+                    {connectorCatalog[source.connectorId].title}
+                  </p>
+                  <p class="mt-0.5 text-[11px] text-ink/45">
+                    {sourceNewRecordSummary(source)}
+                  </p>
+                </div>
+                <span
+                  class={`text-xs font-semibold ${source.status === "success" ? "text-moss" : "text-amber-700"}`}
+                >
+                  {sourceStatusLabel(source.status)}
+                </span>
+              </div>
+            {/each}
+          </div>
+        </details>
+      {/if}
+    </CardContent>
+  </Card>
+{/if}

--- a/apps/web/src/features/overview/model/sync-report.test.ts
+++ b/apps/web/src/features/overview/model/sync-report.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { ScheduledSyncReport } from "@taiwan-fin-hub/core";
+import {
+  financialChangeUnavailableMessage,
+  signedFinancialChange,
+  syncReportStatusPresentation,
+  zeroRateCurrenciesMessage,
+} from "./sync-report";
+
+function report(input: Partial<ScheduledSyncReport> = {}): ScheduledSyncReport {
+  return {
+    id: "default:report",
+    startedAt: "2026-08-12T22:00:00.000Z",
+    completedAt: "2026-08-12T22:05:00.000Z",
+    status: "success",
+    sources: [],
+    sourceSummary: { total: 3, success: 3, failed: 0, needsUserAction: 0 },
+    newRecords: {
+      invoices: 3,
+      bankTransactions: 9,
+      investmentTransactions: 1,
+    },
+    financialChange: {
+      assets: 12_340,
+      creditCardDebt: -1_200,
+      netWorth: 13_540,
+    },
+    financialChangeUnavailableReason: null,
+    missingCurrencies: [],
+    ...input,
+  };
+}
+
+describe("sync report presentation", () => {
+  it("summarizes a successful round", () => {
+    expect(syncReportStatusPresentation(report())).toEqual({
+      label: "同步完成",
+      description: "3 個資料來源已完成",
+      tone: "success",
+    });
+  });
+
+  it("does not present a partial round as a complete financial comparison", () => {
+    const value = report({
+      status: "failed",
+      sourceSummary: { total: 3, success: 2, failed: 1, needsUserAction: 0 },
+      financialChange: null,
+      financialChangeUnavailableReason: "partial_sync",
+    });
+    expect(syncReportStatusPresentation(value).description).toBe(
+      "2 / 3 個來源完成，1 個未更新",
+    );
+    expect(
+      financialChangeUnavailableMessage(value.financialChangeUnavailableReason),
+    ).toBe("部分資料來源未更新，暫不計算資產變化。");
+  });
+
+  it("explains baseline reports and currencies valued at zero", () => {
+    expect(financialChangeUnavailableMessage("baseline")).toContain("資產基準");
+    expect(zeroRateCurrenciesMessage(["USD", "EUR"])).toBe(
+      "缺少 USD、EUR 匯率，相關資產以 NT$0 計算。",
+    );
+    expect(zeroRateCurrenciesMessage([])).toBeNull();
+  });
+
+  it("keeps the displayed sign separate from the absolute currency value", () => {
+    expect(signedFinancialChange(1200)).toEqual({
+      sign: "+",
+      tone: "positive",
+    });
+    expect(signedFinancialChange(-1200)).toEqual({
+      sign: "−",
+      tone: "negative",
+    });
+    expect(signedFinancialChange(0)).toEqual({ sign: "", tone: "neutral" });
+    expect(signedFinancialChange(-1200, false)).toEqual({
+      sign: "−",
+      tone: "positive",
+    });
+  });
+});

--- a/apps/web/src/features/overview/model/sync-report.ts
+++ b/apps/web/src/features/overview/model/sync-report.ts
@@ -1,0 +1,67 @@
+import type {
+  ScheduledSyncReport,
+  SyncFinancialChangeUnavailableReason,
+} from "@taiwan-fin-hub/core";
+
+export type SyncReportStatusPresentation = {
+  label: string;
+  description: string;
+  tone: "success" | "warning";
+};
+
+export function syncReportStatusPresentation(
+  report: ScheduledSyncReport,
+): SyncReportStatusPresentation {
+  const { success, failed, needsUserAction, total } = report.sourceSummary;
+  if (report.status === "success") {
+    return {
+      label: "同步完成",
+      description: `${success} 個資料來源已完成`,
+      tone: "success",
+    };
+  }
+  const pending = failed + needsUserAction;
+  return {
+    label: needsUserAction > 0 ? "同步完成，需要處理" : "同步完成，部分失敗",
+    description: `${success} / ${total} 個來源完成，${pending} 個未更新`,
+    tone: "warning",
+  };
+}
+
+export function financialChangeUnavailableMessage(
+  reason: SyncFinancialChangeUnavailableReason | null,
+) {
+  if (reason === "baseline") return "這是第一份同步報告，已建立資產基準。";
+  if (reason === "partial_sync")
+    return "部分資料來源未更新，暫不計算資產變化。";
+  if (reason === "snapshot_unavailable") return "這次沒有完整的資產比較資料。";
+  return null;
+}
+
+export function zeroRateCurrenciesMessage(missingCurrencies: string[]) {
+  if (missingCurrencies.length === 0) return null;
+  return `缺少 ${missingCurrencies.join("、")} 匯率，相關資產以 NT$0 計算。`;
+}
+
+export function signedFinancialChange(
+  value: number,
+  positiveChangeIsFavorable = true,
+) {
+  if (value > 0) {
+    return {
+      sign: "+",
+      tone: positiveChangeIsFavorable
+        ? ("positive" as const)
+        : ("negative" as const),
+    };
+  }
+  if (value < 0) {
+    return {
+      sign: "−",
+      tone: positiveChangeIsFavorable
+        ? ("negative" as const)
+        : ("positive" as const),
+    };
+  }
+  return { sign: "", tone: "neutral" as const };
+}

--- a/apps/web/src/shared/api/query-keys.ts
+++ b/apps/web/src/shared/api/query-keys.ts
@@ -20,6 +20,7 @@ export const queryKeys = {
   exchangeRates: ["exchange-rates"] as const,
   netWorthHistory: ["netWorthHistory"] as const,
   syncJobs: ["sync-jobs"] as const,
+  latestSyncReport: ["sync-reports", "latest"] as const,
   syncSchedule: ["sync-schedule"] as const,
   notifications: ["notifications"] as const,
   classificationCategories: ["classification-categories"] as const,

--- a/apps/worker/src/features/notifications/payload.ts
+++ b/apps/worker/src/features/notifications/payload.ts
@@ -34,7 +34,7 @@ export function syncNotificationPayload(
   if (event.status === "success") {
     return {
       title: "同步完成",
-      body: `${connector}已完成排程同步。`,
+      body: `${connector}已完成排程同步，開啟 App 查看結果。`,
       url: "/#/overview",
       tag: `sync-${event.connectorId}-success`,
     };
@@ -70,7 +70,7 @@ export function scheduledSyncSummaryPayload(
   if (status === "success") {
     return {
       title: "同步完成",
-      body: `已完成 ${success} 個資料來源的預設排程同步。`,
+      body: "每日同步已完成，開啟 App 查看結果。",
       url: "/#/overview",
       tag: "sync-default-schedule-success",
     };

--- a/apps/worker/src/features/sync/notification-batch-repository.ts
+++ b/apps/worker/src/features/sync/notification-batch-repository.ts
@@ -1,6 +1,14 @@
-import type { ConnectorId, SyncNotificationStatus } from "@taiwan-fin-hub/core";
+import type {
+  ConnectorId,
+  SyncNewRecordCounts,
+  SyncNotificationStatus,
+} from "@taiwan-fin-hub/core";
 import type { SyncJobRow } from "@taiwan-fin-hub/db";
 import type { SyncNotificationEvent } from "../notifications/payload";
+import {
+  calculateCurrentFinancialSnapshot,
+  hasCompletedFinancialBaseline,
+} from "./report-repository";
 
 type BatchRow = {
   id: string;
@@ -48,15 +56,26 @@ export async function ensureDefaultScheduleBatch(db: D1Database) {
 
   const batchId = `default:${crypto.randomUUID()}`;
   const now = new Date().toISOString();
+  const snapshot = await calculateCurrentFinancialSnapshot(db);
+  const isBaseline = !(await hasCompletedFinancialBaseline(db));
   try {
     await db.batch([
       db
         .prepare(
           `INSERT INTO scheduled_sync_batches (
-             id, schedule_key, notification_claimed_at, created_at
-           ) VALUES (?, 'default', NULL, ?)`,
+             id, schedule_key, notification_claimed_at, created_at,
+             is_baseline, assets_before_twd, credit_card_debt_before_twd,
+             missing_currencies_before
+           ) VALUES (?, 'default', NULL, ?, ?, ?, ?, ?)`,
         )
-        .bind(batchId, now),
+        .bind(
+          batchId,
+          now,
+          isBaseline ? 1 : 0,
+          snapshot.assetsTwd,
+          snapshot.creditCardDebtTwd,
+          JSON.stringify(snapshot.missingCurrencies),
+        ),
       ...jobs.results.map((job) =>
         db
           .prepare(
@@ -123,18 +142,25 @@ export async function recordDefaultScheduleBatchResult(
     batchId: string;
     jobId: string;
     notification: SyncNotificationEvent;
+    newRecords: SyncNewRecordCounts;
   },
 ) {
   const result = await db
     .prepare(
       `UPDATE scheduled_sync_batch_results
-       SET connector_id = ?, status = ?, completed_at = ?
+       SET connector_id = ?, status = ?, completed_at = ?,
+           new_invoices = ?,
+           new_bank_transactions = ?,
+           new_investment_transactions = ?
        WHERE batch_id = ? AND job_id = ? AND completed_at IS NULL`,
     )
     .bind(
       input.notification.connectorId,
       input.notification.status,
       new Date().toISOString(),
+      input.newRecords.invoices,
+      input.newRecords.bankTransactions,
+      input.newRecords.investmentTransactions,
       input.batchId,
       input.jobId,
     )
@@ -155,12 +181,18 @@ export async function claimCompletedDefaultScheduleBatch(
   await reconcileDefaultScheduleBatchMembers(db, batchId);
 
   const now = new Date().toISOString();
+  const snapshot = await calculateCurrentFinancialSnapshot(db);
   const claim = await db
     .prepare(
       `UPDATE scheduled_sync_batches
-       SET notification_claimed_at = ?
+       SET notification_claimed_at = ?,
+           completed_at = ?,
+           assets_after_twd = ?,
+           credit_card_debt_after_twd = ?,
+           missing_currencies_after = ?
        WHERE id = ?
          AND notification_claimed_at IS NULL
+         AND completed_at IS NULL
          AND EXISTS (
            SELECT 1
            FROM scheduled_sync_batch_results
@@ -172,7 +204,16 @@ export async function claimCompletedDefaultScheduleBatch(
            WHERE batch_id = ? AND completed_at IS NULL
          )`,
     )
-    .bind(now, batchId, batchId, batchId)
+    .bind(
+      now,
+      now,
+      snapshot.assetsTwd,
+      snapshot.creditCardDebtTwd,
+      JSON.stringify(snapshot.missingCurrencies),
+      batchId,
+      batchId,
+      batchId,
+    )
     .run();
   if (claim.meta.changes !== 1) return null;
 

--- a/apps/worker/src/features/sync/persistence.ts
+++ b/apps/worker/src/features/sync/persistence.ts
@@ -1,3 +1,5 @@
+import type { SyncNewRecordCounts } from "@taiwan-fin-hub/core";
+
 export type SyncEntityType =
   | "invoice"
   | "invoice_line_item"
@@ -309,6 +311,16 @@ const ENTITY_CONFIG: Record<SyncEntityType, EntityConfig> = {
 const STAGING_CHUNK_SIZE = 100;
 const STAGING_RETENTION_MS = 24 * 60 * 60 * 1_000;
 
+const NEW_RECORD_ENTITIES = {
+  invoice: "invoices",
+  bank_transaction: "bankTransactions",
+  investment_transaction: "investmentTransactions",
+} as const satisfies Partial<Record<SyncEntityType, keyof SyncNewRecordCounts>>;
+
+export function emptySyncNewRecordCounts(): SyncNewRecordCounts {
+  return { invoices: 0, bankTransactions: 0, investmentTransactions: 0 };
+}
+
 export async function persistStagedSyncWrite(
   db: D1Database,
   input: {
@@ -354,15 +366,35 @@ export async function persistStagedSyncWrite(
     const entityTypes = new Set(
       input.records.map((record) => record.entityType),
     );
-    await db.batch([
+    const promotionStatements = ENTITY_ORDER.filter((entityType) =>
+      entityTypes.has(entityType),
+    ).map((entityType) => promotionStatement(db, runId, entityType));
+    const newRecordCountStatements = Object.entries(NEW_RECORD_ENTITIES)
+      .filter(([entityType]) => entityTypes.has(entityType as SyncEntityType))
+      .map(([entityType, resultKey]) => ({
+        resultKey,
+        statement: newRecordCountStatement(
+          db,
+          runId,
+          entityType as keyof typeof NEW_RECORD_ENTITIES,
+        ),
+      }));
+    const countResultOffset = input.beforePromoteStatements?.length ?? 0;
+    const batchResults = await db.batch([
       ...(input.beforePromoteStatements ?? []),
-      ...ENTITY_ORDER.filter((entityType) => entityTypes.has(entityType)).map(
-        (entityType) => promotionStatement(db, runId, entityType),
-      ),
+      ...newRecordCountStatements.map(({ statement }) => statement),
+      ...promotionStatements,
       ...(input.afterPromoteStatements ?? []),
       ...(input.finalizeStatements ?? []),
       db.prepare("DELETE FROM sync_write_staging WHERE run_id = ?").bind(runId),
     ]);
+    const newRecords = emptySyncNewRecordCounts();
+    for (const [index, { resultKey }] of newRecordCountStatements.entries()) {
+      const result = batchResults[countResultOffset + index] as
+        { results?: Array<{ count?: number }> } | undefined;
+      newRecords[resultKey] = result?.results?.[0]?.count ?? 0;
+    }
+    return newRecords;
   } catch (error) {
     await db
       .prepare("DELETE FROM sync_write_staging WHERE run_id = ?")
@@ -371,6 +403,33 @@ export async function persistStagedSyncWrite(
       .catch(() => undefined);
     throw error;
   }
+}
+
+function newRecordCountStatement(
+  db: D1Database,
+  runId: string,
+  entityType: keyof typeof NEW_RECORD_ENTITIES,
+) {
+  const config = ENTITY_CONFIG[entityType];
+  const conflictMatch = config.conflictColumns
+    .map(
+      (column) =>
+        `target.${column} = json_extract(staging.payload, '$.${column}')`,
+    )
+    .join(" AND ");
+  return db
+    .prepare(
+      `SELECT COUNT(*) AS count
+       FROM sync_write_staging staging
+       WHERE staging.run_id = ?
+         AND staging.entity_type = ?
+         AND NOT EXISTS (
+           SELECT 1
+           FROM ${config.table} target
+           WHERE ${conflictMatch}
+         )`,
+    )
+    .bind(runId, entityType);
 }
 
 function promotionStatement(

--- a/apps/worker/src/features/sync/report-repository.ts
+++ b/apps/worker/src/features/sync/report-repository.ts
@@ -1,0 +1,316 @@
+import type {
+  ConnectorId,
+  ScheduledSyncReport,
+  ScheduledSyncSourceReport,
+  SyncFinancialChangeUnavailableReason,
+  SyncNewRecordCounts,
+  SyncNotificationStatus,
+} from "@taiwan-fin-hub/core";
+
+export type FinancialSnapshot = {
+  assetsTwd: number;
+  creditCardDebtTwd: number;
+  missingCurrencies: string[];
+};
+
+type FinancialSnapshotRow = {
+  assetsTwd: number;
+  creditCardDebtTwd: number;
+  missingCurrencies: string | null;
+};
+
+type CompletedBatchRow = {
+  id: string;
+  startedAt: string;
+  completedAt: string;
+  isBaseline: number;
+  assetsBeforeTwd: number | null;
+  creditCardDebtBeforeTwd: number | null;
+  missingCurrenciesBefore: string;
+  assetsAfterTwd: number | null;
+  creditCardDebtAfterTwd: number | null;
+  missingCurrenciesAfter: string;
+};
+
+type CompletedBatchResultRow = {
+  connectorId: ConnectorId;
+  status: SyncNotificationStatus;
+  completedAt: string;
+  newInvoices: number;
+  newBankTransactions: number;
+  newInvestmentTransactions: number;
+};
+
+export async function calculateCurrentFinancialSnapshot(
+  db: D1Database,
+): Promise<FinancialSnapshot> {
+  const row = await db
+    .prepare(
+      `WITH latest_bank_balances AS (
+         SELECT
+           account.account_type AS account_type,
+           balance.balance AS amount,
+           balance.currency AS currency
+         FROM bank_accounts account
+         JOIN bank_balance_snapshots balance
+           ON balance.id = (
+             SELECT latest.id
+             FROM bank_balance_snapshots latest
+             WHERE latest.account_id = account.id
+             ORDER BY latest.as_of_at DESC, latest.updated_at DESC
+             LIMIT 1
+           )
+         WHERE account.canonical_account_id IS NULL
+       ), latest_investments AS (
+         SELECT
+           COALESCE(position.market_value, 0) + COALESCE(position.cash_balance, 0) AS amount,
+           position.currency AS currency
+         FROM investment_positions position
+         WHERE position.as_of_date = (
+           SELECT MAX(latest.as_of_date)
+           FROM investment_positions latest
+           WHERE latest.connector_id = position.connector_id
+             AND latest.asset_type = position.asset_type
+         )
+       ), latest_manual_assets AS (
+         SELECT
+           history.net_worth AS amount,
+           asset.currency AS currency
+         FROM manual_assets asset
+         JOIN net_worth_history history
+           ON history.id = (
+             SELECT latest.id
+             FROM net_worth_history latest
+             WHERE latest.source = 'manual'
+               AND latest.asset_type = asset.id
+             ORDER BY latest.date DESC, latest.snapshotted_at DESC
+             LIMIT 1
+           )
+       ), financial_items AS (
+         SELECT
+           CASE WHEN account_type = 'credit' THEN 'debt' ELSE 'asset' END AS kind,
+           amount,
+           currency
+         FROM latest_bank_balances
+         UNION ALL
+         SELECT 'asset', amount, currency FROM latest_investments
+         UNION ALL
+         SELECT 'asset', amount, currency FROM latest_manual_assets
+       ), valued_items AS (
+         SELECT
+           item.kind,
+           item.amount,
+           COALESCE(NULLIF(item.currency, ''), 'TWD') AS currency,
+           CASE
+             WHEN COALESCE(NULLIF(item.currency, ''), 'TWD') != 'TWD'
+               AND rate.rate_to_twd IS NULL
+               THEN 1
+             ELSE 0
+           END AS is_missing_rate,
+           CASE
+             WHEN COALESCE(NULLIF(item.currency, ''), 'TWD') = 'TWD'
+               THEN item.amount
+             WHEN rate.rate_to_twd IS NOT NULL
+               THEN item.amount * rate.rate_to_twd
+             ELSE 0
+           END AS amount_twd
+         FROM financial_items item
+         LEFT JOIN exchange_rates rate
+           ON rate.currency = COALESCE(NULLIF(item.currency, ''), 'TWD')
+       )
+       SELECT
+         COALESCE(ROUND(SUM(CASE WHEN kind = 'asset' THEN amount_twd ELSE 0 END)), 0) AS assetsTwd,
+         COALESCE(ROUND(SUM(CASE WHEN kind = 'debt' THEN ABS(amount_twd) ELSE 0 END)), 0) AS creditCardDebtTwd,
+         COALESCE(
+           json_group_array(DISTINCT currency) FILTER (
+             WHERE amount != 0 AND is_missing_rate = 1
+           ),
+           '[]'
+         ) AS missingCurrencies
+       FROM valued_items`,
+    )
+    .first<FinancialSnapshotRow>();
+  return {
+    assetsTwd: row?.assetsTwd ?? 0,
+    creditCardDebtTwd: row?.creditCardDebtTwd ?? 0,
+    missingCurrencies: parseStringArray(row?.missingCurrencies).sort(),
+  };
+}
+
+export async function hasCompletedFinancialBaseline(db: D1Database) {
+  const row = await db
+    .prepare(
+      `SELECT EXISTS (
+         SELECT 1
+         FROM scheduled_sync_batches batch
+         WHERE batch.completed_at IS NOT NULL
+           AND batch.assets_after_twd IS NOT NULL
+           AND batch.credit_card_debt_after_twd IS NOT NULL
+           AND EXISTS (
+             SELECT 1
+             FROM scheduled_sync_batch_results result
+             WHERE result.batch_id = batch.id AND result.status = 'success'
+           )
+           AND NOT EXISTS (
+             SELECT 1
+             FROM scheduled_sync_batch_results result
+             WHERE result.batch_id = batch.id
+               AND result.status IN ('failed', 'needs_user_action')
+           )
+       ) AS value`,
+    )
+    .first<{ value: number }>();
+  return Boolean(row?.value);
+}
+
+export async function getLatestScheduledSyncReport(
+  db: D1Database,
+): Promise<ScheduledSyncReport | null> {
+  const batch = await db
+    .prepare(
+      `SELECT
+         id,
+         created_at AS startedAt,
+         completed_at AS completedAt,
+         is_baseline AS isBaseline,
+         assets_before_twd AS assetsBeforeTwd,
+         credit_card_debt_before_twd AS creditCardDebtBeforeTwd,
+         missing_currencies_before AS missingCurrenciesBefore,
+         assets_after_twd AS assetsAfterTwd,
+         credit_card_debt_after_twd AS creditCardDebtAfterTwd,
+         missing_currencies_after AS missingCurrenciesAfter
+       FROM scheduled_sync_batches
+       WHERE completed_at IS NOT NULL
+       ORDER BY completed_at DESC, created_at DESC
+       LIMIT 1`,
+    )
+    .first<CompletedBatchRow>();
+  if (!batch) return null;
+
+  const result = await db
+    .prepare(
+      `SELECT
+         connector_id AS connectorId,
+         status,
+         completed_at AS completedAt,
+         new_invoices AS newInvoices,
+         new_bank_transactions AS newBankTransactions,
+         new_investment_transactions AS newInvestmentTransactions
+       FROM scheduled_sync_batch_results
+       WHERE batch_id = ? AND status IS NOT NULL AND completed_at IS NOT NULL
+       ORDER BY job_id ASC`,
+    )
+    .bind(batch.id)
+    .all<CompletedBatchResultRow>();
+  const sources = result.results.map(mapSourceReport);
+  const status = summaryStatus(sources);
+  const newRecords = sumNewRecords(sources);
+  const missingCurrencies = [
+    ...new Set([
+      ...parseStringArray(batch.missingCurrenciesBefore),
+      ...parseStringArray(batch.missingCurrenciesAfter),
+    ]),
+  ].sort();
+  const financialChangeUnavailableReason = unavailableReason({
+    batch,
+    status,
+  });
+
+  return {
+    id: batch.id,
+    startedAt: batch.startedAt,
+    completedAt: batch.completedAt,
+    status,
+    sources,
+    sourceSummary: {
+      total: sources.length,
+      success: sources.filter((source) => source.status === "success").length,
+      failed: sources.filter((source) => source.status === "failed").length,
+      needsUserAction: sources.filter(
+        (source) => source.status === "needs_user_action",
+      ).length,
+    },
+    newRecords,
+    financialChange:
+      financialChangeUnavailableReason === null
+        ? {
+            assets: batch.assetsAfterTwd! - batch.assetsBeforeTwd!,
+            creditCardDebt:
+              batch.creditCardDebtAfterTwd! - batch.creditCardDebtBeforeTwd!,
+            netWorth:
+              batch.assetsAfterTwd! -
+              batch.creditCardDebtAfterTwd! -
+              (batch.assetsBeforeTwd! - batch.creditCardDebtBeforeTwd!),
+          }
+        : null,
+    financialChangeUnavailableReason,
+    missingCurrencies,
+  };
+}
+
+function mapSourceReport(
+  row: CompletedBatchResultRow,
+): ScheduledSyncSourceReport {
+  return {
+    connectorId: row.connectorId,
+    status: row.status,
+    completedAt: row.completedAt,
+    newRecords: {
+      invoices: row.newInvoices,
+      bankTransactions: row.newBankTransactions,
+      investmentTransactions: row.newInvestmentTransactions,
+    },
+  };
+}
+
+function sumNewRecords(sources: ScheduledSyncSourceReport[]) {
+  return sources.reduce<SyncNewRecordCounts>(
+    (total, source) => ({
+      invoices: total.invoices + source.newRecords.invoices,
+      bankTransactions:
+        total.bankTransactions + source.newRecords.bankTransactions,
+      investmentTransactions:
+        total.investmentTransactions + source.newRecords.investmentTransactions,
+    }),
+    { invoices: 0, bankTransactions: 0, investmentTransactions: 0 },
+  );
+}
+
+function summaryStatus(sources: ScheduledSyncSourceReport[]) {
+  if (sources.some((source) => source.status === "needs_user_action")) {
+    return "needs_user_action" as const;
+  }
+  if (sources.some((source) => source.status === "failed")) {
+    return "failed" as const;
+  }
+  return "success" as const;
+}
+
+function unavailableReason(input: {
+  batch: CompletedBatchRow;
+  status: SyncNotificationStatus;
+}): SyncFinancialChangeUnavailableReason | null {
+  if (input.status !== "success") return "partial_sync";
+  if (input.batch.isBaseline) return "baseline";
+  if (
+    input.batch.assetsBeforeTwd === null ||
+    input.batch.creditCardDebtBeforeTwd === null ||
+    input.batch.assetsAfterTwd === null ||
+    input.batch.creditCardDebtAfterTwd === null
+  ) {
+    return "snapshot_unavailable";
+  }
+  return null;
+}
+
+function parseStringArray(value: string | null | undefined): string[] {
+  if (!value) return [];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}

--- a/apps/worker/src/features/sync/schedule-route.ts
+++ b/apps/worker/src/features/sync/schedule-route.ts
@@ -13,6 +13,7 @@ import {
   setDefaultSyncSchedule,
   SyncJobNotFoundError,
 } from "./schedule-service";
+import { getLatestScheduledSyncReport } from "./report-repository";
 
 const syncIntervalSchema = z
   .number()
@@ -70,6 +71,10 @@ function registerSyncScheduleRoutes(api: Hono<AppBindings>) {
   );
 
   api.get("/sync-jobs", async (c) => c.json(await getSyncJobs(c.env.DB)));
+
+  api.get("/sync-reports/latest", async (c) =>
+    c.json(await getLatestScheduledSyncReport(c.env.DB)),
+  );
 
   api.patch(
     "/sync-jobs/:connectorId/:scope",

--- a/apps/worker/src/features/sync/scheduler.ts
+++ b/apps/worker/src/features/sync/scheduler.ts
@@ -90,6 +90,11 @@ async function runDefaultScheduleBatchJob(
   batchId: string,
   job: SyncJobRow<ConnectorId>,
 ) {
+  let outcomeNewRecords = {
+    invoices: 0,
+    bankTransactions: 0,
+    investmentTransactions: 0,
+  };
   const notification = await runScheduledJob(
     env,
     controller,
@@ -99,6 +104,7 @@ async function runDefaultScheduleBatchJob(
         batchId,
         jobId: job.id,
         notification: result,
+        newRecords: outcomeNewRecords,
       });
       if (!recorded) {
         throw new Error(
@@ -106,11 +112,16 @@ async function runDefaultScheduleBatchJob(
         );
       }
     },
+    (outcome) => {
+      outcomeNewRecords = outcome.newRecords;
+    },
   );
   if (!notification) return false;
 
   const summary = await claimCompletedDefaultScheduleBatch(env.DB, batchId);
-  if (summary) await safelySendScheduledSyncSummary(env, summary);
+  if (summary) {
+    await safelySendScheduledSyncSummary(env, summary);
+  }
   return true;
 }
 
@@ -119,6 +130,7 @@ async function runScheduledJob(
   controller: ScheduledController,
   due: SyncJobRow<ConnectorId>,
   beforeRelease?: (notification: SyncNotificationEvent) => Promise<void>,
+  onSuccess?: (outcome: Awaited<ReturnType<typeof runDueSyncJob>>) => void,
 ) {
   const runId = crypto.randomUUID();
   const lockRowId = canonicalSyncLockRowId(due.connector_id);
@@ -137,6 +149,7 @@ async function runScheduledJob(
     let notification: SyncNotificationEvent;
     try {
       const outcome = await runDueSyncJob(env, due);
+      onSuccess?.(outcome);
       await completeSyncJob(env.DB, due);
       console.log(
         JSON.stringify({

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -41,7 +41,7 @@ import {
   recognizeNumericCaptcha,
   recognizeValidateNumber,
 } from "../ocr/service";
-import type { ConnectorId } from "@taiwan-fin-hub/core";
+import type { ConnectorId, SyncNewRecordCounts } from "@taiwan-fin-hub/core";
 import {
   acquireSyncJobLock,
   getConnectorSettings,
@@ -57,7 +57,11 @@ import { configEncryptionKey } from "../../platform/config";
 import { encryptJson, decryptJson } from "../../platform/crypto";
 import type { Env } from "../../platform/env";
 import { dateFromIso, rebuildBankDepositHistory } from "../net-worth/service";
-import { persistStagedSyncWrite, type SyncWriteRecord } from "./persistence";
+import {
+  emptySyncNewRecordCounts,
+  persistStagedSyncWrite,
+  type SyncWriteRecord,
+} from "./persistence";
 import {
   connectorCursorStatement,
   connectorEncryptedConfigStatement,
@@ -108,6 +112,7 @@ export type SyncOutcome = {
   connectorId: ConnectorId;
   scope: SyncScope;
   records: number;
+  newRecords: SyncNewRecordCounts;
   cursorUpdated: boolean;
   detailRecords?: number;
 };
@@ -354,13 +359,17 @@ export async function syncEinvoice(
     ),
   );
 
-  await persistStagedSyncWrite(env.DB, { records, finalizeStatements });
+  const newRecords = await persistStagedSyncWrite(env.DB, {
+    records,
+    finalizeStatements,
+  });
 
   return {
     success: true,
     connectorId,
     scope,
     records: result.records.length,
+    newRecords,
     detailRecords: invoiceLineItems.length,
     cursorUpdated: Boolean(
       result.cursor && result.cursor !== settings.sync_cursor,
@@ -436,7 +445,7 @@ export async function syncEsun(
     );
   }
 
-  await persistStagedSyncWrite(env.DB, {
+  const newRecords = await persistStagedSyncWrite(env.DB, {
     records,
     afterPromoteStatements:
       bankAccounts.length > 0
@@ -464,6 +473,7 @@ export async function syncEsun(
       bankAccounts.length +
       bankBalanceSnapshots.length +
       bankTransactions.length,
+    newRecords,
     cursorUpdated: Boolean(
       persistedCursor && persistedCursor !== settings.sync_cursor,
     ),
@@ -538,7 +548,7 @@ export async function syncCathaybk(
     );
   }
 
-  await persistStagedSyncWrite(env.DB, {
+  const newRecords = await persistStagedSyncWrite(env.DB, {
     records,
     afterPromoteStatements:
       bankAccounts.length > 0
@@ -559,6 +569,7 @@ export async function syncCathaybk(
       bankAccounts.length +
       bankBalanceSnapshots.length +
       bankTransactions.length,
+    newRecords,
     cursorUpdated: Boolean(
       persistedCursor && persistedCursor !== settings.sync_cursor,
     ),
@@ -642,7 +653,7 @@ export async function syncCtbc(
     );
   }
 
-  await persistStagedSyncWrite(env.DB, {
+  const newRecords = await persistStagedSyncWrite(env.DB, {
     records,
     afterPromoteStatements:
       bankAccounts.length > 0
@@ -664,6 +675,7 @@ export async function syncCtbc(
       bankBalanceSnapshots.length +
       bankTransactions.length +
       creditCardBills.length,
+    newRecords,
     cursorUpdated: Boolean(
       persistedCursor && persistedCursor !== settings.sync_cursor,
     ),
@@ -804,7 +816,7 @@ export async function syncSinopac(
       ),
     );
   }
-  await persistStagedSyncWrite(env.DB, {
+  const newRecords = await persistStagedSyncWrite(env.DB, {
     records,
     afterPromoteStatements: [
       ...reconcileSinopacLegacyTransactionStatements(env.DB),
@@ -825,6 +837,7 @@ export async function syncSinopac(
       bankBalanceSnapshots.length +
       bankTransactions.length +
       creditCardBills.length,
+    newRecords,
     cursorUpdated: Boolean(
       persistedCursor && persistedCursor !== settings.sync_cursor,
     ),
@@ -937,7 +950,7 @@ export async function syncObank(
     );
   }
 
-  await persistStagedSyncWrite(env.DB, {
+  const newRecords = await persistStagedSyncWrite(env.DB, {
     records,
     afterPromoteStatements:
       bankAccounts.length > 0
@@ -956,6 +969,7 @@ export async function syncObank(
       bankAccounts.length +
       bankBalanceSnapshots.length +
       bankTransactions.length,
+    newRecords,
     cursorUpdated: Boolean(
       persistedCursor && persistedCursor !== settings.sync_cursor,
     ),
@@ -1080,7 +1094,7 @@ export async function syncTaishin(
     );
   }
 
-  await persistStagedSyncWrite(env.DB, {
+  const newRecords = await persistStagedSyncWrite(env.DB, {
     records,
     afterPromoteStatements:
       bankAccounts.length > 0
@@ -1100,6 +1114,7 @@ export async function syncTaishin(
       bankBalanceSnapshots.length +
       bankTransactions.length +
       creditCardBills.length,
+    newRecords,
     cursorUpdated: Boolean(
       persistedCursor && persistedCursor !== settings.sync_cursor,
     ),
@@ -1119,6 +1134,7 @@ export async function syncTdcc(
   );
   const scope = tdccOutcomeScope(selected);
   let records = 0;
+  const newRecords = emptySyncNewRecordCounts();
   let cursorUpdated = false;
 
   if (selected.has(TDCC_SCOPE_INVESTMENTS) || selected.has(TDCC_SCOPE_BANK)) {
@@ -1128,12 +1144,14 @@ export async function syncTdcc(
       scope,
     });
     records += result.records;
+    mergeSyncNewRecordCounts(newRecords, result.newRecords);
     cursorUpdated = cursorUpdated || result.cursorUpdated;
   }
 
   if (selected.has(TDCC_SCOPE_TRADES)) {
     const result = await syncTdccTrades(env, trigger, overrides, scope);
     records += result.records;
+    mergeSyncNewRecordCounts(newRecords, result.newRecords);
     cursorUpdated = cursorUpdated || result.cursorUpdated;
   }
 
@@ -1142,6 +1160,7 @@ export async function syncTdcc(
     connectorId: "tdcc",
     scope,
     records,
+    newRecords,
     cursorUpdated,
   };
 }
@@ -1155,7 +1174,11 @@ async function syncTdccPositionsAndBank(
     writeBank: boolean;
     scope: SyncScope;
   },
-): Promise<{ records: number; cursorUpdated: boolean }> {
+): Promise<{
+  records: number;
+  newRecords: SyncNewRecordCounts;
+  cursorUpdated: boolean;
+}> {
   const connectorId = "tdcc";
   const settings = await requireConnectorSettings(env.DB, connectorId);
   const config = await decryptJson<unknown>(
@@ -1256,7 +1279,7 @@ async function syncTdccPositionsAndBank(
     );
   }
 
-  await persistStagedSyncWrite(env.DB, {
+  const newRecords = await persistStagedSyncWrite(env.DB, {
     records,
     afterPromoteStatements:
       options.writeBank && bankAccounts.length > 0
@@ -1277,6 +1300,7 @@ async function syncTdccPositionsAndBank(
           bankBalanceSnapshots.length +
           bankTransactions.length
         : 0),
+    newRecords,
     cursorUpdated: Boolean(
       persistedCursor && persistedCursor !== settings.sync_cursor,
     ),
@@ -1288,7 +1312,11 @@ async function syncTdccTrades(
   trigger: SyncTrigger,
   overrides: TdccSyncOverrides,
   scope: SyncScope,
-): Promise<{ records: number; cursorUpdated: boolean }> {
+): Promise<{
+  records: number;
+  newRecords: SyncNewRecordCounts;
+  cursorUpdated: boolean;
+}> {
   const connectorId = "tdcc";
   const settings = await requireConnectorSettings(env.DB, connectorId);
   const config = await decryptJson<unknown>(
@@ -1359,14 +1387,27 @@ async function syncTdccTrades(
     );
   }
 
-  await persistStagedSyncWrite(env.DB, { records, finalizeStatements });
+  const newRecords = await persistStagedSyncWrite(env.DB, {
+    records,
+    finalizeStatements,
+  });
 
   return {
     records: investmentTransactions.length,
+    newRecords,
     cursorUpdated: Boolean(
       persistedCursor && persistedCursor !== settings.sync_cursor,
     ),
   };
+}
+
+function mergeSyncNewRecordCounts(
+  target: SyncNewRecordCounts,
+  source: SyncNewRecordCounts,
+) {
+  target.invoices += source.invoices;
+  target.bankTransactions += source.bankTransactions;
+  target.investmentTransactions += source.investmentTransactions;
 }
 
 function tdccOutcomeScope(scopes: Set<string>): SyncScope {

--- a/apps/worker/tests/features/notifications/payload.test.ts
+++ b/apps/worker/tests/features/notifications/payload.test.ts
@@ -17,7 +17,7 @@ describe("sync notification payload", () => {
 
     expect(payload).toEqual({
       title: "同步完成",
-      body: "玉山銀行已完成排程同步。",
+      body: "玉山銀行已完成排程同步，開啟 App 查看結果。",
       url: "/#/overview",
       tag: "sync-esun-success",
     });
@@ -39,7 +39,7 @@ describe("sync notification payload", () => {
         connectorId: "taishin",
         status: "success",
       }).body,
-    ).toBe("台新銀行已完成排程同步。");
+    ).toBe("台新銀行已完成排程同步，開啟 App 查看結果。");
   });
 
   it("labels CTBC scheduled sync notifications", () => {
@@ -48,7 +48,7 @@ describe("sync notification payload", () => {
         connectorId: "ctbc",
         status: "success",
       }).body,
-    ).toBe("中國信託銀行已完成排程同步。");
+    ).toBe("中國信託銀行已完成排程同步，開啟 App 查看結果。");
   });
 
   it("maps statuses to their preference switches", () => {
@@ -88,7 +88,7 @@ describe("scheduled sync summary payload", () => {
 
     expect(payload).toEqual({
       title: "同步完成",
-      body: "已完成 3 個資料來源的預設排程同步。",
+      body: "每日同步已完成，開啟 App 查看結果。",
       url: "/#/overview",
       tag: "sync-default-schedule-success",
     });

--- a/apps/worker/tests/features/sync/notification-batch-repository.test.ts
+++ b/apps/worker/tests/features/sync/notification-batch-repository.test.ts
@@ -150,6 +150,11 @@ async function completeMember(
     batchId,
     jobId: job.id,
     notification: { connectorId: job.connector_id, status },
+    newRecords: {
+      invoices: job.connector_id === "einvoice" ? 1 : 0,
+      bankTransactions: job.connector_id === "esun" ? 2 : 0,
+      investmentTransactions: job.connector_id === "tdcc" ? 1 : 0,
+    },
   });
 }
 
@@ -299,6 +304,35 @@ describe("default schedule notification rounds", () => {
     expect(summary).toContainEqual({
       connectorId: jobs[0]!.connector_id,
       status: "failed",
+    });
+    expect(
+      database
+        .prepare(
+          `SELECT completed_at AS completedAt,
+                  assets_after_twd AS assetsAfterTwd,
+                  credit_card_debt_after_twd AS creditCardDebtAfterTwd
+           FROM scheduled_sync_batches WHERE id = ?`,
+        )
+        .get(batchId),
+    ).toMatchObject({
+      completedAt: expect.any(String),
+      assetsAfterTwd: 0,
+      creditCardDebtAfterTwd: 0,
+    });
+    expect(
+      database
+        .prepare(
+          `SELECT
+             SUM(new_invoices) AS newInvoices,
+             SUM(new_bank_transactions) AS newBankTransactions,
+             SUM(new_investment_transactions) AS newInvestmentTransactions
+           FROM scheduled_sync_batch_results WHERE batch_id = ?`,
+        )
+        .get(batchId),
+    ).toEqual({
+      newInvoices: 1,
+      newBankTransactions: 2,
+      newInvestmentTransactions: 1,
     });
     await expect(
       claimCompletedDefaultScheduleBatch(db, batchId),

--- a/apps/worker/tests/features/sync/persistence.test.ts
+++ b/apps/worker/tests/features/sync/persistence.test.ts
@@ -30,8 +30,26 @@ class SqliteStatement {
     return this.execute();
   }
 
+  async first<T>() {
+    this.owner.executedSql.push(this.sql);
+    return (
+      (this.owner.database
+        .prepare(this.sql)
+        .get(...(this.values as never[])) as T) ?? null
+    );
+  }
+
   execute() {
     this.owner.executedSql.push(this.sql);
+    if (/^\s*(SELECT|WITH)\b/i.test(this.sql)) {
+      return {
+        success: true,
+        meta: { changes: 0 },
+        results: this.owner.database
+          .prepare(this.sql)
+          .all(...(this.values as never[])),
+      };
+    }
     const result = this.owner.database
       .prepare(this.sql)
       .run(...(this.values as never[]));
@@ -471,22 +489,64 @@ describe("staged sync persistence", () => {
       },
     });
 
-    await persistStagedSyncWrite(db as unknown as D1Database, {
-      records,
-      finalizeStatements: [
-        db
-          .prepare(
-            "UPDATE connector_settings SET sync_cursor = ? WHERE connector_id = ?",
-          )
-          .bind("new-cursor", "tdcc") as unknown as D1PreparedStatement,
-      ],
+    const firstWrite = await persistStagedSyncWrite(
+      db as unknown as D1Database,
+      {
+        records,
+        finalizeStatements: [
+          db
+            .prepare(
+              "UPDATE connector_settings SET sync_cursor = ? WHERE connector_id = ?",
+            )
+            .bind("new-cursor", "tdcc") as unknown as D1PreparedStatement,
+        ],
+      },
+    );
+
+    expect(firstWrite).toEqual({
+      invoices: 0,
+      bankTransactions: 1,
+      investmentTransactions: 0,
     });
+    expect(
+      db.database
+        .prepare(
+          "SELECT created_at AS createdAt FROM bank_transactions WHERE source_id = 'transaction-1'",
+        )
+        .get(),
+    ).toEqual({ createdAt: "2026-07-19T00:00:00.000Z" });
+
+    const repeatedWrite = await persistStagedSyncWrite(
+      db as unknown as D1Database,
+      {
+        records: records.map((record) => ({
+          ...record,
+          payload: {
+            ...record.payload,
+            created_at: "2026-07-20T00:00:00.000Z",
+            updated_at: "2026-07-20T00:00:00.000Z",
+          },
+        })),
+      },
+    );
+    expect(repeatedWrite).toEqual({
+      invoices: 0,
+      bankTransactions: 0,
+      investmentTransactions: 0,
+    });
+    expect(
+      db.database
+        .prepare(
+          "SELECT created_at AS createdAt FROM bank_transactions WHERE source_id = 'transaction-1'",
+        )
+        .get(),
+    ).toEqual({ createdAt: "2026-07-19T00:00:00.000Z" });
 
     expect(
       db.executedSql.filter((sql) =>
         sql.includes("INSERT INTO sync_write_staging"),
       ),
-    ).toHaveLength(3);
+    ).toHaveLength(6);
     expect(
       db.database.prepare("SELECT COUNT(*) AS count FROM bank_accounts").get(),
     ).toMatchObject({ count: 205 });

--- a/apps/worker/tests/features/sync/report-repository.test.ts
+++ b/apps/worker/tests/features/sync/report-repository.test.ts
@@ -1,0 +1,234 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  calculateCurrentFinancialSnapshot,
+  getLatestScheduledSyncReport,
+  hasCompletedFinancialBaseline,
+} from "../../../src/features/sync/report-repository";
+
+class SqliteStatement {
+  private values: unknown[] = [];
+
+  constructor(
+    private readonly database: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: unknown[]) {
+    this.values = values;
+    return this;
+  }
+
+  async first<T>() {
+    return (
+      (this.database.prepare(this.sql).get(...(this.values as never[])) as T) ??
+      null
+    );
+  }
+
+  async all<T>() {
+    return {
+      results: this.database
+        .prepare(this.sql)
+        .all(...(this.values as never[])) as T[],
+    };
+  }
+}
+
+function createDb() {
+  const database = new DatabaseSync(":memory:");
+  database.exec("PRAGMA foreign_keys = ON");
+  const migrationsDirectory = fileURLToPath(
+    new URL("../../../../../packages/db/migrations/", import.meta.url),
+  );
+  for (const file of readdirSync(migrationsDirectory)
+    .filter((name) => name.endsWith(".sql"))
+    .sort()) {
+    database.exec(readFileSync(`${migrationsDirectory}/${file}`, "utf8"));
+  }
+  const db = {
+    prepare(sql: string) {
+      return new SqliteStatement(database, sql);
+    },
+  } as unknown as D1Database;
+  return { database, db };
+}
+
+const databases: DatabaseSync[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+describe("scheduled sync financial reports", () => {
+  it("uses the same latest-value and TWD conversion rules as the overview", async () => {
+    const { database, db } = createDb();
+    databases.push(database);
+    database.exec(`
+      INSERT INTO exchange_rates (currency, rate_to_twd, updated_at)
+      VALUES ('USD', 32, '2026-08-12');
+
+      INSERT INTO bank_accounts
+        (id, connector_id, source_id, account_type, currency, raw_payload, created_at, updated_at)
+      VALUES
+        ('deposit', 'esun', 'deposit', 'savings', 'USD', '{}', '2026-08-12', '2026-08-12'),
+        ('card', 'esun', 'card', 'credit', 'TWD', '{}', '2026-08-12', '2026-08-12');
+      INSERT INTO bank_balance_snapshots
+        (id, connector_id, account_id, source_id, balance, currency, as_of_at, raw_payload, created_at, updated_at)
+      VALUES
+        ('deposit-old', 'esun', 'deposit', 'old', 50, 'USD', '2026-08-11', '{}', '2026-08-11', '2026-08-11'),
+        ('deposit-new', 'esun', 'deposit', 'new', 100, 'USD', '2026-08-12', '{}', '2026-08-12', '2026-08-12'),
+        ('card-new', 'esun', 'card', 'card-new', -1200, 'TWD', '2026-08-12', '{}', '2026-08-12', '2026-08-12');
+
+      INSERT INTO investment_positions
+        (id, connector_id, source_id, asset_type, name, market_value, cash_balance, currency, as_of_date, raw_payload, created_at, updated_at)
+      VALUES
+        ('stock-old', 'tdcc', '2330', 'stock', '台積電', 1000, 0, 'TWD', '2026-08-11', '{}', '2026-08-11', '2026-08-11'),
+        ('stock-new', 'tdcc', '2330', 'stock', '台積電', 2000, 100, 'TWD', '2026-08-12', '{}', '2026-08-12', '2026-08-12');
+
+      INSERT INTO manual_assets (id, name, category, currency, created_at)
+      VALUES ('home', '房屋', 'property', 'TWD', '2026-08-12');
+      INSERT INTO net_worth_history
+        (id, date, net_worth, asset_type, source, snapshotted_at)
+      VALUES ('home-value', '2026-08-12', 5000, 'home', 'manual', '2026-08-12');
+    `);
+
+    await expect(calculateCurrentFinancialSnapshot(db)).resolves.toEqual({
+      assetsTwd: 10_300,
+      creditCardDebtTwd: 1200,
+      missingCurrencies: [],
+    });
+  });
+
+  it("values foreign-currency items at zero when their exchange rate is missing", async () => {
+    const { database, db } = createDb();
+    databases.push(database);
+    database.exec(`
+      INSERT INTO bank_accounts
+        (id, connector_id, source_id, account_type, currency, raw_payload, created_at, updated_at)
+      VALUES
+        ('deposit-usd', 'esun', 'deposit-usd', 'savings', 'USD', '{}', '2026-08-12', '2026-08-12'),
+        ('card-jpy', 'esun', 'card-jpy', 'credit', 'JPY', '{}', '2026-08-12', '2026-08-12'),
+        ('deposit-twd', 'esun', 'deposit-twd', 'savings', 'TWD', '{}', '2026-08-12', '2026-08-12');
+      INSERT INTO bank_balance_snapshots
+        (id, connector_id, account_id, source_id, balance, currency, as_of_at, raw_payload, created_at, updated_at)
+      VALUES
+        ('deposit-usd', 'esun', 'deposit-usd', 'deposit-usd', 100, 'USD', '2026-08-12', '{}', '2026-08-12', '2026-08-12'),
+        ('card-jpy', 'esun', 'card-jpy', 'card-jpy', -5000, 'JPY', '2026-08-12', '{}', '2026-08-12', '2026-08-12'),
+        ('deposit-twd', 'esun', 'deposit-twd', 'deposit-twd', 3000, 'TWD', '2026-08-12', '{}', '2026-08-12', '2026-08-12');
+    `);
+
+    await expect(calculateCurrentFinancialSnapshot(db)).resolves.toEqual({
+      assetsTwd: 3000,
+      creditCardDebtTwd: 0,
+      missingCurrencies: ["JPY", "USD"],
+    });
+  });
+
+  it("returns no financial delta for a partial round but keeps new record counts", async () => {
+    const { database, db } = createDb();
+    databases.push(database);
+    database.exec(`
+      INSERT INTO scheduled_sync_batches
+        (id, schedule_key, notification_claimed_at, created_at, completed_at,
+         is_baseline, assets_before_twd, credit_card_debt_before_twd,
+         missing_currencies_before, assets_after_twd,
+         credit_card_debt_after_twd, missing_currencies_after)
+      VALUES
+        ('batch', 'default', '2026-08-12T22:05:00Z', '2026-08-12T22:00:00Z',
+         '2026-08-12T22:05:00Z', 0, 10000, 1200, '[]', 11000, 1000, '[]');
+      INSERT INTO scheduled_sync_batch_results
+        (batch_id, job_id, connector_id, status, completed_at,
+         new_invoices, new_bank_transactions, new_investment_transactions)
+      VALUES
+        ('batch', 'einvoice:all', 'einvoice', 'success', '2026-08-12T22:02:00Z', 3, 0, 0),
+        ('batch', 'esun:all', 'esun', 'failed', '2026-08-12T22:05:00Z', 0, 2, 0);
+    `);
+
+    await expect(getLatestScheduledSyncReport(db)).resolves.toMatchObject({
+      id: "batch",
+      status: "failed",
+      sourceSummary: { total: 2, success: 1, failed: 1 },
+      newRecords: {
+        invoices: 3,
+        bankTransactions: 2,
+        investmentTransactions: 0,
+      },
+      financialChange: null,
+      financialChangeUnavailableReason: "partial_sync",
+    });
+  });
+
+  it("returns the complete asset, debt and net-worth deltas", async () => {
+    const { database, db } = createDb();
+    databases.push(database);
+    database.exec(`
+      INSERT INTO scheduled_sync_batches
+        (id, schedule_key, notification_claimed_at, created_at, completed_at,
+         is_baseline, assets_before_twd, credit_card_debt_before_twd,
+         missing_currencies_before, assets_after_twd,
+         credit_card_debt_after_twd, missing_currencies_after)
+      VALUES
+        ('batch', 'default', '2026-08-12T22:05:00Z', '2026-08-12T22:00:00Z',
+         '2026-08-12T22:05:00Z', 0, 10000, 1200, '[]', 11000, 1000, '[]');
+      INSERT INTO scheduled_sync_batch_results
+        (batch_id, job_id, connector_id, status, completed_at)
+      VALUES ('batch', 'esun:all', 'esun', 'success', '2026-08-12T22:05:00Z');
+    `);
+
+    await expect(getLatestScheduledSyncReport(db)).resolves.toMatchObject({
+      financialChange: { assets: 1000, creditCardDebt: -200, netWorth: 1200 },
+      financialChangeUnavailableReason: null,
+    });
+    await expect(hasCompletedFinancialBaseline(db)).resolves.toBe(true);
+  });
+
+  it("keeps the financial delta when a currency was valued at zero", async () => {
+    const { database, db } = createDb();
+    databases.push(database);
+    database.exec(`
+      INSERT INTO scheduled_sync_batches
+        (id, schedule_key, notification_claimed_at, created_at, completed_at,
+         is_baseline, assets_before_twd, credit_card_debt_before_twd,
+         missing_currencies_before, assets_after_twd,
+         credit_card_debt_after_twd, missing_currencies_after)
+      VALUES
+        ('batch', 'default', '2026-08-12T22:05:00Z', '2026-08-12T22:00:00Z',
+         '2026-08-12T22:05:00Z', 0, 10000, 1200, '["USD"]', 11000, 1000, '["USD"]');
+      INSERT INTO scheduled_sync_batch_results
+        (batch_id, job_id, connector_id, status, completed_at)
+      VALUES ('batch', 'esun:all', 'esun', 'success', '2026-08-12T22:05:00Z');
+    `);
+
+    await expect(getLatestScheduledSyncReport(db)).resolves.toMatchObject({
+      financialChange: { assets: 1000, creditCardDebt: -200, netWorth: 1200 },
+      financialChangeUnavailableReason: null,
+      missingCurrencies: ["USD"],
+    });
+  });
+
+  it("waits for a complete successful round before establishing the baseline", async () => {
+    const { database, db } = createDb();
+    databases.push(database);
+    database.exec(`
+      INSERT INTO scheduled_sync_batches
+        (id, schedule_key, notification_claimed_at, created_at, completed_at,
+         is_baseline, assets_after_twd, credit_card_debt_after_twd,
+         missing_currencies_after)
+      VALUES
+        ('failed', 'default', '2026-08-12T22:05:00Z', '2026-08-12T22:00:00Z',
+         '2026-08-12T22:05:00Z', 1, 10000, 1200, '[]'),
+        ('missing-rate', 'default', '2026-08-13T22:05:00Z', '2026-08-13T22:00:00Z',
+         '2026-08-13T22:05:00Z', 1, 10000, 1200, '["USD"]');
+      INSERT INTO scheduled_sync_batch_results
+        (batch_id, job_id, connector_id, status, completed_at)
+      VALUES
+        ('failed', 'esun:all', 'esun', 'failed', '2026-08-12T22:05:00Z'),
+        ('missing-rate', 'esun:all', 'esun', 'success', '2026-08-13T22:05:00Z');
+    `);
+
+    await expect(hasCompletedFinancialBaseline(db)).resolves.toBe(true);
+  });
+});

--- a/apps/worker/tests/features/sync/route.test.ts
+++ b/apps/worker/tests/features/sync/route.test.ts
@@ -61,6 +61,11 @@ beforeEach(() => {
     connectorId: "taishin",
     scope: "all",
     records: 3,
+    newRecords: {
+      invoices: 0,
+      bankTransactions: 3,
+      investmentTransactions: 0,
+    },
     cursorUpdated: true,
   });
   mocks.syncCtbc.mockResolvedValue({
@@ -68,6 +73,11 @@ beforeEach(() => {
     connectorId: "ctbc",
     scope: "all",
     records: 4,
+    newRecords: {
+      invoices: 0,
+      bankTransactions: 4,
+      investmentTransactions: 0,
+    },
     cursorUpdated: true,
   });
   mocks.prepareObankCaptchaSession.mockResolvedValue({
@@ -81,6 +91,11 @@ beforeEach(() => {
     connectorId: "obank",
     scope: "all",
     records: 3,
+    newRecords: {
+      invoices: 0,
+      bankTransactions: 3,
+      investmentTransactions: 0,
+    },
     cursorUpdated: true,
   });
 });

--- a/apps/worker/tests/features/sync/scheduler.test.ts
+++ b/apps/worker/tests/features/sync/scheduler.test.ts
@@ -111,11 +111,21 @@ beforeEach(() => {
     connectorId: "esun",
     scope: "all",
     records: 1,
+    newRecords: {
+      invoices: 0,
+      bankTransactions: 1,
+      investmentTransactions: 0,
+    },
   });
   mocks.syncTaishin.mockResolvedValue({
     connectorId: "taishin",
     scope: "all",
     records: 2,
+    newRecords: {
+      invoices: 0,
+      bankTransactions: 2,
+      investmentTransactions: 0,
+    },
   });
   mocks.recordDefaultScheduleBatchResult.mockResolvedValue(true);
   mocks.claimCompletedDefaultScheduleBatch.mockResolvedValue([
@@ -165,6 +175,11 @@ describe("scheduled sync rounds", () => {
         batchId: "default:new-round",
         jobId: job.id,
         notification: { connectorId: "esun", status: "success" },
+        newRecords: {
+          invoices: 0,
+          bankTransactions: 1,
+          investmentTransactions: 0,
+        },
       },
     );
   });

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -9,9 +9,9 @@
 ## 目錄
 
 - Tables：24
-- Explicit indexes：31
+- Explicit indexes：32
 - Other objects：0
-- Migrations：22
+- Migrations：25
 
 ## Tables
 
@@ -36,8 +36,8 @@
 | [`net_worth_history`](#net_worth_history) | 按日期保存的淨資產或資產類別歷史數值，用於圖表與歷史查詢。 | 6 | 0 | 2 |
 | [`notification_preferences`](#notification_preferences) | 此單一部署的同步推播偏好設定。 | 5 | 0 | 0 |
 | [`push_subscriptions`](#push_subscriptions) | 瀏覽器 Web Push 裝置訂閱資料。 | 6 | 0 | 0 |
-| [`scheduled_sync_batch_results`](#scheduled_sync_batch_results) | 預設排程同步批次中各工作的完成結果。 | 5 | 1 | 0 |
-| [`scheduled_sync_batches`](#scheduled_sync_batches) | 追蹤預設排程中需彙總推播的一輪同步工作。 | 4 | 0 | 1 |
+| [`scheduled_sync_batch_results`](#scheduled_sync_batch_results) | 預設排程同步批次中各工作的完成結果。 | 8 | 1 | 0 |
+| [`scheduled_sync_batches`](#scheduled_sync_batches) | 追蹤預設排程中需彙總推播的一輪同步工作。 | 12 | 0 | 2 |
 | [`sync_jobs`](#sync_jobs) | 每個連接器與同步範圍的排程、鎖定狀態與最近執行結果。 | 19 | 0 | 1 |
 | [`sync_schedule_settings`](#sync_schedule_settings) | 所有使用 inherit 模式之同步工作的全域預設排程。 | 6 | 0 | 0 |
 | [`sync_write_staging`](#sync_write_staging) | 同步流程寫入正式資料表前的暫存資料。 | 5 | 0 | 1 |
@@ -81,7 +81,7 @@
 #### DDL
 
 ```sql
-CREATE TABLE bank_accounts (
+CREATE TABLE "bank_accounts" (
   id TEXT PRIMARY KEY,
   connector_id TEXT NOT NULL,
   source_id TEXT NOT NULL,
@@ -89,7 +89,7 @@ CREATE TABLE bank_accounts (
   account_name TEXT,
   account_type TEXT CHECK (
     account_type IS NULL
-    OR account_type IN ('checking', 'savings', 'credit', 'loan', 'settlement_cash', 'stored_value', 'unknown')
+    OR account_type IN ('checking', 'savings', 'credit', 'loan', 'settlement_cash', 'time_deposit', 'stored_value', 'unknown')
   ),
   currency TEXT NOT NULL DEFAULT 'TWD',
   raw_payload TEXT,
@@ -97,7 +97,8 @@ CREATE TABLE bank_accounts (
   updated_at TEXT NOT NULL,
   bank_code TEXT,
   account_last4 TEXT,
-  canonical_account_id TEXT REFERENCES bank_accounts (id), credit_limit INTEGER,
+  canonical_account_id TEXT REFERENCES "bank_accounts" (id),
+  credit_limit INTEGER,
   UNIQUE (connector_id, source_id)
 )
 ```
@@ -143,10 +144,10 @@ CREATE TABLE bank_accounts (
 #### DDL
 
 ```sql
-CREATE TABLE bank_balance_snapshots (
+CREATE TABLE "bank_balance_snapshots" (
   id TEXT PRIMARY KEY,
   connector_id TEXT NOT NULL,
-  account_id TEXT NOT NULL,
+  account_id TEXT NOT NULL REFERENCES "bank_accounts" (id),
   source_id TEXT NOT NULL,
   balance INTEGER NOT NULL,
   available_balance INTEGER,
@@ -154,9 +155,12 @@ CREATE TABLE bank_balance_snapshots (
   as_of_at TEXT NOT NULL,
   raw_payload TEXT,
   created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL, statement_balance INTEGER, payment_due_date TEXT, no_payment_needed INTEGER, statement_closing_date TEXT,
-  UNIQUE (connector_id, account_id, source_id),
-  FOREIGN KEY (account_id) REFERENCES bank_accounts (id)
+  updated_at TEXT NOT NULL,
+  statement_balance INTEGER,
+  payment_due_date TEXT,
+  no_payment_needed INTEGER,
+  statement_closing_date TEXT,
+  UNIQUE (connector_id, account_id, source_id)
 )
 ```
 
@@ -238,10 +242,10 @@ CREATE TABLE bank_transaction_preferences (
 #### DDL
 
 ```sql
-CREATE TABLE bank_transactions (
+CREATE TABLE "bank_transactions" (
   id TEXT PRIMARY KEY,
   connector_id TEXT NOT NULL,
-  account_id TEXT NOT NULL,
+  account_id TEXT NOT NULL REFERENCES "bank_accounts" (id),
   source_id TEXT NOT NULL,
   posted_date TEXT,
   authorized_at TEXT,
@@ -251,10 +255,10 @@ CREATE TABLE bank_transactions (
   counterparty TEXT,
   raw_payload TEXT,
   created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL, effective_date TEXT AS (COALESCE(posted_date, authorized_at, '')), status TEXT NOT NULL DEFAULT 'posted'
-  CHECK (status IN ('pending', 'posted')),
-  UNIQUE (connector_id, account_id, source_id),
-  FOREIGN KEY (account_id) REFERENCES bank_accounts (id)
+  updated_at TEXT NOT NULL,
+  effective_date TEXT AS (COALESCE(posted_date, authorized_at, '')),
+  status TEXT NOT NULL DEFAULT 'posted' CHECK (status IN ('pending', 'posted')),
+  UNIQUE (connector_id, account_id, source_id)
 )
 ```
 
@@ -476,10 +480,10 @@ CREATE TABLE connector_settings (
 #### DDL
 
 ```sql
-CREATE TABLE credit_card_bills (
+CREATE TABLE "credit_card_bills" (
   id TEXT PRIMARY KEY,
   connector_id TEXT NOT NULL,
-  account_id TEXT NOT NULL REFERENCES bank_accounts(id),
+  account_id TEXT NOT NULL REFERENCES "bank_accounts" (id),
   source_id TEXT NOT NULL,
   billing_period TEXT NOT NULL,
   statement_amount INTEGER,
@@ -492,7 +496,7 @@ CREATE TABLE credit_card_bills (
   raw_payload TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
-  UNIQUE(connector_id, account_id, billing_period)
+  UNIQUE (connector_id, account_id, billing_period)
 )
 ```
 
@@ -969,6 +973,9 @@ CREATE TABLE push_subscriptions (
 | 3 | `connector_id` | 此次結果所屬的連接器。 | TEXT | NO | — | — | — |
 | 4 | `status` | 排程執行結果；等待執行或被略過的成員為 NULL。 | TEXT | YES | — | — | — |
 | 5 | `completed_at` | 排程結果或略過決定寫入批次的時間；NULL 表示仍在等待。 | TEXT | YES | — | — | — |
+| 6 | `new_invoices` | 此次工作真正新增的電子發票筆數，不包含更新既有發票。 | INTEGER | NO | 0 | — | — |
+| 7 | `new_bank_transactions` | 此次工作真正新增的銀行或信用卡交易筆數，不包含更新既有交易。 | INTEGER | NO | 0 | — | — |
+| 8 | `new_investment_transactions` | 此次工作真正新增的投資交易筆數，不包含更新既有交易。 | INTEGER | NO | 0 | — | — |
 
 #### Foreign keys
 
@@ -988,7 +995,7 @@ CREATE TABLE scheduled_sync_batch_results (
   job_id TEXT NOT NULL,
   connector_id TEXT NOT NULL,
   status TEXT CHECK (status IN ('success', 'failed', 'needs_user_action')),
-  completed_at TEXT,
+  completed_at TEXT, new_invoices INTEGER NOT NULL DEFAULT 0, new_bank_transactions INTEGER NOT NULL DEFAULT 0, new_investment_transactions INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (batch_id, job_id),
   FOREIGN KEY (batch_id) REFERENCES scheduled_sync_batches(id) ON DELETE CASCADE
 )
@@ -1007,6 +1014,14 @@ CREATE TABLE scheduled_sync_batch_results (
 | 2 | `schedule_key` | 排程類型識別碼，目前固定為 default。 | TEXT | NO | 'default' | — | — |
 | 3 | `notification_claimed_at` | 彙總推播被 scheduler 取得發送權的時間。 | TEXT | YES | — | — | — |
 | 4 | `created_at` | 批次建立時間。 | TEXT | NO | — | — | — |
+| 5 | `completed_at` | 批次所有有效成員結束並完成財務快照的時間。 | TEXT | YES | — | — | — |
+| 6 | `is_baseline` | 是否為第一份同步報告；第一份只建立比較基準，不顯示增減。 | INTEGER | NO | 0 | — | — |
+| 7 | `assets_before_twd` | 批次開始前以新臺幣換算的資產總額。 | INTEGER | YES | — | — | — |
+| 8 | `credit_card_debt_before_twd` | 批次開始前以新臺幣換算的信用卡負債總額。 | INTEGER | YES | — | — | — |
+| 9 | `missing_currencies_before` | 批次開始前缺少匯率、以新台幣 0 元計值的幣別 JSON 陣列。 | TEXT | NO | '[]' | — | — |
+| 10 | `assets_after_twd` | 批次完成後以新臺幣換算的資產總額。 | INTEGER | YES | — | — | — |
+| 11 | `credit_card_debt_after_twd` | 批次完成後以新臺幣換算的信用卡負債總額。 | INTEGER | YES | — | — | — |
+| 12 | `missing_currencies_after` | 批次完成後缺少匯率、以新台幣 0 元計值的幣別 JSON 陣列。 | TEXT | NO | '[]' | — | — |
 
 #### Foreign keys
 
@@ -1016,6 +1031,7 @@ CREATE TABLE scheduled_sync_batch_results (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
+| `idx_scheduled_sync_batches_completed` | 否 | 否 | `completed_at` | `CREATE INDEX idx_scheduled_sync_batches_completed<br>  ON scheduled_sync_batches (completed_at DESC)` |
 | `idx_scheduled_sync_batches_open` | 是 | 是 | `schedule_key` | `CREATE UNIQUE INDEX idx_scheduled_sync_batches_open<br>  ON scheduled_sync_batches (schedule_key)<br>  WHERE notification_claimed_at IS NULL` |
 
 #### DDL
@@ -1026,7 +1042,7 @@ CREATE TABLE scheduled_sync_batches (
   schedule_key TEXT NOT NULL DEFAULT 'default' CHECK (schedule_key = 'default'),
   notification_claimed_at TEXT,
   created_at TEXT NOT NULL
-)
+, completed_at TEXT, is_baseline INTEGER NOT NULL DEFAULT 0, assets_before_twd INTEGER, credit_card_debt_before_twd INTEGER, missing_currencies_before TEXT NOT NULL DEFAULT '[]', assets_after_twd INTEGER, credit_card_debt_after_twd INTEGER, missing_currencies_after TEXT NOT NULL DEFAULT '[]')
 ```
 
 ### `sync_jobs`
@@ -1199,6 +1215,9 @@ Migration 是 schema 演進的 source of truth；若要了解某欄位的變更�
 - [`0021_ctbc_sync_job.sql`](../packages/db/migrations/0021_ctbc_sync_job.sql)
 - [`0023_disable_unconfigured_sync_jobs.sql`](../packages/db/migrations/0023_disable_unconfigured_sync_jobs.sql)
 - [`0024_manual_asset_currency.sql`](../packages/db/migrations/0024_manual_asset_currency.sql)
+- [`0025_bank_time_deposit.sql`](../packages/db/migrations/0025_bank_time_deposit.sql)
+- [`0026_obank_sync_job.sql`](../packages/db/migrations/0026_obank_sync_job.sql)
+- [`0027_scheduled_sync_reports.sql`](../packages/db/migrations/0027_scheduled_sync_reports.sql)
 
 ## 程式碼導覽
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -181,11 +181,50 @@ export interface SyncResponse {
   connectorId: ConnectorId;
   scope: string;
   records: number;
+  newRecords: SyncNewRecordCounts;
   detailRecords?: number;
   cursorUpdated: boolean;
 }
 
 export type SyncNotificationStatus = "success" | "failed" | "needs_user_action";
+
+export interface SyncNewRecordCounts {
+  invoices: number;
+  bankTransactions: number;
+  investmentTransactions: number;
+}
+
+export interface ScheduledSyncSourceReport {
+  connectorId: ConnectorId;
+  status: SyncNotificationStatus;
+  completedAt: string;
+  newRecords: SyncNewRecordCounts;
+}
+
+export type SyncFinancialChangeUnavailableReason =
+  "baseline" | "partial_sync" | "snapshot_unavailable";
+
+export interface ScheduledSyncReport {
+  id: string;
+  startedAt: string;
+  completedAt: string;
+  status: SyncNotificationStatus;
+  sources: ScheduledSyncSourceReport[];
+  sourceSummary: {
+    total: number;
+    success: number;
+    failed: number;
+    needsUserAction: number;
+  };
+  newRecords: SyncNewRecordCounts;
+  financialChange: {
+    assets: number;
+    creditCardDebt: number;
+    netWorth: number;
+  } | null;
+  financialChangeUnavailableReason: SyncFinancialChangeUnavailableReason | null;
+  missingCurrencies: string[];
+}
 
 export interface NotificationPreferences {
   success: boolean;

--- a/packages/db/migrations/0027_scheduled_sync_reports.sql
+++ b/packages/db/migrations/0027_scheduled_sync_reports.sql
@@ -1,0 +1,35 @@
+ALTER TABLE scheduled_sync_batches
+  ADD COLUMN completed_at TEXT;
+
+ALTER TABLE scheduled_sync_batches
+  ADD COLUMN is_baseline INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE scheduled_sync_batches
+  ADD COLUMN assets_before_twd INTEGER;
+
+ALTER TABLE scheduled_sync_batches
+  ADD COLUMN credit_card_debt_before_twd INTEGER;
+
+ALTER TABLE scheduled_sync_batches
+  ADD COLUMN missing_currencies_before TEXT NOT NULL DEFAULT '[]';
+
+ALTER TABLE scheduled_sync_batches
+  ADD COLUMN assets_after_twd INTEGER;
+
+ALTER TABLE scheduled_sync_batches
+  ADD COLUMN credit_card_debt_after_twd INTEGER;
+
+ALTER TABLE scheduled_sync_batches
+  ADD COLUMN missing_currencies_after TEXT NOT NULL DEFAULT '[]';
+
+ALTER TABLE scheduled_sync_batch_results
+  ADD COLUMN new_invoices INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE scheduled_sync_batch_results
+  ADD COLUMN new_bank_transactions INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE scheduled_sync_batch_results
+  ADD COLUMN new_investment_transactions INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_scheduled_sync_batches_completed
+  ON scheduled_sync_batches (completed_at DESC);

--- a/packages/db/schema-metadata.json
+++ b/packages/db/schema-metadata.json
@@ -306,7 +306,10 @@
         "job_id": "批次成員的同步工作識別碼。",
         "connector_id": "此次結果所屬的連接器。",
         "status": "排程執行結果；等待執行或被略過的成員為 NULL。",
-        "completed_at": "排程結果或略過決定寫入批次的時間；NULL 表示仍在等待。"
+        "completed_at": "排程結果或略過決定寫入批次的時間；NULL 表示仍在等待。",
+        "new_invoices": "此次工作真正新增的電子發票筆數，不包含更新既有發票。",
+        "new_bank_transactions": "此次工作真正新增的銀行或信用卡交易筆數，不包含更新既有交易。",
+        "new_investment_transactions": "此次工作真正新增的投資交易筆數，不包含更新既有交易。"
       }
     },
     "scheduled_sync_batches": {
@@ -316,7 +319,15 @@
         "id": "批次識別碼，由 default 與 UUID 組成。",
         "schedule_key": "排程類型識別碼，目前固定為 default。",
         "notification_claimed_at": "彙總推播被 scheduler 取得發送權的時間。",
-        "created_at": "批次建立時間。"
+        "created_at": "批次建立時間。",
+        "completed_at": "批次所有有效成員結束並完成財務快照的時間。",
+        "is_baseline": "是否為第一份同步報告；第一份只建立比較基準，不顯示增減。",
+        "assets_before_twd": "批次開始前以新臺幣換算的資產總額。",
+        "credit_card_debt_before_twd": "批次開始前以新臺幣換算的信用卡負債總額。",
+        "missing_currencies_before": "批次開始前缺少匯率、以新台幣 0 元計值的幣別 JSON 陣列。",
+        "assets_after_twd": "批次完成後以新臺幣換算的資產總額。",
+        "credit_card_debt_after_twd": "批次完成後以新臺幣換算的信用卡負債總額。",
+        "missing_currencies_after": "批次完成後缺少匯率、以新台幣 0 元計值的幣別 JSON 陣列。"
       }
     },
     "sync_jobs": {


### PR DESCRIPTION
## 摘要

- 在每日排程同步批次前後保存資產、信用卡負債與缺少匯率幣別的快照
- 統計實際新增的交易、發票與投資交易筆數，避免重複同步被再次計入
- 在總覽顯示最近一次同步結果、財務增減與各資料來源明細
- 推播維持不含財務數字，只引導使用者開啟 App 查看
- 缺少匯率時以 NT$0 計值，並在總覽清楚提示受影響幣別

## 行為說明

- 第一輪完整成功同步會建立比較基準，不顯示增減
- 後續完整成功同步顯示資產、信用卡負債與淨資產變化
- 部分資料來源失敗時保留新增筆數，但不計算財務差額
- 資產或淨資產減少顯示紅色；信用卡負債減少則顯示綠色
- 尚未產生任何排程同步報告時，總覽不顯示報告卡片

## 驗證

- `npm run typecheck`
- `npm run test:backend`（Worker 217 tests、DB 4 tests、connector self-check、deploy 16 tests）
- `npm run test:unit -w @taiwan-fin-hub/web`（70 tests）
- `npm run format:check`
- `npm run build`
- Svelte autofixer：0 issues / 0 suggestions
- 桌面 1440px 與手機 390px localhost 畫面驗證，無水平溢位