### PR TITLE
品牌：將產品更名為「不用記帳」

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 <p align="center">
-  <img src="apps/web/public/icon-512x512.png" alt="Taiwan Fin Hub Logo" width="160">
+  <img src="apps/web/public/icon-512x512.png" alt="不用記帳 Logo" width="160">
 </p>
 
-# Taiwan Fin Hub
+# 不用記帳
 
-自架個人理財整合工具，將銀行、投資、信用卡與電子發票集中在同一個介面查看。
+**WEALTH OS**
+
+自動同步銀行、信用卡、投資與電子發票的自架個人財務整合工具。
 
 **可免費自架：** 可透過 [Cloudflare Workers Free Plan](https://developers.cloudflare.com/workers/platform/pricing/) 一鍵部署，不需要自行準備伺服器；一般個人低頻使用可從免費方案開始。
 
 > 本專案以 [kevchentw/taiwan-fin-hub](https://github.com/kevchentw/taiwan-fin-hub) 為基礎，持續擴充資料來源、同步流程與 UI/UX。感謝原作者與貢獻者奠定專案基礎。
+>
+> Repository 技術名稱沿用 `taiwan-fin-hub`，以維持既有部署連結與上游同步相容。
 
 ## 支援資料來源
 

--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -123,7 +123,8 @@ test("loads the responsive shell and changes primary views", async ({
   page,
 }) => {
   await page.goto("/");
-  await expect(page.getByText("Taiwan Fin Hub").first()).toBeVisible();
+  await expect(page.getByText("不用記帳").first()).toBeVisible();
+  await expect(page.getByText("WEALTH OS").first()).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "總覽", exact: true }),
   ).toBeVisible();

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
     <link rel="manifest" href="/site.webmanifest" />
-    <title>Taiwan Fin Hub</title>
+    <title>不用記帳 | WEALTH OS</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/public/site.webmanifest
+++ b/apps/web/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Taiwan Fin Hub",
-  "short_name": "Fin Hub",
+  "name": "不用記帳",
+  "short_name": "不用記帳",
   "id": "/",
   "start_url": "/#/overview",
   "scope": "/",

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,7 +1,7 @@
-/* Taiwan Fin Hub notification worker. Keep this file root-scoped for the PWA. */
+/* 不用記帳 notification worker. Keep this file root-scoped for the PWA. */
 self.addEventListener("push", (event) => {
   const fallback = {
-    title: "Taiwan Fin Hub",
+    title: "不用記帳",
     body: "同步狀態已更新。",
     url: "/#/overview",
     tag: "sync-status",

--- a/apps/web/src/app/App.svelte
+++ b/apps/web/src/app/App.svelte
@@ -131,11 +131,11 @@
       class="hidden border-r border-white/10 bg-ink px-6 py-7 text-white xl:sticky xl:top-0 xl:flex xl:h-screen xl:flex-col"
     >
       <div class="px-2">
-        <h1 class="text-xl font-semibold tracking-normal">Taiwan Fin Hub</h1>
+        <h1 class="text-xl font-semibold tracking-normal">不用記帳</h1>
         <p
           class="mt-2 text-xs font-semibold uppercase tracking-[0.16em] text-steel/90"
         >
-          Wealth OS
+          WEALTH OS
         </p>
       </div>
       <nav class="mt-6 grid gap-1">

--- a/apps/web/src/features/settings/components/NotificationPanel.svelte
+++ b/apps/web/src/features/settings/components/NotificationPanel.svelte
@@ -277,8 +277,7 @@
       >
         <Smartphone class="mt-0.5 size-5 shrink-0 text-steel" />
         <p class="text-sm leading-relaxed text-muted-foreground">
-          請先將 Taiwan Fin Hub 加入 iPhone／iPad
-          主畫面，再從主畫面開啟並啟用推播。
+          請先將「不用記帳」加入 iPhone／iPad 主畫面，再從主畫面開啟並啟用推播。
         </p>
       </div>
     {:else if !support.supported}

--- a/apps/worker/src/features/notifications/service.ts
+++ b/apps/worker/src/features/notifications/service.ts
@@ -128,7 +128,7 @@ export async function sendTestNotification(env: Env) {
   requirePushConfiguration(env);
   return deliverPushPayload(env, {
     title: "推播測試成功",
-    body: "Taiwan Fin Hub 已經可以通知你同步狀態。",
+    body: "「不用記帳」已經可以通知你同步狀態。",
     url: "/#/settings",
     tag: "notification-test",
   });


### PR DESCRIPTION
## 變更內容

- 將產品顯示名稱由 Taiwan Fin Hub 更新為「不用記帳」
- 保留副標「WEALTH OS」
- 同步更新 README、瀏覽器標題、PWA 名稱、推播通知與 iOS 安裝提示
- 更新端對端測試的品牌顯示斷言
- 保留 `taiwan-fin-hub` repo、npm scope、Cloudflare 資源與其他技術識別

## 目的

以「不用記帳」直接傳達自動同步銀行、信用卡、投資與電子發票的產品定位，同時維持既有部署連結與上游同步相容。

## 驗證

- Svelte autofixer：無問題
- `npm run verify:web`：83 個單元測試、22 個 Playwright 測試、typecheck 與 production build 通過
- `npm test -w @taiwan-fin-hub/worker`：267 個測試通過
- `npm run format:check`
- `git diff --check`
- PWA manifest JSON 解析通過

## 補充

GitHub repository description 與 topics 已同步更新；這些屬於 GitHub metadata，不包含在本 PR diff。