### PR TITLE
改善總覽資訊呈現與資料來源定位

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -299,6 +299,107 @@ test("keeps the desktop overview within the viewport with long data", async ({
   expect(pageWidth.scroll).toBe(pageWidth.client);
 });
 
+test("keeps partial sync financial changes readable on mobile", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.route("**/api/sync-reports/latest", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "scheduled:mobile-partial-report",
+        startedAt: "2026-08-15T00:00:00.000Z",
+        completedAt: "2026-08-15T00:05:00.000Z",
+        status: "failed",
+        sources: [
+          {
+            connectorId: "esun",
+            status: "success",
+            completedAt: "2026-08-15T00:03:00.000Z",
+            recoveredAt: null,
+            newRecords: {
+              invoices: 0,
+              bankTransactions: 3,
+              investmentTransactions: 0,
+            },
+          },
+          {
+            connectorId: "taishin",
+            status: "failed",
+            completedAt: "2026-08-15T00:04:00.000Z",
+            recoveredAt: null,
+            newRecords: {
+              invoices: 0,
+              bankTransactions: 0,
+              investmentTransactions: 0,
+            },
+          },
+          {
+            connectorId: "einvoice",
+            status: "success",
+            completedAt: "2026-08-15T00:05:00.000Z",
+            recoveredAt: null,
+            newRecords: {
+              invoices: 2,
+              bankTransactions: 0,
+              investmentTransactions: 0,
+            },
+          },
+        ],
+        sourceSummary: {
+          total: 3,
+          success: 2,
+          failed: 1,
+          needsUserAction: 0,
+        },
+        newRecords: {
+          invoices: 2,
+          bankTransactions: 3,
+          investmentTransactions: 0,
+        },
+        financialChange: {
+          assets: -1_234_567,
+          creditCardDebt: 7_654_321,
+          netWorth: -8_888_888,
+        },
+        financialChangeUnavailableReason: null,
+        missingCurrencies: [],
+        recoveredAt: null,
+      }),
+    });
+  });
+
+  await page.goto("/#/overview");
+  await expect(
+    page.getByText("依 2/3 已更新來源計算，其餘沿用上次資料"),
+  ).toBeVisible();
+
+  for (const value of ["−NT$1,234,567", "+NT$7,654,321", "−NT$8,888,888"]) {
+    const amount = page.getByText(value, { exact: true });
+    await expect(amount).toBeVisible();
+    expect(
+      await amount.evaluate((element) => element.scrollWidth),
+      `${value} should not be truncated`,
+    ).toBeLessThanOrEqual(
+      await amount.evaluate((element) => element.clientWidth),
+    );
+  }
+
+  const pageWidth = () =>
+    page.evaluate(() => ({
+      client: document.documentElement.clientWidth,
+      scroll: document.documentElement.scrollWidth,
+    }));
+  expect((await pageWidth()).scroll).toBe((await pageWidth()).client);
+
+  await page.getByText("查看各資料來源", { exact: true }).click();
+  await expect(page.getByText("收合各資料來源", { exact: true })).toBeVisible();
+  await expect(page.getByText("玉山銀行", { exact: true })).toBeVisible();
+  await expect(page.getByText("台新銀行", { exact: true })).toBeVisible();
+  expect((await pageWidth()).scroll).toBe((await pageWidth()).client);
+});
+
 test("shows this month's cash flow on the overview and opens activity", async ({
   page,
 }) => {

--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
   await page.route("**/api/**", async (route) => {
@@ -64,6 +64,61 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
+async function expectSelectedConnectorInView(
+  page: Page,
+  connectorId: string,
+  title: string,
+) {
+  await expect(page).toHaveURL(/#\/data-sources$/);
+  const connectorSettings = page.locator(
+    `[data-connector-settings="${connectorId}"]`,
+  );
+  await expect(connectorSettings).toBeVisible();
+  await expect(
+    connectorSettings.getByRole("heading", { name: title, exact: true }),
+  ).toBeVisible();
+  await expect(
+    connectorSettings.getByRole("button", { name: "收合", exact: true }),
+  ).toBeVisible();
+  await expect(
+    connectorSettings.getByRole("heading", {
+      name: "連線與同步",
+      exact: true,
+    }),
+  ).toBeVisible();
+
+  const scrollPosition = () =>
+    page.evaluate(() =>
+      document.documentElement.classList.contains("is-standalone")
+        ? (document.getElementById("root")?.scrollTop ?? 0)
+        : window.scrollY,
+    );
+  await expect
+    .poll(async () => {
+      const before = await scrollPosition();
+      await page.waitForTimeout(120);
+      const after = await scrollPosition();
+      return after > 0 && Math.abs(after - before) <= 1;
+    })
+    .toBe(true);
+
+  const position = await connectorSettings.evaluate((element) => {
+    const header = document.querySelector("header");
+    return {
+      targetTop: element.getBoundingClientRect().top,
+      headerBottom: header?.getBoundingClientRect().bottom ?? 0,
+    };
+  });
+  expect(position.targetTop).toBeGreaterThanOrEqual(position.headerBottom - 1);
+  expect(position.targetTop).toBeLessThanOrEqual(position.headerBottom + 96);
+
+  const pageWidth = await page.evaluate(() => ({
+    client: document.documentElement.clientWidth,
+    scroll: document.documentElement.scrollWidth,
+  }));
+  expect(pageWidth.scroll).toBe(pageWidth.client);
+}
+
 test("loads the responsive shell and changes primary views", async ({
   page,
 }) => {
@@ -99,6 +154,71 @@ test("renders the mobile bottom navigation", async ({ page }) => {
   await expect(
     page.getByRole("heading", { name: "更多", exact: true }),
   ).toBeVisible();
+});
+
+test("opens and scrolls to the selected connector from mobile more", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/#/more");
+
+  await page.getByRole("button", { name: "管理台新銀行", exact: true }).click();
+
+  await expectSelectedConnectorInView(page, "taishin", "台新銀行");
+});
+
+test("opens and scrolls to the actionable connector from mobile overview", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.route("**/api/sync-jobs", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          id: "taishin:all",
+          connectorId: "taishin",
+          configured: true,
+          scope: "all",
+          enabled: true,
+          intervalMinutes: 1440,
+          nextRunAt: "2026-08-16T01:00:00.000Z",
+          scheduleMode: "inherit",
+          preferredTime: "09:00",
+          preferredWeekday: 1,
+          lockedUntil: null,
+          lockedBy: null,
+          lockTrigger: null,
+          lockScope: null,
+          lastRunAt: "2026-08-15T01:00:00.000Z",
+          lastSuccessAt: "2026-08-14T01:00:00.000Z",
+          lastStatus: "needs_user_action",
+          lastError: "需要重新驗證",
+          updatedAt: "2026-08-15T01:00:00.000Z",
+          running: false,
+        },
+      ]),
+    });
+  });
+  await page.route("**/api/sync-schedule", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        intervalMinutes: 1440,
+        preferredTime: "09:00",
+        preferredWeekday: 1,
+        timezone: "Asia/Taipei",
+        updatedAt: "2026-08-15T01:00:00.000Z",
+      }),
+    });
+  });
+  await page.goto("/#/overview");
+
+  await page.getByRole("button", { name: /1 個資料來源需要處理/ }).click();
+
+  await expectSelectedConnectorInView(page, "taishin", "台新銀行");
 });
 
 test("warns about a missing exchange rate only when the foreign balance is positive", async ({

--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -299,6 +299,82 @@ test("keeps the desktop overview within the viewport with long data", async ({
   expect(pageWidth.scroll).toBe(pageWidth.client);
 });
 
+test("keeps net worth comparison details readable across viewports", async ({
+  page,
+}) => {
+  await page.route("**/api/history/net-worth/chart", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          date: "2026-08-13",
+          netWorth: 2_254_854,
+          assetType: "deposit",
+          source: "bank",
+        },
+        {
+          date: "2026-08-14",
+          netWorth: 2_249_504,
+          assetType: "deposit",
+          source: "bank",
+        },
+      ]),
+    });
+  });
+
+  const comparisonRows = [
+    { label: "目前", date: undefined, value: "NT$2,249,504" },
+    { label: "較昨日", date: "2026/8/13", value: "NT$2,254,854" },
+    { label: "變化", date: undefined, value: "−NT$5,350 （−0.2%）" },
+  ] as const;
+
+  for (const viewport of [
+    { width: 390, height: 844 },
+    { width: 1280, height: 900 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.goto("/#/overview");
+
+    await expect(page.getByRole("heading", { name: "資產走勢" })).toBeVisible();
+    const comparisonCard = page
+      .getByText("目前", { exact: true })
+      .locator("xpath=ancestor::div[contains(@class, 'rounded-lg')][1]");
+
+    for (const { label, date, value } of comparisonRows) {
+      const labelElement = comparisonCard.getByText(label, { exact: true });
+      const row = labelElement.locator(
+        "xpath=ancestor::div[contains(@class, 'grid')][1]",
+      );
+      const amount = row.getByText(value, { exact: true });
+      const visibleElements = [labelElement, amount];
+
+      if (date) {
+        const dateElement = row.getByText(date, { exact: true });
+        await expect(dateElement).toBeVisible();
+        visibleElements.push(dateElement);
+      }
+
+      await expect(labelElement).toBeVisible();
+      await expect(amount).toBeVisible();
+      for (const element of visibleElements) {
+        expect(
+          await element.evaluate((node) => node.scrollWidth),
+          `${label} should not be truncated at ${viewport.width}px`,
+        ).toBeLessThanOrEqual(
+          await element.evaluate((node) => node.clientWidth),
+        );
+      }
+    }
+
+    const pageWidth = await page.evaluate(() => ({
+      client: document.documentElement.clientWidth,
+      scroll: document.documentElement.scrollWidth,
+    }));
+    expect(pageWidth.scroll).toBe(pageWidth.client);
+  }
+});
+
 test("keeps partial sync financial changes readable on mobile", async ({
   page,
 }) => {

--- a/apps/web/src/app/App.svelte
+++ b/apps/web/src/app/App.svelte
@@ -8,6 +8,7 @@
   import ManualAssets from "@/features/assets/ManualAssets.svelte";
   import Overview from "@/features/overview/OverviewPage.svelte";
   import SettingsView from "@/features/settings/SettingsPage.svelte";
+  import type { ConnectorId } from "@/data/connectors/types";
   import { createApiClient } from "@/shared/api/client";
   import { swipeBack } from "@/shared/actions/swipe-back";
   import { moneyState } from "@/shared/state/money-visibility.svelte";
@@ -32,6 +33,7 @@
 
   const api = createApiClient();
   let view = $state<View>("overview");
+  let connectorTarget = $state<ConnectorId | null>(null);
   let runtime = $state<RuntimeInfo>({ demoMode: false });
   const isDetail = (v: View): v is DetailView => Object.hasOwn(detailLabels, v);
   const isMobileSetting = (v: View): v is MobileSettingsView =>
@@ -86,8 +88,10 @@
       localStorage.getItem("taiwan-fin-hub-money-hidden") === "true";
     return () => window.removeEventListener("hashchange", handleHashChange);
   });
-  function navigate(next: View) {
+  function navigate(next: View, targetConnector?: ConnectorId) {
     view = next;
+    connectorTarget =
+      next === "data-sources" ? (targetConnector ?? null) : null;
     const nextHash = viewHash(next);
     if (window.location.hash !== nextHash) {
       if (isStandalone()) {
@@ -242,6 +246,7 @@
         {:else}<SettingsView
             {api}
             demoMode={runtime.demoMode}
+            {connectorTarget}
             mobileView={view === "more"
               ? "more"
               : isMobileSetting(view)

--- a/apps/web/src/features/overview/OverviewPage.svelte
+++ b/apps/web/src/features/overview/OverviewPage.svelte
@@ -19,6 +19,7 @@
   } from "@/data/assets/queries";
   import { bankQuery, bankRangeQuery } from "@/data/bank/queries";
   import { syncJobsQuery } from "@/data/connectors/queries";
+  import type { ConnectorId } from "@/data/connectors/types";
   import { latestSyncReportQuery } from "@/data/sync-reports/queries";
   import {
     getActionableSyncJobs,
@@ -50,10 +51,16 @@
     tone: InsightTone;
     icon: InsightIcon;
     view: View;
+    connectorId?: ConnectorId;
   }
 
-  let { api, navigate }: { api: ApiClient; navigate: (view: View) => void } =
-    $props();
+  let {
+    api,
+    navigate,
+  }: {
+    api: ApiClient;
+    navigate: (view: View, connectorId?: ConnectorId) => void;
+  } = $props();
 
   const bank = createQuery(bankQuery(() => api));
   const monthKey = new Date().toISOString().slice(0, 7);
@@ -173,6 +180,7 @@
         tone: "amber",
         icon: "sync",
         view: "data-sources",
+        connectorId: unhealthy[0]?.connectorId,
       });
     }
 
@@ -184,6 +192,7 @@
         tone: "amber",
         icon: "sync",
         view: "data-sources",
+        connectorId: staleJobs[0]?.connectorId,
       });
     }
 
@@ -446,7 +455,7 @@
                           ? "border-emerald-200 bg-emerald-50/70"
                           : "border-sky-200 bg-sky-50/70"
                   }`}
-                  onclick={() => navigate(insight.view)}
+                  onclick={() => navigate(insight.view, insight.connectorId)}
                 >
                   {#if insight.icon === "sync"}
                     <RefreshCw class="size-5 shrink-0 text-amber-600" />
@@ -569,7 +578,7 @@
                         ? "border-emerald-200 bg-emerald-50/70"
                         : "border-sky-200 bg-sky-50/70"
                 }`}
-                onclick={() => navigate(insight.view)}
+                onclick={() => navigate(insight.view, insight.connectorId)}
               >
                 {#if insight.icon === "sync"}
                   <RefreshCw class="size-5 shrink-0 text-amber-600" />

--- a/apps/web/src/features/overview/components/LatestSyncReportCard.svelte
+++ b/apps/web/src/features/overview/components/LatestSyncReportCard.svelte
@@ -174,19 +174,23 @@
                 {financialChangeScope}
               </p>
             {/if}
-            <div class="mt-3 grid grid-cols-3 gap-2">
+            <div class="mt-3 grid gap-2 sm:grid-cols-3">
               {#each financialItems as item (item.label)}
                 {@const change = signedFinancialChange(
                   item.value,
                   item.positiveChangeIsFavorable,
                 )}
-                <div class="min-w-0">
+                <div
+                  class="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-baseline gap-3 sm:block"
+                >
                   <p
-                    class={`truncate text-base font-bold tabular-nums sm:text-lg ${change.tone === "positive" ? "text-moss" : change.tone === "negative" ? "text-coral" : "text-ink"}`}
+                    class={`col-start-2 row-start-1 whitespace-nowrap text-right text-base font-bold tabular-nums sm:text-left sm:text-lg ${change.tone === "positive" ? "text-moss" : change.tone === "negative" ? "text-coral" : "text-ink"}`}
                   >
                     {formatFinancialChange(item.value)}
                   </p>
-                  <p class="mt-1 truncate text-[11px] text-ink/45">
+                  <p
+                    class="col-start-1 row-start-1 truncate text-[11px] text-ink/45 sm:mt-1"
+                  >
                     {item.label}
                   </p>
                 </div>

--- a/apps/web/src/features/overview/components/NetWorthHistoryChart.svelte
+++ b/apps/web/src/features/overview/components/NetWorthHistoryChart.svelte
@@ -280,7 +280,7 @@
         {/if}
       </div>
       <div
-        class="mt-3 flex min-w-0 flex-wrap items-center justify-between gap-3 border-t border-ink/8 pt-3"
+        class="mt-3 grid min-w-0 gap-3 border-t border-ink/8 pt-3 md:grid-cols-[auto_minmax(18rem,28rem)] md:items-start md:justify-between"
       >
         <div class="flex min-w-0 flex-wrap items-center gap-2">
           <span class="shrink-0 text-xs font-semibold text-ink/50">比較</span>
@@ -299,27 +299,51 @@
         </div>
         {#if comparison && comparisonOption}
           {@const comparisonSign = comparison.changeValue > 0 ? "+" : ""}
-          <div class="min-w-0 text-right text-xs leading-relaxed text-ink/55">
-            <p class="truncate">
-              目前 {formatCurrency(comparison.currentValue)} · {comparisonOption.label}（{formatDate(
-                comparison.previousDate,
-              )}）
-              {formatCurrency(comparison.previousValue)}
-            </p>
-            <p
-              class={`font-semibold ${comparison.changeValue > 0 ? "text-moss" : comparison.changeValue < 0 ? "text-coral" : "text-ink/55"}`}
+          <div class="grid min-w-0 gap-2 rounded-lg bg-paper px-3 py-3 text-sm">
+            <div
+              class="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-baseline gap-3"
             >
-              變化 {comparison.changeValue < 0
-                ? ""
-                : comparisonSign}{formatCurrency(comparison.changeValue)}
-              {#if comparison.changePercent !== null}
-                （{comparison.changePercent > 0
-                  ? "+"
-                  : comparison.changePercent < 0
-                    ? "−"
-                    : ""}{Math.abs(comparison.changePercent).toFixed(1)}%）
-              {/if}
-            </p>
+              <span class="text-ink/45">目前</span>
+              <span
+                class="whitespace-nowrap text-right font-semibold text-ink/70 tabular-nums sm:text-base"
+                >{formatCurrency(comparison.currentValue)}</span
+              >
+            </div>
+            <div
+              class="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3"
+            >
+              <span class="min-w-0">
+                <span class="block font-medium text-ink/50"
+                  >{comparisonOption.label}</span
+                >
+                <span class="mt-0.5 block text-xs text-ink/40">
+                  {formatDate(comparison.previousDate)}
+                </span>
+              </span>
+              <span
+                class="whitespace-nowrap text-right font-semibold text-ink/70 tabular-nums sm:text-base"
+                >{formatCurrency(comparison.previousValue)}</span
+              >
+            </div>
+            <div
+              class="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-baseline gap-3 border-t border-ink/8 pt-1.5"
+            >
+              <span class="font-semibold text-ink/50">變化</span>
+              <span
+                class={`whitespace-nowrap text-right font-semibold tabular-nums sm:text-base ${comparison.changeValue > 0 ? "text-moss" : comparison.changeValue < 0 ? "text-coral" : "text-ink/55"}`}
+              >
+                {comparison.changeValue < 0
+                  ? ""
+                  : comparisonSign}{formatCurrency(comparison.changeValue)}
+                {#if comparison.changePercent !== null}
+                  （{comparison.changePercent > 0
+                    ? "+"
+                    : comparison.changePercent < 0
+                      ? "−"
+                      : ""}{Math.abs(comparison.changePercent).toFixed(1)}%）
+                {/if}
+              </span>
+            </div>
           </div>
         {:else}
           <p class="text-xs text-ink/40">

--- a/apps/web/src/features/settings/SettingsPage.svelte
+++ b/apps/web/src/features/settings/SettingsPage.svelte
@@ -27,11 +27,13 @@
   let {
     api,
     demoMode,
+    connectorTarget,
     mobileView,
     navigate,
   }: {
     api: ApiClient;
     demoMode: boolean;
+    connectorTarget?: ConnectorId | null;
     mobileView?: MobileSettingsView | "more";
     navigate: (view: View) => void;
   } = $props();
@@ -57,7 +59,12 @@
   const bank = createQuery(bankQuery(() => api));
   const rates = createQuery(exchangeRatesQuery(() => api));
   const notifications = createQuery(notificationConfigQuery(() => api));
-  let selectedConnector = $state<ConnectorId | null>(null);
+  let selectedConnector = $state<ConnectorId | null | undefined>(undefined);
+  const activeConnector = $derived(
+    selectedConnector === undefined
+      ? (connectorTarget ?? null)
+      : selectedConnector,
+  );
   const needsAction = $derived(getActionableSyncJobs($jobs.data ?? []).length);
   const configuredSources = $derived(getConfiguredSyncJobs($jobs.data ?? []));
   const healthySources = $derived(
@@ -126,12 +133,40 @@
     }, undefined),
   );
   function selectConnector(id: ConnectorId) {
-    selectedConnector = selectedConnector === id ? null : id;
+    selectedConnector = activeConnector === id ? null : id;
   }
 
   function openConnector(id: ConnectorId) {
     selectedConnector = id;
     navigate("data-sources");
+  }
+
+  function scrollSelectedConnector(node: HTMLElement, selected: boolean) {
+    let firstFrame: number | undefined;
+    let secondFrame: number | undefined;
+
+    function cancelScheduledScroll() {
+      if (firstFrame !== undefined) cancelAnimationFrame(firstFrame);
+      if (secondFrame !== undefined) cancelAnimationFrame(secondFrame);
+      firstFrame = undefined;
+      secondFrame = undefined;
+    }
+
+    function scheduleScroll(active: boolean) {
+      cancelScheduledScroll();
+      if (!active) return;
+      firstFrame = requestAnimationFrame(() => {
+        secondFrame = requestAnimationFrame(() => {
+          node.scrollIntoView({ behavior: "smooth", block: "start" });
+        });
+      });
+    }
+
+    scheduleScroll(selected);
+    return {
+      update: scheduleScroll,
+      destroy: cancelScheduledScroll,
+    };
   }
 
   function isActiveTab(tabView: (typeof settingTabs)[number]["view"]) {
@@ -191,7 +226,7 @@
               jobs={$jobs.data ?? []}
               compact
               compactCard
-              selected={selectedConnector === source.id}
+              selected={activeConnector === source.id}
               onConfigure={() => selectConnector(source.id)}
             />
           {/each}
@@ -201,9 +236,9 @@
           aria-label="連接器詳情"
           class="min-h-[520px] min-w-0 rounded-xl border border-border bg-card p-5 shadow-xs"
         >
-          {#if selectedConnector}
+          {#if activeConnector}
             {@const selectedSource = sources.find(
-              (source) => source.id === selectedConnector,
+              (source) => source.id === activeConnector,
             )}
             <div class="mb-4 flex items-start justify-between gap-3">
               <div>
@@ -217,12 +252,12 @@
                 onclick={() => (selectedConnector = null)}>關閉</button
               >
             </div>
-            {#key selectedConnector}<ConnectorPanel
+            {#key activeConnector}<ConnectorPanel
                 {api}
-                connectorId={selectedConnector}
+                connectorId={activeConnector}
                 {demoMode}
                 title={selectedSource?.title ?? "連接器"}
-                fields={connectorFields[selectedConnector]}
+                fields={connectorFields[activeConnector]}
                 embedded
               />{/key}
           {:else}
@@ -243,25 +278,31 @@
         class="grid min-w-0 gap-3 sm:grid-cols-2 md:hidden"
       >
         {#each sources as source (source.id)}
-          <SourceCard
-            {api}
-            {...source}
-            id={source.id}
-            jobs={$jobs.data ?? []}
-            selected={selectedConnector === source.id}
-            onConfigure={() => selectConnector(source.id)}
+          <div
+            class={`min-w-0 scroll-mt-24 ${activeConnector === source.id ? "sm:col-span-2" : ""}`}
+            data-connector-settings={source.id}
+            use:scrollSelectedConnector={activeConnector === source.id}
           >
-            {#if selectedConnector === source.id}
-              {#key source.id}<ConnectorPanel
-                  {api}
-                  connectorId={source.id}
-                  {demoMode}
-                  title={source.title}
-                  fields={connectorFields[source.id]}
-                  embedded
-                />{/key}
-            {/if}
-          </SourceCard>
+            <SourceCard
+              {api}
+              {...source}
+              id={source.id}
+              jobs={$jobs.data ?? []}
+              selected={activeConnector === source.id}
+              onConfigure={() => selectConnector(source.id)}
+            >
+              {#if activeConnector === source.id}
+                {#key source.id}<ConnectorPanel
+                    {api}
+                    connectorId={source.id}
+                    {demoMode}
+                    title={source.title}
+                    fields={connectorFields[source.id]}
+                    embedded
+                  />{/key}
+              {/if}
+            </SourceCard>
+          </div>
         {/each}
       </section>
     </div>


### PR DESCRIPTION
## 變更內容

- 調整同步報告在手機版的財務變化排列，完整顯示金額
- 將資產走勢比較改為三列資訊，放大主要文字並提升手機與桌面版的可讀性
- 從「更多」或總覽提醒進入資料來源時，自動選取、展開並捲動到對應連接器
- 新增手機、桌面與跨頁自動定位的 Playwright E2E 測試

## 原因與影響

手機窄螢幕下，同步差額與資產比較資訊可能被截斷；資料來源入口也只會開啟設定頁，使用者仍需手動尋找對應銀行。調整後，金額與比較資訊可完整閱讀，異常來源也能直接定位處理。

## 驗證

- `npm run verify:web`
- Svelte typecheck：0 errors / 0 warnings
- Vitest：83 passed
- Playwright：22 passed
- Production build：通過
