### PR TITLE
維護：準備 repository 更名相容性

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   sync:
     # 官方 repository 不需要同步自己；Deploy to Cloudflare 建立的副本才會執行。
-    if: github.repository != 'TedLin1993/taiwan-fin-hub'
+    if: github.repository != 'TedLin1993/taiwan-fin-hub' && github.repository != 'TedLin1993/all-set-tw'
     runs-on: ubuntu-latest
 
     steps:

--- a/deploy/github/sync-upstream.yml
+++ b/deploy/github/sync-upstream.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   sync:
     # 官方 repository 不需要同步自己；Deploy to Cloudflare 建立的副本才會執行。
-    if: github.repository != 'TedLin1993/taiwan-fin-hub'
+    if: github.repository != 'TedLin1993/taiwan-fin-hub' && github.repository != 'TedLin1993/all-set-tw'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## 變更內容

- 讓 canonical repository 在更名前後都略過下游同步 job
- 同步更新正式 workflow 與提供部署專案複製的 workflow 範本

## 目的

Repository 將由 `TedLin1993/taiwan-fin-hub` 更名為 `TedLin1993/all-set-tw`。若只保留舊名稱判斷，改名後 canonical repository 會被誤認為部署副本並執行 upstream sync。

這個過渡變更會先合併，再執行 repository rename；upstream URL 與 README 連結會在改名完成後更新。

## 驗證

- `npm run test:deploy`：16 個測試通過
- 兩份 workflow 通過 Prettier
- `git diff --check`