### PR TITLE
改善台新同步錯誤診斷

### DIFF
--- a/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
+++ b/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
@@ -713,10 +713,14 @@
         {/if}
       </div>
     {/if}
-    {#if error || (job?.lastError && !bankCaptchaImage)}<p
+    {#if error || ((job?.lastStatus === "failed" || job?.lastStatus === "needs_user_action") && !bankCaptchaImage)}<p
         class="mt-2 text-sm text-coral"
       >
-        {error ? `本次同步：${error}` : `上次同步：${job?.lastError}`}
+        {error
+          ? `本次同步：${error}`
+          : job?.lastError?.trim()
+            ? `上次同步：${job.lastError}`
+            : "上次同步失敗，但未取得錯誤原因。"}
       </p>{/if}
   </div>
   <section class="mt-4 overflow-hidden rounded-xl border border-border">

--- a/apps/web/src/features/settings/connectors/ConnectorPanel.test.ts
+++ b/apps/web/src/features/settings/connectors/ConnectorPanel.test.ts
@@ -73,6 +73,16 @@ function renderEinvoicePanel(syncJobs: SyncJobRow[][]) {
 }
 
 describe("ConnectorPanel", () => {
+  it("shows a fallback when a failed sync has an empty stored error", async () => {
+    const { findByText } = renderEinvoicePanel([
+      [syncJob({ lastStatus: "failed", lastError: "" })],
+    ]);
+
+    expect(
+      await findByText("上次同步失敗，但未取得錯誤原因。"),
+    ).toBeInTheDocument();
+  });
+
   it("polls an e-invoice run and refreshes financial data only after success", async () => {
     vi.useFakeTimers();
     const running = syncJob({ running: true });

--- a/apps/worker/src/connectors/taishin.ts
+++ b/apps/worker/src/connectors/taishin.ts
@@ -32,6 +32,32 @@ const USER_AGENT =
 
 type JsonRecord = Record<string, unknown>;
 type BrowserPage = Page | Frame;
+export type TaishinSyncStage =
+  | "acquire_browser"
+  | "initialize_browser_page"
+  | "configure_browser_page"
+  | "restore_session"
+  | "login"
+  | "fetch_realtime"
+  | "fetch_summary"
+  | "fetch_current_bill"
+  | "fetch_historical_bills"
+  | "parse_payload"
+  | "export_session";
+
+const TAISHIN_SYNC_STAGE_LABELS: Record<TaishinSyncStage, string> = {
+  acquire_browser: "啟動瀏覽器",
+  initialize_browser_page: "初始化瀏覽器頁面",
+  configure_browser_page: "設定瀏覽器頁面",
+  restore_session: "還原登入 session",
+  login: "登入台新網銀",
+  fetch_realtime: "取得即時消費",
+  fetch_summary: "取得信用卡摘要",
+  fetch_current_bill: "取得本期帳單",
+  fetch_historical_bills: "取得歷史帳單",
+  parse_payload: "解析信用卡資料",
+  export_session: "保存登入 session",
+};
 
 export class TaishinVerificationRequiredError extends Error {
   constructor(message: string) {
@@ -66,9 +92,29 @@ export class TaishinConnectionError extends Error {
     message: string,
     readonly sessionCookies?: string,
     readonly sessionCreatedAt?: string,
+    cause?: unknown,
   ) {
     super(message);
     this.name = "TaishinConnectionError";
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+export class TaishinSyncStageError extends TaishinConnectionError {
+  constructor(
+    readonly stage: TaishinSyncStage,
+    cause: unknown,
+    sessionCookies?: string,
+    sessionCreatedAt?: string,
+  ) {
+    const detail = safeTaishinRuntimeMessage(cause);
+    super(
+      `台新同步在${TAISHIN_SYNC_STAGE_LABELS[stage]}階段失敗${detail ? `：${detail}` : "。"}`,
+      sessionCookies,
+      sessionCreatedAt,
+      cause,
+    );
+    this.name = "TaishinSyncStageError";
   }
 }
 
@@ -114,19 +160,25 @@ export function createTaishinConnector(
       requireCredentials(config);
       if (!browser) throw new Error("台新銀行同步需要 BROWSER binding。");
 
-      const browserInstance = await acquireBrowser(
-        browser,
-        config.browserSessionId,
-      );
-      const pages = await browserInstance.pages();
-      const page = pages[0] ?? (await browserInstance.newPage());
+      let stage: TaishinSyncStage = "acquire_browser";
+      let browserInstance: Browser | undefined;
+      let page: Page | undefined;
       let authenticated = false;
       try {
+        browserInstance = await acquireBrowser(
+          browser,
+          config.browserSessionId,
+        );
+        stage = "initialize_browser_page";
+        const pages = await browserInstance.pages();
+        page = pages[0] ?? (await browserInstance.newPage());
+        stage = "configure_browser_page";
         await configurePage(page);
         let loggedIn = false;
 
         let pageContext: BrowserPage = page;
         if (config.browserSessionId && config.captcha) {
+          stage = "login";
           if (
             !config.browserSessionExpiresAt ||
             new Date(config.browserSessionExpiresAt) <= new Date()
@@ -140,6 +192,7 @@ export function createTaishinConnector(
           await submitLogin(pageContext, config.captcha);
           loggedIn = true;
         } else if (config.sessionCookies) {
+          stage = "restore_session";
           await importCookies(page, config.sessionCookies);
           await page.goto(RWD_URL, {
             waitUntil: "domcontentloaded",
@@ -150,6 +203,7 @@ export function createTaishinConnector(
         }
 
         if (!loggedIn) {
+          stage = "login";
           if (!recognizeCaptcha) {
             throw new TaishinVerificationRequiredError(
               "台新銀行 session 已失效，需要重新登入。",
@@ -161,7 +215,10 @@ export function createTaishinConnector(
 
         let payloads;
         try {
-          payloads = await fetchCreditCardPayloads(pageContext);
+          payloads = await fetchCreditCardPayloads(
+            pageContext,
+            (nextStage) => (stage = nextStage),
+          );
         } catch (error) {
           if (
             !(error instanceof TaishinVerificationRequiredError) ||
@@ -169,11 +226,16 @@ export function createTaishinConnector(
           ) {
             throw error;
           }
+          stage = "login";
           pageContext = await loginWithOcr(page, config, recognizeCaptcha);
           authenticated = true;
-          payloads = await fetchCreditCardPayloads(pageContext);
+          payloads = await fetchCreditCardPayloads(
+            pageContext,
+            (nextStage) => (stage = nextStage),
+          );
         }
         let data;
+        stage = "parse_payload";
         try {
           data = parseTaishinCreditCardData(payloads);
         } catch (error) {
@@ -186,6 +248,7 @@ export function createTaishinConnector(
           throw error;
         }
         const now = new Date();
+        stage = "export_session";
         return {
           records: [],
           ...data,
@@ -196,22 +259,36 @@ export function createTaishinConnector(
           }),
         };
       } catch (error) {
-        if (authenticated && error instanceof TaishinConnectionError) {
+        const normalized = normalizeTaishinSyncError(error, stage);
+        if (
+          authenticated &&
+          normalized instanceof TaishinConnectionError &&
+          page
+        ) {
           const sessionCookies = await page
             .cookies()
             .then((cookies) => JSON.stringify(cookies))
             .catch(() => undefined);
           if (sessionCookies) {
+            if (normalized instanceof TaishinSyncStageError) {
+              throw new TaishinSyncStageError(
+                normalized.stage,
+                normalized.cause,
+                sessionCookies,
+                new Date().toISOString(),
+              );
+            }
             throw new TaishinConnectionError(
-              error.message,
+              normalized.message,
               sessionCookies,
               new Date().toISOString(),
+              normalized.cause,
             );
           }
         }
-        throw error;
+        throw normalized;
       } finally {
-        await browserInstance.close();
+        if (browserInstance) await closeTaishinBrowser(browserInstance);
       }
     },
   };
@@ -246,7 +323,7 @@ export async function prepareTaishinCaptcha(
       captchaImage: `data:image/jpeg;base64,${bytesToBase64(captcha.bytes)}`,
     };
   } finally {
-    if (!preserved) await browserInstance.close();
+    if (!preserved) await closeTaishinBrowser(browserInstance);
   }
 }
 
@@ -283,10 +360,15 @@ async function loginWithOcr(
   );
 }
 
-async function fetchCreditCardPayloads(page: BrowserPage) {
+async function fetchCreditCardPayloads(
+  page: BrowserPage,
+  setStage: (stage: TaishinSyncStage) => void,
+) {
+  setStage("fetch_realtime");
   const realtime = await fetchRealtimeTransactions(page);
   let summary: unknown = { value: {}, error: null };
   try {
+    setStage("fetch_summary");
     summary = await postJson(page, SUMMARY_PATH, {}, OPTIONAL_API_TIMEOUT_MS);
     const billingContext = taishinBillingContext(summary);
     const months = recentMonths(BANK_SYNC_MONTHS, billingContext.anchor);
@@ -303,10 +385,12 @@ async function fetchCreditCardPayloads(page: BrowserPage) {
         },
         OPTIONAL_API_TIMEOUT_MS,
       );
+    setStage("fetch_current_bill");
     const currentBill = await fetchBill(months[0]!);
     if (!hasBillPayload(currentBill)) {
       return { summary, bills: [], realtime };
     }
+    setStage("fetch_historical_bills");
     const historicalBills = (
       await Promise.all(
         months.slice(1).map((month) => fetchBill(month).catch(() => undefined)),
@@ -961,6 +1045,49 @@ async function launchBrowser(
     }
     throw error;
   }
+}
+
+function normalizeTaishinSyncError(error: unknown, stage: TaishinSyncStage) {
+  if (
+    error instanceof TaishinConnectionError ||
+    error instanceof TaishinVerificationRequiredError ||
+    error instanceof TaishinBrowserCapacityError
+  ) {
+    return error;
+  }
+  return new TaishinSyncStageError(stage, error);
+}
+
+async function closeTaishinBrowser(browser: Browser) {
+  try {
+    await browser.close();
+  } catch (error) {
+    const message = safeTaishinRuntimeMessage(error);
+    console.warn(
+      JSON.stringify({
+        event: "taishin_browser_cleanup_failed",
+        connectorId: "taishin",
+        stage: "close_browser",
+        errorName: error instanceof Error ? error.name : typeof error,
+        message: message || "瀏覽器關閉失敗，但未取得錯誤原因。",
+      }),
+    );
+  }
+}
+
+function safeTaishinRuntimeMessage(error: unknown) {
+  const message =
+    error instanceof Error
+      ? error.message
+      : error === null || error === undefined
+        ? ""
+        : String(error);
+  return sanitizeBrowserErrorPart(message, 240)
+    .replace(
+      /\b(authorization|cookie|password|passwd|token|secret|session(?:cookies?)?)\s*[:=]\s*([^\s,;]+)/gi,
+      "$1=[redacted]",
+    )
+    .replace(/\b(?:Bearer\s+)?[A-Za-z0-9+/_=-]{24,}\b/g, "[redacted]");
 }
 
 async function configurePage(page: Page) {

--- a/apps/worker/src/features/sync/scheduler.ts
+++ b/apps/worker/src/features/sync/scheduler.ts
@@ -12,6 +12,7 @@ import type { Env } from "../../platform/env";
 import {
   canonicalSyncLockRowId,
   isUserActionError,
+  safeErrorLogDetails,
   safeErrorMessage,
   startSyncLockHeartbeat,
   SYNC_LOCK_LEASE_MS,
@@ -211,9 +212,10 @@ async function runScheduledJob(
       const status: SyncStatus = isUserActionError(error)
         ? "needs_user_action"
         : "failed";
+      const message = safeErrorMessage(error);
       await failSyncJob(env.DB, due, {
         status,
-        errorMessage: safeErrorMessage(error),
+        errorMessage: message,
       });
       console.error(
         JSON.stringify({
@@ -224,7 +226,8 @@ async function runScheduledJob(
           scope: due.scope,
           trigger: "scheduled",
           status,
-          message: safeErrorMessage(error),
+          message,
+          ...safeErrorLogDetails(error),
           durationMs: Date.now() - startedAt,
         }),
       );

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -1483,6 +1483,69 @@ export function isUserActionError(error: unknown) {
 }
 
 export function safeErrorMessage(error: unknown) {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.replace(/\s+/g, " ").slice(0, 300);
+  const message = normalizeErrorText(
+    error instanceof Error
+      ? error.message
+      : error === null || error === undefined
+        ? ""
+        : String(error),
+    300,
+  );
+  return message || "同步失敗，但未取得錯誤原因。";
+}
+
+export function safeErrorLogDetails(error: unknown) {
+  const errorName = normalizeErrorText(
+    error instanceof Error ? error.name : typeof error,
+    80,
+  );
+  const stack =
+    error instanceof Error
+      ? sanitizeErrorDiagnostic(
+          (error.stack ?? "").split("\n").slice(1).join("\n"),
+          1_500,
+        )
+      : "";
+  const cause = error instanceof Error ? error.cause : undefined;
+  const causeName =
+    cause instanceof Error
+      ? normalizeErrorText(cause.name, 80) || "UnknownError"
+      : "";
+  const causeStack =
+    cause instanceof Error
+      ? sanitizeErrorDiagnostic(
+          (cause.stack ?? "").split("\n").slice(1).join("\n"),
+          500,
+        )
+      : "";
+  const stage =
+    error instanceof Error &&
+    "stage" in error &&
+    typeof error.stage === "string"
+      ? normalizeErrorText(error.stage, 80)
+      : "";
+
+  return {
+    errorName: errorName || "UnknownError",
+    ...(stage ? { stage } : {}),
+    ...(stack ? { stack } : {}),
+    ...(causeName ? { causeName } : {}),
+    ...(causeStack ? { causeStack } : {}),
+  };
+}
+
+function normalizeErrorText(value: string, maxLength: number) {
+  return value.replace(/\s+/g, " ").trim().slice(0, maxLength);
+}
+
+function sanitizeErrorDiagnostic(value: string, maxLength: number) {
+  return value
+    .replace(/https?:\/\/\S+/gi, "[URL]")
+    .replace(
+      /\b(authorization|cookie|password|passwd|token|secret|session(?:cookies?)?)\s*[:=]\s*([^\s,;]+)/gi,
+      "$1=[redacted]",
+    )
+    .replace(/\b(?:Bearer\s+)?[A-Za-z0-9+/_=-]{24,}\b/g, "[redacted]")
+    .trim()
+    .slice(0, maxLength);
 }

--- a/apps/worker/tests/connectors/taishin-session.test.ts
+++ b/apps/worker/tests/connectors/taishin-session.test.ts
@@ -15,6 +15,7 @@ import {
   TaishinBrowserCapacityError,
   TaishinConnectionError,
   TaishinCredentialRejectedError,
+  TaishinSyncStageError,
 } from "../../src/connectors/taishin";
 
 const credentials = {
@@ -90,6 +91,108 @@ beforeEach(() => {
 });
 
 describe("Taishin browser session lifecycle", () => {
+  it("labels an empty browser acquisition error", async () => {
+    puppeteerMock.launch.mockRejectedValueOnce(new Error(""));
+
+    await expect(
+      createTaishinConnector({} as Fetcher).sync(credentials),
+    ).rejects.toMatchObject({
+      name: "TaishinSyncStageError",
+      stage: "acquire_browser",
+      message: "台新同步在啟動瀏覽器階段失敗。",
+      cause: expect.any(Error),
+    });
+  });
+
+  it("labels an empty runtime error with its sync stage", async () => {
+    const browserPage = page();
+    browserPage.setViewport.mockRejectedValueOnce(new Error(""));
+    const browserInstance = browser(browserPage);
+    puppeteerMock.launch.mockResolvedValue(browserInstance);
+
+    const error = await createTaishinConnector({} as Fetcher)
+      .sync(credentials)
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(TaishinSyncStageError);
+    expect(error).toMatchObject({
+      stage: "configure_browser_page",
+      message: "台新同步在設定瀏覽器頁面階段失敗。",
+      cause: expect.any(Error),
+    });
+    expect(browserInstance.close).toHaveBeenCalledOnce();
+  });
+
+  it("does not turn a successful sync into failure when browser cleanup fails", async () => {
+    const browserPage = page();
+    const response = (value: unknown) => ({
+      ok: true,
+      status: 200,
+      contentType: "application/json",
+      text: JSON.stringify({ value, error: null }),
+    });
+    browserPage.evaluate
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        contentType: "application/json",
+        text: JSON.stringify({
+          RESULT: "SUCCESS",
+          DBSESSIONID: "database-session",
+        }),
+      })
+      .mockResolvedValueOnce(response({ fmtRealTxListMap: [] }))
+      .mockResolvedValueOnce(
+        response({ "001": { "OUT-DTE-LST-STMT": "20260720" } }),
+      )
+      .mockResolvedValueOnce(response({}));
+    const browserInstance = browser(browserPage);
+    browserInstance.close.mockRejectedValueOnce(new Error(""));
+    puppeteerMock.launch.mockResolvedValue(browserInstance);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const result = await createTaishinConnector({} as Fetcher).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "valid",
+          domain: "my.taishinbank.com.tw",
+        },
+      ]),
+    });
+
+    expect(result.bankTransactions).toEqual([]);
+    expect(JSON.parse(String(warn.mock.calls.at(-1)?.[0]))).toMatchObject({
+      event: "taishin_browser_cleanup_failed",
+      connectorId: "taishin",
+      stage: "close_browser",
+      errorName: "Error",
+      message: "瀏覽器關閉失敗，但未取得錯誤原因。",
+    });
+    warn.mockRestore();
+  });
+
+  it("preserves the primary failure when browser cleanup also fails", async () => {
+    const browserPage = page();
+    browserPage.setViewport.mockRejectedValueOnce(new Error("primary failure"));
+    const browserInstance = browser(browserPage);
+    browserInstance.close.mockRejectedValueOnce(new Error("cleanup failure"));
+    puppeteerMock.launch.mockResolvedValue(browserInstance);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(
+      createTaishinConnector({} as Fetcher).sync(credentials),
+    ).rejects.toMatchObject({
+      stage: "configure_browser_page",
+      message: "台新同步在設定瀏覽器頁面階段失敗：primary failure",
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("taishin_browser_cleanup_failed"),
+    );
+    warn.mockRestore();
+  });
+
   it("reuses valid encrypted cookies without running OCR", async () => {
     const browserPage = page();
     const response = (value: unknown, error: unknown = null) => ({

--- a/apps/worker/tests/features/sync/error-details.test.ts
+++ b/apps/worker/tests/features/sync/error-details.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  safeErrorLogDetails,
+  safeErrorMessage,
+} from "../../../src/features/sync/service";
+
+describe("sync error details", () => {
+  it("uses a non-empty fallback when Error.message is blank", () => {
+    expect(safeErrorMessage(new Error("  \n  "))).toBe(
+      "同步失敗，但未取得錯誤原因。",
+    );
+    expect(safeErrorMessage(undefined)).toBe("同步失敗，但未取得錯誤原因。");
+  });
+
+  it("normalizes and bounds the persisted message", () => {
+    expect(safeErrorMessage(new Error("連線   暫時\n失敗"))).toBe(
+      "連線 暫時 失敗",
+    );
+    expect(safeErrorMessage(new Error("a".repeat(301)))).toHaveLength(300);
+  });
+
+  it("redacts sensitive values from structured log diagnostics", () => {
+    const error = new Error("request failed");
+    error.stack =
+      "Error: password=must-not-appear\n    at https://bank.example/path token=abcdefghijklmnopqrstuvwxyz password=hunter2";
+    const cause = new Error(
+      "authorization=Bearer_abcdefghijklmnopqrstuvwx cookie=session-value",
+    );
+    cause.stack =
+      "Error: cookie=must-not-appear\n    at https://bank.example/cause secret=short-value";
+    error.cause = cause;
+
+    const details = safeErrorLogDetails(error);
+
+    expect(details).toMatchObject({
+      errorName: "Error",
+      stack: expect.stringContaining("[URL]"),
+      causeName: "Error",
+      causeStack: expect.stringContaining("secret=[redacted]"),
+    });
+    expect(JSON.stringify(details)).not.toContain("abcdefghijklmnopqrstuvwxyz");
+    expect(JSON.stringify(details)).not.toContain("hunter2");
+    expect(JSON.stringify(details)).not.toContain("session-value");
+    expect(JSON.stringify(details)).not.toContain("must-not-appear");
+    expect(JSON.stringify(details)).not.toContain("short-value");
+  });
+
+  it("includes a bounded stage identifier when an error exposes one", () => {
+    const error = Object.assign(new Error("failed"), {
+      stage: "fetch_realtime",
+    });
+
+    expect(safeErrorLogDetails(error)).toMatchObject({
+      errorName: "Error",
+      stage: "fetch_realtime",
+    });
+  });
+});

--- a/apps/worker/tests/features/sync/scheduler.test.ts
+++ b/apps/worker/tests/features/sync/scheduler.test.ts
@@ -44,7 +44,14 @@ vi.mock("../../../src/features/sync/service", () => ({
   prepareSinopacCaptchaSession: vi.fn(),
   prepareTaishinCaptchaSession: vi.fn(),
   prepareObankCaptchaSession: vi.fn(),
-  safeErrorMessage: (error: unknown) => String(error),
+  safeErrorLogDetails: (error: unknown) => ({
+    errorName: error instanceof Error ? error.name : typeof error,
+    ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+  }),
+  safeErrorMessage: (error: unknown) =>
+    error instanceof Error && error.message.trim()
+      ? error.message.trim()
+      : "同步失敗，但未取得錯誤原因。",
   startSyncLockHeartbeat: mocks.startSyncLockHeartbeat,
   syncCathaybk: vi.fn(),
   syncEinvoice: vi.fn(),
@@ -149,6 +156,29 @@ beforeEach(() => {
 });
 
 describe("scheduled sync rounds", () => {
+  it("persists a fallback and logs diagnostic details for an empty error", async () => {
+    const job = syncJob("custom");
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.findOpenDefaultScheduleBatchId.mockResolvedValue(null);
+    mocks.findNextDueSyncJob.mockResolvedValue(job);
+    mocks.syncEsun.mockRejectedValueOnce(new Error(""));
+
+    await runSchedulerTick(env(), scheduledController);
+
+    expect(mocks.failSyncJob).toHaveBeenCalledWith(expect.anything(), job, {
+      status: "failed",
+      errorMessage: "同步失敗，但未取得錯誤原因。",
+    });
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+      event: "sync_run_failed",
+      connectorId: "esun",
+      status: "failed",
+      message: "同步失敗，但未取得錯誤原因。",
+      errorName: "Error",
+      stack: expect.stringContaining("Error"),
+    });
+  });
+
   it("records a default-round result before releasing the connector lock", async () => {
     const order: string[] = [];
     const job = syncJob();


### PR DESCRIPTION
## 修改內容

- 為台新 Browser 同步加入明確階段標記，未知 Runtime error 會指出失敗發生於瀏覽器啟動、session 還原、登入、API 取得、資料解析或 session 保存等階段。
- 排程失敗紀錄增加 `errorName`、`stage` 與經遮罩、截斷的 stack／cause stack，避免空錯誤無法追查。
- 修正 `browser.close()` 失敗覆蓋主要同步結果或原始錯誤的風險；cleanup 失敗改為獨立結構化 warning。
- 空白錯誤訊息保存安全 fallback，既有空 `lastError` 在設定頁也會顯示提示。
- 補上台新 lifecycle、排程錯誤、敏感資訊遮罩與前端顯示的回歸測試。

## 根因

排程原本只保存 `error.message`。當 Browser／Puppeteer Runtime 傳出空 message，D1 與 `sync_run_failed` log 都只留下空字串；前端又以 truthy 判斷 `lastError`，因此只顯示「需要處理」而沒有原因。此外，`finally` 裡的 `browser.close()` 若失敗，可能覆蓋原本同步結果或主錯誤。

## 影響

下一次未知的台新 Runtime 失敗至少會留下具體階段與安全診斷資訊；browser cleanup 異常不再將成功同步誤判為失敗，也不會覆蓋主要錯誤。既有已知驗證、API 與容量錯誤分類維持不變。

## 驗證

- `npm run typecheck -w @taiwan-fin-hub/worker`
- `npm test -w @taiwan-fin-hub/worker -- --run tests/connectors/taishin-session.test.ts tests/features/sync/error-details.test.ts tests/features/sync/scheduler.test.ts`（39 files、263 tests）
- `npm run typecheck -w @taiwan-fin-hub/web`
- `npm run test:unit -w @taiwan-fin-hub/web`（21 files、76 tests）
- `npm run build -w @taiwan-fin-hub/web`
- `git diff --check`

本次未執行實際銀行同步或登入操作。