### PR TITLE
修正台新信用卡繳款狀態與截止日

### DIFF
--- a/apps/worker/src/connectors/taishin.ts
+++ b/apps/worker/src/connectors/taishin.ts
@@ -14,6 +14,7 @@ const RWD_URL = "https://my.taishinbank.com.tw/TIBNetBank/svc/rwd/index.html";
 const API_ROOT = "/TIBNetBank/svc";
 const SESSION_CHECK_PATH = `${API_ROOT}/web/common/sessioncheck`;
 const SUMMARY_PATH = `${API_ROOT}/web4/rb0708rwd/doXTPA`;
+const OVERVIEW_PATH = `${API_ROOT}/web4/rb0760/getCardOverviewData`;
 const BILL_PATH = `${API_ROOT}/web4/rb0708rwd/init`;
 const REALTIME_PATH = `${API_ROOT}/web4/rb0708rwd/qryRealTime`;
 export const TAISHIN_AUTO_LOGIN_ATTEMPTS = 3;
@@ -387,8 +388,21 @@ async function fetchCreditCardPayloads(
       );
     setStage("fetch_current_bill");
     const currentBill = await fetchBill(months[0]!);
+    const overview = await postJson(
+      page,
+      OVERVIEW_PATH,
+      {},
+      OPTIONAL_API_TIMEOUT_MS,
+    ).catch((error) => {
+      console.warn(
+        `[taishin] current payment overview skipped: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return undefined;
+    });
     if (!hasBillPayload(currentBill)) {
-      return { summary, bills: [], realtime };
+      return { summary, overview, bills: [], realtime };
     }
     setStage("fetch_historical_bills");
     const historicalBills = (
@@ -398,6 +412,7 @@ async function fetchCreditCardPayloads(
     ).filter((bill) => bill !== undefined);
     return {
       summary,
+      overview,
       bills: [currentBill, ...historicalBills],
       realtime,
     };

--- a/apps/worker/tests/connectors/taishin-session.test.ts
+++ b/apps/worker/tests/connectors/taishin-session.test.ts
@@ -263,6 +263,11 @@ describe("Taishin browser session lifecycle", () => {
       timeoutMs: 4_000,
     });
     expect(browserPage.evaluate).toHaveBeenCalledWith(expect.any(Function), {
+      path: "/TIBNetBank/svc/web4/rb0760/getCardOverviewData",
+      body: {},
+      timeoutMs: 4_000,
+    });
+    expect(browserPage.evaluate).toHaveBeenCalledWith(expect.any(Function), {
       path: "/TIBNetBank/svc/web4/rb0708rwd/init",
       body: {
         org: "001",

--- a/apps/worker/tests/connectors/taishin.test.ts
+++ b/apps/worker/tests/connectors/taishin.test.ts
@@ -12,6 +12,20 @@ const summary = {
   error: null,
 };
 
+const overview = {
+  value: {
+    carInfoList: {
+      "001": {
+        BillYear: "2026",
+        BillMon: "07",
+        StmtBalance: "$10,060",
+        LstPymtAmt: "$10,060",
+      },
+    },
+  },
+  error: null,
+};
+
 function transaction(
   description: string,
   amount: string,
@@ -68,6 +82,7 @@ describe("Taishin credit-card parser", () => {
     const result = parseTaishinCreditCardData(
       {
         summary,
+        overview,
         bills: Array.from({ length: 7 }, (_, index) =>
           bill(`2026/${String(7 - index).padStart(2, "0")}`, []),
         ),
@@ -87,7 +102,7 @@ describe("Taishin credit-card parser", () => {
     });
   });
 
-  it("uses the remaining amount as the current card liability", () => {
+  it("uses the current overview payment as the current card liability", () => {
     const partiallyPaidBill = bill();
     Object.assign(partiallyPaidBill.value, {
       showCbalance: "10,060",
@@ -96,6 +111,18 @@ describe("Taishin credit-card parser", () => {
     });
     const partial = parseTaishinCreditCardData({
       summary,
+      overview: {
+        value: {
+          carInfoList: {
+            "001": {
+              BillYear: "2026",
+              BillMon: "07",
+              StmtBalance: "$10,060",
+              LstPymtAmt: "$8,000",
+            },
+          },
+        },
+      },
       bills: [partiallyPaidBill],
     });
 
@@ -105,12 +132,9 @@ describe("Taishin credit-card parser", () => {
       noPaymentNeeded: false,
     });
 
-    Object.assign(partiallyPaidBill.value, {
-      showCdue: "0",
-      showPayment: "10,060",
-    });
     const paid = parseTaishinCreditCardData({
       summary,
+      overview,
       bills: [partiallyPaidBill],
     });
 
@@ -118,6 +142,26 @@ describe("Taishin credit-card parser", () => {
       balance: 0,
       statementBalance: 10060,
       noPaymentNeeded: true,
+    });
+  });
+
+  it("parses compact dates returned by the real bill API", () => {
+    const compactDateBill = bill();
+    Object.assign(compactDateBill.value, {
+      showStmtDate: "2026/7/20",
+      showDueDate: "20260805",
+    });
+    const result = parseTaishinCreditCardData({
+      summary,
+      overview,
+      bills: [compactDateBill],
+    });
+
+    expect(result.creditCardBills[0]).toMatchObject({
+      statementClosingDate: "2026-07-20",
+      paymentDueDate: "2026-08-05",
+      paidAmount: 10060,
+      isPaid: true,
     });
   });
 
@@ -133,6 +177,18 @@ describe("Taishin credit-card parser", () => {
 
     const result = parseTaishinCreditCardData({
       summary,
+      overview: {
+        value: {
+          carInfoList: {
+            "001": {
+              BillYear: "2026",
+              BillMon: "06",
+              StmtBalance: "$8,060",
+              LstPymtAmt: "$6,000",
+            },
+          },
+        },
+      },
       bills: [{ value: {}, error: null }, previousBill],
     });
 
@@ -161,10 +217,7 @@ describe("Taishin credit-card parser", () => {
     });
 
     expect(result.creditCardBills).toHaveLength(1);
-    expect(result.bankBalanceSnapshots[0]).toMatchObject({
-      balance: 0,
-      noPaymentNeeded: undefined,
-    });
+    expect(result.bankBalanceSnapshots).toEqual([]);
   });
 
   it("upgrades merchant-matched pending occurrences and keeps the rest pending", () => {

--- a/packages/connectors/src/taishin.ts
+++ b/packages/connectors/src/taishin.ts
@@ -30,6 +30,7 @@ export function parseTaishinConfig(config: unknown): TaishinConfig {
 
 export type TaishinCreditCardPayloads = {
   summary: unknown;
+  overview?: unknown;
   bills: unknown[];
   realtime?: unknown;
 };
@@ -59,6 +60,7 @@ export function parseTaishinCreditCardData(
 ): TaishinCreditCardData {
   const summary = responseValue(payloads.summary);
   const summaryTwd = firstRecordValue(summary) ?? {};
+  const overview = currentPaymentOverview(responseValue(payloads.overview));
   const billValues = payloads.bills
     .map(responseValue)
     .filter((value): value is JsonRecord => Boolean(value));
@@ -70,9 +72,7 @@ export function parseTaishinCreditCardData(
     .sort((left, right) =>
       right.bill.billingPeriod.localeCompare(left.bill.billingPeriod),
     );
-  const currentBillEntry =
-    billEntries.find(({ value }) => optionalNumber(value.showCdue) != null) ??
-    billEntries[0];
+  const currentBillEntry = billEntries[0];
   const currentBill = currentBillEntry?.value;
   const postedCandidates = billValues.flatMap(postedTransactions);
   const pendingCandidates = realtimeTransactions(
@@ -97,11 +97,30 @@ export function parseTaishinCreditCardData(
   const creditLimit = optionalNumber(summaryTwd["OUT-CRLIMIT-PERM"]);
   const paymentDueDate = normalizeDate(currentBill?.showDueDate);
   const statementClosingDate = normalizeDate(currentBill?.showStmtDate);
-  const parsedRemainingDue = optionalAbsoluteNumber(currentBill?.showCdue);
-  const remainingDue = parsedRemainingDue ?? 0;
+  const overviewMatchesCurrentBill =
+    overview?.billingPeriod != null &&
+    overview.billingPeriod === currentBillEntry?.bill.billingPeriod;
+  const paidAmount = overviewMatchesCurrentBill
+    ? overview.paidAmount
+    : undefined;
+  const remainingDue =
+    overviewMatchesCurrentBill && overview.statementAmount != null
+      ? Math.max(overview.statementAmount - (paidAmount ?? 0), 0)
+      : undefined;
   const asOfAt = now.toISOString();
 
-  const bills = billEntries.map(({ bill }) => bill).slice(0, BANK_SYNC_MONTHS);
+  const bills = billEntries
+    .map(({ bill }) =>
+      overviewMatchesCurrentBill &&
+      bill.billingPeriod === overview.billingPeriod
+        ? {
+            ...bill,
+            paidAmount,
+            isPaid: remainingDue === 0,
+          }
+        : bill,
+    )
+    .slice(0, BANK_SYNC_MONTHS);
 
   return {
     bankAccounts: [
@@ -115,29 +134,29 @@ export function parseTaishinCreditCardData(
         raw: { cardLast4s },
       },
     ],
-    bankBalanceSnapshots: currentBill
-      ? [
-          {
-            accountId: ACCOUNT_SOURCE_ID,
-            sourceId: `${ACCOUNT_SOURCE_ID}:${asOfAt.slice(0, 10)}`,
-            balance: remainingDue > 0 ? -remainingDue : 0,
-            availableBalance: availableCredit,
-            statementBalance: statementAmount,
-            paymentDueDate,
-            statementClosingDate,
-            noPaymentNeeded:
-              parsedRemainingDue == null ? undefined : parsedRemainingDue === 0,
-            currency: "TWD",
-            asOfAt,
-            raw: {
-              statementAmount,
-              availableCredit,
+    bankBalanceSnapshots:
+      currentBill && remainingDue != null
+        ? [
+            {
+              accountId: ACCOUNT_SOURCE_ID,
+              sourceId: `${ACCOUNT_SOURCE_ID}:${asOfAt.slice(0, 10)}`,
+              balance: remainingDue > 0 ? -remainingDue : 0,
+              availableBalance: availableCredit,
+              statementBalance: statementAmount,
               paymentDueDate,
               statementClosingDate,
+              noPaymentNeeded: remainingDue === 0,
+              currency: "TWD",
+              asOfAt,
+              raw: {
+                statementAmount,
+                availableCredit,
+                paymentDueDate,
+                statementClosingDate,
+              },
             },
-          },
-        ]
-      : [],
+          ]
+        : [],
     bankTransactions: transactions.map((transaction) => ({
       ...transaction,
       accountId: ACCOUNT_SOURCE_ID,
@@ -155,8 +174,6 @@ function parseBill(
   const billingPeriod = normalizePeriod(value.showAccoutnYM);
   if (!billingPeriod) return undefined;
   const statementAmount = optionalAbsoluteNumber(value.showCbalance);
-  const paidAmount = optionalAbsoluteNumber(value.showPayment);
-  const remainingDue = optionalAbsoluteNumber(value.showCdue);
   const minimumPayment = optionalAbsoluteNumber(value.showMinPay);
   const paymentDueDate = normalizeDate(value.showDueDate);
   const statementClosingDate = normalizeDate(value.showStmtDate);
@@ -165,8 +182,6 @@ function parseBill(
     billingPeriod,
     statementAmount,
     minimumPayment,
-    paidAmount,
-    isPaid: remainingDue == null ? undefined : remainingDue === 0,
     paymentDueDate,
     statementClosingDate,
     currency: "TWD",
@@ -174,11 +189,24 @@ function parseBill(
       billingPeriod,
       statementAmount,
       minimumPayment,
-      paidAmount,
-      remainingDue,
       paymentDueDate,
       statementClosingDate,
     },
+  };
+}
+
+function currentPaymentOverview(value: JsonRecord | undefined) {
+  const cardInfoList = isRecord(value?.carInfoList)
+    ? value.carInfoList
+    : undefined;
+  const twd = isRecord(cardInfoList?.["001"]) ? cardInfoList["001"] : undefined;
+  const year = stringValue(twd?.BillYear).trim();
+  const month = Number(stringValue(twd?.BillMon).trim());
+  if (!/^\d{4}$/.test(year) || month < 1 || month > 12) return undefined;
+  return {
+    billingPeriod: `${year}-${String(month).padStart(2, "0")}`,
+    statementAmount: optionalAbsoluteNumber(twd?.StmtBalance),
+    paidAmount: optionalAbsoluteNumber(twd?.LstPymtAmt),
   };
 }
 
@@ -472,10 +500,12 @@ function normalizePeriod(value: unknown) {
 
 function normalizeDate(value: unknown) {
   const text = stringValue(value).trim();
-  const match = text.match(/(\d{4})[/-](\d{1,2})[/-](\d{1,2})/);
+  const match = text.match(
+    /(\d{4})(?:[/-](\d{1,2})[/-](\d{1,2})|(\d{2})(\d{2}))/,
+  );
   if (!match) return undefined;
-  const month = Number(match[2]);
-  const day = Number(match[3]);
+  const month = Number(match[2] ?? match[4]);
+  const day = Number(match[3] ?? match[5]);
   if (month < 1 || month > 12 || day < 1 || day > 31) return undefined;
   return `${match[1]}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 }

--- a/packages/connectors/tests/selfcheck/taishin.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/taishin.selfcheck.ts
@@ -47,6 +47,18 @@ function bill(period: string) {
 const result = parseTaishinCreditCardData(
   {
     summary,
+    overview: {
+      value: {
+        carInfoList: {
+          "001": {
+            BillYear: "2026",
+            BillMon: "07",
+            StmtBalance: "$10,060",
+            LstPymtAmt: "$10,060",
+          },
+        },
+      },
+    },
     bills: [
       bill("2026/07"),
       bill("2026/06"),


### PR DESCRIPTION
## 變更內容

- 新增台新 `RB0760/getCardOverviewData` 唯讀摘要，使用目前帳期的帳單金額與已繳金額計算剩餘應繳
- 最新一期帳單會依摘要更新 `paidAmount`、`isPaid` 與信用卡負債
- `RB0708` 保留作為歷史帳單與交易來源，不再把上期實繳金額誤認為本期繳款狀態
- 日期解析支援台新真實回傳的 `YYYYMMDD`，正確保存繳款截止日
- 摘要暫時失敗時，不以不可靠的歷史欄位覆寫目前負債，歷史帳單與交易仍可同步

## 問題原因

台新 `RB0708` 帳單明細中的 `showPayment` 與 `showCdue` 分別呈現上期實繳及本期帳單資料，原本卻將它們當成本期已繳與剩餘應繳，造成已繳清的帳單仍顯示待繳。另因日期 parser 不支援 `YYYYMMDD`，真實回傳的繳款截止日也會遺失。

## 影響

台新同步成功後，已繳清帳單會顯示負債為 0、帳單狀態為已繳，並能顯示正確的繳款截止日。

## 驗證

- `npm test -w @taiwan-fin-hub/worker -- --run tests/connectors/taishin.test.ts tests/connectors/taishin-session.test.ts`
- `npm run test:selfcheck -w @taiwan-fin-hub/connectors`
- `npm run typecheck`
- `npm run format:check`
- `git diff --check`
