### PR TITLE
改善同步報告補救與資產比較

### DIFF
--- a/apps/web/src/features/overview/components/LatestSyncReportCard.svelte
+++ b/apps/web/src/features/overview/components/LatestSyncReportCard.svelte
@@ -9,8 +9,10 @@
   import { formatCurrency, formatDateTime } from "@/shared/format/financial";
   import {
     financialChangeUnavailableMessage,
+    financialChangeScopeMessage,
     signedFinancialChange,
     syncReportStatusPresentation,
+    syncReportRecoveryMessage,
     zeroRateCurrenciesMessage,
   } from "../model/sync-report";
 
@@ -29,6 +31,12 @@
           report.financialChangeUnavailableReason,
         )
       : null,
+  );
+  const financialChangeScope = $derived(
+    report ? financialChangeScopeMessage(report) : null,
+  );
+  const recoveryMessage = $derived(
+    report ? syncReportRecoveryMessage(report) : null,
   );
   const zeroRateMessage = $derived(
     report ? zeroRateCurrenciesMessage(report.missingCurrencies) : null,
@@ -126,6 +134,14 @@
             <p class="mt-1 text-xs text-ink/50">
               {presentation.description}
             </p>
+            {#if recoveryMessage}
+              <p class="mt-1 text-xs font-medium text-moss">
+                已於 {formatDateTime(recoveryMessage)} 手動{report.status ===
+                "success"
+                  ? "補齊"
+                  : "更新部分來源"}
+              </p>
+            {/if}
           </div>
         </div>
         <time
@@ -153,6 +169,11 @@
         {#if report.financialChange}
           <div class="rounded-xl border border-border/80 p-4">
             <p class="text-xs font-semibold text-ink/50">同步後變化</p>
+            {#if financialChangeScope}
+              <p class="mt-1 text-[11px] leading-relaxed text-amber-800">
+                {financialChangeScope}
+              </p>
+            {/if}
             <div class="mt-3 grid grid-cols-3 gap-2">
               {#each financialItems as item (item.label)}
                 {@const change = signedFinancialChange(

--- a/apps/web/src/features/overview/components/NetWorthHistoryChart.svelte
+++ b/apps/web/src/features/overview/components/NetWorthHistoryChart.svelte
@@ -19,12 +19,15 @@
   } from "@/shared/format/financial";
   import {
     buildNetWorthChartData,
+    getNetWorthComparison,
     getAvailableNetWorthAssets,
+    NET_WORTH_COMPARISON_PERIODS,
     NET_WORTH_ASSET_SERIES,
     NET_WORTH_DEFAULT_ASSETS,
     type NetWorthAssetType,
     type NetWorthChartPoint,
     type NetWorthDisplayMode,
+    type NetWorthComparisonPeriod,
     type NetWorthTimeframe,
   } from "../model/net-worth-chart";
   import type { NetWorthHistoryRow } from "@/data/assets/types";
@@ -49,16 +52,28 @@
   ]);
   let timeframe = $state<NetWorthTimeframe>("1Y");
   let displayMode = $state<NetWorthDisplayMode>("sum");
+  let comparisonPeriod = $state<NetWorthComparisonPeriod>("day");
 
   const availableAssets = $derived(getAvailableNetWorthAssets(data));
   const chartData = $derived(
     buildNetWorthChartData(data, includedAssets, timeframe),
+  );
+  const comparisonData = $derived(
+    buildNetWorthChartData(data, includedAssets, "ALL"),
   );
   const firstValue = $derived(chartData[0]?.selectedTotal ?? 0);
   const latestValue = $derived(chartData.at(-1)?.selectedTotal ?? 0);
   const changeValue = $derived(latestValue - firstValue);
   const changePercent = $derived(
     firstValue === 0 ? 0 : (changeValue / Math.abs(firstValue)) * 100,
+  );
+  const comparison = $derived(
+    getNetWorthComparison(comparisonData, comparisonPeriod),
+  );
+  const comparisonOption = $derived(
+    NET_WORTH_COMPARISON_PERIODS.find(
+      (option) => option.key === comparisonPeriod,
+    ),
   );
   const chartSeries = $derived(
     displayMode === "sum"
@@ -262,6 +277,54 @@
           </div>
         {:else}
           <span class="text-xs text-ink/45">已選資產的每日合計</span>
+        {/if}
+      </div>
+      <div
+        class="mt-3 flex min-w-0 flex-wrap items-center justify-between gap-3 border-t border-ink/8 pt-3"
+      >
+        <div class="flex min-w-0 flex-wrap items-center gap-2">
+          <span class="shrink-0 text-xs font-semibold text-ink/50">比較</span>
+          <TabsList
+            class="grid h-8 grid-cols-3 border border-border p-0.5 text-xs"
+          >
+            {#each NET_WORTH_COMPARISON_PERIODS as option (option.key)}
+              <TabsTrigger
+                class="h-7 px-2 py-0.5 text-xs"
+                active={comparisonPeriod === option.key}
+                onclick={() => (comparisonPeriod = option.key)}
+                >{option.label}</TabsTrigger
+              >
+            {/each}
+          </TabsList>
+        </div>
+        {#if comparison && comparisonOption}
+          {@const comparisonSign = comparison.changeValue > 0 ? "+" : ""}
+          <div class="min-w-0 text-right text-xs leading-relaxed text-ink/55">
+            <p class="truncate">
+              目前 {formatCurrency(comparison.currentValue)} · {comparisonOption.label}（{formatDate(
+                comparison.previousDate,
+              )}）
+              {formatCurrency(comparison.previousValue)}
+            </p>
+            <p
+              class={`font-semibold ${comparison.changeValue > 0 ? "text-moss" : comparison.changeValue < 0 ? "text-coral" : "text-ink/55"}`}
+            >
+              變化 {comparison.changeValue < 0
+                ? ""
+                : comparisonSign}{formatCurrency(comparison.changeValue)}
+              {#if comparison.changePercent !== null}
+                （{comparison.changePercent > 0
+                  ? "+"
+                  : comparison.changePercent < 0
+                    ? "−"
+                    : ""}{Math.abs(comparison.changePercent).toFixed(1)}%）
+              {/if}
+            </p>
+          </div>
+        {:else}
+          <p class="text-xs text-ink/40">
+            尚無{comparisonOption?.label ?? "目標"}的有效快照
+          </p>
         {/if}
       </div>
     {/if}

--- a/apps/web/src/features/overview/model/net-worth-chart.test.ts
+++ b/apps/web/src/features/overview/model/net-worth-chart.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildNetWorthChartData,
+  getNetWorthComparison,
   getAvailableNetWorthAssets,
 } from "./net-worth-chart";
 import type { NetWorthHistoryRow } from "@/data/assets/types";
@@ -120,5 +121,57 @@ describe("net worth chart data", () => {
 
     expect(points.map((point) => point.date)).toEqual(["2026-01-03"]);
     expect(points[0]?.stock).toBe(110);
+  });
+
+  it("compares with the latest snapshot on or before the target date", () => {
+    const points = [
+      { date: "2026-01-01", selectedTotal: 100 },
+      { date: "2026-01-03", selectedTotal: 125 },
+      { date: "2026-01-08", selectedTotal: 150 },
+      { date: "2026-01-10", selectedTotal: 140 },
+    ];
+    expect(getNetWorthComparison(points, "week")).toEqual({
+      currentDate: "2026-01-10",
+      currentValue: 140,
+      targetDate: "2026-01-03",
+      previousDate: "2026-01-03",
+      previousValue: 125,
+      changeValue: 15,
+      changePercent: 12,
+    });
+  });
+
+  it("returns no comparison when the history has no target snapshot", () => {
+    expect(
+      getNetWorthComparison(
+        [{ date: "2026-01-10", selectedTotal: 140 }],
+        "day",
+      ),
+    ).toBeNull();
+  });
+
+  it("uses the same day in the previous calendar month and clamps month end", () => {
+    const points = [
+      { date: "2026-01-31", selectedTotal: 90 },
+      { date: "2026-02-28", selectedTotal: 100 },
+      { date: "2026-03-31", selectedTotal: 120 },
+    ];
+    expect(getNetWorthComparison(points, "month")).toMatchObject({
+      targetDate: "2026-02-28",
+      previousDate: "2026-02-28",
+      changeValue: 20,
+    });
+  });
+
+  it("leaves the percentage unavailable when the baseline is zero", () => {
+    expect(
+      getNetWorthComparison(
+        [
+          { date: "2026-01-01", selectedTotal: 0 },
+          { date: "2026-01-02", selectedTotal: 30 },
+        ],
+        "day",
+      )?.changePercent,
+    ).toBeNull();
   });
 });

--- a/apps/web/src/features/overview/model/net-worth-chart.ts
+++ b/apps/web/src/features/overview/model/net-worth-chart.ts
@@ -3,6 +3,17 @@ import type { NetWorthHistoryRow } from "@/data/assets/types";
 export type NetWorthAssetType = "stock" | "fund" | "deposit" | "manual";
 export type NetWorthDisplayMode = "sum" | "breakdown";
 export type NetWorthTimeframe = "1M" | "3M" | "6M" | "1Y" | "ALL";
+export type NetWorthComparisonPeriod = "day" | "week" | "month";
+
+export const NET_WORTH_COMPARISON_PERIODS: Array<{
+  key: NetWorthComparisonPeriod;
+  label: string;
+  days?: number;
+}> = [
+  { key: "day", label: "較昨日", days: 1 },
+  { key: "week", label: "較上週", days: 7 },
+  { key: "month", label: "較上月" },
+];
 
 export interface NetWorthChartPoint {
   date: string;
@@ -11,6 +22,16 @@ export interface NetWorthChartPoint {
   deposit?: number;
   manual?: number;
   selectedTotal: number;
+}
+
+export interface NetWorthComparison {
+  currentDate: string;
+  currentValue: number;
+  targetDate: string;
+  previousDate: string;
+  previousValue: number;
+  changeValue: number;
+  changePercent: number | null;
 }
 
 export const NET_WORTH_ASSET_SERIES: Array<{
@@ -72,6 +93,60 @@ function latestValue(rows: NetWorthHistoryRow[], date: string) {
     value = row.netWorth;
   }
   return value;
+}
+
+function subtractDays(date: string, days: number) {
+  const value = new Date(`${date}T00:00:00Z`);
+  value.setUTCDate(value.getUTCDate() - days);
+  return value.toISOString().slice(0, 10);
+}
+
+function subtractCalendarMonth(date: string) {
+  const value = new Date(`${date}T00:00:00Z`);
+  const originalDay = value.getUTCDate();
+  value.setUTCDate(1);
+  value.setUTCMonth(value.getUTCMonth() - 1);
+  const lastDay = new Date(
+    Date.UTC(value.getUTCFullYear(), value.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+  value.setUTCDate(Math.min(originalDay, lastDay));
+  return value.toISOString().slice(0, 10);
+}
+
+/**
+ * Compares the latest valid snapshot with the latest snapshot on or before
+ * the requested target date. Missing dates are expected for this history.
+ */
+export function getNetWorthComparison(
+  points: NetWorthChartPoint[],
+  period: NetWorthComparisonPeriod,
+): NetWorthComparison | null {
+  const option = NET_WORTH_COMPARISON_PERIODS.find(
+    (option) => option.key === period,
+  );
+  if (!option || points.length === 0) return null;
+  const sorted = points.slice().sort((a, b) => a.date.localeCompare(b.date));
+  const current = sorted.at(-1);
+  if (!current) return null;
+  const targetDate =
+    option.days === undefined
+      ? subtractCalendarMonth(current.date)
+      : subtractDays(current.date, option.days);
+  const previous = sorted.filter((point) => point.date <= targetDate).at(-1);
+  if (!previous) return null;
+  const changeValue = current.selectedTotal - previous.selectedTotal;
+  return {
+    currentDate: current.date,
+    currentValue: current.selectedTotal,
+    targetDate,
+    previousDate: previous.date,
+    previousValue: previous.selectedTotal,
+    changeValue,
+    changePercent:
+      previous.selectedTotal === 0
+        ? null
+        : (changeValue / Math.abs(previous.selectedTotal)) * 100,
+  };
 }
 
 function buildAssetSeries(

--- a/apps/web/src/features/overview/model/sync-report.test.ts
+++ b/apps/web/src/features/overview/model/sync-report.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import type { ScheduledSyncReport } from "@taiwan-fin-hub/core";
 import {
   financialChangeUnavailableMessage,
+  financialChangeScopeMessage,
   signedFinancialChange,
   syncReportStatusPresentation,
+  syncReportRecoveryMessage,
   zeroRateCurrenciesMessage,
 } from "./sync-report";
 
@@ -27,6 +29,7 @@ function report(input: Partial<ScheduledSyncReport> = {}): ScheduledSyncReport {
     },
     financialChangeUnavailableReason: null,
     missingCurrencies: [],
+    recoveredAt: null,
     ...input,
   };
 }
@@ -52,7 +55,28 @@ describe("sync report presentation", () => {
     );
     expect(
       financialChangeUnavailableMessage(value.financialChangeUnavailableReason),
-    ).toBe("部分資料來源未更新，暫不計算資產變化。");
+    ).toBe("部分資料來源未更新，變化包含沿用的上次資料。");
+  });
+
+  it("explains the source scope when a partial round has a financial change", () => {
+    const value = report({
+      status: "failed",
+      sourceSummary: { total: 3, success: 2, failed: 1, needsUserAction: 0 },
+    });
+    expect(financialChangeScopeMessage(value)).toBe(
+      "依 2/3 已更新來源計算，其餘沿用上次資料",
+    );
+  });
+
+  it("does not add a partial scope note to a complete round", () => {
+    expect(financialChangeScopeMessage(report())).toBeNull();
+  });
+
+  it("shows the optional recovery completion timestamp when provided", () => {
+    const value = report({
+      recoveredAt: "2026-08-13T01:02:03.000Z",
+    });
+    expect(syncReportRecoveryMessage(value)).toBe("2026-08-13T01:02:03.000Z");
   });
 
   it("explains baseline reports and currencies valued at zero", () => {

--- a/apps/web/src/features/overview/model/sync-report.ts
+++ b/apps/web/src/features/overview/model/sync-report.ts
@@ -9,6 +9,18 @@ export type SyncReportStatusPresentation = {
   tone: "success" | "warning";
 };
 
+export function financialChangeScopeMessage(report: ScheduledSyncReport) {
+  const { success, total } = report.sourceSummary;
+  if (report.status === "success" || total === 0 || success >= total) {
+    return null;
+  }
+  return `依 ${success}/${total} 已更新來源計算，其餘沿用上次資料`;
+}
+
+export function syncReportRecoveryMessage(report: ScheduledSyncReport) {
+  return report.recoveredAt;
+}
+
 export function syncReportStatusPresentation(
   report: ScheduledSyncReport,
 ): SyncReportStatusPresentation {
@@ -33,7 +45,7 @@ export function financialChangeUnavailableMessage(
 ) {
   if (reason === "baseline") return "這是第一份同步報告，已建立資產基準。";
   if (reason === "partial_sync")
-    return "部分資料來源未更新，暫不計算資產變化。";
+    return "部分資料來源未更新，變化包含沿用的上次資料。";
   if (reason === "snapshot_unavailable") return "這次沒有完整的資產比較資料。";
   return null;
 }

--- a/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
+++ b/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
@@ -169,6 +169,7 @@
         startEinvoiceSyncPolling();
         return;
       }
+      invalidateLatestSyncReport();
       if (connectorId === "tdcc") tdccSetupStep = "complete";
       qc.invalidateQueries({ queryKey: queryKeys.syncJobs });
       qc.invalidateQueries({ queryKey: queryKeys.summary });
@@ -278,6 +279,7 @@
       });
       qc.invalidateQueries({ queryKey: queryKeys.syncJobs });
       qc.invalidateQueries({ queryKey: queryKeys.summary });
+      invalidateLatestSyncReport();
       qc.invalidateQueries({ queryKey: queryKeys.bank });
       qc.invalidateQueries({ queryKey: queryKeys.bills });
       if (
@@ -354,6 +356,7 @@
     });
     qc.invalidateQueries({ queryKey: queryKeys.syncJobs });
     qc.invalidateQueries({ queryKey: queryKeys.summary });
+    invalidateLatestSyncReport();
     qc.invalidateQueries({ queryKey: queryKeys.investments });
     qc.invalidateQueries({ queryKey: queryKeys.investmentTransactions });
     qc.invalidateQueries({ queryKey: queryKeys.bank });
@@ -409,6 +412,7 @@
       const completedSuccessfully = einvoiceJob?.lastStatus === "success";
       stopEinvoiceSyncPolling();
       if (completedSuccessfully) {
+        invalidateLatestSyncReport();
         qc.invalidateQueries({ queryKey: queryKeys.summary });
         qc.invalidateQueries({ queryKey: queryKeys.invoices });
       }
@@ -417,6 +421,9 @@
     einvoiceSyncPollingTimer = setTimeout(() => {
       void pollEinvoiceSyncJob();
     }, 2_000);
+  }
+  function invalidateLatestSyncReport() {
+    qc.invalidateQueries({ queryKey: queryKeys.latestSyncReport });
   }
   function intervalLabel(minutes: number) {
     return (

--- a/apps/web/src/features/settings/connectors/ConnectorPanel.test.ts
+++ b/apps/web/src/features/settings/connectors/ConnectorPanel.test.ts
@@ -122,6 +122,9 @@ describe("ConnectorPanel", () => {
       queryKey: ["summary"],
     });
     expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["sync-reports", "latest"],
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: ["invoices"],
     });
     expect(getByRole("button", { name: "已排入同步" })).toBeEnabled();

--- a/apps/worker/src/features/sync/einvoice-sync-service.ts
+++ b/apps/worker/src/features/sync/einvoice-sync-service.ts
@@ -36,6 +36,7 @@ import {
   type EinvoiceRunTrigger,
 } from "./einvoice-run-repository";
 import { findSyncJob } from "./schedule-repository";
+import { recoverLatestScheduledSyncSource } from "./report-repository";
 import {
   isUserActionError,
   safeErrorMessage,
@@ -398,6 +399,21 @@ async function finalizeEinvoiceRun(
       status: status === "success" ? "completed" : status,
       error,
     });
+    if (status === "success" && run.trigger === "manual") {
+      await recoverLatestScheduledSyncSource(env.DB, {
+        connectorId: "einvoice",
+        newRecords: {
+          invoices: run.new_invoice_count,
+          bankTransactions: 0,
+          investmentTransactions: 0,
+        },
+      }).catch((recoveryError) => {
+        console.error(
+          "[sync] failed to recover latest scheduled report from e-invoice sync",
+          recoveryError,
+        );
+      });
+    }
     return true;
   }
   const now = new Date();
@@ -480,6 +496,23 @@ async function finalizeEinvoiceRun(
   const results = await env.DB.batch(statements);
   const finalized = results.at(-1)?.meta.changes === 1;
   if (!finalized) return false;
+
+  if (success && run.trigger === "manual") {
+    await recoverLatestScheduledSyncSource(env.DB, {
+      connectorId: "einvoice",
+      newRecords: {
+        invoices: run.new_invoice_count,
+        bankTransactions: 0,
+        investmentTransactions: 0,
+      },
+    }).catch((recoveryError) => {
+      // Report recovery is best effort and must not change a completed run.
+      console.error(
+        "[sync] failed to recover latest scheduled report from e-invoice sync",
+        recoveryError,
+      );
+    });
+  }
 
   if (run.scheduled_batch_id) {
     const summary = await claimCompletedDefaultScheduleBatch(

--- a/apps/worker/src/features/sync/report-repository.ts
+++ b/apps/worker/src/features/sync/report-repository.ts
@@ -36,10 +36,143 @@ type CompletedBatchResultRow = {
   connectorId: ConnectorId;
   status: SyncNotificationStatus;
   completedAt: string;
+  recoveredAt: string | null;
   newInvoices: number;
   newBankTransactions: number;
   newInvestmentTransactions: number;
 };
+
+/**
+ * Apply a successful manual sync to the latest completed default schedule
+ * report when that report contains the same connector's failed source.
+ *
+ * The source's scheduled completion time remains unchanged. `recovered_at`
+ * records the later manual repair, while the batch's after-snapshot is
+ * refreshed against the now-current financial data.
+ */
+export async function recoverLatestScheduledSyncSource(
+  db: D1Database,
+  input: {
+    connectorId: ConnectorId;
+    newRecords: SyncNewRecordCounts;
+    batchId?: string | null;
+  },
+) {
+  // A caller that captured no failed report must not accidentally repair a
+  // newly-completed batch while its manual sync was running. Omitted input is
+  // reserved for asynchronous flows that resolve their target at completion.
+  if (input.batchId === null) return false;
+  const batchFilter = `batch.id = (
+       SELECT latest.id
+       FROM scheduled_sync_batches latest
+       WHERE latest.completed_at IS NOT NULL
+       ORDER BY latest.completed_at DESC, latest.created_at DESC
+       LIMIT 1
+     )${input.batchId === undefined ? "" : " AND batch.id = ?"}`;
+  const latest = await db
+    .prepare(
+      `SELECT batch.id AS batchId, result.job_id AS jobId
+       FROM scheduled_sync_batches batch
+       JOIN scheduled_sync_batch_results result
+         ON result.batch_id = batch.id
+       WHERE batch.completed_at IS NOT NULL
+         AND ${batchFilter}
+         AND result.connector_id = ?
+         AND result.status IN ('failed', 'needs_user_action')
+         AND result.recovered_at IS NULL
+       ORDER BY batch.completed_at DESC, batch.created_at DESC
+       LIMIT 1`,
+    )
+    .bind(
+      ...(input.batchId === undefined ? [] : [input.batchId]),
+      input.connectorId,
+    )
+    .first<{ batchId: string; jobId: string }>();
+  if (!latest) return false;
+
+  // Read the post-recovery snapshot before touching the report rows. The
+  // subsequent batch keeps the result transition and snapshot update in one
+  // D1 transaction.
+  const snapshot = await calculateCurrentFinancialSnapshot(db);
+  const recoveredAt = new Date().toISOString();
+  const results = await db.batch([
+    db
+      .prepare(
+        `UPDATE scheduled_sync_batch_results
+         SET status = 'success',
+             recovered_at = ?,
+             new_invoices = new_invoices + ?,
+             new_bank_transactions = new_bank_transactions + ?,
+             new_investment_transactions = new_investment_transactions + ?
+         WHERE batch_id = ?
+           AND job_id = ?
+           AND status IN ('failed', 'needs_user_action')
+           AND recovered_at IS NULL`,
+      )
+      .bind(
+        recoveredAt,
+        input.newRecords.invoices,
+        input.newRecords.bankTransactions,
+        input.newRecords.investmentTransactions,
+        latest.batchId,
+        latest.jobId,
+      ),
+    db
+      .prepare(
+        `UPDATE scheduled_sync_batches
+         SET assets_after_twd = ?,
+             credit_card_debt_after_twd = ?,
+             missing_currencies_after = ?
+         WHERE id = ?
+           AND completed_at IS NOT NULL
+           AND EXISTS (
+             SELECT 1
+             FROM scheduled_sync_batch_results
+             WHERE batch_id = ? AND job_id = ? AND recovered_at = ?
+           )`,
+      )
+      .bind(
+        snapshot.assetsTwd,
+        snapshot.creditCardDebtTwd,
+        JSON.stringify(snapshot.missingCurrencies),
+        latest.batchId,
+        latest.batchId,
+        latest.jobId,
+        recoveredAt,
+      ),
+  ]);
+  return results[0]?.meta.changes === 1;
+}
+
+/** Capture the latest failed source before a manual sync starts. */
+export async function findLatestRecoverableScheduledBatchId(
+  db: D1Database,
+  connectorId: ConnectorId,
+) {
+  const row = await db
+    .prepare(
+      `SELECT batch.id AS batchId
+       FROM scheduled_sync_batches batch
+       JOIN scheduled_sync_batch_results result
+         ON result.batch_id = batch.id
+       WHERE batch.completed_at IS NOT NULL
+         AND batch.id = (
+           SELECT latest.id
+           FROM scheduled_sync_batches latest
+           WHERE latest.completed_at IS NOT NULL
+           ORDER BY latest.completed_at DESC, latest.created_at DESC
+           LIMIT 1
+         )
+         AND result.connector_id = ?
+         AND result.status IN ('failed', 'needs_user_action')
+         AND result.recovered_at IS NULL
+       ORDER BY batch.completed_at DESC, batch.created_at DESC
+       LIMIT 1`,
+    )
+    .bind(connectorId)
+    .first<{ batchId: string }>();
+  return row?.batchId ?? null;
+}
 
 export async function calculateCurrentFinancialSnapshot(
   db: D1Database,
@@ -197,6 +330,7 @@ export async function getLatestScheduledSyncReport(
          connector_id AS connectorId,
          status,
          completed_at AS completedAt,
+         recovered_at AS recoveredAt,
          new_invoices AS newInvoices,
          new_bank_transactions AS newBankTransactions,
          new_investment_transactions AS newInvestmentTransactions
@@ -215,10 +349,7 @@ export async function getLatestScheduledSyncReport(
       ...parseStringArray(batch.missingCurrenciesAfter),
     ]),
   ].sort();
-  const financialChangeUnavailableReason = unavailableReason({
-    batch,
-    status,
-  });
+  const financialChangeUnavailableReason = unavailableReason(batch);
 
   return {
     id: batch.id,
@@ -249,6 +380,7 @@ export async function getLatestScheduledSyncReport(
         : null,
     financialChangeUnavailableReason,
     missingCurrencies,
+    recoveredAt: latestRecoveryAt(sources),
   };
 }
 
@@ -259,12 +391,23 @@ function mapSourceReport(
     connectorId: row.connectorId,
     status: row.status,
     completedAt: row.completedAt,
+    recoveredAt: row.recoveredAt,
     newRecords: {
       invoices: row.newInvoices,
       bankTransactions: row.newBankTransactions,
       investmentTransactions: row.newInvestmentTransactions,
     },
   };
+}
+
+function latestRecoveryAt(sources: ScheduledSyncSourceReport[]) {
+  return (
+    sources
+      .map((source) => source.recoveredAt)
+      .filter((value): value is string => value !== null)
+      .sort()
+      .at(-1) ?? null
+  );
 }
 
 function sumNewRecords(sources: ScheduledSyncSourceReport[]) {
@@ -290,17 +433,15 @@ function summaryStatus(sources: ScheduledSyncSourceReport[]) {
   return "success" as const;
 }
 
-function unavailableReason(input: {
-  batch: CompletedBatchRow;
-  status: SyncNotificationStatus;
-}): SyncFinancialChangeUnavailableReason | null {
-  if (input.status !== "success") return "partial_sync";
-  if (input.batch.isBaseline) return "baseline";
+function unavailableReason(
+  batch: CompletedBatchRow,
+): SyncFinancialChangeUnavailableReason | null {
+  if (batch.isBaseline) return "baseline";
   if (
-    input.batch.assetsBeforeTwd === null ||
-    input.batch.creditCardDebtBeforeTwd === null ||
-    input.batch.assetsAfterTwd === null ||
-    input.batch.creditCardDebtAfterTwd === null
+    batch.assetsBeforeTwd === null ||
+    batch.creditCardDebtBeforeTwd === null ||
+    batch.assetsAfterTwd === null ||
+    batch.creditCardDebtAfterTwd === null
   ) {
     return "snapshot_unavailable";
   }

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -56,6 +56,10 @@ import { encryptJson, decryptJson } from "../../platform/crypto";
 import type { Env } from "../../platform/env";
 import { dateFromIso, rebuildBankDepositHistory } from "../net-worth/service";
 import {
+  findLatestRecoverableScheduledBatchId,
+  recoverLatestScheduledSyncSource,
+} from "./report-repository";
+import {
   emptySyncNewRecordCounts,
   persistStagedSyncWrite,
   type SyncWriteRecord,
@@ -1407,9 +1411,28 @@ export async function withManualSyncLock(
   }
 
   const stopHeartbeat = startSyncLockHeartbeat(env.DB, lockRowId, runId);
+  let recoveryBatchId: string | null = null;
   try {
+    recoveryBatchId =
+      connectorId !== "tdcc" || scope === SYNC_SCOPE_ALL
+        ? await findLatestRecoverableScheduledBatchId(env.DB, connectorId)
+        : null;
     const outcome = await task();
     await markManualSyncSuccess(env.DB, connectorId, scope);
+    if (connectorId !== "tdcc" || scope === SYNC_SCOPE_ALL) {
+      await recoverLatestScheduledSyncSource(env.DB, {
+        connectorId,
+        newRecords: outcome.newRecords,
+        batchId: recoveryBatchId,
+      }).catch((error) => {
+        // A report repair must never turn an otherwise successful manual sync
+        // into a failed sync response.
+        console.error(
+          "[sync] failed to recover latest scheduled report",
+          error,
+        );
+      });
+    }
     return outcome;
   } catch (error) {
     const status: SyncStatus = isUserActionError(error)

--- a/apps/worker/tests/features/sync/report-repository.test.ts
+++ b/apps/worker/tests/features/sync/report-repository.test.ts
@@ -4,8 +4,10 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   calculateCurrentFinancialSnapshot,
+  findLatestRecoverableScheduledBatchId,
   getLatestScheduledSyncReport,
   hasCompletedFinancialBaseline,
+  recoverLatestScheduledSyncSource,
 } from "../../../src/features/sync/report-repository";
 
 class SqliteStatement {
@@ -19,6 +21,17 @@ class SqliteStatement {
   bind(...values: unknown[]) {
     this.values = values;
     return this;
+  }
+
+  async run() {
+    const result = this.database
+      .prepare(this.sql)
+      .run(...(this.values as never[]));
+    return {
+      success: true,
+      meta: { changes: Number(result.changes) },
+      results: [],
+    };
   }
 
   async first<T>() {
@@ -37,7 +50,7 @@ class SqliteStatement {
   }
 }
 
-function createDb() {
+function createDb(options: { failBatchAt?: number } = {}) {
   const database = new DatabaseSync(":memory:");
   database.exec("PRAGMA foreign_keys = ON");
   const migrationsDirectory = fileURLToPath(
@@ -51,6 +64,23 @@ function createDb() {
   const db = {
     prepare(sql: string) {
       return new SqliteStatement(database, sql);
+    },
+    async batch(statements: D1PreparedStatement[]) {
+      database.exec("BEGIN");
+      try {
+        const results = [];
+        for (const [index, statement] of statements.entries()) {
+          if (options.failBatchAt === index) {
+            throw new Error("simulated D1 batch failure");
+          }
+          results.push(await (statement as unknown as SqliteStatement).run());
+        }
+        database.exec("COMMIT");
+        return results;
+      } catch (error) {
+        database.exec("ROLLBACK");
+        throw error;
+      }
     },
   } as unknown as D1Database;
   return { database, db };
@@ -150,7 +180,7 @@ describe("scheduled sync financial reports", () => {
     });
   });
 
-  it("returns no financial delta for a partial round but keeps new record counts", async () => {
+  it("keeps the financial delta for a partial round and preserves new record counts", async () => {
     const { database, db } = createDb();
     databases.push(database);
     database.exec(`
@@ -179,8 +209,8 @@ describe("scheduled sync financial reports", () => {
         bankTransactions: 2,
         investmentTransactions: 0,
       },
-      financialChange: null,
-      financialChangeUnavailableReason: "partial_sync",
+      financialChange: { assets: 1000, creditCardDebt: -200, netWorth: 1200 },
+      financialChangeUnavailableReason: null,
     });
   });
 
@@ -232,6 +262,131 @@ describe("scheduled sync financial reports", () => {
     });
   });
 
+  it("repairs only a failed source in the latest completed report", async () => {
+    const { database, db } = createDb();
+    databases.push(database);
+    database.exec(`
+      INSERT INTO scheduled_sync_batches
+        (id, schedule_key, notification_claimed_at, created_at, completed_at,
+         is_baseline, assets_before_twd, credit_card_debt_before_twd,
+         missing_currencies_before, assets_after_twd,
+         credit_card_debt_after_twd, missing_currencies_after)
+      VALUES
+        ('old', 'default', '2026-08-12T22:05:00Z', '2026-08-12T22:00:00Z',
+         '2026-08-12T22:05:00Z', 0, 100, 0, '[]', 100, 0, '[]'),
+        ('latest', 'default', '2026-08-13T22:05:00Z', '2026-08-13T22:00:00Z',
+         '2026-08-13T22:05:00Z', 0, 100, 0, '[]', 100, 0, '[]');
+      INSERT INTO scheduled_sync_batch_results
+        (batch_id, job_id, connector_id, status, completed_at,
+         new_invoices, new_bank_transactions, new_investment_transactions)
+      VALUES
+        ('old', 'esun:all', 'esun', 'failed', '2026-08-12T22:05:00Z', 1, 2, 3),
+        ('latest', 'esun:all', 'esun', 'failed', '2026-08-13T22:05:00Z', 4, 5, 6);
+    `);
+
+    await expect(
+      recoverLatestScheduledSyncSource(db, {
+        connectorId: "esun",
+        newRecords: {
+          invoices: 2,
+          bankTransactions: 3,
+          investmentTransactions: 4,
+        },
+      }),
+    ).resolves.toBe(true);
+
+    expect(
+      database
+        .prepare(
+          `SELECT status, completed_at AS completedAt,
+                  recovered_at AS recoveredAt, new_invoices AS invoices,
+                  new_bank_transactions AS bankTransactions,
+                  new_investment_transactions AS investmentTransactions
+           FROM scheduled_sync_batch_results
+           WHERE batch_id = 'latest'`,
+        )
+        .get(),
+    ).toMatchObject({
+      status: "success",
+      completedAt: "2026-08-13T22:05:00Z",
+      recoveredAt: expect.any(String),
+      invoices: 6,
+      bankTransactions: 8,
+      investmentTransactions: 10,
+    });
+    expect(
+      database
+        .prepare(
+          "SELECT status FROM scheduled_sync_batch_results WHERE batch_id = 'old'",
+        )
+        .get(),
+    ).toEqual({ status: "failed" });
+
+    const report = await getLatestScheduledSyncReport(db);
+    expect(report).toMatchObject({
+      status: "success",
+      recoveredAt: expect.any(String),
+      financialChange: { assets: -100, creditCardDebt: 0, netWorth: -100 },
+    });
+    expect(report?.sources[0]).toMatchObject({
+      completedAt: "2026-08-13T22:05:00Z",
+      recoveredAt: expect.any(String),
+    });
+    await expect(
+      recoverLatestScheduledSyncSource(db, {
+        connectorId: "esun",
+        newRecords: {
+          invoices: 1,
+          bankTransactions: 1,
+          investmentTransactions: 1,
+        },
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("does not repair an older failed report when the latest report is successful", async () => {
+    const { database, db } = createDb();
+    databases.push(database);
+    database.exec(`
+      INSERT INTO scheduled_sync_batches
+        (id, schedule_key, notification_claimed_at, created_at, completed_at,
+         is_baseline, assets_before_twd, credit_card_debt_before_twd,
+         missing_currencies_before, assets_after_twd,
+         credit_card_debt_after_twd, missing_currencies_after)
+      VALUES
+        ('old', 'default', '2026-08-12T22:05:00Z', '2026-08-12T22:00:00Z',
+         '2026-08-12T22:05:00Z', 0, 100, 0, '[]', 100, 0, '[]'),
+        ('latest', 'default', '2026-08-13T22:05:00Z', '2026-08-13T22:00:00Z',
+         '2026-08-13T22:05:00Z', 0, 100, 0, '[]', 100, 0, '[]');
+      INSERT INTO scheduled_sync_batch_results
+        (batch_id, job_id, connector_id, status, completed_at)
+      VALUES
+        ('old', 'esun:all', 'esun', 'failed', '2026-08-12T22:05:00Z'),
+        ('latest', 'esun:all', 'esun', 'success', '2026-08-13T22:05:00Z');
+    `);
+
+    await expect(
+      recoverLatestScheduledSyncSource(db, {
+        connectorId: "esun",
+        newRecords: {
+          invoices: 1,
+          bankTransactions: 1,
+          investmentTransactions: 1,
+        },
+      }),
+    ).resolves.toBe(false);
+    expect(
+      database
+        .prepare(
+          "SELECT status, recovered_at AS recoveredAt FROM scheduled_sync_batch_results WHERE batch_id = 'old'",
+        )
+        .get(),
+    ).toEqual({ status: "failed", recoveredAt: null });
+    await expect(
+      findLatestRecoverableScheduledBatchId(db, "esun"),
+    ).resolves.toBeNull();
+  });
+
   it("waits for a complete successful round before establishing the baseline", async () => {
     const { database, db } = createDb();
     databases.push(database);
@@ -253,5 +408,44 @@ describe("scheduled sync financial reports", () => {
     `);
 
     await expect(hasCompletedFinancialBaseline(db)).resolves.toBe(true);
+  });
+
+  it("rolls back the source repair when the report snapshot update fails", async () => {
+    const { database, db } = createDb({ failBatchAt: 1 });
+    databases.push(database);
+    database.exec(`
+      INSERT INTO scheduled_sync_batches
+        (id, schedule_key, notification_claimed_at, created_at, completed_at,
+         is_baseline, assets_before_twd, credit_card_debt_before_twd,
+         missing_currencies_before, assets_after_twd,
+         credit_card_debt_after_twd, missing_currencies_after)
+      VALUES
+        ('latest', 'default', '2026-08-13T22:05:00Z', '2026-08-13T22:00:00Z',
+         '2026-08-13T22:05:00Z', 0, 100, 0, '[]', 100, 0, '[]');
+      INSERT INTO scheduled_sync_batch_results
+        (batch_id, job_id, connector_id, status, completed_at)
+      VALUES ('latest', 'esun:all', 'esun', 'failed', '2026-08-13T22:05:00Z');
+    `);
+
+    await expect(
+      recoverLatestScheduledSyncSource(db, {
+        connectorId: "esun",
+        newRecords: {
+          invoices: 1,
+          bankTransactions: 2,
+          investmentTransactions: 3,
+        },
+      }),
+    ).rejects.toThrow("simulated D1 batch failure");
+    expect(
+      database
+        .prepare(
+          `SELECT status, recovered_at AS recoveredAt,
+                  new_invoices AS invoices
+           FROM scheduled_sync_batch_results
+           WHERE batch_id = 'latest'`,
+        )
+        .get(),
+    ).toEqual({ status: "failed", recoveredAt: null, invoices: 0 });
   });
 });

--- a/docs/001-cron-sync-design.md
+++ b/docs/001-cron-sync-design.md
@@ -348,6 +348,9 @@ Manual recovery:
 - After a manual sync succeeds for a disabled job, update `last_status = 'success'`, `last_error = NULL`, `last_run_at`, `last_success_at`, and `next_run_at = now + interval_minutes`.
 - Do not automatically set `enabled = 1` after manual success.
 - The UI should ask the user whether to re-enable automatic sync for that connector/scope. If the user agrees, the UI can update `sync_jobs.enabled = 1`.
+- A successful full-scope manual sync may repair the same connector in the latest completed default-schedule report. Preserve the scheduled `completed_at`, record the later repair in `recovered_at`, add the manual run's new-record counts once, and refresh the report's after-snapshot atomically.
+- Capture the recoverable batch before a synchronous manual run starts so a newly completed schedule round cannot be repaired by the wrong run. TDCC partial-scope runs must not repair the `tdcc/all` batch member.
+- A partial schedule report still calculates its financial delta when both snapshots are available. The UI must state how many sources updated and that the remaining sources use their previous values.
 
 Manual sync adapter rules:
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -206,6 +206,8 @@ export interface ScheduledSyncSourceReport {
   connectorId: ConnectorId;
   status: SyncNotificationStatus;
   completedAt: string;
+  /** Time when a later manual sync repaired this source in the latest report. */
+  recoveredAt: string | null;
   newRecords: SyncNewRecordCounts;
 }
 
@@ -232,6 +234,8 @@ export interface ScheduledSyncReport {
   } | null;
   financialChangeUnavailableReason: SyncFinancialChangeUnavailableReason | null;
   missingCurrencies: string[];
+  /** Time when a later manual sync repaired one or more sources in this report. */
+  recoveredAt: string | null;
 }
 
 export interface NotificationPreferences {

--- a/packages/db/migrations/0029_scheduled_sync_manual_recovery.sql
+++ b/packages/db/migrations/0029_scheduled_sync_manual_recovery.sql
@@ -1,0 +1,2 @@
+ALTER TABLE scheduled_sync_batch_results
+  ADD COLUMN recovered_at TEXT;

--- a/packages/db/schema-metadata.json
+++ b/packages/db/schema-metadata.json
@@ -309,7 +309,8 @@
         "completed_at": "排程結果或略過決定寫入批次的時間；NULL 表示仍在等待。",
         "new_invoices": "此次工作真正新增的電子發票筆數，不包含更新既有發票。",
         "new_bank_transactions": "此次工作真正新增的銀行或信用卡交易筆數，不包含更新既有交易。",
-        "new_investment_transactions": "此次工作真正新增的投資交易筆數，不包含更新既有交易。"
+        "new_investment_transactions": "此次工作真正新增的投資交易筆數，不包含更新既有交易。",
+        "recovered_at": "後續手動同步成功補救此排程來源的時間；NULL 表示尚未補救。"
       }
     },
     "scheduled_sync_batches": {


### PR DESCRIPTION
## 變更內容

- 部分資料來源同步失敗時，仍依已更新來源計算資產、負債與淨資產變化，並清楚標示其餘來源沿用舊資料
- 手動同步成功後補救最近一輪排程報告，原子更新來源狀態、新增資料筆數與同步後財務快照
- 支援一般連接器與電子發票非同步流程，並避免重複累加、補錯批次及 TDCC 局部範圍誤判
- 手動同步完成後重新整理總覽同步報告，顯示補救時間
- 資產走勢新增較昨日、較上週、較上月比較；上月採曆月日期並處理月底
- 新增 D1 migration `0029_scheduled_sync_manual_recovery.sql`

## 問題原因

最近同步卡片原本只呈現已封存的排程批次。即使使用者後續手動同步失敗來源，只有 `sync_jobs` 會更新，原排程報告仍停留在失敗狀態；同時部分批次會完全省略財務變化。

## 影響

部署時會先套用新增的 D1 migration。完成後，部分同步可立即呈現目前可計算的變化，後續手動補救也會更新同一輪報告，而不必等下一次排程。

## 驗證

- `npm run typecheck`
- `npm run format:check`
- Worker：39 個測試檔、267 項測試通過
- Web：21 個測試檔、83 項測試通過
- 同步報告 repository：10 項測試通過，包含原子回滾、latest-only 與重複補救
- `npm run build -w @taiwan-fin-hub/web`
- Svelte autofixer：無問題
- localhost 桌面與 390px 手機寬度檢查：無水平溢出