### PR TITLE
修正同步錯誤即時顯示

### DIFF
--- a/apps/worker/src/features/sync/route.ts
+++ b/apps/worker/src/features/sync/route.ts
@@ -358,48 +358,64 @@ async function syncRouteResponse(
     return c.json(await result);
   } catch (error) {
     if (error instanceof SyncAlreadyRunningError) {
-      return jsonError("SYNC_ALREADY_RUNNING", error.message, 409);
+      return jsonError("SYNC_ALREADY_RUNNING", safeErrorMessage(error), 409);
     }
     if (error instanceof TdccVerificationRequiredError) {
       return jsonError(
         error.channel === "sms"
           ? "TDCC_SMS_OTP_REQUIRED"
           : "TDCC_EMAIL_OTP_REQUIRED",
-        error.message,
+        safeErrorMessage(error),
         400,
       );
     }
     if (error instanceof TdccConnectionError) {
-      return jsonError("TDCC_CONNECTION_FAILED", error.message, 400);
+      return jsonError("TDCC_CONNECTION_FAILED", safeErrorMessage(error), 400);
     }
     if (error instanceof NeedsUserActionError) {
-      return jsonError("USER_ACTION_REQUIRED", error.message, 400);
+      return jsonError("USER_ACTION_REQUIRED", safeErrorMessage(error), 400);
     }
     if (error instanceof EInvoiceProtocolUnavailableError) {
-      return jsonError("CONNECTOR_PROTOCOL_UNAVAILABLE", error.message, 503);
+      return jsonError(
+        "CONNECTOR_PROTOCOL_UNAVAILABLE",
+        safeErrorMessage(error),
+        503,
+      );
     }
     if (error instanceof SinopacBrowserCapacityError) {
-      const response = jsonError("SINOPAC_BROWSER_BUSY", error.message, 429);
+      const response = jsonError(
+        "SINOPAC_BROWSER_BUSY",
+        safeErrorMessage(error),
+        429,
+      );
       response.headers.set("Retry-After", String(error.retryAfterSeconds));
       return response;
     }
     if (error instanceof TaishinBrowserCapacityError) {
-      const response = jsonError("TAISHIN_BROWSER_BUSY", error.message, 429);
+      const response = jsonError(
+        "TAISHIN_BROWSER_BUSY",
+        safeErrorMessage(error),
+        429,
+      );
       response.headers.set("Retry-After", String(error.retryAfterSeconds));
       return response;
     }
     if (error instanceof CtbcConnectionError) {
-      return jsonError("CTBC_CONNECTION_FAILED", error.message, 502);
+      return jsonError("CTBC_CONNECTION_FAILED", safeErrorMessage(error), 502);
     }
     if (error instanceof TaishinConnectionError) {
-      return jsonError("TAISHIN_CONNECTION_FAILED", error.message, 502);
+      return jsonError(
+        "TAISHIN_CONNECTION_FAILED",
+        safeErrorMessage(error),
+        502,
+      );
     }
     if (
       error instanceof ObankConnectionError ||
       error instanceof ObankProtocolError
     ) {
-      return jsonError("OBANK_CONNECTION_FAILED", error.message, 502);
+      return jsonError("OBANK_CONNECTION_FAILED", safeErrorMessage(error), 502);
     }
-    throw error;
+    return jsonError("SYNC_FAILED", safeErrorMessage(error), 500);
   }
 }

--- a/apps/worker/tests/features/sync/route.test.ts
+++ b/apps/worker/tests/features/sync/route.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   prepareObankCaptchaSession: vi.fn(),
   startEinvoiceSyncRun: vi.fn(),
   syncCtbc: vi.fn(),
+  syncEsun: vi.fn(),
   syncObank: vi.fn(),
   syncTaishin: vi.fn(),
 }));
@@ -39,7 +40,7 @@ vi.mock("../../../src/features/sync/service", () => ({
   syncCathaybk: vi.fn(),
   syncCtbc: mocks.syncCtbc,
   syncEinvoice: vi.fn(),
-  syncEsun: vi.fn(),
+  syncEsun: mocks.syncEsun,
   syncSinopac: vi.fn(),
   syncObank: mocks.syncObank,
   syncTaishin: mocks.syncTaishin,
@@ -89,6 +90,18 @@ beforeEach(() => {
   mocks.syncCtbc.mockResolvedValue({
     success: true,
     connectorId: "ctbc",
+    scope: "all",
+    records: 4,
+    newRecords: {
+      invoices: 0,
+      bankTransactions: 4,
+      investmentTransactions: 0,
+    },
+    cursorUpdated: true,
+  });
+  mocks.syncEsun.mockResolvedValue({
+    success: true,
+    connectorId: "esun",
     scope: "all",
     records: 4,
     newRecords: {
@@ -206,6 +219,31 @@ describe("CTBC sync route", () => {
     expect(failed.status).toBe(502);
     await expect(failed.json()).resolves.toMatchObject({
       error: { code: "CTBC_CONNECTION_FAILED" },
+    });
+  });
+});
+
+describe("E.SUN sync route", () => {
+  it("returns the same safe error message persisted by the sync service", async () => {
+    mocks.syncEsun.mockRejectedValueOnce(
+      new Error(
+        "E.SUN browser login: duplicate-login dialog kept reappearing.",
+      ),
+    );
+
+    const response = await syncRoutes.request(
+      "/connectors/esun/sync",
+      { method: "POST" },
+      env,
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "SYNC_FAILED",
+        message:
+          "E.SUN browser login: duplicate-login dialog kept reappearing.",
+      },
     });
   });
 });


### PR DESCRIPTION
## 變更內容

- 手動同步 API 的所有錯誤回應統一使用 `safeErrorMessage`
- 未分類同步錯誤改回傳 `SYNC_FAILED` 與具體安全訊息
- 新增玉山重複登入失敗的 route 回歸測試

## 問題原因

同步服務會先把具體錯誤寫入 `sync_jobs.last_error`，但未分類例外接著落入全域錯誤處理，導致前端第一次只看到 `An unexpected error occurred.`；重新整理後才會顯示資料庫保存的實際原因。

## 使用者影響

手動同步失敗時，前端即時顯示的錯誤會與重新整理後保存的錯誤一致，不再先顯示通用英文訊息。

## 驗證

- Worker 測試：39 個測試檔、268 個測試通過
- Worker TypeScript typecheck 通過
- Prettier 與 `git diff --check` 通過
- Svelte autofixer 通過