### PR TITLE
品牌：完成 ALL SET 與 repository 更名

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -39,7 +39,7 @@ jobs:
             # 舊版 Cloudflare 部署 repo 尚未包含 updater script；只下載至 runner 暫存目錄。
             updater="$RUNNER_TEMP/sync-upstream.mjs"
             curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
-              "https://raw.githubusercontent.com/TedLin1993/taiwan-fin-hub/main/scripts/sync-upstream.mjs" \
+              "https://raw.githubusercontent.com/TedLin1993/all-set-tw/main/scripts/sync-upstream.mjs" \
               --output "$updater"
           fi
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 不用記帳
 
-**WEALTH OS**
+**ALL SET**
 
 自動同步銀行、信用卡、投資與電子發票的自架個人財務整合工具。
 
@@ -12,7 +12,7 @@
 
 > 本專案以 [kevchentw/taiwan-fin-hub](https://github.com/kevchentw/taiwan-fin-hub) 為基礎，持續擴充資料來源、同步流程與 UI/UX。感謝原作者與貢獻者奠定專案基礎。
 >
-> Repository 技術名稱沿用 `taiwan-fin-hub`，以維持既有部署連結與上游同步相容。
+> GitHub repository 使用 `all-set-tw`；npm scope 與 Cloudflare 資源仍沿用 `taiwan-fin-hub`，以維持既有部署相容。
 
 ## 支援資料來源
 
@@ -78,7 +78,7 @@
 
 點擊下方按鈕。Cloudflare 會在你的 GitHub 帳號建立新的 repository、自動建立 D1 Database，並部署至 Cloudflare Workers：
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/TedLin1993/taiwan-fin-hub)
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/TedLin1993/all-set-tw)
 
 Cloudflare Builds 會在 build 階段自動檢查並建立排程同步所需的 Queue；正式部署腳本也會再次檢查。既有安裝更新到使用 Queue 的版本時不需要手動建立資源。
 
@@ -169,7 +169,7 @@ git push
 
 每次執行時，workflow 會：
 
-1. 取得 `TedLin1993/taiwan-fin-hub` 的最新 `main`
+1. 取得 `TedLin1993/all-set-tw` 的最新 `main`
 2. 以前次同步版本為基準進行安全三方合併
 3. 有新版本時將更新推送至部署 repository
 4. 由 Cloudflare Workers Builds 自動重新部署

--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -124,7 +124,7 @@ test("loads the responsive shell and changes primary views", async ({
 }) => {
   await page.goto("/");
   await expect(page.getByText("不用記帳").first()).toBeVisible();
-  await expect(page.getByText("WEALTH OS").first()).toBeVisible();
+  await expect(page.getByText("ALL SET").first()).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "總覽", exact: true }),
   ).toBeVisible();

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
     <link rel="manifest" href="/site.webmanifest" />
-    <title>不用記帳 | WEALTH OS</title>
+    <title>不用記帳 | ALL SET</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/app/App.svelte
+++ b/apps/web/src/app/App.svelte
@@ -135,7 +135,7 @@
         <p
           class="mt-2 text-xs font-semibold uppercase tracking-[0.16em] text-steel/90"
         >
-          WEALTH OS
+          ALL SET
         </p>
       </div>
       <nav class="mt-6 grid gap-1">

--- a/deploy/github/sync-upstream.yml
+++ b/deploy/github/sync-upstream.yml
@@ -39,7 +39,7 @@ jobs:
             # 舊版 Cloudflare 部署 repo 尚未包含 updater script；只下載至 runner 暫存目錄。
             updater="$RUNNER_TEMP/sync-upstream.mjs"
             curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
-              "https://raw.githubusercontent.com/TedLin1993/taiwan-fin-hub/main/scripts/sync-upstream.mjs" \
+              "https://raw.githubusercontent.com/TedLin1993/all-set-tw/main/scripts/sync-upstream.mjs" \
               --output "$updater"
           fi
 

--- a/scripts/sync-upstream.mjs
+++ b/scripts/sync-upstream.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 
 const WORKFLOW_PREFIX = ".github/workflows/";
 const WORKFLOW_PATHSPEC = ".github/workflows";
-const DEFAULT_UPSTREAM_URL = "https://github.com/TedLin1993/taiwan-fin-hub.git";
+const DEFAULT_UPSTREAM_URL = "https://github.com/TedLin1993/all-set-tw.git";
 const UPSTREAM_TRAILER = "Taiwan-Fin-Hub-Upstream";
 
 class SyncError extends Error {}


### PR DESCRIPTION
## 變更內容

- 將英文標題由 `WEALTH OS` 更新為 `ALL SET`
- 更新 README、瀏覽器標題與端對端品牌斷言
- 將 Deploy to Cloudflare、upstream updater 與同步說明改用 `TedLin1993/all-set-tw`
- 保留新舊 canonical repo 的 workflow self-guard，確保更名過渡期安全
- 明確保留 `@taiwan-fin-hub/*` npm scope 與 Cloudflare Worker／Queue／D1 技術識別

## 目的

完成「不用記帳｜ALL SET」品牌與 GitHub repository 更名，同時讓既有 Cloudflare 部署專案持續透過 updater 同步。

## 驗證

- Svelte autofixer：無問題
- `npm run verify:web`：83 個單元測試、22 個 Playwright 測試、typecheck 與 production build 通過
- `npm run test:deploy`：16 個部署與 upstream sync 測試通過
- `npm run format:check`
- `git diff --check`

## 外部狀態

- GitHub repository 已更名為 `TedLin1993/all-set-tw`
- 舊 Git URL 已確認仍可透過 GitHub redirect 取得相同 HEAD
- GitHub description 已更新為「不用記帳｜ALL SET」