### PR TITLE
修正永豐無消費紀錄的同步判定

### DIFF
--- a/apps/worker/src/connectors/sinopac.ts
+++ b/apps/worker/src/connectors/sinopac.ts
@@ -776,6 +776,7 @@ function assertSinopacApiSuccess(payload: unknown, label: string) {
       "永豐銀行 session 已失效，請重新完成圖形驗證。",
     );
   }
+  if (message === "查無消費紀錄") return;
   if (header !== "SUCCESS")
     throw new Error(`永豐${label} API 失敗：${message}`);
 }

--- a/apps/worker/tests/connectors/sinopac.test.ts
+++ b/apps/worker/tests/connectors/sinopac.test.ts
@@ -465,6 +465,33 @@ describe("sinopac App JSON parser", () => {
     });
   });
 
+  it("treats no purchase records from the summary as a successful response", async () => {
+    const noPurchaseRecordsPayload = [
+      { Header: "FAIL", Message: "查無消費紀錄" },
+    ];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const payload = url.includes("ws_cardsum")
+        ? noPurchaseRecordsPayload
+        : payloadForUrl(url);
+      return new Response(JSON.stringify(payload), { status: 200 });
+    });
+
+    const result = await createSinopacConnector(
+      undefined,
+      fetchMock as typeof fetch,
+    ).sync({
+      userId: "A123456789",
+      sessionCookies,
+      protocol: "sinopac-mobile-app-json-v1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(result.bankBalanceSnapshots).toHaveLength(1);
+    expect(result.creditCardBills).toHaveLength(1);
+    expect(result.bankTransactions).toHaveLength(2);
+  });
+
   it("isolates App cookies and follows SinoCard cookie rotation", async () => {
     const authCookies = JSON.stringify([
       ...JSON.parse(sessionCookies),


### PR DESCRIPTION
## 摘要

- 將永豐信用卡總覽回傳「查無消費紀錄」視為成功回應
- 保留其他 API 失敗訊息的原有錯誤處理
- 新增回歸測試，確認同步仍會繼續處理帳單與交易

## 測試

- `npm exec -w @taiwan-fin-hub/worker -- vitest run tests/connectors/sinopac.test.ts`（11 tests）
- `npm exec -w @taiwan-fin-hub/worker -- tsc --noEmit`
- `npm exec prettier -- --check apps/worker/src/connectors/sinopac.ts apps/worker/tests/connectors/sinopac.test.ts`
- `git diff --check`