### PR TITLE
新增電子發票分批同步並修正匯率警示

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -29,6 +29,7 @@ test.beforeEach(async ({ page }) => {
     else if (path === "/api/exchange-rates") body = [];
     else if (path === "/api/history/net-worth/chart") body = [];
     else if (path === "/api/sync-jobs") body = [];
+    else if (path === "/api/sync-reports/latest") body = null;
     else if (path === "/api/classification/categories")
       body = [
         { id: "salary", label: "薪資", sortOrder: 1, isSystem: true },
@@ -98,6 +99,100 @@ test("renders the mobile bottom navigation", async ({ page }) => {
   await expect(
     page.getByRole("heading", { name: "更多", exact: true }),
   ).toBeVisible();
+});
+
+test("warns about a missing exchange rate only when the foreign balance is positive", async ({
+  page,
+}) => {
+  let hkdBalance = 0;
+  await page.route("**/api/bank**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        accounts: [
+          {
+            id: "hkd-account",
+            connectorId: "esun",
+            sourceId: "hkd-account",
+            institutionName: "玉山銀行",
+            accountName: "港幣帳戶",
+            accountType: "savings",
+            balance: hkdBalance,
+            currency: "HKD",
+          },
+        ],
+        transactions: [],
+      }),
+    });
+  });
+
+  const warning = page.getByText(/資產含外幣（HKD）尚未設定匯率/);
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/#/overview");
+  await expect(
+    page.getByRole("heading", { name: "總覽", exact: true }),
+  ).toBeVisible();
+  await expect(warning).toHaveCount(0);
+
+  hkdBalance = 100;
+  await page.reload();
+  await expect(warning).toBeVisible();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(warning).toBeVisible();
+
+  hkdBalance = 0;
+  await page.reload();
+  await expect(warning).toHaveCount(0);
+});
+
+test("does not show a missing-rate warning while exchange rates are loading", async ({
+  page,
+}) => {
+  await page.route("**/api/bank**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        accounts: [
+          {
+            id: "hkd-account",
+            connectorId: "esun",
+            sourceId: "hkd-account",
+            accountType: "savings",
+            balance: 100,
+            currency: "HKD",
+          },
+        ],
+        transactions: [],
+      }),
+    });
+  });
+
+  let releaseRates!: () => void;
+  const pendingRates = new Promise<void>((resolve) => {
+    releaseRates = resolve;
+  });
+  await page.route("**/api/exchange-rates", async (route) => {
+    await pendingRates;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: "[]",
+    });
+  });
+
+  await page.goto("/#/overview");
+  const warning = page.getByText(/資產含外幣（HKD）尚未設定匯率/);
+  await expect(
+    page.getByRole("heading", { name: "總覽", exact: true }),
+  ).toBeVisible();
+  await expect(warning).toHaveCount(0);
+
+  releaseRates();
+  await expect(warning).toBeVisible();
 });
 
 test("shows a loading state while a connector sync is pending", async ({

--- a/apps/web/src/data/connectors/definitions.test.ts
+++ b/apps/web/src/data/connectors/definitions.test.ts
@@ -32,12 +32,13 @@ describe("connector definitions", () => {
     }
   });
 
-  it("keeps invoice line-item sync as the only public preference", () => {
-    expect(connectorCatalog.einvoice.publicFields).toEqual(["fetchDetails"]);
-
+  it("does not expose retired sync preferences", () => {
     for (const connectorId of supportedConnectorIds) {
-      if (connectorId === "einvoice") continue;
       expect(connectorCatalog[connectorId].publicFields).toEqual([]);
     }
+
+    expect(connectorFields.einvoice.map(({ key }) => key)).not.toContain(
+      "fetchDetails",
+    );
   });
 });

--- a/apps/web/src/data/connectors/definitions.ts
+++ b/apps/web/src/data/connectors/definitions.ts
@@ -28,7 +28,6 @@ export const connectorFields = {
   einvoice: [
     { key: "mobile", label: "手機號碼（電子發票帳號）", type: "text" },
     { key: "password", label: "電子發票 App 登入密碼", type: "password" },
-    { key: "fetchDetails", label: "同步品項明細", type: "checkbox" },
   ],
   tdcc: [
     { key: "userId", label: "身分證字號", type: "text" },

--- a/apps/web/src/data/connectors/types.ts
+++ b/apps/web/src/data/connectors/types.ts
@@ -1,6 +1,6 @@
-import type { ConnectorId } from "@taiwan-fin-hub/core";
+import type { ConnectorId, QueuedSyncResponse } from "@taiwan-fin-hub/core";
 
-export type { ConnectorId } from "@taiwan-fin-hub/core";
+export type { ConnectorId, QueuedSyncResponse } from "@taiwan-fin-hub/core";
 
 export type SyncTarget = "default" | "investments" | "bank" | "trades";
 
@@ -47,6 +47,6 @@ export interface SyncScheduleSettings {
 export interface ConnectorField<TKey extends string = string> {
   key: TKey;
   label: string;
-  type: "text" | "password" | "number" | "checkbox";
+  type: "text" | "password" | "number";
   placeholder?: string;
 }

--- a/apps/web/src/features/assets/model/summary.test.ts
+++ b/apps/web/src/features/assets/model/summary.test.ts
@@ -101,4 +101,71 @@ describe("calculateAssetSummary", () => {
     expect(summary.grossAssets).toBe(0);
     expect(summary.missingCurrencies).toEqual(["JPY", "USD"]);
   });
+
+  it("ignores empty foreign accounts while preserving non-zero card debt warnings", () => {
+    const summary = calculateAssetSummary({
+      bank: {
+        accounts: [
+          {
+            id: "empty-hkd",
+            connectorId: "esun",
+            sourceId: "empty-hkd",
+            accountType: "savings",
+            balance: 0,
+            currency: "HKD",
+          },
+          {
+            id: "overdrawn-cny",
+            connectorId: "esun",
+            sourceId: "overdrawn-cny",
+            accountType: "savings",
+            balance: -10,
+            currency: "CNY",
+          },
+          {
+            id: "empty-card",
+            connectorId: "esun",
+            sourceId: "empty-card",
+            accountType: "credit",
+            balance: 0,
+            currency: "AUD",
+          },
+          {
+            id: "foreign-card",
+            connectorId: "esun",
+            sourceId: "foreign-card",
+            accountType: "credit",
+            balance: -50,
+            currency: "SGD",
+          },
+        ],
+        transactions: [],
+      },
+      investments: [
+        {
+          id: "empty-investment",
+          assetType: "fund",
+          name: "空投資部位",
+          marketValue: 0,
+          cashBalance: 0,
+          currency: "GBP",
+          asOfDate: "2026-08-12",
+        },
+      ],
+      manualAssets: [
+        {
+          id: "empty-manual",
+          name: "零估值資產",
+          category: "other",
+          note: null,
+          currency: "CHF",
+          createdAt: "2026-08-12",
+          value: 0,
+        },
+      ],
+      rates: [],
+    });
+
+    expect(summary.missingCurrencies).toEqual(["SGD"]);
+  });
 });

--- a/apps/web/src/features/assets/model/summary.ts
+++ b/apps/web/src/features/assets/model/summary.ts
@@ -1,6 +1,7 @@
 import type { ExchangeRateRow, ManualAssetRow } from "@/data/assets/types";
 import type { BankAccountRow, BankData } from "@/data/bank/types";
 import type { InvestmentRow } from "@/data/investments/types";
+import { missingExchangeRateCurrencies } from "@/shared/format/financial";
 
 const CONNECTOR_BANK_CODES: Record<string, string> = {
   cathaybk: "013",
@@ -56,28 +57,32 @@ export function calculateAssetSummary({
   );
   const toTwd = (value: number, currency: string) =>
     currency === "TWD" ? value : value * (rateValues[currency] ?? 0);
-  const missingCurrencies = new Set<string>();
-  const recordMissingRate = (value: number, currency: string) => {
-    if (value !== 0 && currency !== "TWD" && rateValues[currency] == null)
-      missingCurrencies.add(currency);
-  };
-  bank.accounts.forEach((account) =>
-    recordMissingRate(account.balance ?? 0, account.currency),
-  );
-  investments.forEach((item) =>
-    recordMissingRate(
-      (item.marketValue ?? 0) + (item.cashBalance ?? 0),
-      item.currency,
-    ),
-  );
-  manualAssets.forEach((item) =>
-    recordMissingRate(item.value ?? 0, item.currency),
-  );
   const deposits = bank.accounts.filter(
     (account) => account.accountType !== "credit",
   );
   const cards = bank.accounts.filter(
     (account) => account.accountType === "credit",
+  );
+  const missingCurrencies = missingExchangeRateCurrencies(
+    [
+      ...deposits.map((account) => ({
+        currency: account.currency,
+        amount: account.balance ?? 0,
+      })),
+      ...cards.map((account) => ({
+        currency: account.currency,
+        amount: Math.abs(account.balance ?? 0),
+      })),
+      ...investments.map((item) => ({
+        currency: item.currency,
+        amount: (item.marketValue ?? 0) + (item.cashBalance ?? 0),
+      })),
+      ...manualAssets.map((item) => ({
+        currency: item.currency,
+        amount: item.value ?? 0,
+      })),
+    ],
+    rateValues,
   );
   const bankTotal = deposits.reduce(
     (sum, account) => sum + toTwd(account.balance ?? 0, account.currency),
@@ -167,6 +172,6 @@ export function calculateAssetSummary({
     grossAssets,
     netWorth: grossAssets - cardDebt,
     institutionGroups,
-    missingCurrencies: [...missingCurrencies].sort(),
+    missingCurrencies,
   };
 }

--- a/apps/web/src/features/overview/OverviewPage.svelte
+++ b/apps/web/src/features/overview/OverviewPage.svelte
@@ -34,6 +34,7 @@
   import {
     formatCompactTwd,
     formatCurrency,
+    missingExchangeRateCurrencies,
     rateMap,
   } from "@/shared/format/financial";
   import NetWorthHistoryChart from "./components/NetWorthHistoryChart.svelte";
@@ -219,15 +220,31 @@
 
     return items.slice(0, 2);
   });
-  const missingRates = $derived([
-    ...new Set(
-      [
-        ...bankData.accounts.map((account) => account.currency),
-        ...($investments.data ?? []).map((item) => item.currency),
-        ...($manualAssets.data ?? []).map((item) => item.currency),
-      ].filter((currency) => currency !== "TWD" && !rateValues[currency]),
-    ),
-  ]);
+  const missingRates = $derived(
+    $rates.isSuccess
+      ? missingExchangeRateCurrencies(
+          [
+            ...deposits.map((account) => ({
+              currency: account.currency,
+              amount: account.balance ?? 0,
+            })),
+            ...cards.map((account) => ({
+              currency: account.currency,
+              amount: Math.abs(account.balance ?? 0),
+            })),
+            ...($investments.data ?? []).map((item) => ({
+              currency: item.currency,
+              amount: (item.marketValue ?? 0) + (item.cashBalance ?? 0),
+            })),
+            ...($manualAssets.data ?? []).map((item) => ({
+              currency: item.currency,
+              amount: item.value ?? 0,
+            })),
+          ],
+          rateValues,
+        )
+      : [],
+  );
   const loading = $derived(
     $bank.isPending ||
       $monthlyBank.isPending ||

--- a/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
+++ b/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { toStore } from "svelte/store";
   import {
     createMutation,
@@ -18,7 +18,6 @@
   import TdccConnectionProgress from "./TdccConnectionProgress.svelte";
   import Card from "@/shared/ui/Card.svelte";
   import Button from "@/shared/ui/Button.svelte";
-  import Checkbox from "@/shared/ui/Checkbox.svelte";
   import Input from "@/shared/ui/Input.svelte";
   import Select from "@/shared/ui/Select.svelte";
   import TimePicker from "@/shared/ui/TimePicker.svelte";
@@ -33,6 +32,7 @@
   import type {
     ConnectorField,
     ConnectorId,
+    QueuedSyncResponse,
     SyncTarget,
   } from "@/data/connectors/types";
   import { formatDateTime } from "@/shared/format/financial";
@@ -59,7 +59,7 @@
   );
   const jobs = createQuery(syncJobsQuery(() => api));
   const defaultSchedule = createQuery(syncScheduleQuery(() => api));
-  let values = $state<Record<string, string | boolean>>({});
+  let values = $state<Record<string, string>>({});
   let error = $state("");
   let otp = $state("");
   let tdccSetupStep = $state<"credentials" | "email" | "sms" | "complete">(
@@ -70,6 +70,12 @@
   let bankCaptchaDigitCount = $state(6);
   let bankCaptchaKind = $state<"numeric" | "alphanumeric">("numeric");
   let pendingSyncTarget = $state<SyncTarget>("default");
+  let einvoiceSyncQueued = $state(false);
+  let einvoiceSyncQueuedTimer: ReturnType<typeof setTimeout> | undefined;
+  let einvoiceSyncPolling = $state<"awaiting-active" | "active" | null>(null);
+  let einvoiceSyncPreviousLastRunAt = $state<string | null>(null);
+  let einvoiceSyncPollingTimer: ReturnType<typeof setTimeout> | undefined;
+  let destroyed = false;
   const job = $derived(
     ($jobs.data ?? []).find(
       (j) => j.connectorId === connectorId && j.scope === "all",
@@ -111,13 +117,15 @@
       for (const [key, value] of Object.entries(
         result.data?.publicConfig ?? {},
       )) {
-        if (values[key] === undefined)
-          values[key] = typeof value === "boolean" ? value : String(value);
+        if (values[key] === undefined) values[key] = String(value);
       }
-      if (connectorId === "einvoice" && values.fetchDetails === undefined)
-        values.fetchDetails = true;
     }),
   );
+  onDestroy(() => {
+    destroyed = true;
+    clearTimeout(einvoiceSyncQueuedTimer);
+    stopEinvoiceSyncPolling();
+  });
 
   const save = createMutation({
     mutationFn: (config: Record<string, unknown>) => {
@@ -150,19 +158,21 @@
           ? `/api/connectors/${connectorId}/sync/${target}`
           : `/api/connectors/${connectorId}/sync`;
       pendingSyncTarget = target;
-      return api.post(
-        path,
-        connectorId === "einvoice" ? { fetchDetails: true } : undefined,
-      );
+      return connectorId === "einvoice"
+        ? api.post<QueuedSyncResponse>(path, {})
+        : api.post(path);
     },
     onSuccess: () => {
       error = "";
+      if (connectorId === "einvoice") {
+        showEinvoiceSyncQueued();
+        startEinvoiceSyncPolling();
+        return;
+      }
       if (connectorId === "tdcc") tdccSetupStep = "complete";
       qc.invalidateQueries({ queryKey: queryKeys.syncJobs });
       qc.invalidateQueries({ queryKey: queryKeys.summary });
-      if (connectorId === "einvoice")
-        qc.invalidateQueries({ queryKey: queryKeys.invoices });
-      else if (
+      if (
         connectorId === "esun" ||
         connectorId === "cathaybk" ||
         connectorId === "ctbc"
@@ -350,7 +360,7 @@
   }
 
   function buildConfig() {
-    const entries: Array<[string, string | number | boolean]> = [];
+    const entries: Array<[string, string | number]> = [];
     for (const field of fields) {
       const raw = values[field.key];
       if (raw === undefined || raw === "") continue;
@@ -362,6 +372,51 @@
       if (Number.isFinite(number)) entries.push([field.key, number]);
     }
     return Object.fromEntries(entries);
+  }
+  function showEinvoiceSyncQueued() {
+    einvoiceSyncQueued = true;
+    clearTimeout(einvoiceSyncQueuedTimer);
+    einvoiceSyncQueuedTimer = setTimeout(() => {
+      einvoiceSyncQueued = false;
+    }, 5_000);
+  }
+  function startEinvoiceSyncPolling() {
+    einvoiceSyncPolling = "awaiting-active";
+    einvoiceSyncPreviousLastRunAt = job?.lastRunAt ?? null;
+    clearTimeout(einvoiceSyncPollingTimer);
+    void pollEinvoiceSyncJob();
+  }
+  function stopEinvoiceSyncPolling() {
+    einvoiceSyncPolling = null;
+    clearTimeout(einvoiceSyncPollingTimer);
+    einvoiceSyncPollingTimer = undefined;
+  }
+  async function pollEinvoiceSyncJob() {
+    const syncJobs = await qc
+      .fetchQuery({ ...syncJobsQuery(() => api), staleTime: 0 })
+      .catch(() => undefined);
+    if (!einvoiceSyncPolling || destroyed) return;
+    const einvoiceJob = syncJobs?.find(
+      (syncJob) =>
+        syncJob.connectorId === "einvoice" && syncJob.scope === "all",
+    );
+    if (einvoiceJob?.running) {
+      einvoiceSyncPolling = "active";
+    } else if (
+      einvoiceSyncPolling === "active" ||
+      einvoiceJob?.lastRunAt !== einvoiceSyncPreviousLastRunAt
+    ) {
+      const completedSuccessfully = einvoiceJob?.lastStatus === "success";
+      stopEinvoiceSyncPolling();
+      if (completedSuccessfully) {
+        qc.invalidateQueries({ queryKey: queryKeys.summary });
+        qc.invalidateQueries({ queryKey: queryKeys.invoices });
+      }
+      return;
+    }
+    einvoiceSyncPollingTimer = setTimeout(() => {
+      void pollEinvoiceSyncJob();
+    }, 2_000);
   }
   function intervalLabel(minutes: number) {
     return (
@@ -473,14 +528,22 @@
       {:else}
         <Button
           size="sm"
-          disabled={demoMode || $sync.isPending}
+          disabled={demoMode ||
+            $sync.isPending ||
+            (connectorId === "einvoice" && einvoiceSyncPolling !== null)}
           onclick={() => {
             error = "";
             $sync.mutate("default");
           }}
           ><RefreshCw
             class={$sync.isPending ? "size-4 animate-spin" : "size-4"}
-          />{$sync.isPending ? "同步中…" : "同步"}</Button
+          />{$sync.isPending
+            ? "同步中…"
+            : connectorId === "einvoice" && einvoiceSyncQueued
+              ? "已排入同步"
+              : connectorId === "einvoice" && einvoiceSyncPolling
+                ? "同步中…"
+                : "同步"}</Button
         >
       {/if}
     </div>
@@ -677,50 +740,36 @@
     </div>
     <div class="grid gap-3 p-4">
       {#each fields as field (field.key)}
-        {#if field.type === "checkbox"}
-          <label class="flex items-center gap-2 text-sm"
-            ><Checkbox
-              checked={Boolean(values[field.key])}
-              onchange={(e: Event) =>
-                (values[field.key] = (
-                  e.currentTarget as HTMLInputElement
-                ).checked)}
-            />{field.label}</label
-          >
-        {:else}
-          {@const storedCredential = Boolean(
-            $settings.data?.configured &&
-            (connectorId !== "tdcc" || tdccCredentialsComplete) &&
-            (field.type === "text" || field.type === "password"),
-          )}
-          {@const hasReplacement = Boolean(String(values[field.key] ?? ""))}
-          <label class="grid gap-1.5 text-sm font-medium">
-            <span class="flex flex-wrap items-center gap-2">
-              <span>{field.label}</span>
-              {#if storedCredential}
-                <span
-                  class={`rounded-full px-2 py-0.5 text-sm font-semibold ${hasReplacement ? "bg-steel/10 text-steel" : "bg-moss/10 text-moss"}`}
-                >
-                  {hasReplacement ? "將更新" : "已儲存"}
-                </span>
-              {/if}
-            </span>
-            <Input
-              class={storedCredential && !hasReplacement
-                ? "bg-moss/[0.035] placeholder:text-ink/55"
-                : ""}
-              type={field.type}
-              placeholder={storedCredential && !hasReplacement
-                ? "••••••••　已安全儲存"
-                : field.placeholder}
-              value={String(values[field.key] ?? "")}
-              oninput={(e: Event) =>
-                (values[field.key] = (
-                  e.currentTarget as HTMLInputElement
-                ).value)}
-            />
-          </label>
-        {/if}
+        {@const storedCredential = Boolean(
+          $settings.data?.configured &&
+          (connectorId !== "tdcc" || tdccCredentialsComplete) &&
+          (field.type === "text" || field.type === "password"),
+        )}
+        {@const hasReplacement = Boolean(String(values[field.key] ?? ""))}
+        <label class="grid gap-1.5 text-sm font-medium">
+          <span class="flex flex-wrap items-center gap-2">
+            <span>{field.label}</span>
+            {#if storedCredential}
+              <span
+                class={`rounded-full px-2 py-0.5 text-sm font-semibold ${hasReplacement ? "bg-steel/10 text-steel" : "bg-moss/10 text-moss"}`}
+              >
+                {hasReplacement ? "將更新" : "已儲存"}
+              </span>
+            {/if}
+          </span>
+          <Input
+            class={storedCredential && !hasReplacement
+              ? "bg-moss/[0.035] placeholder:text-ink/55"
+              : ""}
+            type={field.type}
+            placeholder={storedCredential && !hasReplacement
+              ? "••••••••　已安全儲存"
+              : field.placeholder}
+            value={String(values[field.key] ?? "")}
+            oninput={(e: Event) =>
+              (values[field.key] = (e.currentTarget as HTMLInputElement).value)}
+          />
+        </label>
       {/each}
     </div>
     <div

--- a/apps/web/src/features/settings/connectors/ConnectorPanel.test.ts
+++ b/apps/web/src/features/settings/connectors/ConnectorPanel.test.ts
@@ -1,0 +1,175 @@
+import { fireEvent, render } from "@testing-library/svelte";
+import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
+import { describe, expect, it, vi } from "vitest";
+import { connectorFields } from "@/data/connectors/definitions";
+import type { ConnectorField, SyncJobRow } from "@/data/connectors/types";
+import type { ApiClient } from "@/shared/api/client";
+import ConnectorPanel from "./ConnectorPanel.svelte";
+
+function syncJob(overrides: Partial<SyncJobRow> = {}): SyncJobRow {
+  return {
+    id: "einvoice:all",
+    connectorId: "einvoice",
+    configured: true,
+    scope: "all",
+    enabled: true,
+    intervalMinutes: 1440,
+    nextRunAt: "2026-08-13T00:00:00.000Z",
+    scheduleMode: "inherit",
+    preferredTime: "08:00",
+    preferredWeekday: 1,
+    lockedUntil: null,
+    lockedBy: null,
+    lockTrigger: null,
+    lockScope: null,
+    lastRunAt: null,
+    lastSuccessAt: null,
+    lastStatus: null,
+    lastError: null,
+    updatedAt: "2026-08-12T00:00:00.000Z",
+    running: false,
+    ...overrides,
+  };
+}
+
+function renderEinvoicePanel(syncJobs: SyncJobRow[][]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 30_000 } },
+  });
+  let syncJobRequest = 0;
+  const api = {
+    get: vi.fn((path: string) => {
+      if (path === "/api/sync-jobs")
+        return Promise.resolve(
+          syncJobs[Math.min(syncJobRequest++, syncJobs.length - 1)] ?? [],
+        );
+      return Promise.resolve({});
+    }),
+    post: vi.fn().mockResolvedValue({
+      success: true,
+      connectorId: "einvoice",
+      scope: "all",
+      status: "queued",
+      runId: "run-1",
+    }),
+  } as unknown as ApiClient;
+  const result = render(
+    ConnectorPanel,
+    {
+      props: {
+        api,
+        connectorId: "einvoice",
+        demoMode: false,
+        title: "電子發票",
+        fields: connectorFields.einvoice as ConnectorField[],
+      },
+    },
+    {
+      wrapper: QueryClientProvider,
+      wrapperProps: { client: queryClient },
+    },
+  );
+  return { ...result, api, queryClient };
+}
+
+describe("ConnectorPanel", () => {
+  it("polls an e-invoice run and refreshes financial data only after success", async () => {
+    vi.useFakeTimers();
+    const running = syncJob({ running: true });
+    const completed = syncJob({
+      lastRunAt: "2026-08-12T00:01:00.000Z",
+      lastSuccessAt: "2026-08-12T00:01:00.000Z",
+      lastStatus: "success",
+    });
+    const { api, getByRole, queryByText, queryClient } = renderEinvoicePanel([
+      [],
+      [running],
+      [completed],
+    ]);
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+    expect(queryByText("同步品項明細")).not.toBeInTheDocument();
+    await fireEvent.click(getByRole("button", { name: "同步" }));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(api.post).toHaveBeenCalledWith("/api/connectors/einvoice/sync", {});
+    expect(getByRole("button", { name: "已排入同步" })).toBeDisabled();
+    expect(invalidateQueries).not.toHaveBeenCalledWith({
+      queryKey: ["summary"],
+    });
+    expect(invalidateQueries).not.toHaveBeenCalledWith({
+      queryKey: ["invoices"],
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(
+      (api.get as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([path]) => path === "/api/sync-jobs",
+      ),
+    ).toHaveLength(4);
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["summary"],
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["invoices"],
+    });
+    expect(getByRole("button", { name: "已排入同步" })).toBeEnabled();
+    vi.useRealTimers();
+  });
+
+  it("stops polling without refreshing data when an e-invoice run fails", async () => {
+    vi.useFakeTimers();
+    const { api, getByRole, queryClient } = renderEinvoicePanel([
+      [],
+      [syncJob({ running: true })],
+      [
+        syncJob({
+          lastRunAt: "2026-08-12T00:01:00.000Z",
+          lastStatus: "failed",
+          lastError: "連線失敗",
+        }),
+      ],
+    ]);
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+    await fireEvent.click(getByRole("button", { name: "同步" }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(api.post).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(getByRole("button", { name: "已排入同步" })).toBeEnabled();
+    expect(invalidateQueries).not.toHaveBeenCalledWith({
+      queryKey: ["summary"],
+    });
+    expect(invalidateQueries).not.toHaveBeenCalledWith({
+      queryKey: ["invoices"],
+    });
+    vi.useRealTimers();
+  });
+
+  it("cancels e-invoice polling when the panel is destroyed", async () => {
+    vi.useFakeTimers();
+    const { api, getByRole, unmount } = renderEinvoicePanel([
+      [],
+      [syncJob({ running: true })],
+    ]);
+
+    await fireEvent.click(getByRole("button", { name: "同步" }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(api.post).toHaveBeenCalledOnce();
+    const syncJobRequestsBeforeUnmount = (
+      api.get as ReturnType<typeof vi.fn>
+    ).mock.calls.filter(([path]) => path === "/api/sync-jobs").length;
+
+    unmount();
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    expect(
+      (api.get as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([path]) => path === "/api/sync-jobs",
+      ),
+    ).toHaveLength(syncJobRequestsBeforeUnmount);
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/src/shared/format/financial.test.ts
+++ b/apps/web/src/shared/format/financial.test.ts
@@ -3,6 +3,7 @@ import {
   bankAccountLast5,
   formatBankAccountName,
   formatNumber,
+  missingExchangeRateCurrencies,
   normalizeFinancialDate,
   parseValidDate,
   rateMap,
@@ -51,5 +52,21 @@ describe("financial formatting helpers", () => {
     expect(
       transactionValueTwd({ currency: "USD", amount: 10 } as never, rates),
     ).toBe(320);
+  });
+
+  it("reports missing rates only for positive foreign-currency amounts", () => {
+    expect(
+      missingExchangeRateCurrencies(
+        [
+          { currency: "HKD", amount: 0 },
+          { currency: "HKD", amount: 100 },
+          { currency: "HKD", amount: 200 },
+          { currency: "CNY", amount: -100 },
+          { currency: "USD", amount: 100 },
+          { currency: "TWD", amount: 100 },
+        ],
+        { USD: 32 },
+      ),
+    ).toEqual(["HKD"]);
   });
 });

--- a/apps/web/src/shared/format/financial.ts
+++ b/apps/web/src/shared/format/financial.ts
@@ -130,6 +130,22 @@ export function rateMap(rates: ExchangeRate[] | undefined) {
   return Object.fromEntries((rates ?? []).map((r) => [r.currency, r.rateTwd]));
 }
 
+export function missingExchangeRateCurrencies(
+  amounts: ReadonlyArray<CurrencyAmount>,
+  rates: Readonly<Record<string, number>>,
+) {
+  return [
+    ...new Set(
+      amounts
+        .filter(
+          ({ currency, amount }) =>
+            amount > 0 && currency !== "TWD" && rates[currency] == null,
+        )
+        .map(({ currency }) => currency),
+    ),
+  ].sort();
+}
+
 export function transactionValueTwd(
   transaction: CurrencyAmount,
   rates: Record<string, number>,

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -28,6 +28,6 @@
     "@cloudflare/workers-types": "^4.20260621.1",
     "@types/web-push": "^3.6.4",
     "vitest": "^4.1.10",
-    "wrangler": "^4.103.0"
+    "wrangler": "^4.121.0"
   }
 }

--- a/apps/worker/src/features/sync/connector-state.ts
+++ b/apps/worker/src/features/sync/connector-state.ts
@@ -22,6 +22,8 @@ export function sensitiveConnectorConfig(
   config: Record<string, unknown>,
 ) {
   const sensitive = { ...config };
+  // Retired public preferences must not migrate into encrypted connector state.
+  if (connectorId === "einvoice") delete sensitive.fetchDetails;
   for (const key of connectorCatalog[connectorId].publicFields) {
     delete sensitive[key];
   }

--- a/apps/worker/src/features/sync/einvoice-run-repository.ts
+++ b/apps/worker/src/features/sync/einvoice-run-repository.ts
@@ -1,0 +1,1038 @@
+export type EinvoiceRunStatus =
+  | "queued"
+  | "initializing"
+  | "processing"
+  | "completed"
+  | "failed"
+  | "needs_user_action";
+
+export type EinvoiceRunTrigger = "manual" | "scheduled";
+export type EinvoiceRunItemStatus = "pending" | "processing" | "done";
+
+export type EinvoiceRunRow = {
+  id: string;
+  connector_id: "einvoice";
+  trigger: EinvoiceRunTrigger;
+  sync_job_id: string | null;
+  scheduled_batch_id: string | null;
+  settings_version: string | null;
+  status: EinvoiceRunStatus;
+  total_item_count: number;
+  pending_item_count: number;
+  processing_item_count: number;
+  done_item_count: number;
+  line_item_count: number;
+  new_invoice_count: number;
+  session_refresh_count: number;
+  last_error: string | null;
+  chunk_lease_owner: string | null;
+  chunk_lease_expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+  promoted_at: string | null;
+  completed_at: string | null;
+};
+
+export type EinvoiceRunItemRow = {
+  id: string;
+  run_id: string;
+  invoice_source_id: string;
+  header_json: string;
+  normalized_invoice_json: string;
+  detail_key: string | null;
+  detail_metadata_json: string | null;
+  detail_items_json: string | null;
+  line_item_count: number;
+  status: EinvoiceRunItemStatus;
+  attempt_count: number;
+  last_error: string | null;
+  lease_token: string | null;
+  lease_expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+};
+
+export type CreateEinvoiceRunInput = {
+  id?: string;
+  trigger: EinvoiceRunTrigger;
+  syncJobId?: string | null;
+  scheduledBatchId?: string | null;
+  now?: string;
+};
+
+export type MergeEinvoiceRunItemInput = {
+  invoiceSourceId: string;
+  /** The provider's list/header payload, retained for retry-safe detail work. */
+  header: unknown;
+  /** The normalized Invoice record to promote only after this run is complete. */
+  normalizedInvoice: unknown;
+  detailKey?: string | null;
+  detailMetadata?: unknown;
+  /** Supplying this (including []) means detail work already completed. */
+  detailItems?: unknown[];
+};
+
+const ACTIVE_RUN_STATUSES: EinvoiceRunStatus[] = [
+  "queued",
+  "initializing",
+  "processing",
+];
+
+const TERMINAL_RUN_STATUSES: EinvoiceRunStatus[] = [
+  "completed",
+  "failed",
+  "needs_user_action",
+];
+
+/**
+ * Creates the connector's only active run, or returns the concurrent active
+ * one unchanged. Callers must use `created` to decide whether they own enqueue
+ * compensation; a retry must never rewrite another trigger's job or batch.
+ */
+export async function createOrGetActiveEinvoiceRun(
+  db: D1Database,
+  input: CreateEinvoiceRunInput,
+): Promise<{ run: EinvoiceRunRow; created: boolean }> {
+  const now = input.now ?? new Date().toISOString();
+  const id = input.id ?? `einvoice:${crypto.randomUUID()}`;
+  try {
+    await db
+      .prepare(
+        `INSERT INTO einvoice_sync_runs (
+           id, connector_id, trigger, sync_job_id, scheduled_batch_id, status,
+           created_at, updated_at
+         ) VALUES (?, 'einvoice', ?, ?, ?, 'queued', ?, ?)`,
+      )
+      .bind(
+        id,
+        input.trigger,
+        input.syncJobId ?? null,
+        input.scheduledBatchId ?? null,
+        now,
+        now,
+      )
+      .run();
+  } catch (error) {
+    const existing = await getActiveEinvoiceRun(db);
+    if (!existing) throw error;
+    return { run: existing, created: false };
+  }
+  return { run: (await getEinvoiceRun(db, id))!, created: true };
+}
+
+export async function getActiveEinvoiceRun(db: D1Database) {
+  return (
+    (await db
+      .prepare(
+        `SELECT * FROM einvoice_sync_runs
+         WHERE connector_id = 'einvoice'
+           AND status IN ('queued', 'initializing', 'processing')
+         ORDER BY created_at ASC
+         LIMIT 1`,
+      )
+      .first<EinvoiceRunRow>()) ?? null
+  );
+}
+
+export async function getEinvoiceRun(db: D1Database, runId: string) {
+  return (
+    (await db
+      .prepare("SELECT * FROM einvoice_sync_runs WHERE id = ?")
+      .bind(runId)
+      .first<EinvoiceRunRow>()) ?? null
+  );
+}
+
+/**
+ * Acquires the one run-level Queue chunk lease. A replay may take over only
+ * after the previous lease has expired; active and terminal runs are never
+ * accidentally leased.
+ */
+export async function acquireEinvoiceRunChunkLease(
+  db: D1Database,
+  input: {
+    runId: string;
+    owner: string;
+    leaseMs: number;
+    now?: Date;
+  },
+) {
+  const now = input.now ?? new Date();
+  const nowIso = now.toISOString();
+  const expiresAt = new Date(now.getTime() + input.leaseMs).toISOString();
+  const result = await db
+    .prepare(
+      `UPDATE einvoice_sync_runs
+       SET chunk_lease_owner = ?, chunk_lease_expires_at = ?, updated_at = ?
+       WHERE id = ?
+         AND status IN ('queued', 'initializing', 'processing')
+         AND (
+           chunk_lease_owner IS NULL
+           OR chunk_lease_expires_at IS NULL
+           OR chunk_lease_expires_at < ?
+         )`,
+    )
+    .bind(input.owner, expiresAt, nowIso, input.runId, nowIso)
+    .run();
+  return result.meta.changes === 1;
+}
+
+/** Extends only the active owner's lease while a long detail chunk is running. */
+export async function renewEinvoiceRunChunkLease(
+  db: D1Database,
+  input: {
+    runId: string;
+    owner: string;
+    leaseMs: number;
+    now?: Date;
+  },
+) {
+  const now = input.now ?? new Date();
+  const nowIso = now.toISOString();
+  const expiresAt = new Date(now.getTime() + input.leaseMs).toISOString();
+  const result = await db
+    .prepare(
+      `UPDATE einvoice_sync_runs
+       SET chunk_lease_expires_at = ?, updated_at = ?
+       WHERE id = ?
+         AND status IN ('queued', 'initializing', 'processing')
+         AND chunk_lease_owner = ?`,
+    )
+    .bind(expiresAt, nowIso, input.runId, input.owner)
+    .run();
+  return result.meta.changes === 1;
+}
+
+/** Releases only the caller's lease; stale Queue deliveries cannot unlock it. */
+export async function releaseEinvoiceRunChunkLease(
+  db: D1Database,
+  input: { runId: string; owner: string; now?: string },
+) {
+  const result = await db
+    .prepare(
+      `UPDATE einvoice_sync_runs
+       SET chunk_lease_owner = NULL, chunk_lease_expires_at = NULL,
+           updated_at = ?
+       WHERE id = ? AND chunk_lease_owner = ?`,
+    )
+    .bind(input.now ?? new Date().toISOString(), input.runId, input.owner)
+    .run();
+  return result.meta.changes === 1;
+}
+
+export async function transitionEinvoiceRunStatus(
+  db: D1Database,
+  input: {
+    runId: string;
+    from: Extract<EinvoiceRunStatus, "queued" | "initializing" | "processing">;
+    to: Extract<EinvoiceRunStatus, "initializing" | "processing">;
+    now?: string;
+  },
+) {
+  const result = await db
+    .prepare(
+      `UPDATE einvoice_sync_runs
+       SET status = ?, updated_at = ?
+       WHERE id = ? AND status = ?`,
+    )
+    .bind(
+      input.to,
+      input.now ?? new Date().toISOString(),
+      input.runId,
+      input.from,
+    )
+    .run();
+  return result.meta.changes === 1;
+}
+
+/** Durable merge of discovered invoice headers. Existing processing/done work is never reset. */
+export async function mergeEinvoiceRunItems(
+  db: D1Database,
+  runId: string,
+  items: MergeEinvoiceRunItemInput[],
+  now = new Date().toISOString(),
+) {
+  if (items.length === 0) {
+    await refreshEinvoiceRunCounts(db, runId, now);
+    return;
+  }
+  await db.batch([
+    mergeEinvoiceRunItemsStatement(db, runId, items, now),
+    refreshEinvoiceRunCountsStatement(db, runId, now),
+  ]);
+}
+
+/**
+ * Persists provider headers, refreshed secret session state, and the run phase
+ * in one D1 batch. The settings version guard prevents an in-flight login from
+ * overwriting credentials that the user saved while the network calls ran.
+ */
+export async function initializeEinvoiceRun(
+  db: D1Database,
+  input: {
+    runId: string;
+    items: MergeEinvoiceRunItemInput[];
+    encryptedConfig: string;
+    expectedSettingsUpdatedAt: string;
+    cursor: string;
+    now?: string;
+  },
+) {
+  const now = input.now ?? new Date().toISOString();
+  const results = await db.batch([
+    mergeEinvoiceRunItemsStatement(
+      db,
+      input.runId,
+      input.items,
+      now,
+      input.expectedSettingsUpdatedAt,
+    ),
+    refreshEinvoiceRunCountsStatement(db, input.runId, now),
+    db
+      .prepare(
+        `UPDATE connector_settings
+         SET encrypted_config = ?, public_config = NULL, sync_cursor = ?,
+             updated_at = ?
+         WHERE connector_id = 'einvoice' AND updated_at = ?`,
+      )
+      .bind(
+        input.encryptedConfig,
+        input.cursor,
+        now,
+        input.expectedSettingsUpdatedAt,
+      ),
+    db
+      .prepare(
+        `UPDATE einvoice_sync_runs
+         SET status = 'processing', settings_version = ?, updated_at = ?
+         WHERE id = ? AND status = 'initializing'
+           AND EXISTS (
+             SELECT 1 FROM connector_settings
+             WHERE connector_id = 'einvoice'
+               AND encrypted_config = ? AND updated_at = ?
+           )`,
+      )
+      .bind(now, now, input.runId, input.encryptedConfig, now),
+  ]);
+  return {
+    settingsUpdated: results[2]!.meta.changes === 1,
+    transitioned: results[3]!.meta.changes === 1,
+  };
+}
+
+/** Allows at most a bounded number of automatic session rebuilds per run. */
+export async function claimEinvoiceRunSessionRefresh(
+  db: D1Database,
+  input: { runId: string; maxRefreshes?: number; now?: string },
+) {
+  const result = await db
+    .prepare(
+      `UPDATE einvoice_sync_runs
+       SET session_refresh_count = session_refresh_count + 1, updated_at = ?
+       WHERE id = ?
+         AND status IN ('queued', 'initializing', 'processing')
+         AND session_refresh_count < ?`,
+    )
+    .bind(
+      input.now ?? new Date().toISOString(),
+      input.runId,
+      Math.max(1, Math.floor(input.maxRefreshes ?? 1)),
+    )
+    .run();
+  return result.meta.changes === 1;
+}
+
+/**
+ * Clears an expired provider session and advances the run's pinned settings
+ * version in the same transaction. A concurrent credential save makes both
+ * compare-and-set statements no-ops.
+ */
+export async function resetEinvoiceRunSession(
+  db: D1Database,
+  input: {
+    runId: string;
+    encryptedConfig: string;
+    expectedSettingsUpdatedAt: string;
+    now?: string;
+  },
+) {
+  const now = input.now ?? new Date().toISOString();
+  const results = await db.batch([
+    db
+      .prepare(
+        `UPDATE connector_settings
+         SET encrypted_config = ?, updated_at = ?
+         WHERE connector_id = 'einvoice' AND updated_at = ?
+           AND EXISTS (
+             SELECT 1 FROM einvoice_sync_runs
+             WHERE id = ? AND (
+               (status = 'processing' AND settings_version = ?)
+               OR (status = 'initializing' AND settings_version IS NULL)
+             )
+           )`,
+      )
+      .bind(
+        input.encryptedConfig,
+        now,
+        input.expectedSettingsUpdatedAt,
+        input.runId,
+        input.expectedSettingsUpdatedAt,
+      ),
+    db
+      .prepare(
+        `UPDATE einvoice_sync_runs
+         SET status = 'initializing', settings_version = ?, updated_at = ?
+         WHERE id = ? AND (
+             (status = 'processing' AND settings_version = ?)
+             OR (status = 'initializing' AND settings_version IS NULL)
+           )
+           AND EXISTS (
+             SELECT 1 FROM connector_settings
+             WHERE connector_id = 'einvoice'
+               AND encrypted_config = ? AND updated_at = ?
+           )`,
+      )
+      .bind(
+        now,
+        now,
+        input.runId,
+        input.expectedSettingsUpdatedAt,
+        input.encryptedConfig,
+        now,
+      ),
+  ]);
+  return {
+    settingsUpdated: results[0]!.meta.changes === 1,
+    transitioned: results[1]!.meta.changes === 1,
+  };
+}
+
+/** Atomically leases up to limit pending (or expired) detail items to one consumer. */
+export async function claimEinvoiceRunItems(
+  db: D1Database,
+  input: {
+    runId: string;
+    claimToken?: string;
+    limit?: number;
+    leaseMs: number;
+    now?: Date;
+  },
+): Promise<EinvoiceRunItemRow[]> {
+  const now = input.now ?? new Date();
+  const nowIso = now.toISOString();
+  const claimToken = input.claimToken ?? crypto.randomUUID();
+  const leaseExpiresAt = new Date(now.getTime() + input.leaseMs).toISOString();
+  const limit = Math.max(1, Math.floor(input.limit ?? 35));
+  await db.batch([
+    db
+      .prepare(
+        `UPDATE einvoice_sync_run_items
+         SET status = 'processing',
+             lease_token = ?,
+             lease_expires_at = ?,
+             attempt_count = attempt_count + 1,
+             last_error = NULL,
+             updated_at = ?
+         WHERE id IN (
+           SELECT id
+           FROM einvoice_sync_run_items
+           WHERE run_id = ?
+             AND (status = 'pending' OR (
+               status = 'processing'
+               AND (lease_expires_at IS NULL OR lease_expires_at < ?)
+             ))
+           ORDER BY created_at ASC, invoice_source_id ASC
+           LIMIT ?
+         )`,
+      )
+      .bind(claimToken, leaseExpiresAt, nowIso, input.runId, nowIso, limit),
+    refreshEinvoiceRunCountsStatement(db, input.runId, nowIso),
+  ]);
+  return (
+    await db
+      .prepare(
+        `SELECT * FROM einvoice_sync_run_items
+         WHERE run_id = ? AND lease_token = ? AND status = 'processing'
+         ORDER BY created_at ASC, invoice_source_id ASC`,
+      )
+      .bind(input.runId, claimToken)
+      .all<EinvoiceRunItemRow>()
+  ).results;
+}
+
+/**
+ * CAS completion: a stale retry cannot overwrite another worker's lease. The
+ * item update and run-counter refresh execute in one D1 batch.
+ */
+export async function markEinvoiceRunItemSucceeded(
+  db: D1Database,
+  input: {
+    runId: string;
+    invoiceSourceId: string;
+    claimToken: string;
+    detailItems: unknown[];
+    normalizedInvoice?: unknown;
+    now?: string;
+  },
+) {
+  const now = input.now ?? new Date().toISOString();
+  const result = await db.batch([
+    db
+      .prepare(
+        `UPDATE einvoice_sync_run_items
+         SET detail_items_json = ?,
+             normalized_invoice_json = CASE
+               WHEN ? IS NULL THEN normalized_invoice_json
+               ELSE ?
+             END,
+             line_item_count = ?,
+             status = 'done',
+             lease_token = NULL,
+             lease_expires_at = NULL,
+             last_error = NULL,
+             completed_at = ?,
+             updated_at = ?
+         WHERE run_id = ?
+           AND invoice_source_id = ?
+           AND status = 'processing'
+           AND lease_token = ?`,
+      )
+      .bind(
+        json(input.detailItems),
+        input.normalizedInvoice === undefined
+          ? null
+          : json(input.normalizedInvoice),
+        input.normalizedInvoice === undefined
+          ? null
+          : json(input.normalizedInvoice),
+        input.detailItems.length,
+        now,
+        now,
+        input.runId,
+        input.invoiceSourceId,
+        input.claimToken,
+      ),
+    refreshEinvoiceRunCountsStatement(db, input.runId, now),
+  ]);
+  return result[0]!.meta.changes === 1;
+}
+
+/**
+ * Completes one whole provider chunk with one set-based D1 update. This keeps a
+ * 35-detail Queue invocation below D1's Free-plan 50-query limit.
+ */
+export async function markEinvoiceRunItemsSucceeded(
+  db: D1Database,
+  input: {
+    runId: string;
+    claimToken: string;
+    items: Array<{
+      invoiceSourceId: string;
+      detailItems: unknown[];
+      normalizedInvoice: unknown;
+    }>;
+    now?: string;
+  },
+) {
+  if (input.items.length === 0) return 0;
+  const now = input.now ?? new Date().toISOString();
+  const payload = input.items.map((item) => ({
+    invoiceSourceId: item.invoiceSourceId,
+    detailItemsJson: json(item.detailItems),
+    normalizedInvoiceJson: json(item.normalizedInvoice),
+    lineItemCount: item.detailItems.length,
+  }));
+  const results = await db.batch([
+    db
+      .prepare(
+        `WITH updates AS (
+           SELECT
+             json_extract(value, '$.invoiceSourceId') AS invoice_source_id,
+             json_extract(value, '$.detailItemsJson') AS detail_items_json,
+             json_extract(value, '$.normalizedInvoiceJson') AS normalized_invoice_json,
+             json_extract(value, '$.lineItemCount') AS line_item_count
+           FROM json_each(?)
+         )
+         UPDATE einvoice_sync_run_items
+         SET detail_items_json = (
+               SELECT detail_items_json FROM updates
+               WHERE updates.invoice_source_id = einvoice_sync_run_items.invoice_source_id
+             ),
+             normalized_invoice_json = (
+               SELECT normalized_invoice_json FROM updates
+               WHERE updates.invoice_source_id = einvoice_sync_run_items.invoice_source_id
+             ),
+             line_item_count = (
+               SELECT line_item_count FROM updates
+               WHERE updates.invoice_source_id = einvoice_sync_run_items.invoice_source_id
+             ),
+             status = 'done', lease_token = NULL, lease_expires_at = NULL,
+             last_error = NULL, completed_at = ?, updated_at = ?
+         WHERE run_id = ? AND status = 'processing' AND lease_token = ?
+           AND EXISTS (
+             SELECT 1 FROM updates
+             WHERE updates.invoice_source_id = einvoice_sync_run_items.invoice_source_id
+           )`,
+      )
+      .bind(json(payload), now, now, input.runId, input.claimToken),
+    refreshEinvoiceRunCountsStatement(db, input.runId, now),
+  ]);
+  return results[0]!.meta.changes;
+}
+
+/** Releases a matching lease for retry while retaining the durable header and error. */
+export async function releaseEinvoiceRunItemForRetry(
+  db: D1Database,
+  input: {
+    runId: string;
+    invoiceSourceId: string;
+    claimToken: string;
+    error: string;
+    now?: string;
+  },
+) {
+  const now = input.now ?? new Date().toISOString();
+  const result = await db.batch([
+    db
+      .prepare(
+        `UPDATE einvoice_sync_run_items
+         SET status = 'pending',
+             lease_token = NULL,
+             lease_expires_at = NULL,
+             last_error = ?,
+             updated_at = ?
+         WHERE run_id = ?
+           AND invoice_source_id = ?
+           AND status = 'processing'
+           AND lease_token = ?`,
+      )
+      .bind(
+        input.error,
+        now,
+        input.runId,
+        input.invoiceSourceId,
+        input.claimToken,
+      ),
+    refreshEinvoiceRunCountsStatement(db, input.runId, now),
+  ]);
+  return result[0]!.meta.changes === 1;
+}
+
+/** Releases every remaining item owned by a failed chunk in one idempotent write. */
+export async function releaseEinvoiceRunClaimForRetry(
+  db: D1Database,
+  input: {
+    runId: string;
+    claimToken: string;
+    error: string;
+    now?: string;
+  },
+) {
+  const now = input.now ?? new Date().toISOString();
+  const result = await db.batch([
+    db
+      .prepare(
+        `UPDATE einvoice_sync_run_items
+         SET status = 'pending',
+             lease_token = NULL,
+             lease_expires_at = NULL,
+             last_error = ?,
+             updated_at = ?
+         WHERE run_id = ?
+           AND status = 'processing'
+           AND lease_token = ?`,
+      )
+      .bind(input.error, now, input.runId, input.claimToken),
+    refreshEinvoiceRunCountsStatement(db, input.runId, now),
+  ]);
+  return result[0]!.meta.changes;
+}
+
+/**
+ * Promotes every completed invoice and line item directly from the durable run
+ * tables with a fixed five-statement D1 transaction. Every write repeats the
+ * pinned-settings guard, so a concurrent credential save makes the whole batch
+ * a no-op instead of mixing two accounts' data.
+ */
+export async function promoteEinvoiceRunRecords(
+  db: D1Database,
+  input: {
+    runId: string;
+    expectedSettingsUpdatedAt: string;
+    cursor: string;
+    now: string;
+  },
+) {
+  const guard = `EXISTS (
+    SELECT 1
+    FROM einvoice_sync_runs guard_run
+    JOIN connector_settings guard_settings
+      ON guard_settings.connector_id = 'einvoice'
+    WHERE guard_run.id = ?
+      AND guard_run.status = 'processing'
+      AND guard_run.promoted_at IS NULL
+      AND guard_run.settings_version = guard_settings.updated_at
+      AND guard_settings.updated_at = ?
+      AND NOT EXISTS (
+        SELECT 1 FROM einvoice_sync_run_items unfinished
+        WHERE unfinished.run_id = guard_run.id AND unfinished.status != 'done'
+      )
+  )`;
+  const invoiceRaw = jsonRawPayloadExpression("source.normalized_invoice_json");
+  const lineItemRaw = jsonRawPayloadExpression("line.value");
+  const results = await db.batch([
+    db
+      .prepare(
+        `UPDATE einvoice_sync_runs
+         SET new_invoice_count = (
+               SELECT COUNT(*)
+               FROM einvoice_sync_run_items source
+               WHERE source.run_id = ? AND source.status = 'done'
+                 AND NOT EXISTS (
+                   SELECT 1 FROM invoices target
+                   WHERE target.connector_id = 'einvoice'
+                     AND target.source_id = source.invoice_source_id
+                 )
+             ),
+             updated_at = ?
+         WHERE id = ? AND ${guard}`,
+      )
+      .bind(
+        input.runId,
+        input.now,
+        input.runId,
+        input.runId,
+        input.expectedSettingsUpdatedAt,
+      ),
+    db
+      .prepare(
+        `INSERT INTO invoices (
+           id, connector_id, source_id, invoice_number, invoice_date,
+           seller_name, amount, raw_payload, created_at, updated_at
+         )
+         SELECT
+           'einvoice:' || source.invoice_source_id,
+           'einvoice',
+           source.invoice_source_id,
+           json_extract(source.normalized_invoice_json, '$.invoiceNumber'),
+           json_extract(source.normalized_invoice_json, '$.invoiceDate'),
+           json_extract(source.normalized_invoice_json, '$.sellerName'),
+           CAST(json_extract(source.normalized_invoice_json, '$.amount') AS INTEGER),
+           ${invoiceRaw},
+           ?,
+           ?
+         FROM einvoice_sync_run_items source
+         WHERE source.run_id = ? AND source.status = 'done' AND ${guard}
+         ON CONFLICT(connector_id, source_id) DO UPDATE SET
+           invoice_number = excluded.invoice_number,
+           invoice_date = excluded.invoice_date,
+           seller_name = excluded.seller_name,
+           amount = excluded.amount,
+           raw_payload = excluded.raw_payload,
+           updated_at = excluded.updated_at`,
+      )
+      .bind(
+        input.now,
+        input.now,
+        input.runId,
+        input.runId,
+        input.expectedSettingsUpdatedAt,
+      ),
+    db
+      .prepare(
+        `INSERT INTO invoice_line_items (
+           id, invoice_id, connector_id, invoice_source_id, source_id,
+           line_number, description, quantity, unit_price, amount,
+           raw_payload, created_at, updated_at
+         )
+         SELECT
+           'einvoice:' || source.invoice_source_id || ':item:' ||
+             json_extract(line.value, '$.sourceId'),
+           'einvoice:' || source.invoice_source_id,
+           'einvoice',
+           source.invoice_source_id,
+           json_extract(line.value, '$.sourceId'),
+           CAST(json_extract(line.value, '$.lineNumber') AS INTEGER),
+           json_extract(line.value, '$.description'),
+           CAST(json_extract(line.value, '$.quantity') AS REAL),
+           CAST(json_extract(line.value, '$.unitPrice') AS INTEGER),
+           CAST(json_extract(line.value, '$.amount') AS INTEGER),
+           ${lineItemRaw},
+           ?,
+           ?
+         FROM einvoice_sync_run_items source
+         JOIN json_each(COALESCE(source.detail_items_json, '[]')) line
+         WHERE source.run_id = ? AND source.status = 'done' AND ${guard}
+         ON CONFLICT(connector_id, invoice_source_id, source_id) DO UPDATE SET
+           invoice_id = excluded.invoice_id,
+           line_number = excluded.line_number,
+           description = excluded.description,
+           quantity = excluded.quantity,
+           unit_price = excluded.unit_price,
+           amount = excluded.amount,
+           raw_payload = excluded.raw_payload,
+           updated_at = excluded.updated_at`,
+      )
+      .bind(
+        input.now,
+        input.now,
+        input.runId,
+        input.runId,
+        input.expectedSettingsUpdatedAt,
+      ),
+    db
+      .prepare(
+        `UPDATE einvoice_sync_runs
+         SET promoted_at = ?, settings_version = ?, updated_at = ?
+         WHERE id = ? AND ${guard}`,
+      )
+      .bind(
+        input.now,
+        input.now,
+        input.now,
+        input.runId,
+        input.runId,
+        input.expectedSettingsUpdatedAt,
+      ),
+    db
+      .prepare(
+        `UPDATE connector_settings
+         SET sync_cursor = ?, updated_at = ?
+         WHERE connector_id = 'einvoice' AND updated_at = ?
+           AND EXISTS (
+             SELECT 1 FROM einvoice_sync_runs
+             WHERE id = ? AND status = 'processing'
+               AND promoted_at = ? AND settings_version = ?
+           )`,
+      )
+      .bind(
+        input.cursor,
+        input.now,
+        input.expectedSettingsUpdatedAt,
+        input.runId,
+        input.now,
+        input.now,
+      ),
+  ]);
+  return results[3]!.meta.changes === 1 && results[4]!.meta.changes === 1;
+}
+
+/** Terminal CAS. A completed run additionally requires every item to be done. */
+export async function completeEinvoiceRun(
+  db: D1Database,
+  input: {
+    runId: string;
+    status: Extract<
+      EinvoiceRunStatus,
+      "completed" | "failed" | "needs_user_action"
+    >;
+    error?: string | null;
+    now?: string;
+  },
+) {
+  const now = input.now ?? new Date().toISOString();
+  const result = await db
+    .prepare(
+      `UPDATE einvoice_sync_runs
+       SET status = ?, last_error = ?, completed_at = ?, updated_at = ?
+       WHERE id = ?
+         AND status IN ('queued', 'initializing', 'processing')
+         AND (
+           ? != 'completed'
+           OR NOT EXISTS (
+             SELECT 1 FROM einvoice_sync_run_items
+             WHERE run_id = einvoice_sync_runs.id AND status != 'done'
+           )
+         )`,
+    )
+    .bind(
+      input.status,
+      input.error ?? null,
+      now,
+      now,
+      input.runId,
+      input.status,
+    )
+    .run();
+  return result.meta.changes === 1;
+}
+
+export async function listPendingEinvoiceRunItems(
+  db: D1Database,
+  runId: string,
+) {
+  return (
+    await db
+      .prepare(
+        `SELECT * FROM einvoice_sync_run_items
+         WHERE run_id = ? AND status != 'done'
+         ORDER BY created_at ASC, invoice_source_id ASC`,
+      )
+      .bind(runId)
+      .all<EinvoiceRunItemRow>()
+  ).results;
+}
+
+export async function listCompletedEinvoiceRunItems(
+  db: D1Database,
+  runId: string,
+) {
+  return (
+    await db
+      .prepare(
+        `SELECT * FROM einvoice_sync_run_items
+         WHERE run_id = ? AND status = 'done'
+         ORDER BY created_at ASC, invoice_source_id ASC`,
+      )
+      .bind(runId)
+      .all<EinvoiceRunItemRow>()
+  ).results;
+}
+
+function refreshEinvoiceRunCountsStatement(
+  db: D1Database,
+  runId: string,
+  now: string,
+) {
+  return db
+    .prepare(
+      `UPDATE einvoice_sync_runs
+       SET total_item_count = (
+             SELECT COUNT(*) FROM einvoice_sync_run_items WHERE run_id = ?
+           ),
+           pending_item_count = (
+             SELECT COUNT(*) FROM einvoice_sync_run_items
+             WHERE run_id = ? AND status = 'pending'
+           ),
+           processing_item_count = (
+             SELECT COUNT(*) FROM einvoice_sync_run_items
+             WHERE run_id = ? AND status = 'processing'
+           ),
+           done_item_count = (
+             SELECT COUNT(*) FROM einvoice_sync_run_items
+             WHERE run_id = ? AND status = 'done'
+           ),
+           line_item_count = (
+             SELECT COALESCE(SUM(line_item_count), 0)
+             FROM einvoice_sync_run_items WHERE run_id = ? AND status = 'done'
+           ),
+           updated_at = ?
+       WHERE id = ?`,
+    )
+    .bind(runId, runId, runId, runId, runId, now, runId);
+}
+
+function mergeEinvoiceRunItemsStatement(
+  db: D1Database,
+  runId: string,
+  items: MergeEinvoiceRunItemInput[],
+  now: string,
+  expectedSettingsUpdatedAt?: string,
+) {
+  const payload = items.map((item) => {
+    const isDone = item.detailItems !== undefined || item.detailKey == null;
+    return {
+      id: `${runId}:${item.invoiceSourceId}`,
+      invoiceSourceId: item.invoiceSourceId,
+      headerJson: json(item.header),
+      normalizedInvoiceJson: json(item.normalizedInvoice),
+      detailKey: item.detailKey ?? null,
+      detailMetadataJson:
+        item.detailMetadata === undefined ? null : json(item.detailMetadata),
+      detailItemsJson:
+        item.detailItems === undefined ? null : json(item.detailItems),
+      lineItemCount: item.detailItems?.length ?? 0,
+      status: isDone ? "done" : "pending",
+      completedAt: isDone ? now : null,
+    };
+  });
+  const settingsGuard = expectedSettingsUpdatedAt
+    ? `WHERE EXISTS (
+         SELECT 1 FROM connector_settings
+         WHERE connector_id = 'einvoice' AND updated_at = ?
+       )`
+    : "WHERE 1";
+  const statement = db.prepare(
+    `INSERT INTO einvoice_sync_run_items (
+       id, run_id, invoice_source_id, header_json, normalized_invoice_json,
+       detail_key, detail_metadata_json, detail_items_json, line_item_count,
+       status, created_at, updated_at, completed_at
+     )
+     SELECT
+       json_extract(value, '$.id'), ?,
+       json_extract(value, '$.invoiceSourceId'),
+       json_extract(value, '$.headerJson'),
+       json_extract(value, '$.normalizedInvoiceJson'),
+       json_extract(value, '$.detailKey'),
+       json_extract(value, '$.detailMetadataJson'),
+       json_extract(value, '$.detailItemsJson'),
+       json_extract(value, '$.lineItemCount'),
+       json_extract(value, '$.status'), ?, ?,
+       json_extract(value, '$.completedAt')
+     FROM json_each(?)
+     ${settingsGuard}
+     ON CONFLICT(run_id, invoice_source_id) DO UPDATE SET
+       header_json = excluded.header_json,
+       normalized_invoice_json = CASE
+         WHEN einvoice_sync_run_items.status IN ('processing', 'done')
+           THEN einvoice_sync_run_items.normalized_invoice_json
+         ELSE excluded.normalized_invoice_json
+       END,
+       detail_key = excluded.detail_key,
+       detail_metadata_json = excluded.detail_metadata_json,
+       detail_items_json = CASE
+         WHEN einvoice_sync_run_items.status = 'done'
+           THEN einvoice_sync_run_items.detail_items_json
+         ELSE COALESCE(excluded.detail_items_json, einvoice_sync_run_items.detail_items_json)
+       END,
+       line_item_count = CASE
+         WHEN einvoice_sync_run_items.status = 'done'
+           THEN einvoice_sync_run_items.line_item_count
+         WHEN excluded.detail_items_json IS NOT NULL THEN excluded.line_item_count
+         ELSE einvoice_sync_run_items.line_item_count
+       END,
+       status = CASE
+         WHEN einvoice_sync_run_items.status IN ('processing', 'done')
+           THEN einvoice_sync_run_items.status
+         ELSE excluded.status
+       END,
+       completed_at = CASE
+         WHEN einvoice_sync_run_items.status = 'done'
+           THEN einvoice_sync_run_items.completed_at
+         WHEN excluded.status = 'done' THEN excluded.completed_at
+         ELSE NULL
+       END,
+       updated_at = excluded.updated_at`,
+  );
+  const bindings: unknown[] = [runId, now, now, json(payload)];
+  if (expectedSettingsUpdatedAt) bindings.push(expectedSettingsUpdatedAt);
+  return statement.bind(...bindings);
+}
+
+async function refreshEinvoiceRunCounts(
+  db: D1Database,
+  runId: string,
+  now: string,
+) {
+  await refreshEinvoiceRunCountsStatement(db, runId, now).run();
+}
+
+function json(value: unknown) {
+  return JSON.stringify(value) ?? "null";
+}
+
+function jsonRawPayloadExpression(document: string) {
+  return `CASE json_type(${document}, '$.raw')
+    WHEN 'text' THEN json_quote(json_extract(${document}, '$.raw'))
+    WHEN 'integer' THEN CAST(json_extract(${document}, '$.raw') AS TEXT)
+    WHEN 'real' THEN CAST(json_extract(${document}, '$.raw') AS TEXT)
+    WHEN 'true' THEN 'true'
+    WHEN 'false' THEN 'false'
+    WHEN 'object' THEN json_extract(${document}, '$.raw')
+    WHEN 'array' THEN json_extract(${document}, '$.raw')
+    ELSE ${document}
+  END`;
+}
+
+export { ACTIVE_RUN_STATUSES, TERMINAL_RUN_STATUSES };

--- a/apps/worker/src/features/sync/einvoice-sync-service.ts
+++ b/apps/worker/src/features/sync/einvoice-sync-service.ts
@@ -1,0 +1,686 @@
+import {
+  fetchEInvoiceInvoiceDetail,
+  initializeEInvoiceSync,
+  parseInvoiceConfig,
+  EInvoiceV2Client,
+  type EInvoiceDetailTask,
+  type EInvoiceV2Session,
+  type InvoiceConfig,
+} from "@taiwan-fin-hub/connectors";
+import type { SyncNotificationStatus } from "@taiwan-fin-hub/core";
+import { getConnectorSettings, nextSyncRunAt } from "@taiwan-fin-hub/db";
+import { configEncryptionKey } from "../../platform/config";
+import { decryptJson, encryptJson } from "../../platform/crypto";
+import type { Env } from "../../platform/env";
+import {
+  safelySendScheduledSyncSummary,
+  safelySendSyncNotification,
+} from "../notifications/service";
+import { claimCompletedDefaultScheduleBatch } from "./notification-batch-repository";
+import {
+  acquireEinvoiceRunChunkLease,
+  claimEinvoiceRunItems,
+  claimEinvoiceRunSessionRefresh,
+  completeEinvoiceRun,
+  createOrGetActiveEinvoiceRun,
+  getEinvoiceRun,
+  initializeEinvoiceRun,
+  markEinvoiceRunItemsSucceeded,
+  promoteEinvoiceRunRecords,
+  releaseEinvoiceRunClaimForRetry,
+  releaseEinvoiceRunChunkLease,
+  renewEinvoiceRunChunkLease,
+  resetEinvoiceRunSession,
+  transitionEinvoiceRunStatus,
+  type EinvoiceRunRow,
+  type EinvoiceRunTrigger,
+} from "./einvoice-run-repository";
+import { findSyncJob } from "./schedule-repository";
+import {
+  isUserActionError,
+  safeErrorMessage,
+  NeedsUserActionError,
+  SyncAlreadyRunningError,
+  SYNC_LOCK_LEASE_MS,
+} from "./service";
+
+export const EINVOICE_DETAIL_CHUNK_SIZE = 35;
+const EINVOICE_LEASE_MS = 3 * 60 * 1000;
+const EINVOICE_LEASE_RENEW_EVERY_ITEMS = 5;
+const EINVOICE_REQUEST_TIMEOUT_MS = 20_000;
+const EINVOICE_MAX_SESSION_REFRESHES = 1;
+const EINVOICE_JOB_ID = "einvoice:all";
+
+export type EinvoiceChunkResult =
+  | { status: "continue" }
+  | { status: "completed" }
+  | { status: "terminal" }
+  | { status: "busy"; retryAfterSeconds: number };
+
+export type StartEinvoiceSyncRunResult = {
+  run: EinvoiceRunRow;
+  created: boolean;
+};
+
+export async function startEinvoiceSyncRun(
+  env: Env,
+  input: {
+    trigger: EinvoiceRunTrigger;
+    scheduledBatchId?: string | null;
+  },
+): Promise<StartEinvoiceSyncRunResult> {
+  await loadEinvoiceConfig(env);
+  const result = await createOrGetActiveEinvoiceRun(env.DB, {
+    trigger: input.trigger,
+    syncJobId: EINVOICE_JOB_ID,
+    scheduledBatchId: input.scheduledBatchId,
+  });
+  const { run, created } = result;
+  if (
+    run.trigger !== input.trigger ||
+    (input.scheduledBatchId &&
+      run.scheduled_batch_id !== input.scheduledBatchId)
+  ) {
+    throw new SyncAlreadyRunningError("einvoice");
+  }
+  if (created) {
+    if (!(await holdEinvoiceRunLock(env.DB, run.id, input.trigger))) {
+      await completeEinvoiceRun(env.DB, {
+        runId: run.id,
+        status: "failed",
+        error: "Electronic invoice sync lock is already held.",
+      });
+      throw new SyncAlreadyRunningError("einvoice");
+    }
+    await updateEinvoiceProgressCursor(env.DB, run, "queued");
+  }
+  return { run, created };
+}
+
+export async function processEinvoiceSyncChunk(
+  env: Env,
+  runId: string,
+  chunkOwner: string = crypto.randomUUID(),
+): Promise<EinvoiceChunkResult> {
+  let run = await getEinvoiceRun(env.DB, runId);
+  if (!run || isTerminal(run)) return { status: "terminal" };
+  if (
+    !(await acquireEinvoiceRunChunkLease(env.DB, {
+      runId,
+      owner: chunkOwner,
+      leaseMs: EINVOICE_LEASE_MS,
+    }))
+  ) {
+    return {
+      status: "busy",
+      retryAfterSeconds: chunkLeaseRetryAfterSeconds(run),
+    };
+  }
+  try {
+    return await processLeasedEinvoiceSyncChunk(env, run, chunkOwner);
+  } finally {
+    await releaseEinvoiceRunChunkLease(env.DB, {
+      runId,
+      owner: chunkOwner,
+    }).catch(() => undefined);
+  }
+}
+
+async function processLeasedEinvoiceSyncChunk(
+  env: Env,
+  initialRun: EinvoiceRunRow,
+  chunkOwner: string,
+): Promise<EinvoiceChunkResult> {
+  let run = initialRun;
+  const runId = run.id;
+  const client = new EInvoiceV2Client({
+    timeoutMs: EINVOICE_REQUEST_TIMEOUT_MS,
+  });
+  if (!(await holdEinvoiceRunLock(env.DB, run.id, run.trigger))) {
+    throw new Error("Electronic invoice sync lost its connector lock.");
+  }
+
+  let settings = await loadEinvoiceSettings(env);
+  if (run.settings_version && settings.updatedAt !== run.settings_version) {
+    throw new NeedsUserActionError(
+      "電子發票設定已在同步期間更新，請重新啟動同步。",
+    );
+  }
+  let config = settings.config;
+  if (run.status === "queued" || run.status === "initializing") {
+    if (run.status === "queued") {
+      const initializing = await transitionEinvoiceRunStatus(env.DB, {
+        runId,
+        from: "queued",
+        to: "initializing",
+      });
+      if (!initializing) return { status: "terminal" };
+    }
+    const reusedPersistedSession = sessionFromConfig(config) !== null;
+    let initialized: Awaited<ReturnType<typeof initializeEInvoiceSync>>;
+    try {
+      initialized = await initializeEInvoiceSync(config, { client });
+    } catch (error) {
+      if (
+        reusedPersistedSession &&
+        isExpiredEinvoiceSessionError(error) &&
+        (await claimEinvoiceRunSessionRefresh(env.DB, {
+          runId,
+          maxRefreshes: EINVOICE_MAX_SESSION_REFRESHES,
+        })) &&
+        (await clearPersistedEinvoiceSession(
+          env,
+          runId,
+          run.settings_version ?? settings.updatedAt,
+        ))
+      ) {
+        return { status: "continue" };
+      }
+      throw error;
+    }
+    config = parseInvoiceConfig({ ...config, ...initialized.configUpdates });
+    const persisted = await persistInitializedEinvoiceRun(
+      env,
+      runId,
+      config,
+      settings.updatedAt,
+      initialized,
+    );
+    if (!persisted) {
+      throw new NeedsUserActionError(
+        "電子發票設定已在同步期間更新，請重新啟動同步。",
+      );
+    }
+    run = (await getEinvoiceRun(env.DB, runId))!;
+  }
+
+  const session = sessionFromConfig(config);
+  if (!session) {
+    await transitionEinvoiceRunStatus(env.DB, {
+      runId,
+      from: "processing",
+      to: "initializing",
+    });
+    return { status: "continue" };
+  }
+
+  const claimToken = crypto.randomUUID();
+  const claimed = await claimEinvoiceRunItems(env.DB, {
+    runId,
+    claimToken,
+    limit: EINVOICE_DETAIL_CHUNK_SIZE,
+    leaseMs: EINVOICE_LEASE_MS,
+  });
+  const completedItems: Parameters<
+    typeof markEinvoiceRunItemsSucceeded
+  >[1]["items"] = [];
+  try {
+    for (const [index, item] of claimed.entries()) {
+      if (index % EINVOICE_LEASE_RENEW_EVERY_ITEMS === 0) {
+        const renewed = await renewEinvoiceRunChunkLease(env.DB, {
+          runId,
+          owner: chunkOwner,
+          leaseMs: EINVOICE_LEASE_MS,
+        });
+        if (!renewed) {
+          throw new Error("Electronic invoice detail chunk lease was lost.");
+        }
+      }
+      const task = JSON.parse(item.detail_metadata_json!) as EInvoiceDetailTask;
+      const result = await fetchEInvoiceInvoiceDetail(session, task, {
+        client,
+      });
+      const raw = asRecord(result.invoice.raw);
+      const normalizedInvoice = {
+        ...result.invoice,
+        raw: {
+          ...raw,
+          detail: result.detail,
+          detailItems: result.detailItems,
+        },
+      };
+      completedItems.push({
+        invoiceSourceId: item.invoice_source_id,
+        detailItems: result.invoiceLineItems,
+        normalizedInvoice,
+      });
+    }
+    const updated = await markEinvoiceRunItemsSucceeded(env.DB, {
+      runId,
+      claimToken,
+      items: completedItems,
+    });
+    if (updated !== completedItems.length) {
+      throw new Error("Electronic invoice detail chunk lease was lost.");
+    }
+  } catch (error) {
+    await releaseEinvoiceRunClaimForRetry(env.DB, {
+      runId,
+      claimToken,
+      error: safeErrorMessage(error),
+    });
+    if (
+      isExpiredEinvoiceSessionError(error) &&
+      (await claimEinvoiceRunSessionRefresh(env.DB, {
+        runId,
+        maxRefreshes: EINVOICE_MAX_SESSION_REFRESHES,
+      }))
+    ) {
+      if (
+        run.settings_version &&
+        (await clearPersistedEinvoiceSession(env, runId, run.settings_version))
+      ) {
+        return { status: "continue" };
+      }
+      throw new NeedsUserActionError(
+        "電子發票設定已在同步期間更新，請重新啟動同步。",
+      );
+    }
+    throw error;
+  }
+
+  run = (await getEinvoiceRun(env.DB, runId))!;
+  await updateEinvoiceProgressCursor(env.DB, run, "processing");
+  if (run.pending_item_count > 0 || run.processing_item_count > 0) {
+    return { status: "continue" };
+  }
+
+  if (!run.promoted_at) {
+    await promoteCompletedEinvoiceRun(env, run);
+    run = (await getEinvoiceRun(env.DB, runId))!;
+  }
+  const finalized = await finalizeEinvoiceRun(env, run, "success");
+  return finalized ? { status: "completed" } : { status: "terminal" };
+}
+
+export async function failEinvoiceSyncRun(
+  env: Env,
+  runId: string,
+  error: unknown,
+  forceFailed = false,
+) {
+  const run = await getEinvoiceRun(env.DB, runId);
+  if (!run || isTerminal(run)) return false;
+  const status: Exclude<SyncNotificationStatus, "success"> =
+    !forceFailed && isEinvoiceUserActionError(error)
+      ? "needs_user_action"
+      : "failed";
+  return finalizeEinvoiceRun(env, run, status, safeErrorMessage(error));
+}
+
+export async function cancelQueuedEinvoiceSyncRun(
+  env: Env,
+  runId: string,
+  error: unknown,
+) {
+  const run = await getEinvoiceRun(env.DB, runId);
+  if (!run || run.status !== "queued") return false;
+  return failEinvoiceSyncRun(env, runId, error, true);
+}
+
+async function persistInitializedEinvoiceRun(
+  env: Env,
+  runId: string,
+  config: InvoiceConfig,
+  expectedSettingsUpdatedAt: string,
+  initialized: Awaited<ReturnType<typeof initializeEInvoiceSync>>,
+) {
+  const detailIds = new Set(
+    initialized.detailTasks.map((task) => task.sourceId),
+  );
+  const items = initialized.headers.map((header) => ({
+    invoiceSourceId: header.sourceId,
+    header,
+    normalizedInvoice: header.invoice,
+    ...(detailIds.has(header.sourceId)
+      ? {
+          detailKey: `${header.invNum}:${header.detailInvDate}`,
+          detailMetadata: header,
+        }
+      : { detailItems: [] }),
+  }));
+  const now = new Date().toISOString();
+  const run = (await getEinvoiceRun(env.DB, runId))!;
+  const result = await initializeEinvoiceRun(env.DB, {
+    runId,
+    items,
+    encryptedConfig: await encryptJson(config, configEncryptionKey(env)),
+    expectedSettingsUpdatedAt,
+    cursor: progressCursor(
+      { ...run, total_item_count: items.length },
+      "processing",
+    ),
+    now,
+  });
+  return result.settingsUpdated && result.transitioned;
+}
+
+async function promoteCompletedEinvoiceRun(env: Env, run: EinvoiceRunRow) {
+  if (run.done_item_count !== run.total_item_count) {
+    throw new Error("Electronic invoice run is not ready for promotion.");
+  }
+  const now = new Date().toISOString();
+  const settings = await getConnectorSettings(env.DB, "einvoice");
+  if (!settings) {
+    throw new NeedsUserActionError(
+      "Connector settings are required before sync.",
+    );
+  }
+  const completedCursor = JSON.stringify({
+    version: 2,
+    completedAt: now,
+    previousCompletedAt: previousCompletedAt(settings.sync_cursor),
+    syncedPeriods: 2,
+  });
+  const promoted = await promoteEinvoiceRunRecords(env.DB, {
+    runId: run.id,
+    expectedSettingsUpdatedAt: settings.updated_at,
+    cursor: completedCursor,
+    now,
+  });
+  if (!promoted) {
+    throw new NeedsUserActionError(
+      "電子發票設定已在同步期間更新，請重新啟動同步。",
+    );
+  }
+}
+
+async function finalizeEinvoiceRun(
+  env: Env,
+  run: EinvoiceRunRow,
+  status: SyncNotificationStatus,
+  error: string | null = null,
+) {
+  const job = await findSyncJob(env.DB, "einvoice", "all");
+  if (!job) {
+    await completeEinvoiceRun(env.DB, {
+      runId: run.id,
+      status: status === "success" ? "completed" : status,
+      error,
+    });
+    return true;
+  }
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const success = status === "success";
+  const nextRunAt =
+    success || (status === "failed" && run.trigger === "scheduled")
+      ? nextSyncRunAt(
+          job.interval_minutes,
+          job.preferred_time,
+          now,
+          job.next_run_at,
+          job.preferred_weekday,
+        )
+      : job.next_run_at;
+  const activeGuard = `EXISTS (
+    SELECT 1 FROM einvoice_sync_runs
+    WHERE id = ? AND status IN ('queued', 'initializing', 'processing')
+  )`;
+  const statements: D1PreparedStatement[] = [
+    env.DB.prepare(
+      `UPDATE sync_jobs
+       SET last_status = ?,
+           last_error = ?,
+           last_run_at = ?,
+           last_success_at = CASE WHEN ? = 'success' THEN ? ELSE last_success_at END,
+           next_run_at = ?,
+           locked_by = NULL,
+           locked_until = NULL,
+           lock_trigger = NULL,
+           lock_scope = NULL,
+           updated_at = ?
+       WHERE id = ? AND ${activeGuard}`,
+    ).bind(
+      status,
+      error,
+      nowIso,
+      status,
+      nowIso,
+      nextRunAt,
+      nowIso,
+      job.id,
+      run.id,
+    ),
+  ];
+  if (run.scheduled_batch_id) {
+    statements.push(
+      env.DB.prepare(
+        `UPDATE scheduled_sync_batch_results
+         SET connector_id = 'einvoice', status = ?, completed_at = ?,
+             new_invoices = ?, new_bank_transactions = 0,
+             new_investment_transactions = 0
+         WHERE batch_id = ? AND job_id = ? AND completed_at IS NULL
+           AND ${activeGuard}`,
+      ).bind(
+        status,
+        nowIso,
+        success ? run.new_invoice_count : 0,
+        run.scheduled_batch_id,
+        job.id,
+        run.id,
+      ),
+    );
+  }
+  statements.push(
+    env.DB.prepare(
+      `UPDATE einvoice_sync_runs
+       SET status = ?, last_error = ?, completed_at = ?, updated_at = ?
+       WHERE id = ? AND status IN ('queued', 'initializing', 'processing')
+         AND (? != 'completed' OR promoted_at IS NOT NULL)`,
+    ).bind(
+      success ? "completed" : status,
+      error,
+      nowIso,
+      nowIso,
+      run.id,
+      success ? "completed" : status,
+    ),
+  );
+  const results = await env.DB.batch(statements);
+  const finalized = results.at(-1)?.meta.changes === 1;
+  if (!finalized) return false;
+
+  if (run.scheduled_batch_id) {
+    const summary = await claimCompletedDefaultScheduleBatch(
+      env.DB,
+      run.scheduled_batch_id,
+    );
+    if (summary) await safelySendScheduledSyncSummary(env, summary);
+  } else if (run.trigger === "scheduled") {
+    await safelySendSyncNotification(env, { connectorId: "einvoice", status });
+  }
+  return true;
+}
+
+async function loadEinvoiceConfig(env: Env) {
+  return (await loadEinvoiceSettings(env)).config;
+}
+
+async function loadEinvoiceSettings(env: Env) {
+  const settings = await getConnectorSettings(env.DB, "einvoice");
+  if (!settings) {
+    throw new NeedsUserActionError(
+      "Connector settings are required before sync.",
+    );
+  }
+  return {
+    config: parseInvoiceConfig(
+      await decryptJson<Record<string, unknown>>(
+        settings.encrypted_config,
+        configEncryptionKey(env),
+      ),
+    ),
+    updatedAt: settings.updated_at,
+  };
+}
+
+async function clearPersistedEinvoiceSession(
+  env: Env,
+  runId: string,
+  expectedSettingsUpdatedAt: string,
+) {
+  const settings = await getConnectorSettings(env.DB, "einvoice");
+  if (!settings) return;
+  const config = await decryptJson<Record<string, unknown>>(
+    settings.encrypted_config,
+    configEncryptionKey(env),
+  );
+  for (const key of [
+    "sid",
+    "token",
+    "iv",
+    "svrCode",
+    "loginAppId",
+    "loginLiat",
+    "loginSsMe",
+    "ltoken",
+    "hkey",
+    "serverTimeOffset",
+  ]) {
+    delete config[key];
+  }
+  const parsed = parseInvoiceConfig(config);
+  const result = await resetEinvoiceRunSession(env.DB, {
+    runId,
+    encryptedConfig: await encryptJson(parsed, configEncryptionKey(env)),
+    expectedSettingsUpdatedAt,
+  });
+  return result.settingsUpdated && result.transitioned;
+}
+
+async function holdEinvoiceRunLock(
+  db: D1Database,
+  runId: string,
+  trigger: EinvoiceRunTrigger,
+) {
+  const now = new Date();
+  const result = await db
+    .prepare(
+      `UPDATE sync_jobs
+       SET locked_by = ?, locked_until = ?, lock_trigger = ?, lock_scope = 'all',
+           updated_at = ?
+       WHERE id = ?
+         AND (locked_until IS NULL OR locked_until < ? OR locked_by = ?)`,
+    )
+    .bind(
+      runId,
+      new Date(now.getTime() + SYNC_LOCK_LEASE_MS).toISOString(),
+      trigger,
+      now.toISOString(),
+      EINVOICE_JOB_ID,
+      now.toISOString(),
+      runId,
+    )
+    .run();
+  return result.meta.changes === 1;
+}
+
+async function updateEinvoiceProgressCursor(
+  db: D1Database,
+  run: EinvoiceRunRow,
+  phase: "queued" | "processing",
+) {
+  const settings = await getConnectorSettings(db, "einvoice");
+  if (!settings) return;
+  await db
+    .prepare(
+      `UPDATE connector_settings SET sync_cursor = ?
+       WHERE connector_id = 'einvoice'
+         AND (? IS NULL OR updated_at = ?)`,
+    )
+    .bind(
+      progressCursor(run, phase),
+      run.settings_version,
+      run.settings_version,
+    )
+    .run();
+}
+
+function progressCursor(run: EinvoiceRunRow, phase: "queued" | "processing") {
+  return JSON.stringify({
+    version: 2,
+    activeRunId: run.id,
+    phase,
+    completedItems: run.done_item_count,
+    totalItems: run.total_item_count,
+  });
+}
+
+function sessionFromConfig(config: InvoiceConfig): EInvoiceV2Session | null {
+  if (
+    !config.sid ||
+    !config.token ||
+    !config.loginAppId ||
+    config.loginLiat == null ||
+    !config.loginSsMe
+  ) {
+    return null;
+  }
+  return {
+    sid: config.sid,
+    token: config.token,
+    loginAppId: config.loginAppId,
+    loginLiat: config.loginLiat,
+    loginSsMe: config.loginSsMe,
+    ...(config.iv === undefined ? {} : { iv: config.iv }),
+    ...(config.svrCode === undefined ? {} : { svrCode: config.svrCode }),
+    ...(config.loginClientCode === undefined
+      ? {}
+      : { clientCode: config.loginClientCode }),
+    ...(config.ltoken === undefined ? {} : { ltoken: config.ltoken }),
+    ...(config.hkey === undefined ? {} : { hkey: config.hkey }),
+    ...(config.mobileBarcode === undefined
+      ? {}
+      : { carrierCode: config.mobileBarcode }),
+    ...(config.serverTimeOffset === undefined
+      ? {}
+      : { serverTimeOffset: config.serverTimeOffset }),
+  };
+}
+
+function previousCompletedAt(cursor: string | null | undefined) {
+  if (!cursor) return undefined;
+  try {
+    const parsed = JSON.parse(cursor) as {
+      completedAt?: unknown;
+      syncedAt?: unknown;
+    };
+    if (typeof parsed.completedAt === "string") return parsed.completedAt;
+    return typeof parsed.syncedAt === "string" ? parsed.syncedAt : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isTerminal(run: EinvoiceRunRow) {
+  return ["completed", "failed", "needs_user_action"].includes(run.status);
+}
+
+function chunkLeaseRetryAfterSeconds(run: EinvoiceRunRow) {
+  if (!run.chunk_lease_expires_at) return 30;
+  const remainingMs =
+    new Date(run.chunk_lease_expires_at).getTime() - Date.now();
+  if (!Number.isFinite(remainingMs)) return 30;
+  return Math.max(1, Math.min(5 * 60, Math.ceil(remainingMs / 1000) + 1));
+}
+
+export function isEinvoiceUserActionError(error: unknown) {
+  if (isUserActionError(error)) return true;
+  const message = error instanceof Error ? error.message : String(error);
+  if (/HTTP (?:429|5\d\d)\b/.test(message)) return false;
+  return /登入失敗|帳號|密碼|credential|unauthori[sz]ed|HTTP 40[13]\b/i.test(
+    message,
+  );
+}
+
+function isExpiredEinvoiceSessionError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return /HTTP 40[13]\b/i.test(message);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}

--- a/apps/worker/src/features/sync/notification-batch-repository.ts
+++ b/apps/worker/src/features/sync/notification-batch-repository.ts
@@ -127,6 +127,11 @@ export async function findNextDefaultScheduleBatchJob(
            )
            AND j.schedule_mode = 'inherit'
            AND (j.last_status IS NULL OR j.last_status != 'needs_user_action')
+           AND NOT EXISTS (
+             SELECT 1 FROM einvoice_sync_runs einvoice_run
+             WHERE einvoice_run.sync_job_id = j.id
+               AND einvoice_run.status IN ('queued', 'initializing', 'processing')
+           )
            AND (j.locked_until IS NULL OR j.locked_until < ?)
          ORDER BY j.next_run_at ASC, j.id ASC
          LIMIT 1`,

--- a/apps/worker/src/features/sync/record-mapper.ts
+++ b/apps/worker/src/features/sync/record-mapper.ts
@@ -17,35 +17,6 @@ function stableId(...parts: string[]) {
   return parts.join(":");
 }
 
-export function invoiceConfigSnapshot(config: Record<string, unknown>) {
-  return Object.fromEntries(
-    [
-      "protocol",
-      "fetchDetails",
-      "mobileBarcode",
-      "userToken",
-      "loginClientCode",
-      "sid",
-      "token",
-      "iv",
-      "svrCode",
-      "loginAppId",
-      "loginLiat",
-      "loginSsMe",
-      "ltoken",
-      "hkey",
-      "serverTimeOffset",
-    ].map((key) => [key, config[key]]),
-  );
-}
-
-export function invoiceConfigChanged(
-  before: Record<string, unknown>,
-  after: Record<string, unknown>,
-) {
-  return Object.keys(before).some((key) => before[key] !== after[key]);
-}
-
 export function invoiceRecord(
   connectorId: ConnectorId,
   invoice: Omit<Invoice, "id" | "connectorId">,

--- a/apps/worker/src/features/sync/registry.ts
+++ b/apps/worker/src/features/sync/registry.ts
@@ -7,7 +7,6 @@ import {
   prepareObankCaptchaSession,
   syncCathaybk,
   syncCtbc,
-  syncEinvoice,
   syncEsun,
   syncSinopac,
   syncObank,
@@ -17,7 +16,6 @@ import {
   TDCC_SCOPE_BANK,
   TDCC_SCOPE_INVESTMENTS,
   TDCC_SCOPE_TRADES,
-  type EinvoiceSyncOverrides,
   type SinopacSyncOverrides,
   type ObankSyncOverrides,
   type SyncOutcome,
@@ -41,8 +39,11 @@ export const connectorRuntimeRegistry: Record<
   ConnectorRuntimeDefinition
 > = {
   einvoice: {
-    run: (env, trigger, _scope, overrides) =>
-      syncEinvoice(env, trigger, overrides as EinvoiceSyncOverrides),
+    run: async () => {
+      throw new Error(
+        "Electronic invoice sync must be started through its durable Queue flow.",
+      );
+    },
   },
   tdcc: {
     run: (env, trigger, scope, overrides) =>

--- a/apps/worker/src/features/sync/report-repository.ts
+++ b/apps/worker/src/features/sync/report-repository.ts
@@ -123,7 +123,11 @@ export async function calculateCurrentFinancialSnapshot(
          COALESCE(ROUND(SUM(CASE WHEN kind = 'debt' THEN ABS(amount_twd) ELSE 0 END)), 0) AS creditCardDebtTwd,
          COALESCE(
            json_group_array(DISTINCT currency) FILTER (
-             WHERE amount != 0 AND is_missing_rate = 1
+             WHERE (
+               (kind = 'debt' AND ABS(amount) > 0)
+               OR (kind = 'asset' AND amount > 0)
+             )
+               AND is_missing_rate = 1
            ),
            '[]'
          ) AS missingCurrencies

--- a/apps/worker/src/features/sync/route.ts
+++ b/apps/worker/src/features/sync/route.ts
@@ -36,10 +36,6 @@ const tdccSyncBodySchema = z.object({
   otpChannel: z.enum(["email", "sms"]).optional(),
 });
 
-const einvoiceSyncBodySchema = z.object({
-  fetchDetails: z.boolean().optional(),
-});
-
 const sinopacSyncBodySchema = z.object({
   captcha: z
     .string()
@@ -65,29 +61,42 @@ export const syncRoutes = honoFactory.createApp();
 registerSyncRoutes(syncRoutes);
 
 function registerSyncRoutes(api: Hono<AppBindings>) {
-  api.post(
-    "/connectors/einvoice/sync",
-    zValidator(
-      "json",
-      einvoiceSyncBodySchema,
-      validationHook("INVALID_REQUEST", "E-Invoice sync options are invalid."),
-    ),
-    async (c) => {
-      const overrides = c.req.valid("json");
-      return syncRouteResponse(
-        c,
-        withManualSyncLock(c.env, "einvoice", SYNC_SCOPE_ALL, () =>
-          runConnectorSync(
-            c.env,
-            "einvoice",
-            "manual",
-            SYNC_SCOPE_ALL,
-            overrides,
-          ),
-        ),
+  api.post("/connectors/einvoice/sync", async (c) => {
+    try {
+      const { cancelQueuedEinvoiceSyncRun, startEinvoiceSyncRun } =
+        await import("./einvoice-sync-service");
+      const { enqueueEinvoiceSyncChunk } = await import("./scheduler-queue");
+      const { run, created } = await startEinvoiceSyncRun(c.env, {
+        trigger: "manual",
+      });
+      if (created) {
+        try {
+          await enqueueEinvoiceSyncChunk(c.env, run.id);
+        } catch (error) {
+          await cancelQueuedEinvoiceSyncRun(c.env, run.id, error);
+          throw error;
+        }
+      }
+      return c.json(
+        {
+          success: true as const,
+          connectorId: "einvoice" as const,
+          scope: SYNC_SCOPE_ALL,
+          status: "queued" as const,
+          runId: run.id,
+        },
+        202,
       );
-    },
-  );
+    } catch (error) {
+      if (error instanceof SyncAlreadyRunningError) {
+        return jsonError("SYNC_ALREADY_RUNNING", error.message, 409);
+      }
+      if (error instanceof NeedsUserActionError) {
+        return jsonError("USER_ACTION_REQUIRED", error.message, 400);
+      }
+      throw error;
+    }
+  });
 
   api.post(
     "/connectors/tdcc/sync",

--- a/apps/worker/src/features/sync/schedule-service.ts
+++ b/apps/worker/src/features/sync/schedule-service.ts
@@ -1,5 +1,6 @@
 import type { ConnectorId } from "@taiwan-fin-hub/core";
 import { nextSyncRunAt, type SyncScheduleMode } from "@taiwan-fin-hub/db";
+import { getActiveEinvoiceRun } from "./einvoice-run-repository";
 import {
   findDefaultSyncSchedule,
   findSyncJob,
@@ -52,11 +53,14 @@ export async function setDefaultSyncSchedule(
 export async function getSyncJobs(db: D1Database) {
   const rows = await listSyncJobs(db);
   const now = new Date();
+  const activeEinvoiceRun = await getActiveEinvoiceRun(db);
   return rows.map((row) => ({
     ...row,
     configured: Boolean(row.configured),
     enabled: Boolean(row.enabled),
-    running: Boolean(row.lockedUntil && new Date(row.lockedUntil) > now),
+    running:
+      (row.connectorId === "einvoice" && Boolean(activeEinvoiceRun)) ||
+      Boolean(row.lockedUntil && new Date(row.lockedUntil) > now),
   }));
 }
 

--- a/apps/worker/src/features/sync/scheduler-queue.ts
+++ b/apps/worker/src/features/sync/scheduler-queue.ts
@@ -1,14 +1,34 @@
 import type { Env, ScheduledSyncQueueMessage } from "../../platform/env";
 import { runSchedulerTick } from "./scheduler";
+import {
+  failEinvoiceSyncRun,
+  isEinvoiceUserActionError,
+  processEinvoiceSyncChunk,
+} from "./einvoice-sync-service";
 
 const queueController = {
   cron: "queue:scheduled-sync",
 } as ScheduledController;
 
 export const SCHEDULED_SYNC_CHAIN_DELAY_SECONDS = 20;
+export const EINVOICE_SYNC_CHAIN_DELAY_SECONDS = 1;
+const EINVOICE_MAX_QUEUE_ATTEMPTS = 3;
 
 export async function enqueueScheduledSync(env: Env, delaySeconds = 0) {
   const message = { type: "run-next-scheduled-sync" } as const;
+  if (delaySeconds > 0) {
+    await env.SYNC_QUEUE.send(message, { delaySeconds });
+    return;
+  }
+  await env.SYNC_QUEUE.send(message);
+}
+
+export async function enqueueEinvoiceSyncChunk(
+  env: Env,
+  runId: string,
+  delaySeconds = 0,
+) {
+  const message = { type: "run-einvoice-chunk", runId } as const;
   if (delaySeconds > 0) {
     await env.SYNC_QUEUE.send(message, { delaySeconds });
     return;
@@ -21,6 +41,10 @@ export async function consumeScheduledSyncQueue(
   env: Env,
 ) {
   for (const message of batch.messages) {
+    if (message.body.type === "run-einvoice-chunk") {
+      await consumeEinvoiceChunkMessage(message, env);
+      continue;
+    }
     if (message.body.type !== "run-next-scheduled-sync") {
       console.error(
         JSON.stringify({
@@ -38,4 +62,58 @@ export async function consumeScheduledSyncQueue(
     }
     message.ack();
   }
+}
+
+async function consumeEinvoiceChunkMessage(
+  message: Message<ScheduledSyncQueueMessage>,
+  env: Env,
+) {
+  if (message.body.type !== "run-einvoice-chunk") return;
+  try {
+    const result = await processEinvoiceSyncChunk(
+      env,
+      message.body.runId,
+      message.id,
+    );
+    if (result.status === "busy") {
+      try {
+        await enqueueEinvoiceSyncChunk(
+          env,
+          message.body.runId,
+          result.retryAfterSeconds,
+        );
+        message.ack();
+      } catch {
+        message.retry({ delaySeconds: result.retryAfterSeconds });
+      }
+      return;
+    }
+    if (result.status === "continue") {
+      await enqueueEinvoiceSyncChunk(
+        env,
+        message.body.runId,
+        EINVOICE_SYNC_CHAIN_DELAY_SECONDS,
+      );
+    }
+    message.ack();
+  } catch (error) {
+    if (
+      isEinvoiceUserActionError(error) ||
+      message.attempts >= EINVOICE_MAX_QUEUE_ATTEMPTS
+    ) {
+      await failEinvoiceSyncRun(
+        env,
+        message.body.runId,
+        error,
+        !isEinvoiceUserActionError(error),
+      );
+      message.ack();
+      return;
+    }
+    message.retry({ delaySeconds: retryDelaySeconds(message.attempts) });
+  }
+}
+
+function retryDelaySeconds(attempts: number) {
+  return Math.min(15 * 2 ** Math.max(0, attempts - 1), 5 * 60);
 }

--- a/apps/worker/src/features/sync/scheduler.ts
+++ b/apps/worker/src/features/sync/scheduler.ts
@@ -24,6 +24,10 @@ import {
 } from "../notifications/service";
 import type { SyncNotificationEvent } from "../notifications/payload";
 import {
+  cancelQueuedEinvoiceSyncRun,
+  startEinvoiceSyncRun,
+} from "./einvoice-sync-service";
+import {
   claimCompletedDefaultScheduleBatch,
   ensureDefaultScheduleBatch,
   finalizeOpenDefaultScheduleBatch,
@@ -79,6 +83,23 @@ async function runCustomScheduleJob(
   controller: ScheduledController,
   job: SyncJobRow<ConnectorId>,
 ) {
+  if (job.connector_id === "einvoice") {
+    const { run, created } = await startEinvoiceSyncRun(env, {
+      trigger: "scheduled",
+    });
+    if (created) {
+      try {
+        await env.SYNC_QUEUE.send({
+          type: "run-einvoice-chunk",
+          runId: run.id,
+        });
+      } catch (error) {
+        await cancelQueuedEinvoiceSyncRun(env, run.id, error);
+        throw error;
+      }
+    }
+    return true;
+  }
   const notification = await runScheduledJob(env, controller, job);
   if (notification) await safelySendSyncNotification(env, notification);
   return notification !== undefined;
@@ -90,6 +111,24 @@ async function runDefaultScheduleBatchJob(
   batchId: string,
   job: SyncJobRow<ConnectorId>,
 ) {
+  if (job.connector_id === "einvoice") {
+    const { run, created } = await startEinvoiceSyncRun(env, {
+      trigger: "scheduled",
+      scheduledBatchId: batchId,
+    });
+    if (created) {
+      try {
+        await env.SYNC_QUEUE.send({
+          type: "run-einvoice-chunk",
+          runId: run.id,
+        });
+      } catch (error) {
+        await cancelQueuedEinvoiceSyncRun(env, run.id, error);
+        throw error;
+      }
+    }
+    return true;
+  }
   let outcomeNewRecords = {
     invoices: 0,
     bankTransactions: 0,
@@ -209,6 +248,6 @@ async function runDueSyncJob(env: Env, job: SyncJobRow<ConnectorId>) {
     job.connector_id,
     "scheduled",
     job.scope as SyncScope,
-    job.connector_id === "einvoice" ? { fetchDetails: true } : {},
+    {},
   );
 }

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -1,5 +1,4 @@
 import {
-  einvoiceConnector,
   EInvoiceProtocolUnavailableError,
   createCtbcConnector,
   CtbcVerificationRequiredError,
@@ -9,7 +8,6 @@ import {
   parseCathaybkConfig,
   parseCtbcConfig,
   parseEsunConfig,
-  parseInvoiceConfig,
   parseObankConfig,
   parseSinopacConfig,
   parseTaishinConfig,
@@ -128,10 +126,6 @@ export class NeedsUserActionError extends Error {
     super(message);
   }
 }
-
-export type EinvoiceSyncOverrides = {
-  fetchDetails?: boolean;
-};
 
 export type SinopacSyncOverrides = {
   captcha?: string;
@@ -287,94 +281,6 @@ export async function prepareObankCaptchaSession(env: Env) {
   } finally {
     await releaseSyncJobLock(env.DB, lockRowId, runId);
   }
-}
-
-export async function syncEinvoice(
-  env: Env,
-  trigger: SyncTrigger,
-  overrides: EinvoiceSyncOverrides = {},
-): Promise<SyncOutcome> {
-  const connectorId = "einvoice";
-  const scope = "all";
-  const settings = await requireConnectorSettings(env.DB, connectorId);
-  const stored = await decryptJson<Record<string, unknown>>(
-    settings.encrypted_config,
-    configEncryptionKey(env),
-  );
-  const config = {
-    ...stored,
-    ...parsePublicConnectorConfig(connectorId, settings.public_config),
-  };
-  const configuredConfig = parseInvoiceConfig(config);
-  const effectiveConfig = parseInvoiceConfig({
-    ...configuredConfig,
-    ...overrides,
-  });
-  console.log(
-    `[sync] ${connectorId}/${scope}: starting trigger=${trigger} (cursor=${settings.sync_cursor ? "set" : "none"})`,
-  );
-  const result = await einvoiceConnector.sync(
-    effectiveConfig,
-    settings.sync_cursor ?? undefined,
-  );
-  const invoiceLineItems = result.invoiceLineItems ?? [];
-  const detailErrorCount =
-    "detailErrorCount" in result && typeof result.detailErrorCount === "number"
-      ? result.detailErrorCount
-      : 0;
-  console.log(
-    `[sync] ${connectorId}/${scope}: fetched ${result.records.length} invoices, ${invoiceLineItems.length} detail rows` +
-      (detailErrorCount > 0 ? `, ${detailErrorCount} detail errors` : ""),
-  );
-  const now = new Date().toISOString();
-
-  const records: SyncWriteRecord[] = [
-    ...result.records.map((invoice) =>
-      invoiceRecord(connectorId, invoice, now),
-    ),
-    ...invoiceLineItems.map((item) =>
-      invoiceLineItemRecord(connectorId, item, now),
-    ),
-  ];
-  const finalizeStatements: D1PreparedStatement[] = [];
-
-  if (result.cursor) {
-    finalizeStatements.push(
-      connectorCursorStatement(env.DB, connectorId, result.cursor, now),
-    );
-  }
-
-  const persistedConfig = restoreConfiguredPublicFields(
-    connectorId,
-    effectiveConfig,
-    configuredConfig,
-  );
-  finalizeStatements.push(
-    connectorEncryptedConfigStatement(
-      env.DB,
-      connectorId,
-      await encryptConnectorConfig(env, connectorId, persistedConfig),
-      serializePublicConfig(connectorId, persistedConfig),
-      now,
-    ),
-  );
-
-  const newRecords = await persistStagedSyncWrite(env.DB, {
-    records,
-    finalizeStatements,
-  });
-
-  return {
-    success: true,
-    connectorId,
-    scope,
-    records: result.records.length,
-    newRecords,
-    detailRecords: invoiceLineItems.length,
-    cursorUpdated: Boolean(
-      result.cursor && result.cursor !== settings.sync_cursor,
-    ),
-  };
 }
 
 export async function syncEsun(

--- a/apps/worker/src/platform/env.ts
+++ b/apps/worker/src/platform/env.ts
@@ -1,8 +1,8 @@
 import type { ConnectorId } from "@taiwan-fin-hub/core";
 
-export type ScheduledSyncQueueMessage = {
-  type: "run-next-scheduled-sync";
-};
+export type ScheduledSyncQueueMessage =
+  | { type: "run-next-scheduled-sync" }
+  | { type: "run-einvoice-chunk"; runId: string };
 
 export interface Env {
   DB: D1Database;

--- a/apps/worker/tests/features/connectors/service.test.ts
+++ b/apps/worker/tests/features/connectors/service.test.ts
@@ -40,7 +40,7 @@ beforeEach(() => {
 });
 
 describe("connector settings state boundaries", () => {
-  it("stores the remaining invoice preference separately from credentials", async () => {
+  it("ignores the retired invoice detail preference", async () => {
     await updateConnectorSettings(env, "einvoice", {
       mobile: "0912345678",
       password: "password",
@@ -56,7 +56,7 @@ describe("connector settings state boundaries", () => {
     expect(JSON.parse(saved.encryptedConfig)).not.toHaveProperty(
       "fetchDetails",
     );
-    expect(JSON.parse(saved.publicConfig)).toEqual({ fetchDetails: false });
+    expect(saved.publicConfig).toBeNull();
   });
 
   it("removes retired lookback settings while preserving credentials", async () => {

--- a/apps/worker/tests/features/sync/connector-state.test.ts
+++ b/apps/worker/tests/features/sync/connector-state.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../src/features/sync/connector-state";
 
 describe("connector state boundaries", () => {
-  it("keeps public preferences out of encrypted config", () => {
+  it("keeps retired public preferences out of encrypted config", () => {
     expect(
       sensitiveConnectorConfig("einvoice", {
         mobile: "0912345678",
@@ -21,20 +21,20 @@ describe("connector state boundaries", () => {
         mobile: "0912345678",
         fetchDetails: false,
       }),
-    ).toBe(JSON.stringify({ fetchDetails: false }));
+    ).toBeNull();
   });
 
-  it("does not persist one-time sync overrides as public preferences", () => {
+  it("does not persist retired invoice preferences", () => {
     expect(
-      restoreConfiguredPublicFields(
+      sensitiveConnectorConfig(
         "einvoice",
-        { fetchDetails: true, sid: "refreshed-session" },
-        { fetchDetails: false },
+        restoreConfiguredPublicFields(
+          "einvoice",
+          { fetchDetails: true, sid: "refreshed-session" },
+          { fetchDetails: false },
+        ),
       ),
-    ).toEqual({
-      fetchDetails: false,
-      sid: "refreshed-session",
-    });
+    ).toEqual({ sid: "refreshed-session" });
   });
 
   it("filters retired public fields before parsing runtime config", () => {
@@ -49,7 +49,7 @@ describe("connector state boundaries", () => {
         "einvoice",
         JSON.stringify({ periodsBack: 6, fetchDetails: false }),
       ),
-    ).toEqual({ fetchDetails: false });
+    ).toEqual({});
   });
 
   it("removes reusable browser sessions from bank cursors", () => {

--- a/apps/worker/tests/features/sync/einvoice-run-repository.test.ts
+++ b/apps/worker/tests/features/sync/einvoice-run-repository.test.ts
@@ -1,0 +1,1229 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  acquireEinvoiceRunChunkLease,
+  claimEinvoiceRunItems,
+  claimEinvoiceRunSessionRefresh,
+  completeEinvoiceRun,
+  createOrGetActiveEinvoiceRun,
+  getEinvoiceRun,
+  initializeEinvoiceRun,
+  listCompletedEinvoiceRunItems,
+  listPendingEinvoiceRunItems,
+  markEinvoiceRunItemSucceeded,
+  markEinvoiceRunItemsSucceeded,
+  mergeEinvoiceRunItems,
+  promoteEinvoiceRunRecords,
+  releaseEinvoiceRunChunkLease,
+  releaseEinvoiceRunItemForRetry,
+  renewEinvoiceRunChunkLease,
+  resetEinvoiceRunSession,
+  transitionEinvoiceRunStatus,
+} from "../../../src/features/sync/einvoice-run-repository";
+
+class SqliteStatement {
+  private values: unknown[] = [];
+
+  constructor(
+    private readonly database: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: unknown[]) {
+    this.values = values;
+    return this;
+  }
+
+  async run() {
+    const result = this.database
+      .prepare(this.sql)
+      .run(...(this.values as never[]));
+    return {
+      success: true,
+      meta: { changes: Number(result.changes) },
+      results: [],
+    };
+  }
+
+  async first<T>() {
+    return (
+      (this.database.prepare(this.sql).get(...(this.values as never[])) as T) ??
+      null
+    );
+  }
+
+  async all<T>() {
+    return {
+      success: true,
+      meta: {},
+      results: this.database
+        .prepare(this.sql)
+        .all(...(this.values as never[])) as T[],
+    };
+  }
+}
+
+const databases: DatabaseSync[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+function createDb() {
+  const database = new DatabaseSync(":memory:");
+  const batchStatementCounts: number[] = [];
+  database.exec("PRAGMA foreign_keys = ON");
+  const migrationsDirectory = fileURLToPath(
+    new URL("../../../../../packages/db/migrations/", import.meta.url),
+  );
+  for (const file of readdirSync(migrationsDirectory)
+    .filter((name) => name.endsWith(".sql"))
+    .sort()) {
+    database.exec(readFileSync(`${migrationsDirectory}/${file}`, "utf8"));
+  }
+  databases.push(database);
+  const db = {
+    prepare(sql: string) {
+      return new SqliteStatement(database, sql);
+    },
+    async batch(statements: D1PreparedStatement[]) {
+      batchStatementCounts.push(statements.length);
+      database.exec("BEGIN");
+      try {
+        const results = [];
+        for (const statement of statements) {
+          results.push(await (statement as unknown as SqliteStatement).run());
+        }
+        database.exec("COMMIT");
+        return results;
+      } catch (error) {
+        database.exec("ROLLBACK");
+        throw error;
+      }
+    },
+  } as unknown as D1Database;
+  return { database, db, batchStatementCounts };
+}
+
+function header(sourceId: string) {
+  return {
+    invoiceSourceId: sourceId,
+    invoiceNumber: `AB${sourceId}`,
+    amount: 100,
+  };
+}
+
+function insertEinvoiceSettings(
+  database: DatabaseSync,
+  input: {
+    encryptedConfig?: string;
+    cursor?: string;
+    updatedAt?: string;
+  } = {},
+) {
+  database
+    .prepare(
+      `INSERT INTO connector_settings (
+         id, connector_id, encrypted_config, sync_cursor, created_at, updated_at
+       ) VALUES ('einvoice', 'einvoice', ?, ?, 'created', ?)`,
+    )
+    .run(
+      input.encryptedConfig ?? "encrypted-config",
+      input.cursor ?? "cursor-old",
+      input.updatedAt ?? "version-1",
+    );
+}
+
+async function createProcessingEinvoiceRun(
+  database: DatabaseSync,
+  db: D1Database,
+  input: {
+    runId: string;
+    settingsVersion: string;
+    items: Parameters<typeof mergeEinvoiceRunItems>[2];
+  },
+) {
+  const { run } = await createOrGetActiveEinvoiceRun(db, {
+    id: input.runId,
+    trigger: "manual",
+    now: "run-created",
+  });
+  await mergeEinvoiceRunItems(db, run.id, input.items, "items-merged");
+  database
+    .prepare(
+      `UPDATE einvoice_sync_runs
+       SET status = 'processing', settings_version = ?, updated_at = 'processing'
+       WHERE id = ?`,
+    )
+    .run(input.settingsVersion, run.id);
+  return run;
+}
+
+function promotionState(database: DatabaseSync, runId: string) {
+  return {
+    run: database
+      .prepare("SELECT * FROM einvoice_sync_runs WHERE id = ?")
+      .get(runId),
+    settings: database
+      .prepare(
+        "SELECT * FROM connector_settings WHERE connector_id = 'einvoice'",
+      )
+      .get(),
+    invoices: database
+      .prepare("SELECT * FROM invoices ORDER BY source_id")
+      .all(),
+    lineItems: database
+      .prepare("SELECT * FROM invoice_line_items ORDER BY source_id")
+      .all(),
+  };
+}
+
+describe("durable e-invoice sync runs", () => {
+  it("keeps one active connector run and reports whether this caller created it", async () => {
+    const { db } = createDb();
+    const first = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-1",
+      trigger: "manual",
+      now: "2026-08-12T00:00:00.000Z",
+    });
+    const second = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-2",
+      trigger: "scheduled",
+      syncJobId: "einvoice:all",
+      now: "2026-08-12T00:01:00.000Z",
+    });
+
+    expect(first).toMatchObject({ created: true, run: { id: "run-1" } });
+    expect(second).toMatchObject({ created: false, run: { id: "run-1" } });
+    expect(second.run).toMatchObject({
+      trigger: "manual",
+      sync_job_id: null,
+      scheduled_batch_id: null,
+    });
+  });
+
+  it("does not let a scheduled caller attach a manual run to its default batch", async () => {
+    const { database, db } = createDb();
+    database
+      .prepare(
+        "INSERT INTO scheduled_sync_batches (id, schedule_key, created_at) VALUES ('batch-1', 'default', 'now')",
+      )
+      .run();
+    const manual = await createOrGetActiveEinvoiceRun(db, {
+      id: "manual-run",
+      trigger: "manual",
+      syncJobId: "einvoice:all",
+    });
+    const scheduled = await createOrGetActiveEinvoiceRun(db, {
+      id: "scheduled-run",
+      trigger: "scheduled",
+      syncJobId: "einvoice:all",
+      scheduledBatchId: "batch-1",
+    });
+
+    expect(scheduled).toMatchObject({
+      created: false,
+      run: { id: manual.run.id },
+    });
+    expect(
+      (await getEinvoiceRun(db, manual.run.id))?.scheduled_batch_id,
+    ).toBeNull();
+  });
+
+  it("allows only one Queue consumer to hold a chunk lease until it expires", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    const startedAt = new Date("2026-08-12T00:00:00.000Z");
+
+    await expect(
+      acquireEinvoiceRunChunkLease(db, {
+        runId: run.id,
+        owner: "consumer-a",
+        leaseMs: 60_000,
+        now: startedAt,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      acquireEinvoiceRunChunkLease(db, {
+        runId: run.id,
+        owner: "consumer-b",
+        leaseMs: 60_000,
+        now: new Date("2026-08-12T00:00:30.000Z"),
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      releaseEinvoiceRunChunkLease(db, {
+        runId: run.id,
+        owner: "consumer-b",
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      acquireEinvoiceRunChunkLease(db, {
+        runId: run.id,
+        owner: "consumer-b",
+        leaseMs: 60_000,
+        now: new Date("2026-08-12T00:01:01.000Z"),
+      }),
+    ).resolves.toBe(true);
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      chunk_lease_owner: "consumer-b",
+      chunk_lease_expires_at: "2026-08-12T00:02:01.000Z",
+    });
+    await expect(
+      releaseEinvoiceRunChunkLease(db, {
+        runId: run.id,
+        owner: "consumer-b",
+        now: "2026-08-12T00:01:02.000Z",
+      }),
+    ).resolves.toBe(true);
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      chunk_lease_owner: null,
+      chunk_lease_expires_at: null,
+    });
+  });
+
+  it("renews the run lease only for the current owner", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    await mergeEinvoiceRunItems(
+      db,
+      run.id,
+      Array.from({ length: 2 }, (_, index) => ({
+        invoiceSourceId: `invoice-${index}`,
+        header: header(`${index}`),
+        normalizedInvoice: { sourceId: `${index}` },
+        detailKey: `key-${index}`,
+      })),
+    );
+    await acquireEinvoiceRunChunkLease(db, {
+      runId: run.id,
+      owner: "consumer-a",
+      leaseMs: 60_000,
+      now: new Date("2026-08-12T00:00:00.000Z"),
+    });
+    await claimEinvoiceRunItems(db, {
+      runId: run.id,
+      claimToken: "claim-a",
+      leaseMs: 60_000,
+      now: new Date("2026-08-12T00:00:00.000Z"),
+    });
+
+    await expect(
+      renewEinvoiceRunChunkLease(db, {
+        runId: run.id,
+        owner: "consumer-a",
+        leaseMs: 90_000,
+        now: new Date("2026-08-12T00:00:30.000Z"),
+      }),
+    ).resolves.toBe(true);
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      chunk_lease_owner: "consumer-a",
+      chunk_lease_expires_at: "2026-08-12T00:02:00.000Z",
+    });
+    expect(await listPendingEinvoiceRunItems(db, run.id)).toMatchObject([
+      {
+        status: "processing",
+        lease_token: "claim-a",
+        lease_expires_at: "2026-08-12T00:01:00.000Z",
+      },
+      {
+        status: "processing",
+        lease_token: "claim-a",
+        lease_expires_at: "2026-08-12T00:01:00.000Z",
+      },
+    ]);
+
+    await expect(
+      renewEinvoiceRunChunkLease(db, {
+        runId: run.id,
+        owner: "consumer-b",
+        leaseMs: 180_000,
+        now: new Date("2026-08-12T00:00:45.000Z"),
+      }),
+    ).resolves.toBe(false);
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      chunk_lease_owner: "consumer-a",
+      chunk_lease_expires_at: "2026-08-12T00:02:00.000Z",
+    });
+    expect(
+      (await listPendingEinvoiceRunItems(db, run.id)).map(
+        (item) => item.lease_expires_at,
+      ),
+    ).toEqual(["2026-08-12T00:01:00.000Z", "2026-08-12T00:01:00.000Z"]);
+  });
+
+  it("durably merges headers and marks invoices without a detail key done", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    await mergeEinvoiceRunItems(
+      db,
+      run.id,
+      [
+        {
+          invoiceSourceId: "header-only",
+          header: header("header-only"),
+          normalizedInvoice: { sourceId: "header-only", amount: 100 },
+        },
+        {
+          invoiceSourceId: "needs-detail",
+          header: header("needs-detail"),
+          normalizedInvoice: { sourceId: "needs-detail", amount: 200 },
+          detailKey: "provider-key",
+          detailMetadata: { period: "202608" },
+        },
+      ],
+      "2026-08-12T00:00:00.000Z",
+    );
+
+    expect(await listCompletedEinvoiceRunItems(db, run.id)).toMatchObject([
+      {
+        invoice_source_id: "header-only",
+        status: "done",
+        detail_items_json: null,
+      },
+    ]);
+    expect(await listPendingEinvoiceRunItems(db, run.id)).toMatchObject([
+      {
+        invoice_source_id: "needs-detail",
+        status: "pending",
+        detail_key: "provider-key",
+      },
+    ]);
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      total_item_count: 2,
+      pending_item_count: 1,
+      done_item_count: 1,
+    });
+  });
+
+  it("claims a bounded batch, retries safely, and prevents stale completion", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    await mergeEinvoiceRunItems(
+      db,
+      run.id,
+      Array.from({ length: 36 }, (_, index) => ({
+        invoiceSourceId: `invoice-${index}`,
+        header: header(`${index}`),
+        normalizedInvoice: { sourceId: `${index}` },
+        detailKey: `key-${index}`,
+      })),
+    );
+
+    const firstClaim = await claimEinvoiceRunItems(db, {
+      runId: run.id,
+      claimToken: "first",
+      leaseMs: 1_000,
+      now: new Date("2026-08-12T00:00:00.000Z"),
+    });
+    expect(firstClaim).toHaveLength(35);
+    expect(
+      await completeEinvoiceRun(db, { runId: run.id, status: "completed" }),
+    ).toBe(false);
+
+    const target = firstClaim[0]!;
+    expect(
+      await releaseEinvoiceRunItemForRetry(db, {
+        runId: run.id,
+        invoiceSourceId: target.invoice_source_id,
+        claimToken: "first",
+        error: "temporary provider error",
+      }),
+    ).toBe(true);
+    const retryClaim = await claimEinvoiceRunItems(db, {
+      runId: run.id,
+      claimToken: "retry",
+      limit: 1,
+      leaseMs: 1_000,
+    });
+    expect(retryClaim.map((item) => item.invoice_source_id)).toEqual([
+      target.invoice_source_id,
+    ]);
+    expect(
+      await markEinvoiceRunItemSucceeded(db, {
+        runId: run.id,
+        invoiceSourceId: target.invoice_source_id,
+        claimToken: "first",
+        detailItems: [],
+      }),
+    ).toBe(false);
+    expect(
+      await markEinvoiceRunItemSucceeded(db, {
+        runId: run.id,
+        invoiceSourceId: target.invoice_source_id,
+        claimToken: "retry",
+        detailItems: [{ sourceId: "line-1" }, { sourceId: "line-2" }],
+      }),
+    ).toBe(true);
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      line_item_count: 2,
+    });
+  });
+
+  it("completes a claimed 35-item chunk with one set-based update and refreshes counts", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    await mergeEinvoiceRunItems(
+      db,
+      run.id,
+      Array.from({ length: 35 }, (_, index) => ({
+        invoiceSourceId: `invoice-${index}`,
+        header: header(`${index}`),
+        normalizedInvoice: { sourceId: `${index}`, version: "header" },
+        detailKey: `key-${index}`,
+      })),
+    );
+    const claimed = await claimEinvoiceRunItems(db, {
+      runId: run.id,
+      claimToken: "chunk-1",
+      limit: 35,
+      leaseMs: 60_000,
+      now: new Date("2026-08-12T00:00:00.000Z"),
+    });
+
+    expect(claimed).toHaveLength(35);
+    expect(
+      await markEinvoiceRunItemsSucceeded(db, {
+        runId: run.id,
+        claimToken: "chunk-1",
+        items: claimed.map((item, index) => ({
+          invoiceSourceId: item.invoice_source_id,
+          detailItems: [
+            { sourceId: `line-${index}-1` },
+            { sourceId: `line-${index}-2` },
+          ],
+          normalizedInvoice: {
+            sourceId: item.invoice_source_id,
+            version: "detail",
+          },
+        })),
+        now: "2026-08-12T00:00:10.000Z",
+      }),
+    ).toBe(35);
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      total_item_count: 35,
+      pending_item_count: 0,
+      processing_item_count: 0,
+      done_item_count: 35,
+      line_item_count: 70,
+    });
+    expect(await listCompletedEinvoiceRunItems(db, run.id)).toHaveLength(35);
+  });
+
+  it("does not let an expired claim batch-complete items reclaimed by another consumer", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    await mergeEinvoiceRunItems(
+      db,
+      run.id,
+      Array.from({ length: 35 }, (_, index) => ({
+        invoiceSourceId: `invoice-${index}`,
+        header: header(`${index}`),
+        normalizedInvoice: { sourceId: `${index}` },
+        detailKey: `key-${index}`,
+      })),
+    );
+    const staleClaim = await claimEinvoiceRunItems(db, {
+      runId: run.id,
+      claimToken: "stale",
+      leaseMs: 1_000,
+      now: new Date("2026-08-12T00:00:00.000Z"),
+    });
+    const replacementClaim = await claimEinvoiceRunItems(db, {
+      runId: run.id,
+      claimToken: "replacement",
+      leaseMs: 60_000,
+      now: new Date("2026-08-12T00:00:02.000Z"),
+    });
+
+    expect(replacementClaim).toHaveLength(35);
+    expect(
+      await markEinvoiceRunItemsSucceeded(db, {
+        runId: run.id,
+        claimToken: "stale",
+        items: staleClaim.map((item) => ({
+          invoiceSourceId: item.invoice_source_id,
+          detailItems: [],
+          normalizedInvoice: { sourceId: item.invoice_source_id },
+        })),
+      }),
+    ).toBe(0);
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      pending_item_count: 0,
+      processing_item_count: 35,
+      done_item_count: 0,
+    });
+  });
+
+  it("preserves completed normalized invoices and detail items when headers are merged again", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    await mergeEinvoiceRunItems(db, run.id, [
+      {
+        invoiceSourceId: "invoice-1",
+        header: { version: "first" },
+        normalizedInvoice: { version: "first" },
+        detailKey: "first-key",
+        detailMetadata: { version: "first" },
+        detailItems: [{ sourceId: "first-line" }],
+      },
+    ]);
+    await mergeEinvoiceRunItems(db, run.id, [
+      {
+        invoiceSourceId: "invoice-1",
+        header: { version: "second" },
+        normalizedInvoice: { version: "second" },
+        detailKey: "second-key",
+        detailMetadata: { version: "second" },
+        detailItems: [{ sourceId: "second-line" }],
+      },
+    ]);
+
+    const [item] = await listCompletedEinvoiceRunItems(db, run.id);
+    expect(item).toMatchObject({
+      header_json: JSON.stringify({ version: "second" }),
+      normalized_invoice_json: JSON.stringify({ version: "first" }),
+      detail_items_json: JSON.stringify([{ sourceId: "first-line" }]),
+      line_item_count: 1,
+      status: "done",
+    });
+  });
+
+  it("initializes atomically only while the connector settings version still matches", async () => {
+    const { database, db } = createDb();
+    database
+      .prepare(
+        `INSERT INTO connector_settings (
+           id, connector_id, encrypted_config, created_at, updated_at
+         ) VALUES ('einvoice', 'einvoice', 'old-config', 'created', 'version-1')`,
+      )
+      .run();
+    const { run } = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    await transitionEinvoiceRunStatus(db, {
+      runId: run.id,
+      from: "queued",
+      to: "initializing",
+    });
+
+    await expect(
+      initializeEinvoiceRun(db, {
+        runId: run.id,
+        items: [
+          {
+            invoiceSourceId: "invoice-1",
+            header: header("1"),
+            normalizedInvoice: { sourceId: "1" },
+          },
+        ],
+        encryptedConfig: "new-config",
+        expectedSettingsUpdatedAt: "version-1",
+        cursor: "cursor-1",
+        now: "2026-08-12T00:00:00.000Z",
+      }),
+    ).resolves.toEqual({ settingsUpdated: true, transitioned: true });
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      status: "processing",
+      settings_version: "2026-08-12T00:00:00.000Z",
+      total_item_count: 1,
+      done_item_count: 1,
+    });
+    expect(
+      database
+        .prepare(
+          "SELECT encrypted_config, sync_cursor, updated_at FROM connector_settings WHERE connector_id = 'einvoice'",
+        )
+        .get(),
+    ).toEqual({
+      encrypted_config: "new-config",
+      sync_cursor: "cursor-1",
+      updated_at: "2026-08-12T00:00:00.000Z",
+    });
+
+    await completeEinvoiceRun(db, {
+      runId: run.id,
+      status: "completed",
+    });
+
+    const secondRun = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-2",
+      trigger: "manual",
+    });
+    await transitionEinvoiceRunStatus(db, {
+      runId: secondRun.run.id,
+      from: "queued",
+      to: "initializing",
+    });
+    database
+      .prepare(
+        "UPDATE connector_settings SET encrypted_config = 'user-saved', updated_at = 'version-3' WHERE connector_id = 'einvoice'",
+      )
+      .run();
+
+    await expect(
+      initializeEinvoiceRun(db, {
+        runId: secondRun.run.id,
+        items: [
+          {
+            invoiceSourceId: "invoice-2",
+            header: header("2"),
+            normalizedInvoice: { sourceId: "2" },
+          },
+        ],
+        encryptedConfig: "stale-login-config",
+        expectedSettingsUpdatedAt: "2026-08-12T00:00:00.000Z",
+        cursor: "stale-cursor",
+        now: "2026-08-12T00:01:00.000Z",
+      }),
+    ).resolves.toEqual({ settingsUpdated: false, transitioned: false });
+    expect(await getEinvoiceRun(db, secondRun.run.id)).toMatchObject({
+      status: "initializing",
+      total_item_count: 0,
+    });
+    expect(
+      database
+        .prepare(
+          "SELECT encrypted_config, sync_cursor, updated_at FROM connector_settings WHERE connector_id = 'einvoice'",
+        )
+        .get(),
+    ).toEqual({
+      encrypted_config: "user-saved",
+      sync_cursor: "cursor-1",
+      updated_at: "version-3",
+    });
+  });
+
+  it("bounds automatic session refresh claims for an active run", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+
+    await expect(
+      claimEinvoiceRunSessionRefresh(db, {
+        runId: run.id,
+        maxRefreshes: 2,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      claimEinvoiceRunSessionRefresh(db, {
+        runId: run.id,
+        maxRefreshes: 2,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      claimEinvoiceRunSessionRefresh(db, {
+        runId: run.id,
+        maxRefreshes: 2,
+      }),
+    ).resolves.toBe(false);
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      session_refresh_count: 2,
+    });
+  });
+
+  it("resets a pinned session atomically and rejects a concurrent settings save", async () => {
+    const { database, db } = createDb();
+    database
+      .prepare(
+        `INSERT INTO connector_settings (
+           id, connector_id, encrypted_config, sync_cursor, created_at, updated_at
+         ) VALUES (
+           'einvoice', 'einvoice', 'session-1', 'cursor-1', 'created', 'version-1'
+         )`,
+      )
+      .run();
+    const { run } = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    database
+      .prepare(
+        `UPDATE einvoice_sync_runs
+         SET status = 'processing', settings_version = 'version-1'
+         WHERE id = ?`,
+      )
+      .run(run.id);
+
+    await expect(
+      resetEinvoiceRunSession(db, {
+        runId: run.id,
+        encryptedConfig: "session-reset",
+        expectedSettingsUpdatedAt: "version-1",
+        now: "version-2",
+      }),
+    ).resolves.toEqual({ settingsUpdated: true, transitioned: true });
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      status: "initializing",
+      settings_version: "version-2",
+      updated_at: "version-2",
+    });
+    expect(
+      database
+        .prepare(
+          `SELECT encrypted_config, sync_cursor, updated_at
+           FROM connector_settings WHERE connector_id = 'einvoice'`,
+        )
+        .get(),
+    ).toEqual({
+      encrypted_config: "session-reset",
+      sync_cursor: "cursor-1",
+      updated_at: "version-2",
+    });
+
+    database
+      .prepare(
+        `UPDATE einvoice_sync_runs
+         SET status = 'processing'
+         WHERE id = ?`,
+      )
+      .run(run.id);
+    database
+      .prepare(
+        `UPDATE connector_settings
+         SET encrypted_config = 'user-saved', updated_at = 'version-3'
+         WHERE connector_id = 'einvoice'`,
+      )
+      .run();
+    await expect(
+      resetEinvoiceRunSession(db, {
+        runId: run.id,
+        encryptedConfig: "stale-reset",
+        expectedSettingsUpdatedAt: "version-2",
+        now: "version-4",
+      }),
+    ).resolves.toEqual({ settingsUpdated: false, transitioned: false });
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      status: "processing",
+      settings_version: "version-2",
+      updated_at: "version-2",
+    });
+    expect(
+      database
+        .prepare(
+          `SELECT encrypted_config, sync_cursor, updated_at
+           FROM connector_settings WHERE connector_id = 'einvoice'`,
+        )
+        .get(),
+    ).toEqual({
+      encrypted_config: "user-saved",
+      sync_cursor: "cursor-1",
+      updated_at: "version-3",
+    });
+  });
+
+  it("resets a persisted session during the first header initialization", async () => {
+    const { database, db } = createDb();
+    database
+      .prepare(
+        `INSERT INTO connector_settings (
+           id, connector_id, encrypted_config, created_at, updated_at
+         ) VALUES ('einvoice', 'einvoice', 'session-config', 'created', 'version-1')`,
+      )
+      .run();
+    const { run } = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    await transitionEinvoiceRunStatus(db, {
+      runId: run.id,
+      from: "queued",
+      to: "initializing",
+    });
+
+    await expect(
+      resetEinvoiceRunSession(db, {
+        runId: run.id,
+        encryptedConfig: "credentials-only",
+        expectedSettingsUpdatedAt: "version-1",
+        now: "version-2",
+      }),
+    ).resolves.toEqual({ settingsUpdated: true, transitioned: true });
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      status: "initializing",
+      settings_version: "version-2",
+    });
+    expect(
+      database
+        .prepare(
+          `SELECT encrypted_config, updated_at
+           FROM connector_settings WHERE connector_id = 'einvoice'`,
+        )
+        .get(),
+    ).toEqual({
+      encrypted_config: "credentials-only",
+      updated_at: "version-2",
+    });
+  });
+
+  it("promotes completed invoices and lines with stable records and makes replay a no-op", async () => {
+    const { database, db } = createDb();
+    insertEinvoiceSettings(database);
+    database
+      .prepare(
+        `INSERT INTO invoices (
+           id, connector_id, source_id, invoice_number, invoice_date,
+           seller_name, amount, raw_payload, created_at, updated_at
+         ) VALUES (
+           'einvoice:invoice-existing', 'einvoice', 'invoice-existing',
+           'OLD', '2026-01-01', 'old seller', 1, '{}', 'old', 'old'
+         )`,
+      )
+      .run();
+    const run = await createProcessingEinvoiceRun(database, db, {
+      runId: "run-1",
+      settingsVersion: "version-1",
+      items: [
+        {
+          invoiceSourceId: "invoice-existing",
+          header: header("existing"),
+          normalizedInvoice: {
+            sourceId: "invoice-existing",
+            invoiceNumber: "AB-EXISTING",
+            invoiceDate: "2026-08-01",
+            sellerName: "existing seller",
+            amount: 80,
+            raw: { provider: "updated-existing" },
+          },
+          detailItems: [],
+        },
+        {
+          invoiceSourceId: "invoice-new",
+          header: header("new"),
+          normalizedInvoice: {
+            sourceId: "invoice-new",
+            invoiceNumber: "AB-NEW",
+            invoiceDate: "2026-08-02",
+            sellerName: "new seller",
+            amount: 120,
+            raw: { provider: "invoice-raw", nested: { value: 1 } },
+          },
+          detailItems: [
+            {
+              invoiceSourceId: "invoice-new",
+              sourceId: "line-1",
+              lineNumber: 1,
+              description: "line one",
+              quantity: 2,
+              unitPrice: 60,
+              amount: 120,
+              raw: "line-raw",
+            },
+          ],
+        },
+      ],
+    });
+
+    await expect(
+      promoteEinvoiceRunRecords(db, {
+        runId: run.id,
+        expectedSettingsUpdatedAt: "version-1",
+        cursor: "cursor-new",
+        now: "2026-08-12T01:00:00.000Z",
+      }),
+    ).resolves.toBe(true);
+    expect(
+      database
+        .prepare(
+          `SELECT id, source_id, invoice_number, invoice_date, seller_name,
+                  amount, raw_payload, created_at, updated_at
+           FROM invoices ORDER BY source_id`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        id: "einvoice:invoice-existing",
+        source_id: "invoice-existing",
+        invoice_number: "AB-EXISTING",
+        invoice_date: "2026-08-01",
+        seller_name: "existing seller",
+        amount: 80,
+        raw_payload: JSON.stringify({ provider: "updated-existing" }),
+        created_at: "old",
+        updated_at: "2026-08-12T01:00:00.000Z",
+      },
+      {
+        id: "einvoice:invoice-new",
+        source_id: "invoice-new",
+        invoice_number: "AB-NEW",
+        invoice_date: "2026-08-02",
+        seller_name: "new seller",
+        amount: 120,
+        raw_payload: JSON.stringify({
+          provider: "invoice-raw",
+          nested: { value: 1 },
+        }),
+        created_at: "2026-08-12T01:00:00.000Z",
+        updated_at: "2026-08-12T01:00:00.000Z",
+      },
+    ]);
+    expect(
+      database
+        .prepare(
+          `SELECT id, invoice_id, invoice_source_id, source_id, line_number,
+                  description, quantity, unit_price, amount, raw_payload
+           FROM invoice_line_items`,
+        )
+        .get(),
+    ).toEqual({
+      id: "einvoice:invoice-new:item:line-1",
+      invoice_id: "einvoice:invoice-new",
+      invoice_source_id: "invoice-new",
+      source_id: "line-1",
+      line_number: 1,
+      description: "line one",
+      quantity: 2,
+      unit_price: 60,
+      amount: 120,
+      raw_payload: JSON.stringify("line-raw"),
+    });
+    expect(await getEinvoiceRun(db, run.id)).toMatchObject({
+      new_invoice_count: 1,
+      promoted_at: "2026-08-12T01:00:00.000Z",
+      settings_version: "2026-08-12T01:00:00.000Z",
+    });
+    expect(
+      database
+        .prepare(
+          `SELECT sync_cursor, updated_at FROM connector_settings
+           WHERE connector_id = 'einvoice'`,
+        )
+        .get(),
+    ).toEqual({
+      sync_cursor: "cursor-new",
+      updated_at: "2026-08-12T01:00:00.000Z",
+    });
+
+    const promotedState = promotionState(database, run.id);
+    await expect(
+      promoteEinvoiceRunRecords(db, {
+        runId: run.id,
+        expectedSettingsUpdatedAt: "2026-08-12T01:00:00.000Z",
+        cursor: "cursor-replay",
+        now: "2026-08-12T02:00:00.000Z",
+      }),
+    ).resolves.toBe(false);
+    expect(promotionState(database, run.id)).toEqual(promotedState);
+  });
+
+  it("does not promote anything with stale settings or unfinished detail work", async () => {
+    const stale = createDb();
+    insertEinvoiceSettings(stale.database, { updatedAt: "user-version" });
+    const staleRun = await createProcessingEinvoiceRun(
+      stale.database,
+      stale.db,
+      {
+        runId: "stale-run",
+        settingsVersion: "run-version",
+        items: [
+          {
+            invoiceSourceId: "invoice-stale",
+            header: header("stale"),
+            normalizedInvoice: {
+              invoiceNumber: "AB-STALE",
+              invoiceDate: "2026-08-01",
+              amount: 1,
+            },
+            detailItems: [],
+          },
+        ],
+      },
+    );
+    const staleState = promotionState(stale.database, staleRun.id);
+    await expect(
+      promoteEinvoiceRunRecords(stale.db, {
+        runId: staleRun.id,
+        expectedSettingsUpdatedAt: "run-version",
+        cursor: "stale-cursor",
+        now: "promotion-time",
+      }),
+    ).resolves.toBe(false);
+    expect(promotionState(stale.database, staleRun.id)).toEqual(staleState);
+
+    const unfinished = createDb();
+    insertEinvoiceSettings(unfinished.database, { updatedAt: "version-1" });
+    const unfinishedRun = await createProcessingEinvoiceRun(
+      unfinished.database,
+      unfinished.db,
+      {
+        runId: "unfinished-run",
+        settingsVersion: "version-1",
+        items: [
+          {
+            invoiceSourceId: "invoice-done",
+            header: header("done"),
+            normalizedInvoice: {
+              invoiceNumber: "AB-DONE",
+              invoiceDate: "2026-08-01",
+              amount: 1,
+            },
+            detailItems: [],
+          },
+          {
+            invoiceSourceId: "invoice-pending",
+            header: header("pending"),
+            normalizedInvoice: {
+              invoiceNumber: "AB-PENDING",
+              invoiceDate: "2026-08-02",
+              amount: 2,
+            },
+            detailKey: "needs-detail",
+          },
+        ],
+      },
+    );
+    const unfinishedState = promotionState(
+      unfinished.database,
+      unfinishedRun.id,
+    );
+    await expect(
+      promoteEinvoiceRunRecords(unfinished.db, {
+        runId: unfinishedRun.id,
+        expectedSettingsUpdatedAt: "version-1",
+        cursor: "unfinished-cursor",
+        now: "promotion-time",
+      }),
+    ).resolves.toBe(false);
+    expect(promotionState(unfinished.database, unfinishedRun.id)).toEqual(
+      unfinishedState,
+    );
+  });
+
+  it("promotes a large run in one fixed five-statement batch", async () => {
+    const { database, db, batchStatementCounts } = createDb();
+    insertEinvoiceSettings(database);
+    const run = await createProcessingEinvoiceRun(database, db, {
+      runId: "large-run",
+      settingsVersion: "version-1",
+      items: Array.from({ length: 120 }, (_, index) => ({
+        invoiceSourceId: `invoice-${index}`,
+        header: header(`${index}`),
+        normalizedInvoice: {
+          invoiceNumber: `AB-${index}`,
+          invoiceDate: "2026-08-01",
+          sellerName: `seller-${index}`,
+          amount: index,
+          raw: { invoice: index },
+        },
+        detailItems: [
+          {
+            sourceId: `line-${index}`,
+            lineNumber: 1,
+            description: `line-${index}`,
+            quantity: 1,
+            unitPrice: index,
+            amount: index,
+            raw: { line: index },
+          },
+        ],
+      })),
+    });
+    batchStatementCounts.length = 0;
+
+    await expect(
+      promoteEinvoiceRunRecords(db, {
+        runId: run.id,
+        expectedSettingsUpdatedAt: "version-1",
+        cursor: "large-cursor",
+        now: "2026-08-12T03:00:00.000Z",
+      }),
+    ).resolves.toBe(true);
+    expect(batchStatementCounts).toEqual([5]);
+    expect(
+      database.prepare("SELECT COUNT(*) AS count FROM invoices").get(),
+    ).toEqual({ count: 120 });
+    expect(
+      database
+        .prepare("SELECT COUNT(*) AS count FROM invoice_line_items")
+        .get(),
+    ).toEqual({ count: 120 });
+  });
+
+  it("uses status compare-and-set for active and terminal transitions", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveEinvoiceRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    expect(
+      await transitionEinvoiceRunStatus(db, {
+        runId: run.id,
+        from: "queued",
+        to: "initializing",
+      }),
+    ).toBe(true);
+    expect(
+      await transitionEinvoiceRunStatus(db, {
+        runId: run.id,
+        from: "queued",
+        to: "processing",
+      }),
+    ).toBe(false);
+    expect(
+      await completeEinvoiceRun(db, {
+        runId: run.id,
+        status: "failed",
+        error: "boom",
+      }),
+    ).toBe(true);
+    expect(
+      await completeEinvoiceRun(db, { runId: run.id, status: "failed" }),
+    ).toBe(false);
+  });
+
+  it("removes an obsolete fetchDetails-only public config during migration", () => {
+    const { database } = createDb();
+    database
+      .prepare(
+        `INSERT INTO connector_settings
+           (id, connector_id, encrypted_config, public_config, created_at, updated_at)
+         VALUES ('einvoice', 'einvoice', '{}', '{"fetchDetails":true}', 'old', 'old')`,
+      )
+      .run();
+    // The migration is idempotent in production but has already run in this fixture;
+    // execute just its cleanup statement to model an upgraded populated database.
+    const migrationPath = fileURLToPath(
+      new URL(
+        "../../../../../packages/db/migrations/0028_einvoice_durable_runs.sql",
+        import.meta.url,
+      ),
+    );
+    const cleanup = readFileSync(migrationPath, "utf8").match(
+      /UPDATE connector_settings[\s\S]*?;\s*$/,
+    )![0];
+    database.exec(cleanup);
+    expect(
+      database
+        .prepare(
+          "SELECT public_config FROM connector_settings WHERE connector_id = 'einvoice'",
+        )
+        .get(),
+    ).toEqual({ public_config: null });
+  });
+});

--- a/apps/worker/tests/features/sync/einvoice-sync-service.test.ts
+++ b/apps/worker/tests/features/sync/einvoice-sync-service.test.ts
@@ -1,0 +1,380 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../../../src/platform/env";
+
+const mocks = vi.hoisted(() => ({
+  acquireEinvoiceRunChunkLease: vi.fn(),
+  claimEinvoiceRunSessionRefresh: vi.fn(),
+  claimEinvoiceRunItems: vi.fn(),
+  decryptJson: vi.fn(),
+  encryptJson: vi.fn(),
+  fetchEInvoiceInvoiceDetail: vi.fn(),
+  getEinvoiceRun: vi.fn(),
+  getConnectorSettings: vi.fn(),
+  initializeEInvoiceSync: vi.fn(),
+  markEinvoiceRunItemsSucceeded: vi.fn(),
+  releaseEinvoiceRunClaimForRetry: vi.fn(),
+  releaseEinvoiceRunChunkLease: vi.fn(),
+  resetEinvoiceRunSession: vi.fn(),
+  renewEinvoiceRunChunkLease: vi.fn(),
+  transitionEinvoiceRunStatus: vi.fn(),
+  holdRunResult: { meta: { changes: 1 } },
+}));
+
+vi.mock("@taiwan-fin-hub/connectors", () => ({
+  EInvoiceV2Client: class EInvoiceV2Client {},
+  fetchEInvoiceInvoiceDetail: mocks.fetchEInvoiceInvoiceDetail,
+  initializeEInvoiceSync: mocks.initializeEInvoiceSync,
+  parseInvoiceConfig: (config: unknown) => config,
+}));
+
+vi.mock("@taiwan-fin-hub/db", () => ({
+  getConnectorSettings: mocks.getConnectorSettings,
+  nextSyncRunAt: vi.fn(),
+}));
+
+vi.mock("../../../src/features/sync/einvoice-run-repository", () => ({
+  acquireEinvoiceRunChunkLease: mocks.acquireEinvoiceRunChunkLease,
+  claimEinvoiceRunItems: mocks.claimEinvoiceRunItems,
+  claimEinvoiceRunSessionRefresh: mocks.claimEinvoiceRunSessionRefresh,
+  completeEinvoiceRun: vi.fn(),
+  createOrGetActiveEinvoiceRun: vi.fn(),
+  getEinvoiceRun: mocks.getEinvoiceRun,
+  initializeEinvoiceRun: vi.fn(),
+  listCompletedEinvoiceRunItems: vi.fn(),
+  markEinvoiceRunItemsSucceeded: mocks.markEinvoiceRunItemsSucceeded,
+  releaseEinvoiceRunClaimForRetry: mocks.releaseEinvoiceRunClaimForRetry,
+  releaseEinvoiceRunChunkLease: mocks.releaseEinvoiceRunChunkLease,
+  renewEinvoiceRunChunkLease: mocks.renewEinvoiceRunChunkLease,
+  resetEinvoiceRunSession: mocks.resetEinvoiceRunSession,
+  promoteEinvoiceRunRecords: vi.fn(),
+  transitionEinvoiceRunStatus: mocks.transitionEinvoiceRunStatus,
+}));
+
+vi.mock("../../../src/features/sync/notification-batch-repository", () => ({
+  claimCompletedDefaultScheduleBatch: vi.fn(),
+}));
+
+vi.mock("../../../src/features/notifications/service", () => ({
+  safelySendScheduledSyncSummary: vi.fn(),
+  safelySendSyncNotification: vi.fn(),
+}));
+
+vi.mock("../../../src/features/sync/schedule-repository", () => ({
+  findSyncJob: vi.fn(),
+}));
+
+vi.mock("../../../src/platform/crypto", () => ({
+  decryptJson: mocks.decryptJson,
+  encryptJson: mocks.encryptJson,
+}));
+
+import {
+  EINVOICE_DETAIL_CHUNK_SIZE,
+  processEinvoiceSyncChunk,
+} from "../../../src/features/sync/einvoice-sync-service";
+
+const preparedStatements: Array<{
+  sql: string;
+  bind: ReturnType<typeof vi.fn>;
+}> = [];
+
+function env(): Env {
+  return {
+    DB: {
+      prepare: vi.fn((sql: string) => {
+        const run = vi.fn().mockResolvedValue(mocks.holdRunResult);
+        const bind = vi.fn(() => ({ run }));
+        preparedStatements.push({ sql, bind });
+        return { bind };
+      }),
+    } as unknown as D1Database,
+    CONFIG_ENCRYPTION_KEY: "test-key",
+  } as Env;
+}
+
+function claimedItem(index: number) {
+  return {
+    invoice_source_id: `invoice-${index}`,
+    detail_metadata_json: JSON.stringify({ sourceId: `invoice-${index}` }),
+  };
+}
+
+function detailResult(index: number) {
+  return {
+    invoice: {
+      sourceId: `invoice-${index}`,
+      raw: { source: "list" },
+    },
+    detail: { source: "detail" },
+    detailItems: [{ description: `item-${index}` }],
+    invoiceLineItems: [{ sourceId: `line-${index}` }],
+  };
+}
+
+function persistedSessionConfig() {
+  return {
+    mobile: "0912345678",
+    password: "secret",
+    sid: "123456789012345678",
+    token: "x".repeat(44),
+    loginAppId: "app",
+    loginLiat: 1,
+    loginSsMe: "secret",
+    mobileBarcode: "/ABC",
+  };
+}
+
+describe("e-invoice chunk sync service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    preparedStatements.length = 0;
+    mocks.getConnectorSettings.mockResolvedValue({
+      encrypted_config: "encrypted",
+      sync_cursor: null,
+      updated_at: "2026-08-12T00:00:00.000Z",
+    });
+    mocks.acquireEinvoiceRunChunkLease.mockResolvedValue(true);
+    mocks.claimEinvoiceRunSessionRefresh.mockResolvedValue(false);
+    mocks.decryptJson.mockResolvedValue(persistedSessionConfig());
+    mocks.encryptJson.mockResolvedValue("refreshed-encrypted-config");
+    mocks.initializeEInvoiceSync.mockResolvedValue({
+      configUpdates: {},
+      headers: [],
+      detailTasks: [],
+    });
+    mocks.releaseEinvoiceRunChunkLease.mockResolvedValue(true);
+    mocks.resetEinvoiceRunSession.mockResolvedValue({
+      settingsUpdated: true,
+      transitioned: true,
+    });
+    mocks.renewEinvoiceRunChunkLease.mockResolvedValue(true);
+    mocks.transitionEinvoiceRunStatus.mockResolvedValue(true);
+    mocks.getEinvoiceRun.mockResolvedValue({
+      id: "run-1",
+      trigger: "manual",
+      status: "processing",
+      settings_version: "2026-08-12T00:00:00.000Z",
+      total_item_count: 36,
+      pending_item_count: 36,
+      processing_item_count: 0,
+      done_item_count: 0,
+      promoted_at: null,
+    });
+    mocks.claimEinvoiceRunItems.mockResolvedValue([]);
+    mocks.fetchEInvoiceInvoiceDetail.mockImplementation(
+      async (_session, task: { sourceId: string }) =>
+        detailResult(Number(task.sourceId.replace("invoice-", ""))),
+    );
+    mocks.markEinvoiceRunItemsSucceeded.mockResolvedValue(0);
+    mocks.releaseEinvoiceRunClaimForRetry.mockResolvedValue(0);
+  });
+
+  it("claims no more than the configured safe detail batch size", async () => {
+    await expect(processEinvoiceSyncChunk(env(), "run-1")).resolves.toEqual({
+      status: "continue",
+    });
+
+    expect(mocks.claimEinvoiceRunItems).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        runId: "run-1",
+        limit: EINVOICE_DETAIL_CHUNK_SIZE,
+      }),
+    );
+    expect(EINVOICE_DETAIL_CHUNK_SIZE).toBe(35);
+  });
+
+  it("renews the run lease at indexes 0, 5, and 10 before set-based completion", async () => {
+    const order: string[] = [];
+    const claimed = Array.from({ length: 11 }, (_, index) =>
+      claimedItem(index),
+    );
+    mocks.claimEinvoiceRunItems.mockResolvedValue(claimed);
+    mocks.renewEinvoiceRunChunkLease.mockImplementation(async () => {
+      order.push("renew");
+      return true;
+    });
+    mocks.fetchEInvoiceInvoiceDetail.mockImplementation(
+      async (_session, task: { sourceId: string }) => {
+        const index = Number(task.sourceId.replace("invoice-", ""));
+        order.push(`fetch-${index}`);
+        return detailResult(index);
+      },
+    );
+    mocks.markEinvoiceRunItemsSucceeded.mockImplementation(async () => {
+      order.push("mark");
+      return claimed.length;
+    });
+
+    await expect(
+      processEinvoiceSyncChunk(env(), "run-1", "queue-message-1"),
+    ).resolves.toEqual({ status: "continue" });
+
+    const claimToken = mocks.claimEinvoiceRunItems.mock.calls[0]![1].claimToken;
+    expect(order).toEqual([
+      "renew",
+      "fetch-0",
+      "fetch-1",
+      "fetch-2",
+      "fetch-3",
+      "fetch-4",
+      "renew",
+      "fetch-5",
+      "fetch-6",
+      "fetch-7",
+      "fetch-8",
+      "fetch-9",
+      "renew",
+      "fetch-10",
+      "mark",
+    ]);
+    expect(mocks.renewEinvoiceRunChunkLease).toHaveBeenCalledTimes(3);
+    for (let call = 1; call <= 3; call += 1) {
+      expect(mocks.renewEinvoiceRunChunkLease).toHaveBeenNthCalledWith(
+        call,
+        expect.anything(),
+        {
+          runId: "run-1",
+          owner: "queue-message-1",
+          leaseMs: 3 * 60 * 1000,
+        },
+      );
+    }
+    expect(mocks.markEinvoiceRunItemsSucceeded).toHaveBeenCalledOnce();
+    expect(mocks.markEinvoiceRunItemsSucceeded.mock.calls[0]![1]).toMatchObject(
+      {
+        runId: "run-1",
+        claimToken,
+        items: claimed.map((item) => ({
+          invoiceSourceId: item.invoice_source_id,
+        })),
+      },
+    );
+    expect(mocks.releaseEinvoiceRunClaimForRetry).not.toHaveBeenCalled();
+  });
+
+  it("releases the whole claim and skips completion when a renewal is lost", async () => {
+    const claimed = Array.from({ length: 11 }, (_, index) =>
+      claimedItem(index),
+    );
+    mocks.claimEinvoiceRunItems.mockResolvedValue(claimed);
+    mocks.renewEinvoiceRunChunkLease
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    await expect(
+      processEinvoiceSyncChunk(env(), "run-1", "queue-message-1"),
+    ).rejects.toThrow("Electronic invoice detail chunk lease was lost.");
+
+    const claimToken = mocks.claimEinvoiceRunItems.mock.calls[0]![1].claimToken;
+    expect(mocks.fetchEInvoiceInvoiceDetail).toHaveBeenCalledTimes(5);
+    expect(mocks.releaseEinvoiceRunClaimForRetry).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        runId: "run-1",
+        claimToken,
+        error: "Electronic invoice detail chunk lease was lost.",
+      },
+    );
+    expect(mocks.markEinvoiceRunItemsSucceeded).not.toHaveBeenCalled();
+  });
+
+  it("continues with the pinned settings version and updates progress without changing updated_at", async () => {
+    await expect(
+      processEinvoiceSyncChunk(env(), "run-1", "queue-message-1"),
+    ).resolves.toEqual({ status: "continue" });
+
+    expect(mocks.getConnectorSettings).toHaveBeenCalledWith(
+      expect.anything(),
+      "einvoice",
+    );
+    const progressStatement = preparedStatements.find(({ sql }) =>
+      sql.includes("UPDATE connector_settings SET sync_cursor"),
+    );
+    expect(progressStatement).toBeDefined();
+    const normalizedSql = progressStatement!.sql.replace(/\s+/g, " ").trim();
+    expect(normalizedSql.split(" WHERE ")[0]).toBe(
+      "UPDATE connector_settings SET sync_cursor = ?",
+    );
+    const [cursor, expectedVersion, pinnedVersion] =
+      progressStatement!.bind.mock.calls[0]!;
+    expect(JSON.parse(cursor as string)).toMatchObject({
+      activeRunId: "run-1",
+      phase: "processing",
+    });
+    expect(expectedVersion).toBe("2026-08-12T00:00:00.000Z");
+    expect(pinnedVersion).toBe("2026-08-12T00:00:00.000Z");
+  });
+
+  it("refreshes one expired persisted session while initializing headers", async () => {
+    mocks.getEinvoiceRun.mockResolvedValueOnce({
+      id: "run-1",
+      trigger: "manual",
+      status: "queued",
+      settings_version: null,
+      total_item_count: 0,
+      pending_item_count: 0,
+      processing_item_count: 0,
+      done_item_count: 0,
+      promoted_at: null,
+    });
+    mocks.initializeEInvoiceSync.mockRejectedValueOnce(new Error("HTTP 401"));
+    mocks.claimEinvoiceRunSessionRefresh.mockResolvedValueOnce(true);
+
+    await expect(
+      processEinvoiceSyncChunk(env(), "run-1", "queue-message-1"),
+    ).resolves.toEqual({ status: "continue" });
+
+    expect(mocks.transitionEinvoiceRunStatus).toHaveBeenCalledWith(
+      expect.anything(),
+      { runId: "run-1", from: "queued", to: "initializing" },
+    );
+    expect(mocks.initializeEInvoiceSync).toHaveBeenCalledOnce();
+    expect(mocks.claimEinvoiceRunSessionRefresh).toHaveBeenCalledOnce();
+    expect(mocks.claimEinvoiceRunSessionRefresh).toHaveBeenCalledWith(
+      expect.anything(),
+      { runId: "run-1", maxRefreshes: 1 },
+    );
+    expect(mocks.resetEinvoiceRunSession).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        runId: "run-1",
+        encryptedConfig: "refreshed-encrypted-config",
+        expectedSettingsUpdatedAt: "2026-08-12T00:00:00.000Z",
+      },
+    );
+    expect(mocks.claimEinvoiceRunItems).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-refresh a fresh login failure without a persisted session", async () => {
+    mocks.getEinvoiceRun.mockResolvedValueOnce({
+      id: "run-1",
+      trigger: "manual",
+      status: "queued",
+      settings_version: null,
+      total_item_count: 0,
+      pending_item_count: 0,
+      processing_item_count: 0,
+      done_item_count: 0,
+      promoted_at: null,
+    });
+    mocks.decryptJson.mockResolvedValueOnce({
+      mobile: "0912345678",
+      password: "secret",
+      mobileBarcode: "/ABC",
+    });
+    mocks.initializeEInvoiceSync.mockRejectedValueOnce(new Error("HTTP 401"));
+
+    await expect(
+      processEinvoiceSyncChunk(env(), "run-1", "queue-message-1"),
+    ).rejects.toThrow("HTTP 401");
+
+    expect(mocks.transitionEinvoiceRunStatus).toHaveBeenCalledWith(
+      expect.anything(),
+      { runId: "run-1", from: "queued", to: "initializing" },
+    );
+    expect(mocks.claimEinvoiceRunSessionRefresh).not.toHaveBeenCalled();
+    expect(mocks.resetEinvoiceRunSession).not.toHaveBeenCalled();
+    expect(mocks.claimEinvoiceRunItems).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/tests/features/sync/report-repository.test.ts
+++ b/apps/worker/tests/features/sync/report-repository.test.ts
@@ -127,6 +127,29 @@ describe("scheduled sync financial reports", () => {
     });
   });
 
+  it("warns only for positive assets or nonzero credit-card debt", async () => {
+    const { database, db } = createDb();
+    databases.push(database);
+    database.exec(`
+      INSERT INTO bank_accounts
+        (id, connector_id, source_id, account_type, currency, raw_payload, created_at, updated_at)
+      VALUES
+        ('zero-hkd', 'esun', 'zero-hkd', 'savings', 'HKD', '{}', '2026-08-12', '2026-08-12'),
+        ('negative-usd', 'esun', 'negative-usd', 'savings', 'USD', '{}', '2026-08-12', '2026-08-12'),
+        ('card-jpy', 'esun', 'card-jpy', 'credit', 'JPY', '{}', '2026-08-12', '2026-08-12');
+      INSERT INTO bank_balance_snapshots
+        (id, connector_id, account_id, source_id, balance, currency, as_of_at, raw_payload, created_at, updated_at)
+      VALUES
+        ('zero-hkd', 'esun', 'zero-hkd', 'zero-hkd', 0, 'HKD', '2026-08-12', '{}', '2026-08-12', '2026-08-12'),
+        ('negative-usd', 'esun', 'negative-usd', 'negative-usd', -100, 'USD', '2026-08-12', '{}', '2026-08-12', '2026-08-12'),
+        ('card-jpy', 'esun', 'card-jpy', 'card-jpy', -5000, 'JPY', '2026-08-12', '{}', '2026-08-12', '2026-08-12');
+    `);
+
+    await expect(calculateCurrentFinancialSnapshot(db)).resolves.toMatchObject({
+      missingCurrencies: ["JPY"],
+    });
+  });
+
   it("returns no financial delta for a partial round but keeps new record counts", async () => {
     const { database, db } = createDb();
     databases.push(database);

--- a/apps/worker/tests/features/sync/route.test.ts
+++ b/apps/worker/tests/features/sync/route.test.ts
@@ -10,11 +10,23 @@ import {
 import type { Env } from "../../../src/platform/env";
 
 const mocks = vi.hoisted(() => ({
+  cancelQueuedEinvoiceSyncRun: vi.fn(),
+  enqueueEinvoiceSyncChunk: vi.fn(),
   prepareTaishinCaptchaSession: vi.fn(),
   prepareObankCaptchaSession: vi.fn(),
+  startEinvoiceSyncRun: vi.fn(),
   syncCtbc: vi.fn(),
   syncObank: vi.fn(),
   syncTaishin: vi.fn(),
+}));
+
+vi.mock("../../../src/features/sync/einvoice-sync-service", () => ({
+  cancelQueuedEinvoiceSyncRun: mocks.cancelQueuedEinvoiceSyncRun,
+  startEinvoiceSyncRun: mocks.startEinvoiceSyncRun,
+}));
+
+vi.mock("../../../src/features/sync/scheduler-queue", () => ({
+  enqueueEinvoiceSyncChunk: mocks.enqueueEinvoiceSyncChunk,
 }));
 
 vi.mock("../../../src/features/sync/service", () => ({
@@ -51,6 +63,12 @@ const env = {} as Env;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.startEinvoiceSyncRun.mockResolvedValue({
+    run: { id: "einvoice-run-1" },
+    created: true,
+  });
+  mocks.enqueueEinvoiceSyncChunk.mockResolvedValue(undefined);
+  mocks.cancelQueuedEinvoiceSyncRun.mockResolvedValue(undefined);
   mocks.prepareTaishinCaptchaSession.mockResolvedValue({
     captchaImage: "data:image/jpeg;base64,AQID",
     expiresAt: "2026-07-23T12:02:00.000Z",
@@ -97,6 +115,70 @@ beforeEach(() => {
       investmentTransactions: 0,
     },
     cursorUpdated: true,
+  });
+});
+
+describe("e-invoice sync route", () => {
+  it("queues a newly-created manual durable run and returns its run ID", async () => {
+    const response = await syncRoutes.request(
+      "/connectors/einvoice/sync",
+      { method: "POST" },
+      env,
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      connectorId: "einvoice",
+      scope: "all",
+      status: "queued",
+      runId: "einvoice-run-1",
+    });
+    expect(mocks.startEinvoiceSyncRun).toHaveBeenCalledWith(env, {
+      trigger: "manual",
+    });
+    expect(mocks.enqueueEinvoiceSyncChunk).toHaveBeenCalledWith(
+      env,
+      "einvoice-run-1",
+    );
+  });
+
+  it("returns a reused run without enqueueing it again", async () => {
+    mocks.startEinvoiceSyncRun.mockResolvedValueOnce({
+      run: { id: "einvoice-running" },
+      created: false,
+    });
+
+    const response = await syncRoutes.request(
+      "/connectors/einvoice/sync",
+      { method: "POST" },
+      env,
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "queued",
+      runId: "einvoice-running",
+    });
+    expect(mocks.enqueueEinvoiceSyncChunk).not.toHaveBeenCalled();
+    expect(mocks.cancelQueuedEinvoiceSyncRun).not.toHaveBeenCalled();
+  });
+
+  it("cancels only its newly-created run when Queue enqueueing fails", async () => {
+    const error = new Error("Queue unavailable");
+    mocks.enqueueEinvoiceSyncChunk.mockRejectedValueOnce(error);
+
+    const response = await syncRoutes.request(
+      "/connectors/einvoice/sync",
+      { method: "POST" },
+      env,
+    );
+
+    expect(response.status).toBe(500);
+    expect(mocks.cancelQueuedEinvoiceSyncRun).toHaveBeenCalledWith(
+      env,
+      "einvoice-run-1",
+      error,
+    );
   });
 });
 

--- a/apps/worker/tests/features/sync/scheduler-queue.test.ts
+++ b/apps/worker/tests/features/sync/scheduler-queue.test.ts
@@ -2,11 +2,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env, ScheduledSyncQueueMessage } from "../../../src/platform/env";
 
 const mocks = vi.hoisted(() => ({
+  failEinvoiceSyncRun: vi.fn(),
+  isEinvoiceUserActionError: vi.fn(),
+  processEinvoiceSyncChunk: vi.fn(),
   runSchedulerTick: vi.fn(),
 }));
 
 vi.mock("../../../src/features/sync/scheduler", () => ({
   runSchedulerTick: mocks.runSchedulerTick,
+}));
+
+vi.mock("../../../src/features/sync/einvoice-sync-service", () => ({
+  failEinvoiceSyncRun: mocks.failEinvoiceSyncRun,
+  isEinvoiceUserActionError: mocks.isEinvoiceUserActionError,
+  processEinvoiceSyncChunk: mocks.processEinvoiceSyncChunk,
 }));
 
 import {
@@ -19,6 +28,7 @@ function queueMessage(body: ScheduledSyncQueueMessage) {
     id: "message-1",
     timestamp: new Date(),
     body,
+    attempts: 1,
     ack: vi.fn(),
     retry: vi.fn(),
   } as unknown as Message<ScheduledSyncQueueMessage>;
@@ -42,6 +52,7 @@ function env(send = vi.fn().mockResolvedValue(undefined)) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.isEinvoiceUserActionError.mockReturnValue(false);
 });
 
 describe("scheduled sync queue", () => {
@@ -77,5 +88,119 @@ describe("scheduled sync queue", () => {
 
     expect(send).not.toHaveBeenCalled();
     expect(message.ack).toHaveBeenCalledOnce();
+  });
+
+  it("sends the next e-invoice chunk before acknowledging the current one", async () => {
+    const order: string[] = [];
+    const send = vi.fn(async () => order.push("send"));
+    const message = queueMessage({
+      type: "run-einvoice-chunk",
+      runId: "run-1",
+    });
+    message.ack = vi.fn(() => order.push("ack"));
+    mocks.processEinvoiceSyncChunk.mockResolvedValue({ status: "continue" });
+
+    await consumeScheduledSyncQueue(queueBatch(message), env(send));
+
+    expect(mocks.processEinvoiceSyncChunk).toHaveBeenCalledWith(
+      expect.anything(),
+      "run-1",
+      "message-1",
+    );
+    expect(send).toHaveBeenCalledWith(
+      { type: "run-einvoice-chunk", runId: "run-1" },
+      { delaySeconds: 1 },
+    );
+    expect(order).toEqual(["send", "ack"]);
+  });
+
+  it("retries transient e-invoice failures with a delay", async () => {
+    const message = queueMessage({
+      type: "run-einvoice-chunk",
+      runId: "run-1",
+    });
+    mocks.processEinvoiceSyncChunk.mockRejectedValue(new Error("HTTP 503"));
+
+    await consumeScheduledSyncQueue(queueBatch(message), env());
+
+    expect(message.retry).toHaveBeenCalledWith({ delaySeconds: 15 });
+    expect(message.ack).not.toHaveBeenCalled();
+    expect(mocks.failEinvoiceSyncRun).not.toHaveBeenCalled();
+  });
+
+  it("marks an exhausted e-invoice message failed before acknowledging it", async () => {
+    const message = {
+      ...queueMessage({ type: "run-einvoice-chunk", runId: "run-1" }),
+      attempts: 3,
+    } as unknown as Message<ScheduledSyncQueueMessage>;
+    mocks.processEinvoiceSyncChunk.mockRejectedValue(new Error("HTTP 503"));
+
+    await consumeScheduledSyncQueue(queueBatch(message), env());
+
+    expect(mocks.failEinvoiceSyncRun).toHaveBeenCalledWith(
+      expect.anything(),
+      "run-1",
+      expect.any(Error),
+      true,
+    );
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(message.retry).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges a duplicate chunk that cannot acquire the run lease", async () => {
+    const message = queueMessage({
+      type: "run-einvoice-chunk",
+      runId: "run-1",
+    });
+    mocks.processEinvoiceSyncChunk.mockResolvedValue({ status: "terminal" });
+
+    await consumeScheduledSyncQueue(queueBatch(message), env());
+
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(message.retry).not.toHaveBeenCalled();
+    expect(mocks.failEinvoiceSyncRun).not.toHaveBeenCalled();
+  });
+
+  it("requeues an active chunk after its run lease expires", async () => {
+    const order: string[] = [];
+    const send = vi.fn(async () => order.push("send"));
+    const message = queueMessage({
+      type: "run-einvoice-chunk",
+      runId: "run-1",
+    });
+    message.ack = vi.fn(() => order.push("ack"));
+    mocks.processEinvoiceSyncChunk.mockResolvedValue({
+      status: "busy",
+      retryAfterSeconds: 42,
+    });
+
+    await consumeScheduledSyncQueue(queueBatch(message), env(send));
+
+    expect(send).toHaveBeenCalledWith(
+      { type: "run-einvoice-chunk", runId: "run-1" },
+      { delaySeconds: 42 },
+    );
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(message.retry).not.toHaveBeenCalled();
+    expect(mocks.failEinvoiceSyncRun).not.toHaveBeenCalled();
+    expect(order).toEqual(["send", "ack"]);
+  });
+
+  it("retries the original busy message when delayed requeue fails", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("queue unavailable"));
+    const message = queueMessage({
+      type: "run-einvoice-chunk",
+      runId: "run-1",
+    });
+    mocks.processEinvoiceSyncChunk.mockResolvedValue({
+      status: "busy",
+      retryAfterSeconds: 42,
+    });
+
+    await consumeScheduledSyncQueue(queueBatch(message), env(send));
+
+    expect(message.retry).toHaveBeenCalledWith({ delaySeconds: 42 });
+    expect(message.ack).not.toHaveBeenCalled();
+    expect(mocks.failEinvoiceSyncRun).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/tests/features/sync/scheduler.test.ts
+++ b/apps/worker/tests/features/sync/scheduler.test.ts
@@ -5,6 +5,7 @@ import type { Env } from "../../../src/platform/env";
 
 const mocks = vi.hoisted(() => ({
   acquireSyncJobLock: vi.fn(),
+  cancelQueuedEinvoiceSyncRun: vi.fn(),
   claimCompletedDefaultScheduleBatch: vi.fn(),
   completeSyncJob: vi.fn(),
   ensureDefaultScheduleBatch: vi.fn(),
@@ -17,9 +18,15 @@ const mocks = vi.hoisted(() => ({
   releaseSyncJobLock: vi.fn(),
   safelySendScheduledSyncSummary: vi.fn(),
   safelySendSyncNotification: vi.fn(),
+  startEinvoiceSyncRun: vi.fn(),
   startSyncLockHeartbeat: vi.fn(),
   syncEsun: vi.fn(),
   syncTaishin: vi.fn(),
+}));
+
+vi.mock("../../../src/features/sync/einvoice-sync-service", () => ({
+  cancelQueuedEinvoiceSyncRun: mocks.cancelQueuedEinvoiceSyncRun,
+  startEinvoiceSyncRun: mocks.startEinvoiceSyncRun,
 }));
 
 vi.mock("@taiwan-fin-hub/db", () => ({
@@ -96,8 +103,11 @@ function syncJob(
   };
 }
 
-function env() {
-  return { DB: {} as D1Database } as Env;
+function env(send = vi.fn().mockResolvedValue(undefined)) {
+  return {
+    DB: {} as D1Database,
+    SYNC_QUEUE: { send } as unknown as Queue,
+  } as Env;
 }
 
 beforeEach(() => {
@@ -107,6 +117,11 @@ beforeEach(() => {
   mocks.completeSyncJob.mockResolvedValue(undefined);
   mocks.releaseSyncJobLock.mockResolvedValue(undefined);
   mocks.startSyncLockHeartbeat.mockReturnValue(vi.fn());
+  mocks.startEinvoiceSyncRun.mockResolvedValue({
+    run: { id: "einvoice-run-1" },
+    created: true,
+  });
+  mocks.cancelQueuedEinvoiceSyncRun.mockResolvedValue(undefined);
   mocks.syncEsun.mockResolvedValue({
     connectorId: "esun",
     scope: "all",
@@ -216,6 +231,65 @@ describe("scheduled sync rounds", () => {
       "scheduled",
       {},
     );
+  });
+
+  it("starts and enqueues a newly-created custom e-invoice durable run", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const job = syncJob("custom", "einvoice");
+    mocks.findOpenDefaultScheduleBatchId.mockResolvedValue(null);
+    mocks.findNextDueSyncJob.mockResolvedValue(job);
+
+    await expect(
+      runSchedulerTick(env(send), scheduledController),
+    ).resolves.toBe(true);
+
+    expect(mocks.startEinvoiceSyncRun).toHaveBeenCalledWith(expect.anything(), {
+      trigger: "scheduled",
+    });
+    expect(send).toHaveBeenCalledWith({
+      type: "run-einvoice-chunk",
+      runId: "einvoice-run-1",
+    });
+  });
+
+  it("does not enqueue a reused custom e-invoice run", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const job = syncJob("custom", "einvoice");
+    mocks.findOpenDefaultScheduleBatchId.mockResolvedValue(null);
+    mocks.findNextDueSyncJob.mockResolvedValue(job);
+    mocks.startEinvoiceSyncRun.mockResolvedValueOnce({
+      run: { id: "einvoice-running" },
+      created: false,
+    });
+
+    await expect(
+      runSchedulerTick(env(send), scheduledController),
+    ).resolves.toBe(true);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(mocks.cancelQueuedEinvoiceSyncRun).not.toHaveBeenCalled();
+  });
+
+  it("preserves the default batch ID when starting an e-invoice durable run", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const job = syncJob("inherit", "einvoice");
+    mocks.findOpenDefaultScheduleBatchId.mockResolvedValue(null);
+    mocks.findNextDueSyncJob.mockResolvedValue(job);
+    mocks.ensureDefaultScheduleBatch.mockResolvedValue("default:einvoice");
+    mocks.findNextDefaultScheduleBatchJob.mockResolvedValue(job);
+
+    await expect(
+      runSchedulerTick(env(send), scheduledController),
+    ).resolves.toBe(true);
+
+    expect(mocks.startEinvoiceSyncRun).toHaveBeenCalledWith(expect.anything(), {
+      trigger: "scheduled",
+      scheduledBatchId: "default:einvoice",
+    });
+    expect(send).toHaveBeenCalledWith({
+      type: "run-einvoice-chunk",
+      runId: "einvoice-run-1",
+    });
   });
 
   it("reports whether a job was processed so the queue can continue", async () => {

--- a/docs/001-cron-sync-design.md
+++ b/docs/001-cron-sync-design.md
@@ -5,6 +5,10 @@
 > 本文件後續內容保留最初 v1 設計背景；現行架構以
 > [`002-backend-architecture.md`](002-backend-architecture.md) 為準。
 
+> 電子發票的同步明細現採 durable run：建立 run 後由 Queue 分段處理，每個
+> invocation 最多取得 35 張發票明細，再 enqueue 下一段。這不是使用者設定；
+> 前端不再提供「同步品項明細」選項，電子發票一律同步明細。
+
 ## Context
 
 Taiwan Fin Hub currently syncs data only through authenticated API requests from the web UI:
@@ -51,7 +55,7 @@ Default v1 intervals:
 
 | Job            | Default interval | Notes                                                                                                                                         |
 | -------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `einvoice/all` | 24 hours         | Fetch invoice list and details.                                                                                                               |
+| `einvoice/all` | 24 hours         | Fetch invoice list and details. Details are always enabled and are processed by durable Queue chunks.                                         |
 | `tdcc/all`     | 24 hours         | Sync positions, settlement bank data, and trade history together. Reuse trusted session only; disable the scheduled job when OTP is required. |
 | `esun/all`     | 24 hours         | Reuse valid session only in v1.                                                                                                               |
 
@@ -123,7 +127,7 @@ The scheduler framework treats `scope` as connector-local data. For example, TDC
 
 | Connector  | Scheduled behavior                                                                                                                                                                         | Reasoning                                                                                                                                                                                       |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `einvoice` | Run when `sync_jobs.next_run_at` is due, with `fetchDetails: true`.                                                                                                                        | Login token and mobile barcode can be refreshed and stored in encrypted config. Writes are idempotent by `connector_id + source_id`.                                                            |
+| `einvoice` | Run when `sync_jobs.next_run_at` is due. Header discovery and every invoice's line-item detail are always synchronized; detail work is continued in Queue chunks.                          | Login token and mobile barcode can be refreshed and stored in encrypted config. Writes are idempotent by `connector_id + source_id`.                                                            |
 | `tdcc`     | Run `tdcc/all` when due: positions, settlement bank data, and trade history are synced in one connector job. If OTP is required, mark `needs_user_action` and set `sync_jobs.enabled = 0`. | TDCC device verification is interactive. The TDCC scopes share cursor/session state, so scheduled sync treats them as one connector job.                                                        |
 | `esun`     | Run when due if stored session cookies are still valid; allow browser login only after an explicit config flag is added.                                                                   | Current implementation can perform browser login with credentials, but automated bank login may trigger duplicate-login or security checks. V1 should prefer session reuse and manual recovery. |
 
@@ -141,6 +145,35 @@ For v1, seeded `sync_jobs` rows should mean:
 - `einvoice`: enabled.
 - `tdcc`: enabled, but no OTP automation.
 - `esun`: enabled for valid-session reuse only.
+
+## 電子發票 Durable Run
+
+電子發票清單與品項明細可能超過單一 Worker invocation 的 external subrequest
+額度，因此不以一次 connector sync 完成所有明細。建立 `einvoice_sync_runs` 與
+`einvoice_sync_run_items` 保存 run、已發現的 header、每張明細的狀態與 retry
+資訊；同一時間只允許一個 active electronic-invoice run。
+
+1. 手動 API 或排程先建立／取得 active run，取得 connector lock 後只 enqueue
+   `run-einvoice-chunk`，HTTP 回應為已排入同步，並不等待明細完成。
+2. 第一個 chunk 初始化或更新可恢復的登入 session，取得最近兩期 header，並以
+   `connector_id + source_id` 將待抓明細寫入 run items。品項明細固定同步，沒有
+   `fetchDetails` public config 或 request override。
+3. 每個 Queue invocation 最多 claim 35 張 pending 明細。成功的整批 item 以一次
+   set-based D1 寫入標記 `done`；失敗的 claim 會釋放為可 retry。尚有 pending 或 processing item 時，
+   consumer enqueue 下一個 chunk，而非在同一 invocation 繼續呼叫外部 API。
+4. 只有所有 item 都完成後，才把 durable run items 當作 staging source，以固定五個
+   set-based D1 statements 一次寫入發票與品項，並更新完成 cursor。查詢數不隨品項數
+   成長；`settings_version` CAS 防止同步期間更新憑證後混入舊資料，`promoted_at` 讓
+   Queue 重送時可安全跳過重複 promotion。`sync_jobs` 與排程批次結果在後續終態 batch
+   一併完成。
+5. 可恢復的外部錯誤採 Queue retry；登入失效會清除可恢復 session 並回到初始化。
+   憑證／互動式登入問題終止為 `needs_user_action`，重試達上限的其他錯誤終止為
+   `failed`。終止前不 promotion 部分明細，避免資料與 cursor 不一致。
+
+Run 與每個 item 都有 lease。處理明細時每五張 rolling renew run lease，Queue 訊息重送或並行
+delivery 必須先取得 run chunk lease；沒有取得者不可平行處理或解除另一個 invocation 的 lease。item
+claim token 在完成／釋放時提供 CAS，只有 run lease 過期並被接管後才可 reclaim 過期 item。connector lock
+維持到 completed、failed 或 needs_user_action，確保手動與排程不會互相覆寫。
 
 ## Job State and Locking
 

--- a/docs/002-backend-architecture.md
+++ b/docs/002-backend-architecture.md
@@ -422,6 +422,20 @@ invocation 因此不必等待下一個 10 分鐘 Cron，且擁有獨立的 Worke
 逐一執行。是否到期仍由 D1 sync job 狀態判斷；沒有可執行工作時 consumer 不再送出訊息，
 結束本次串接。
 
+電子發票不在單一 connector invocation 內擷取所有品項明細。它使用
+`einvoice_sync_runs` / `einvoice_sync_run_items` 作為 durable work queue：手動或排程
+建立 run 後 enqueue `run-einvoice-chunk`，每個 Queue invocation 最多 claim 並取得 35
+張發票明細，並以 set-based D1 寫入完成整批；仍有 pending work 時再 enqueue continuation。品項明細一律同步，並非
+`public_config`、HTTP request 或 catalog 可選的 `fetchDetails` 偏好。
+
+電子發票 run 與 item 都以 owner-scoped rolling lease 防止 Queue delivery 重送時平行處理。
+只有全部 item 成功後，service 才把 durable run items 當作 staging source，以固定五個
+set-based D1 statements promotion 至正式表並更新 cursor；這個 batch 以設定版本 CAS 防止
+憑證更新競態。後續 finalize path 更新 `sync_jobs`、排程批次結果與通知；`promoted_at` 讓
+promotion 前後的重送皆可冪等。
+暫時錯誤由 Queue retry，session 失效會清除 session 後重新初始化；需要使用者操作或重試
+耗盡才將 run 結案為 `needs_user_action` 或 `failed`，不寫入部分完成的明細。
+
 ## 同步結果通知
 
 同步結果通知位於 `apps/worker/src/features/notifications/`，不放入 sync repository。

--- a/docs/004-connector-development.md
+++ b/docs/004-connector-development.md
@@ -37,7 +37,7 @@ Connector 採三層 registry：
 
 | 狀態           | 儲存位置                         | 允許內容                                                     |
 | -------------- | -------------------------------- | ------------------------------------------------------------ |
-| 公開偏好       | `public_config`                  | 是否抓電子發票品項明細等非敏感選項                           |
+| 公開偏好       | `public_config`                  | 使用者可調整、且不影響敏感狀態的 connector 偏好              |
 | 機密設定       | `encrypted_config`               | 帳密、cookie、access token、device token、Browser session ID |
 | 同步 cursor    | `sync_cursor`                    | 日期、頁碼、watermark、已完成區間等非敏感增量位置            |
 | 暫時 challenge | `encrypted_config`，且必須有 TTL | CAPTCHA、OTP、待提交的 API／Browser session                  |
@@ -49,6 +49,7 @@ Connector 採三層 registry：
 - 舊版已存在於 cursor 的 session 不得直接由 D1 migration 刪除；應讓新版 connector 相容讀取一次，並在首次成功同步時搬入 `encrypted_config`，避免強迫使用者重新驗證。
 - 公開設定透過 `parsePublicConnectorConfig` 合併後再交給 config schema；不得把相同欄位複製到 encrypted config。
 - 同步回溯範圍是 connector 的 runtime policy，不得做成公開偏好：電子發票固定同步最近 2 期；銀行 connector 固定同步最近 3 個月或 3 期帳單。舊版 `periodsBack` 與 `lookbackMonths` 必須忽略並在後續設定儲存時移除。
+- 電子發票品項明細是固定同步 policy，不是公開偏好：不得新增 `fetchDetails` catalog field、前端 checkbox 或 sync request override。既有 `public_config.fetchDetails` 在 migration 與下一次設定儲存時必須移除。
 - 任一 credential 變更時，必須清除 catalog `resetOnCredentialChangeFields` 宣告的衍生狀態與既有 cursor。
 - Challenge 成功、失敗或逾時後都必須清除 CAPTCHA、OTP 與 Browser session reference。
 - Log、錯誤回應與 `raw` 不得包含帳密、完整帳號／卡號、cookie 或 token。
@@ -89,7 +90,9 @@ Connector 不得依賴 Hono、D1、Worker `Env`，也不得直接寫入資料庫
 - 日期使用 ISO 8601；帳單期間使用 `YYYY-MM`；幣別使用大寫代碼。
 - 支出與負債為負，退款與入帳為正。
 - `raw` 只能保留遮罩或白名單資料，主要功能不得依賴 raw shape。
-- 所有資料必須經 `record-mapper.ts` 與 staged persistence。資料 promotion、cursor 與 secret state 更新必須放在同一 finalize batch。
+- 一般 connector 的資料必須經 `record-mapper.ts` 與 staged persistence；durable-run
+  connector 可直接以其 run item table 作為 staging source。資料 promotion 與 cursor
+  必須放在同一 guarded D1 batch，secret state 需以設定版本 CAS 保護。
 
 ## 路由、排程與 challenge
 
@@ -100,6 +103,28 @@ Connector 不得依賴 Hono、D1、Worker `Env`，也不得直接寫入資料庫
 - 排程不得主動寄送 OTP；需要互動時標記 `needs_user_action`。
 - 若外部服務支援接管其他登入中的裝置，必須明確定義手動與排程的 `force` policy，並在介面與使用文件提示可能中斷使用者目前的工作階段。
 - 新 connector 必須透過 D1 migration 建立 `<connectorId>:all` sync job，預設停用。
+
+### 電子發票分段明細同步
+
+電子發票是例外的 durable-run connector，不能使用一般 `runConnectorSync` 的單次
+同步流程。`einvoice_sync_runs` 保存 run lifecycle，`einvoice_sync_run_items` 保存
+已發現的發票 header 與每張明細的處理狀態；run items 本身也是 promotion 的 durable
+staging source。設定儲存、登入 session 與資料 promotion 仍遵守本文件的敏感狀態與
+設定版本 CAS 規則。
+
+- 啟動手動或排程同步時只建立／取得 active run 並 enqueue `run-einvoice-chunk`；API
+  可以回傳已排入同步，前端必須依 sync job lifecycle 顯示完成結果。
+- 初始化只取得清單並 durable 地寫入 item；明細一律同步。每個 Queue invocation 最多
+  claim 並擷取 35 張發票，完成狀態以 set-based D1 寫入；若尚有工作便 enqueue continuation，不能在同一 invocation
+  繼續處理下一批。
+- item claim、run chunk 都必須使用 owner-scoped lease；明細處理期間每五張 rolling renew
+  run lease，item 完成／釋放則以 claim token CAS。Queue 重送時只可接管已過期的 run lease
+  與 item，且不得解除其他 invocation 的 lease。
+- 所有 item `done` 前不得 promotion。完成後由 run items 以固定五個 set-based statements
+  一次 promotion invoice 與 line item，並以設定版本 CAS 在同一 batch 更新 cursor；後續
+  finalize path 更新 sync job 和排程批次結果。`promoted_at` 必須使重送可冪等。
+- 暫時外部錯誤釋放 item claim 並使用 Queue retry；session 過期清除已保存 session 後回到
+  初始化；憑證或互動式登入需求則標記 `needs_user_action`，retry 上限後標記 `failed`。
 
 ## 測試最低要求
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,8 +84,15 @@
         "@cloudflare/workers-types": "^4.20260621.1",
         "@types/web-push": "^3.6.4",
         "vitest": "^4.1.10",
-        "wrangler": "^4.103.0"
+        "wrangler": "^4.121.0"
       }
+    },
+    "apps/worker/node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.5.0",
@@ -235,9 +242,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260617.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260617.1.tgz",
-      "integrity": "sha512-jWwmgEVVWbsHNrLSNXzwjJaH90VzRxq1cWkQFUidxyeUPnMxemeNE8I9qFAfrpzGgE11e9sKDcE3ettJW08swQ==",
+      "version": "1.20260804.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260804.1.tgz",
+      "integrity": "sha512-191/PPEFicRK2wK69eXzSjnLgHL79k7zR2VUpyIr8rhFgGns1b5bTHgnBuUrgU2LPbEtwbE5eL2hJ0uhLAFEow==",
       "cpu": [
         "x64"
       ],
@@ -252,9 +259,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260617.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260617.1.tgz",
-      "integrity": "sha512-LHH7b565g9znfCUOkwbec6FG2rmRbsgCy6aJiU9KN662mNheWl5sw/iKleiFSiljPKQQP3HkjnC/NSkdgi/aSA==",
+      "version": "1.20260804.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260804.1.tgz",
+      "integrity": "sha512-aI2cAFLsrNkSz3kLSQrgrO9ICTfY7jb2h0jgaWDE9mQLQQDfpXeYrKWt07tTgMmeNP79o9w3NZe3aqtt8mTGHQ==",
       "cpu": [
         "arm64"
       ],
@@ -269,9 +276,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260617.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260617.1.tgz",
-      "integrity": "sha512-FMnaAKXe4Cfd8TQurCVd9fs2XQVBFRCsP+Id/SRdUv89MlwYu9zXfoyx6BxM+brPTIUK38SHbo8iaxiwzLi9JQ==",
+      "version": "1.20260804.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260804.1.tgz",
+      "integrity": "sha512-KBCjxBIlN2jucfQGaTK4EgmPsWzQgYR/zYhPfi3mkWwdoTyG1dgrt2aizKps/SYse85ci/SOxojKk0/K7vstPw==",
       "cpu": [
         "x64"
       ],
@@ -286,9 +293,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260617.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260617.1.tgz",
-      "integrity": "sha512-MRoifFYcqbxxIIQy7PqO5tFY/qPFSnjXzakWl0sO93l+HLyG35jRAgOi6jfqa4kBxc7gKKtH861DcewjxUfkjA==",
+      "version": "1.20260804.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260804.1.tgz",
+      "integrity": "sha512-7lswfarBZ7xkHpTFrNb74ExwOltIalVaASc+GOYfCNtnwFxK/JZSVByfm/hnZEBtrHU7fMY2z7dYT64rwS0pHg==",
       "cpu": [
         "arm64"
       ],
@@ -303,9 +310,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260617.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260617.1.tgz",
-      "integrity": "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw==",
+      "version": "1.20260804.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260804.1.tgz",
+      "integrity": "sha512-GOgRWYtxISN5rAWfx3K7zubt3xEn0/ZPFrbcLL+GwT4ouCKyNoHqfT1cPNB6Nx7t8BHEjnuTG7gkHO4Wd5ORdg==",
       "cpu": [
         "x64"
       ],
@@ -318,13 +325,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260621.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260621.1.tgz",
-      "integrity": "sha512-c4xrf4shZdDOK1ihh1UKzlS/3MDYiGThT/Oqr4Y3qR9NLCSNzHB7rt+Vk/LOp0ZSNjA+7WNJEQsOhpiQtpT2GA==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1045,9 +1045,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
       "cpu": [
         "arm64"
       ],
@@ -1058,19 +1058,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
       "cpu": [
         "x64"
       ],
@@ -1081,19 +1081,39 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
       "cpu": [
         "arm64"
       ],
@@ -1108,9 +1128,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
       "cpu": [
         "x64"
       ],
@@ -1125,9 +1145,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
       "cpu": [
         "arm"
       ],
@@ -1142,9 +1162,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
       "cpu": [
         "arm64"
       ],
@@ -1159,9 +1179,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
       "cpu": [
         "ppc64"
       ],
@@ -1176,9 +1196,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
       "cpu": [
         "riscv64"
       ],
@@ -1193,9 +1213,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
       "cpu": [
         "s390x"
       ],
@@ -1210,9 +1230,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
       "cpu": [
         "x64"
       ],
@@ -1227,9 +1247,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
       "cpu": [
         "arm64"
       ],
@@ -1244,9 +1264,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
       "cpu": [
         "x64"
       ],
@@ -1261,9 +1281,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
       "cpu": [
         "arm"
       ],
@@ -1274,19 +1294,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
       "cpu": [
         "arm64"
       ],
@@ -1297,19 +1317,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
       "cpu": [
         "ppc64"
       ],
@@ -1320,19 +1340,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
       "cpu": [
         "riscv64"
       ],
@@ -1343,19 +1363,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
       "cpu": [
         "s390x"
       ],
@@ -1366,19 +1386,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
       "cpu": [
         "x64"
       ],
@@ -1389,19 +1409,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
       "cpu": [
         "arm64"
       ],
@@ -1412,19 +1432,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
       "cpu": [
         "x64"
       ],
@@ -1435,39 +1455,56 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
       "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
       "cpu": [
         "arm64"
       ],
@@ -1478,16 +1515,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
       "cpu": [
         "ia32"
       ],
@@ -1498,16 +1535,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
       "cpu": [
         "x64"
       ],
@@ -1518,7 +1555,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1725,18 +1762,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2010,9 +2035,9 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
-      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -4622,21 +4647,18 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260617.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260617.1.tgz",
-      "integrity": "sha512-Go3/gzStm99QHptsSgU+q1S+xDfLoRgwjJNY80kaTVi0ENhTyqKq+sc4xZiWBSbM7uUcJwmzm8+QFKtcYLJ9nw==",
+      "version": "5.20260804.1-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260804.1-alpha.tgz",
+      "integrity": "sha512-J0QBHEj+d75TyFE9VhH+2dXgvdYt/pfyDlm+9IiYUFocQvqYy9iuW1DIqNawh1N7Kr6iMrDzVkgDSdt6pA75uA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "0.34.5",
-        "undici": "7.28.0",
-        "workerd": "1.20260617.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260804.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -5198,62 +5220,61 @@
         "node": ">=v12.22.7"
       }
     },
-    "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
-    "node_modules/sharp/node_modules/semver": {
+    "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
       }
     },
     "node_modules/siginfo": {
@@ -5741,9 +5762,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6067,9 +6088,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260617.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260617.1.tgz",
-      "integrity": "sha512-Re5pl6pdowt3ZmWUzGlOuB7jbRIIPetgKalmo4cYmucQnVhpo7/3e4MfpekbhLi2EhZZz5EY9NWRu8zFzuEZew==",
+      "version": "1.20260804.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260804.1.tgz",
+      "integrity": "sha512-b0P38g5/ssemwWxd/mafNYggEZ0ere7PCiUH6RCHkgqjRhhXTP45nDiL2L3iIvi8uF2IjNrGpVgMXEunCaeY/w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -6080,17 +6101,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260617.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260617.1",
-        "@cloudflare/workerd-linux-64": "1.20260617.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260617.1",
-        "@cloudflare/workerd-windows-64": "1.20260617.1"
+        "@cloudflare/workerd-darwin-64": "1.20260804.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260804.1",
+        "@cloudflare/workerd-linux-64": "1.20260804.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260804.1",
+        "@cloudflare/workerd-windows-64": "1.20260804.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.103.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.103.0.tgz",
-      "integrity": "sha512-3Lv1P5t2xcSEkSTKtG+Lz+3JFryuU7YPLkaCUj7gNe+CJsjZJLtUwqsh1x595QBxkIbCE0GAvDx2DCJUU4+oqw==",
+      "version": "4.121.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.121.0.tgz",
+      "integrity": "sha512-dcARWk6CyaD0vJBSLjJn4K2yo+mYko73hzryq+t/9DXnyAq877RWIMl7uOMcDKs5dDXdoickNhZTKxBYT9XKsA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -6098,10 +6119,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260617.1",
+        "miniflare": "5.20260804.1-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260617.1"
+        "workerd": "1.20260804.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -6115,7 +6136,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260617.1"
+        "@cloudflare/workers-types": "^5.20260804.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -6294,6 +6315,13 @@
         "@cloudflare/workers-types": "^4.20240620.0",
         "vitest": "^4.1.10"
       }
+    },
+    "packages/db/node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     }
   }
 }

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -131,13 +131,66 @@ export const invoiceConfigSchema = z.object({
   ltoken: z.string().optional(),
   hkey: z.string().optional(),
   serverTimeOffset: z.number().int().optional(),
-  fetchDetails: z.boolean().default(true),
 });
 
 export type InvoiceConfig = z.infer<typeof invoiceConfigSchema>;
 export function parseInvoiceConfig(config: unknown) {
   return invoiceConfigSchema.parse(config);
 }
+
+type NormalizedInvoice = Omit<Invoice, "id" | "connectorId">;
+type NormalizedInvoiceLineItem = Omit<
+  InvoiceLineItem,
+  "id" | "connectorId" | "invoiceId"
+>;
+
+/** JSON-serializable protocol state which is safe to persist between Queue invocations. */
+export type EInvoiceSessionConfigUpdates = Pick<
+  EInvoiceV2Session,
+  | "sid"
+  | "token"
+  | "iv"
+  | "svrCode"
+  | "loginAppId"
+  | "loginLiat"
+  | "loginSsMe"
+  | "ltoken"
+  | "hkey"
+  | "serverTimeOffset"
+> & {
+  loginClientCode?: string;
+  mobileBarcode?: string;
+};
+
+export type EInvoiceInvoiceHeader = {
+  sourceId: string;
+  invNum: string;
+  detailInvDate: string;
+  invoice: NormalizedInvoice;
+  period: ReturnType<typeof periodFromIndex>;
+};
+
+/** A fully serializable work item for one detail request. */
+export type EInvoiceDetailTask = EInvoiceInvoiceHeader;
+
+export type EInvoiceSyncInitialization = {
+  session: EInvoiceV2Session;
+  configUpdates: EInvoiceSessionConfigUpdates;
+  headers: EInvoiceInvoiceHeader[];
+  detailTasks: EInvoiceDetailTask[];
+};
+
+export type EInvoiceDetailResult = {
+  invoice: NormalizedInvoice;
+  invoiceLineItems: NormalizedInvoiceLineItem[];
+  detail: unknown;
+  detailItems: ReturnType<typeof getV2DetailItems>;
+};
+
+export type EInvoicePrimitiveOptions = {
+  client?: EInvoiceV2Client;
+  now?: Date;
+};
 
 export const einvoiceConnector: Connector<
   InvoiceConfig,
@@ -169,16 +222,147 @@ async function syncTaiwanEInvoices(config: InvoiceConfig, cursor?: string) {
 }
 
 async function syncTaiwanEInvoicesV2(config: InvoiceConfig, cursor?: string) {
+  const initialized = await initializeEInvoiceSync(config);
+  Object.assign(config, initialized.configUpdates);
+  const details: EInvoiceDetailResult[] = [];
+  for (const task of initialized.detailTasks) {
+    details.push(await fetchEInvoiceInvoiceDetail(initialized.session, task));
+  }
+  const detailsBySourceId = new Map(
+    details.map((detail) => [detail.invoice.sourceId, detail]),
+  );
+  const records = initialized.headers.map((header) => {
+    const detail = detailsBySourceId.get(header.sourceId);
+    return {
+      ...header.invoice,
+      raw: {
+        ...(header.invoice.raw as Record<string, unknown>),
+        detail: detail?.detail,
+        detailItems: detail?.detailItems ?? [],
+      },
+    };
+  });
+  const invoiceLineItems = details.flatMap((detail) => detail.invoiceLineItems);
+  const now = new Date();
+  const currentIndex = currentPeriodIndex(now);
+
+  return {
+    records: dedupeInvoices(records),
+    invoiceLineItems: dedupeInvoiceLineItems(invoiceLineItems),
+    detailErrorCount: 0,
+    cursor: JSON.stringify({
+      syncedAt: now.toISOString(),
+      previousSyncedAt: cursor ? readPreviousSyncedAt(cursor) : undefined,
+      latestPeriodIndex: currentIndex,
+      syncedPeriods: EINVOICE_SYNC_PERIODS,
+    }),
+  };
+}
+
+/**
+ * Login (or restore a persisted session) and retrieve headers for exactly the
+ * fixed two invoice periods. No detail request is made here.
+ */
+export async function initializeEInvoiceSync(
+  config: InvoiceConfig,
+  options: EInvoicePrimitiveOptions = {},
+): Promise<EInvoiceSyncInitialization> {
   if (!config.mobile || !config.password) {
     throw new Error("新版電子發票需要手機號碼與密碼。");
   }
 
-  const client = new EInvoiceV2Client({
-    androidId: config.androidId,
-    loginClientCode: config.loginClientCode,
-    ptoken: config.ptoken,
-  });
-  let session: EInvoiceV2Session;
+  const client =
+    options.client ??
+    new EInvoiceV2Client({
+      androidId: config.androidId,
+      loginClientCode: config.loginClientCode,
+      ptoken: config.ptoken,
+    });
+  const session = jsonEInvoiceSession(await getEInvoiceSession(config, client));
+  const carrierCode = config.mobileBarcode ?? session.carrierCode;
+  if (!carrierCode) throw new Error("新版電子發票登入未回傳手機條碼。");
+  session.carrierCode = carrierCode;
+
+  const now = options.now ?? new Date();
+  const currentIndex = currentPeriodIndex(now);
+  const headers: EInvoiceInvoiceHeader[] = [];
+  for (let offset = 0; offset < EINVOICE_SYNC_PERIODS; offset += 1) {
+    const period = periodFromIndex(currentIndex - offset, now);
+    const payload = await client.queryCarrierInvoices(
+      session,
+      period.startDate,
+      period.endDate,
+    );
+    for (const invoice of getV2Invoices(payload)) {
+      const sourceId = invoiceSourceId(
+        invoice.invNum,
+        invoice.invDate,
+        invoice.id,
+      );
+      headers.push({
+        sourceId,
+        invNum: invoice.invNum,
+        detailInvDate: invoice.detailInvDate,
+        invoice: {
+          sourceId,
+          invoiceNumber: invoice.invNum || undefined,
+          invoiceDate: normalizeInvoiceDate(invoice.invDate),
+          sellerName: invoice.sellerName,
+          amount: Math.max(0, Math.trunc(invoice.amount)),
+          raw: { invoice, period },
+        },
+        period,
+      });
+    }
+  }
+
+  return {
+    session,
+    configUpdates: sessionConfigUpdates(session),
+    headers,
+    detailTasks: headers.filter((header): header is EInvoiceDetailTask =>
+      Boolean(header.invNum && header.detailInvDate),
+    ),
+  };
+}
+
+/**
+ * Fetch and normalize one invoice's detail. Errors deliberately propagate so
+ * Queue chunks and the legacy full sync cannot report a partial success.
+ */
+export async function fetchEInvoiceInvoiceDetail(
+  session: EInvoiceV2Session,
+  task: EInvoiceDetailTask,
+  options: EInvoicePrimitiveOptions = {},
+): Promise<EInvoiceDetailResult> {
+  const client = options.client ?? new EInvoiceV2Client();
+  const detail = await client.queryCarrierInvoiceDetail(
+    session,
+    task.invNum,
+    task.detailInvDate,
+  );
+  const detailItems = getV2DetailItems(detail);
+  return {
+    invoice: task.invoice,
+    detail,
+    detailItems,
+    invoiceLineItems: detailItems.map((item, index) => ({
+      invoiceSourceId: task.sourceId,
+      sourceId: item.id || String(index + 1),
+      lineNumber: index + 1,
+      description: item.description || "未命名品項",
+      quantity: parseOptionalNumber(item.quantity),
+      unitPrice: parseOptionalInteger(item.unitPrice),
+      amount: parseRequiredInteger(item.amount),
+      raw: item,
+    })),
+  };
+}
+
+async function getEInvoiceSession(
+  config: InvoiceConfig,
+  client: EInvoiceV2Client,
+) {
   if (
     config.sid &&
     config.token &&
@@ -186,7 +370,7 @@ async function syncTaiwanEInvoicesV2(config: InvoiceConfig, cursor?: string) {
     config.loginLiat != null &&
     config.loginSsMe
   ) {
-    session = {
+    return {
       sid: config.sid,
       token: config.token,
       iv: config.iv,
@@ -199,111 +383,70 @@ async function syncTaiwanEInvoicesV2(config: InvoiceConfig, cursor?: string) {
       hkey: config.hkey,
       serverTimeOffset: config.serverTimeOffset,
       carrierCode: config.mobileBarcode,
-    };
-  } else {
-    try {
-      session = await client.login({
-        mobile: config.mobile,
-        password: config.password,
-        androidId: config.androidId,
-        loginClientCode: config.loginClientCode,
-        ptoken: config.ptoken,
-        loginType: config.loginType,
-        carrierCode: config.mobileBarcode,
-      });
-    } catch (error) {
-      throw new Error(
-        `電子發票登入失敗：${error instanceof Error ? error.message : "發生未知錯誤"}`,
-      );
-    }
-    Object.assign(config, session);
-    config.loginClientCode = session.clientCode ?? config.loginClientCode;
-    config.mobileBarcode = session.carrierCode ?? config.mobileBarcode;
+    } satisfies EInvoiceV2Session;
   }
-
-  const carrierCode = config.mobileBarcode ?? session.carrierCode;
-  if (!carrierCode) throw new Error("新版電子發票登入未回傳手機條碼。");
-  session.carrierCode = carrierCode;
-
-  const now = new Date();
-  const currentIndex = currentPeriodIndex(now);
-  const periodIndexes = Array.from(
-    { length: EINVOICE_SYNC_PERIODS },
-    (_, index) => currentIndex - index,
-  );
-  const records: Array<Omit<Invoice, "id" | "connectorId">> = [];
-  const invoiceLineItems: Array<
-    Omit<InvoiceLineItem, "id" | "connectorId" | "invoiceId">
-  > = [];
-  let detailErrorCount = 0;
-
-  for (const periodIndex of periodIndexes) {
-    const period = periodFromIndex(periodIndex, now);
-    const payload = await client.queryCarrierInvoices(
-      session,
-      period.startDate,
-      period.endDate,
+  try {
+    return await client.login({
+      mobile: config.mobile!,
+      password: config.password!,
+      androidId: config.androidId,
+      loginClientCode: config.loginClientCode,
+      ptoken: config.ptoken,
+      loginType: config.loginType,
+      carrierCode: config.mobileBarcode,
+    });
+  } catch (error) {
+    throw new Error(
+      `電子發票登入失敗：${error instanceof Error ? error.message : "發生未知錯誤"}`,
     );
-    const invoices = getV2Invoices(payload);
-    for (const invoice of invoices) {
-      const sourceId = invoiceSourceId(
-        invoice.invNum,
-        invoice.invDate,
-        invoice.id,
-      );
-      let detail: unknown;
-      let detailItems: ReturnType<typeof getV2DetailItems> = [];
-      if (config.fetchDetails && invoice.invNum && invoice.detailInvDate) {
-        try {
-          detail = await client.queryCarrierInvoiceDetail(
-            session,
-            invoice.invNum,
-            invoice.detailInvDate,
-          );
-          detailItems = getV2DetailItems(detail);
-          detailItems.forEach((item, index) => {
-            invoiceLineItems.push({
-              invoiceSourceId: sourceId,
-              sourceId: item.id || String(index + 1),
-              lineNumber: index + 1,
-              description: item.description || "未命名品項",
-              quantity: parseOptionalNumber(item.quantity),
-              unitPrice: parseOptionalInteger(item.unitPrice),
-              amount: parseRequiredInteger(item.amount),
-              raw: item,
-            });
-          });
-        } catch (error) {
-          detailErrorCount += 1;
-          detail = {
-            error:
-              error instanceof Error
-                ? error.message
-                : "Unable to fetch invoice detail.",
-          };
-        }
-      }
-      records.push({
-        sourceId,
-        invoiceNumber: invoice.invNum || undefined,
-        invoiceDate: normalizeInvoiceDate(invoice.invDate),
-        sellerName: invoice.sellerName,
-        amount: Math.max(0, Math.trunc(invoice.amount)),
-        raw: { invoice, period, detail, detailItems },
-      });
-    }
   }
+}
 
+function sessionConfigUpdates(
+  session: EInvoiceV2Session,
+): EInvoiceSessionConfigUpdates {
   return {
-    records: dedupeInvoices(records),
-    invoiceLineItems: dedupeInvoiceLineItems(invoiceLineItems),
-    detailErrorCount,
-    cursor: JSON.stringify({
-      syncedAt: now.toISOString(),
-      previousSyncedAt: cursor ? readPreviousSyncedAt(cursor) : undefined,
-      latestPeriodIndex: currentIndex,
-      syncedPeriods: EINVOICE_SYNC_PERIODS,
-    }),
+    sid: session.sid,
+    token: session.token,
+    loginAppId: session.loginAppId,
+    loginLiat: session.loginLiat,
+    loginSsMe: session.loginSsMe,
+    ...(session.iv === undefined ? {} : { iv: session.iv }),
+    ...(session.svrCode === undefined ? {} : { svrCode: session.svrCode }),
+    ...(session.ltoken === undefined ? {} : { ltoken: session.ltoken }),
+    ...(session.hkey === undefined ? {} : { hkey: session.hkey }),
+    ...(session.serverTimeOffset === undefined
+      ? {}
+      : { serverTimeOffset: session.serverTimeOffset }),
+    ...(session.clientCode === undefined
+      ? {}
+      : { loginClientCode: session.clientCode }),
+    ...(session.carrierCode === undefined
+      ? {}
+      : { mobileBarcode: session.carrierCode }),
+  };
+}
+
+function jsonEInvoiceSession(session: EInvoiceV2Session): EInvoiceV2Session {
+  return {
+    sid: session.sid,
+    token: session.token,
+    loginAppId: session.loginAppId,
+    loginLiat: session.loginLiat,
+    loginSsMe: session.loginSsMe,
+    ...(session.iv === undefined ? {} : { iv: session.iv }),
+    ...(session.svrCode === undefined ? {} : { svrCode: session.svrCode }),
+    ...(session.clientCode === undefined
+      ? {}
+      : { clientCode: session.clientCode }),
+    ...(session.ltoken === undefined ? {} : { ltoken: session.ltoken }),
+    ...(session.hkey === undefined ? {} : { hkey: session.hkey }),
+    ...(session.carrierCode === undefined
+      ? {}
+      : { carrierCode: session.carrierCode }),
+    ...(session.serverTimeOffset === undefined
+      ? {}
+      : { serverTimeOffset: session.serverTimeOffset }),
   };
 }
 

--- a/packages/connectors/src/tw-einvoice-v2.ts
+++ b/packages/connectors/src/tw-einvoice-v2.ts
@@ -37,6 +37,10 @@ export type EInvoiceV2Options = {
   loginType?: number;
   osVersion?: string;
   userAgent?: string;
+  /** Cancels every request made by this client when the caller aborts it. */
+  signal?: AbortSignal;
+  /** Per-request deadline. Defaults to 30 seconds. */
+  timeoutMs?: number;
   fetchImpl?: typeof fetch;
 };
 
@@ -51,6 +55,7 @@ const PROD_BIG_HOST = "https://upi.einvoice.nat.gov.tw";
 const DEFAULT_APP_VERSION = "6.800.2";
 const DEFAULT_APP_BUILD = 66;
 const DEFAULT_USER_AGENT = "okhttp/5.3.0";
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const ALPHANUMERIC =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
@@ -426,9 +431,13 @@ export class EInvoiceV2Client {
       pdid: `a:${androidId}`,
     };
     const encrypted = await encryptLoginDataWithContext(inner);
-    const body = await this.middleRequest("/mid/v1/login", {
-      ldata: encrypted.value,
-    });
+    const body = await this.middleRequest(
+      "/mid/v1/login",
+      {
+        ldata: encrypted.value,
+      },
+      params.signal,
+    );
     const data = await decodeMiddleBody(body, encrypted.context);
     try {
       return sessionFromLoginData(data, {
@@ -473,9 +482,13 @@ export class EInvoiceV2Client {
       pdid: `a:${androidId}`,
     };
     const encrypted = await encryptLoginDataWithContext(inner);
-    const body = await this.middleRequest("/mid/v1/logintoken", {
-      ldata: encrypted.value,
-    });
+    const body = await this.middleRequest(
+      "/mid/v1/logintoken",
+      {
+        ldata: encrypted.value,
+      },
+      options.signal,
+    );
     return sessionFromLoginData(
       await decodeMiddleBody(body, encrypted.context),
       session,
@@ -564,23 +577,68 @@ export class EInvoiceV2Client {
     );
   }
 
-  private async middleRequest(path: string, body: Record<string, unknown>) {
-    const response = await this.fetcher(`${this.options.middleHost}${path}`, {
+  private async middleRequest(
+    path: string,
+    body: Record<string, unknown>,
+    signal?: AbortSignal,
+  ) {
+    const response = await this.request(`${this.options.middleHost}${path}`, {
       method: "POST",
       headers: jsonHeaders(this.options),
       body: JSON.stringify(body),
+      signal,
     });
     return readJsonResponse(response, path);
   }
 
   private async bigRequest(path: string, jwt: string) {
     const form = new URLSearchParams({ einvoiceJwt: jwt });
-    const response = await this.fetcher(`${this.options.bigHost}${path}`, {
+    const response = await this.request(`${this.options.bigHost}${path}`, {
       method: "POST",
       headers: formHeaders(this.options),
       body: form.toString(),
     });
     return readJsonResponse(response, path);
+  }
+
+  private async request(input: RequestInfo | URL, init: RequestInit) {
+    return fetchWithTimeout(this.fetcher, input, init, {
+      signal: init.signal ?? this.options.signal,
+      timeoutMs: this.options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+  }
+}
+
+async function fetchWithTimeout(
+  fetcher: typeof fetch,
+  input: RequestInfo | URL,
+  init: RequestInit,
+  options: { signal?: AbortSignal; timeoutMs: number },
+) {
+  const controller = new AbortController();
+  const timeoutMs = Math.max(0, Math.floor(options.timeoutMs));
+  let timedOut = false;
+  const abortFromCaller = () => controller.abort(options.signal?.reason);
+  if (options.signal?.aborted) abortFromCaller();
+  else
+    options.signal?.addEventListener("abort", abortFromCaller, { once: true });
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort(new Error(`新版電子發票請求逾時（${timeoutMs}ms）。`));
+  }, timeoutMs);
+
+  try {
+    return await fetcher(input, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (timedOut) {
+      throw new Error(`新版電子發票請求逾時（${timeoutMs}ms）。`, {
+        cause: error,
+      });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    options.signal?.removeEventListener("abort", abortFromCaller);
   }
 }
 

--- a/packages/connectors/tests/selfcheck/einvoice-v2.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/einvoice-v2.selfcheck.ts
@@ -9,6 +9,8 @@ import {
 import {
   EINVOICE_SYNC_PERIODS,
   einvoiceConnector,
+  fetchEInvoiceInvoiceDetail,
+  initializeEInvoiceSync,
   parseInvoiceConfig,
 } from "../../src/index";
 
@@ -158,6 +160,119 @@ async function main() {
     "/einvoice/carriers/query-invoices-details",
   );
 
+  const primitiveConfig = parseInvoiceConfig({
+    protocol: "v2",
+    mobile: "0912345678",
+    password: "synthetic-password",
+    androidId: "synthetic-android-id",
+  });
+  const initialized = await initializeEInvoiceSync(primitiveConfig, { client });
+  assert.equal(initialized.headers.length, EINVOICE_SYNC_PERIODS);
+  assert.equal(initialized.detailTasks.length, EINVOICE_SYNC_PERIODS);
+  assert.equal(
+    initialized.detailTasks[0].sourceId,
+    "AA-12345678:2026-07-01T04:34:56.000Z",
+  );
+  assert.equal(initialized.detailTasks[0].invNum, "AA-12345678");
+  assert.equal(initialized.detailTasks[0].detailInvDate, "2026/07/01");
+  assert.equal(initialized.configUpdates.sid, syntheticSession.sid);
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(initialized.session)),
+    initialized.session,
+  );
+  const detailResult = await fetchEInvoiceInvoiceDetail(
+    initialized.session,
+    initialized.detailTasks[0],
+    { client },
+  );
+  assert.equal(detailResult.invoiceLineItems.length, 1);
+  assert.equal(
+    detailResult.invoiceLineItems[0].invoiceSourceId,
+    initialized.detailTasks[0].sourceId,
+  );
+
+  const failedDetailClient = new EInvoiceV2Client({
+    bigHost: "https://detail-error.test",
+    fetchImpl: async () => new Response("detail failed", { status: 503 }),
+  });
+  await assert.rejects(
+    () =>
+      fetchEInvoiceInvoiceDetail(
+        initialized.session,
+        initialized.detailTasks[0],
+        { client: failedDetailClient },
+      ),
+    /HTTP 503/,
+  );
+
+  let timeoutSignal: AbortSignal | undefined;
+  const timeoutClient = new EInvoiceV2Client({
+    bigHost: "https://timeout.test",
+    timeoutMs: 10,
+    fetchImpl: async (_input, init) => {
+      timeoutSignal = init?.signal ?? undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        timeoutSignal?.addEventListener(
+          "abort",
+          () => reject(timeoutSignal?.reason),
+          { once: true },
+        );
+      });
+    },
+  });
+  await assert.rejects(
+    () =>
+      timeoutClient.queryCarrierInvoiceDetail(
+        initialized.session,
+        "AA-12345678",
+        "2026/07/01",
+      ),
+    /請求逾時（10ms）/,
+  );
+  assert.equal(timeoutSignal?.aborted, true);
+
+  const callerAbort = new AbortController();
+  const callerAbortClient = new EInvoiceV2Client({
+    bigHost: "https://caller-abort.test",
+    signal: callerAbort.signal,
+    fetchImpl: async (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal?.aborted) {
+          reject(signal.reason);
+          return;
+        }
+        signal?.addEventListener("abort", () => reject(signal.reason), {
+          once: true,
+        });
+      }),
+  });
+  const callerAbortRequest = callerAbortClient.queryCarrierInvoiceDetail(
+    initialized.session,
+    "AA-12345678",
+    "2026/07/01",
+  );
+  callerAbort.abort(new Error("caller cancelled"));
+  await assert.rejects(callerAbortRequest, /caller cancelled/);
+
+  const connectorDetailFailureConfig = parseInvoiceConfig({
+    protocol: "v2",
+    mobile: "0912345678",
+    password: "synthetic-password",
+    androidId: "synthetic-android-id",
+  });
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = async (
+    input,
+    init,
+  ) =>
+    String(input).endsWith("/einvoice/carriers/query-invoices-details")
+      ? new Response("detail failed", { status: 503 })
+      : fakeFetch(input, init);
+  await assert.rejects(
+    () => einvoiceConnector.sync(connectorDetailFailureConfig),
+    /HTTP 503/,
+  );
+
   (globalThis as unknown as { fetch: typeof fetch }).fetch = fakeFetch;
   const requestsBeforeSync = requests.length;
   const connectorConfig = parseInvoiceConfig({
@@ -165,7 +280,6 @@ async function main() {
     mobile: "0912345678",
     password: "synthetic-password",
     androidId: "synthetic-android-id",
-    fetchDetails: true,
   });
   const syncResult = await einvoiceConnector.sync(connectorConfig);
   assert.equal(syncResult.records.length, 1);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -186,6 +186,14 @@ export interface SyncResponse {
   cursorUpdated: boolean;
 }
 
+export interface QueuedSyncResponse {
+  success: true;
+  connectorId: ConnectorId;
+  scope: string;
+  status: "queued";
+  runId: string;
+}
+
 export type SyncNotificationStatus = "success" | "failed" | "needs_user_action";
 
 export interface SyncNewRecordCounts {
@@ -308,7 +316,7 @@ export const connectorCatalog = {
     connectionMode: "api_credentials",
     scopes: ["all"],
     capabilities: ["invoice", "invoice_line_item"],
-    publicFields: ["fetchDetails"],
+    publicFields: [],
     credentialFields: ["mobile", "password"],
     secretStateFields: [
       "userToken",

--- a/packages/db/migrations/0028_einvoice_durable_runs.sql
+++ b/packages/db/migrations/0028_einvoice_durable_runs.sql
@@ -1,0 +1,69 @@
+CREATE TABLE IF NOT EXISTS einvoice_sync_runs (
+  id TEXT PRIMARY KEY,
+  connector_id TEXT NOT NULL DEFAULT 'einvoice'
+    CHECK (connector_id = 'einvoice'),
+  trigger TEXT NOT NULL CHECK (trigger IN ('manual', 'scheduled')),
+  sync_job_id TEXT REFERENCES sync_jobs(id) ON DELETE SET NULL,
+  scheduled_batch_id TEXT REFERENCES scheduled_sync_batches(id) ON DELETE SET NULL,
+  settings_version TEXT,
+  status TEXT NOT NULL CHECK (status IN (
+    'queued', 'initializing', 'processing', 'completed', 'failed', 'needs_user_action'
+  )),
+  total_item_count INTEGER NOT NULL DEFAULT 0,
+  pending_item_count INTEGER NOT NULL DEFAULT 0,
+  processing_item_count INTEGER NOT NULL DEFAULT 0,
+  done_item_count INTEGER NOT NULL DEFAULT 0,
+  line_item_count INTEGER NOT NULL DEFAULT 0,
+  new_invoice_count INTEGER NOT NULL DEFAULT 0,
+  session_refresh_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  chunk_lease_owner TEXT,
+  chunk_lease_expires_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  promoted_at TEXT,
+  completed_at TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_einvoice_sync_runs_one_active
+  ON einvoice_sync_runs (connector_id)
+  WHERE status IN ('queued', 'initializing', 'processing');
+
+CREATE INDEX IF NOT EXISTS idx_einvoice_sync_runs_completed
+  ON einvoice_sync_runs (completed_at DESC);
+
+CREATE TABLE IF NOT EXISTS einvoice_sync_run_items (
+  id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES einvoice_sync_runs(id) ON DELETE CASCADE,
+  invoice_source_id TEXT NOT NULL,
+  header_json TEXT NOT NULL,
+  normalized_invoice_json TEXT NOT NULL,
+  detail_key TEXT,
+  detail_metadata_json TEXT,
+  detail_items_json TEXT,
+  line_item_count INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'processing', 'done')),
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  lease_token TEXT,
+  lease_expires_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT,
+  UNIQUE (run_id, invoice_source_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_einvoice_sync_run_items_claim
+  ON einvoice_sync_run_items (run_id, status, lease_expires_at, created_at);
+
+-- Detail fetching is now an explicit durable-run operation, not a connector preference.
+UPDATE connector_settings
+SET public_config = CASE
+      WHEN json_remove(public_config, '$.fetchDetails') = '{}' THEN NULL
+      ELSE json_remove(public_config, '$.fetchDetails')
+    END,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE connector_id = 'einvoice'
+  AND public_config IS NOT NULL
+  AND json_valid(public_config)
+  AND json_type(public_config, '$.fetchDetails') IN ('true', 'false');


### PR DESCRIPTION
## 摘要

- 電子發票明細固定同步，移除前端「同步品項明細」選項。
- 新增 durable e-invoice run/items，將明細拆成每批最多 35 張 Queue 工作。
- 加入 Queue continuation、rolling lease、重試與冪等 promotion，避免單次 Worker invocation 超過外部請求與 D1 查詢限制。
- 修正外幣匯率警示：只有帳戶金額大於 0 且缺少匯率時才提示。

## 根因與影響

電子發票原本在單一 Worker invocation 逐張抓取明細，發票數較多時會超過 Cloudflare subrequest 上限。現在改由 durable run 保存進度，逐批執行並在完成後一次性 promotion；手動與排程同步共用同一流程。

## 驗證

- `npm run test:backend`
- `npm run verify:web`
- `npm run typecheck`
- `npm run format:check`

以上檢查均通過。遠端 D1 migration `0028_einvoice_durable_runs.sql` 已套用。