### PR TITLE
修正永豐無有效卡同步判定並保留上次成功時間

### DIFF
--- a/apps/web/src/features/settings/components/SourceCard.svelte
+++ b/apps/web/src/features/settings/components/SourceCard.svelte
@@ -85,10 +85,10 @@
         >{title}</span
       >
       <span class="block truncate text-sm text-muted-foreground">
-        {sourceStatus === "healthy" && job?.lastSuccessAt
-          ? `最近同步 ${formatDateTime(job.lastSuccessAt)}`
-          : sourceStatus === "unconfigured"
-            ? "尚未設定"
+        {sourceStatus === "unconfigured"
+          ? "尚未設定"
+          : job?.lastSuccessAt
+            ? `${sourceStatus === "healthy" ? "最近同步" : "上次成功"} ${formatDateTime(job.lastSuccessAt)}`
             : "尚未成功同步"}
       </span>
     </span>

--- a/apps/web/src/features/settings/components/SourceCard.test.ts
+++ b/apps/web/src/features/settings/components/SourceCard.test.ts
@@ -1,0 +1,70 @@
+import { render } from "@testing-library/svelte";
+import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
+import { describe, expect, it, vi } from "vitest";
+import type { SyncJobRow } from "@/data/connectors/types";
+import type { ApiClient } from "@/shared/api/client";
+import { formatDateTime } from "@/shared/format/financial";
+import SourceCard from "./SourceCard.svelte";
+
+function renderSourceCard(job: SyncJobRow) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const api = {
+    get: vi.fn().mockResolvedValue({ configured: true }),
+  } as unknown as ApiClient;
+
+  return render(
+    SourceCard,
+    {
+      props: {
+        api,
+        id: "sinopac",
+        title: "永豐行動銀行",
+        description: "信用卡帳務、近期帳單與消費",
+        selected: false,
+        onConfigure: vi.fn(),
+        jobs: [job],
+        compact: true,
+        compactCard: true,
+      },
+    },
+    {
+      wrapper: QueryClientProvider,
+      wrapperProps: { client: queryClient },
+    },
+  );
+}
+
+describe("SourceCard", () => {
+  it("keeps the last successful sync time visible after a later failure", () => {
+    const lastSuccessAt = "2026-08-20T22:00:00.000Z";
+    const { getByText } = renderSourceCard({
+      id: "sinopac:all",
+      connectorId: "sinopac",
+      configured: true,
+      scope: "all",
+      enabled: true,
+      intervalMinutes: 1440,
+      nextRunAt: "2026-08-22T02:00:00.000Z",
+      scheduleMode: "inherit",
+      preferredTime: "02:00",
+      preferredWeekday: 1,
+      lockedUntil: null,
+      lockedBy: null,
+      lockTrigger: null,
+      lockScope: null,
+      lastRunAt: "2026-08-21T22:00:00.000Z",
+      lastSuccessAt,
+      lastStatus: "failed",
+      lastError: "同步失敗",
+      updatedAt: "2026-08-21T22:00:00.000Z",
+      running: false,
+    });
+
+    expect(
+      getByText(`上次成功 ${formatDateTime(lastSuccessAt)}`),
+    ).toBeInTheDocument();
+    expect(getByText("需要處理")).toBeInTheDocument();
+  });
+});

--- a/apps/worker/src/connectors/sinopac.ts
+++ b/apps/worker/src/connectors/sinopac.ts
@@ -38,6 +38,7 @@ type FetchImpl = typeof fetch;
 type SinopacApiPayloads = {
   summary: unknown;
   bills: unknown;
+  hasValidCard?: boolean;
   latest?: unknown;
   outstanding?: unknown;
   unbilled?: unknown;
@@ -218,6 +219,13 @@ class SinopacAppClient {
       { ID: customerId },
       customerId,
     );
+    if (latest == null) {
+      return {
+        summary,
+        bills: [initialBills, ...olderBills],
+        hasValidCard: false,
+      };
+    }
     const outstanding = await this.postSinoCard(
       CARD_OUTSTANDING_DETAIL_PATH,
       "已請款消費明細",
@@ -314,6 +322,13 @@ class SinopacAppClient {
         );
       }
       throw new Error(`永豐${label} API 回應不是有效 JSON。`);
+    }
+    if (
+      path === CARD_LATEST_TX_PATH &&
+      isRecord(payload) &&
+      stringValue(payload.ResultMessage) === "您沒有有效卡"
+    ) {
+      return undefined;
     }
     assertSinoCardApiSuccess(payload, label);
     return payload;
@@ -809,6 +824,14 @@ export function parseSinopacCardData(
   payloads: SinopacApiPayloads,
   now = new Date(),
 ): Scraped {
+  if (payloads.hasValidCard === false) {
+    return {
+      bankAccounts: [],
+      bankBalanceSnapshots: [],
+      bankTransactions: [],
+      creditCardBills: [],
+    };
+  }
   const summary = parseSummary(payloads.summary);
   const bills = parseBills(payloads.bills, now);
   const transactions =

--- a/apps/worker/tests/connectors/sinopac.test.ts
+++ b/apps/worker/tests/connectors/sinopac.test.ts
@@ -492,6 +492,50 @@ describe("sinopac App JSON parser", () => {
     expect(result.bankTransactions).toHaveLength(2);
   });
 
+  it("treats no valid card as a successful sync without requesting outstanding transactions", async () => {
+    const noPurchaseRecordsPayload = [
+      { Header: "FAIL", Message: "查無消費紀錄" },
+    ];
+    const noValidCardPayload = {
+      Result: {},
+      Header: {},
+      ResultCode: "01",
+      ResultMessage: "您沒有有效卡",
+      Error: null,
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const payload = url.includes("/ws/card/cardqry/")
+        ? noPurchaseRecordsPayload
+        : url.endsWith("/Accounting/LatestTx")
+          ? noValidCardPayload
+          : payloadForUrl(url);
+      return new Response(JSON.stringify(payload), { status: 200 });
+    });
+
+    const result = await createSinopacConnector(
+      undefined,
+      fetchMock as typeof fetch,
+    ).sync({
+      userId: "A123456789",
+      sessionCookies,
+      protocol: "sinopac-mobile-app-json-v1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(fetchMock.mock.calls.map(([input]) => String(input))).not.toContain(
+      "https://m.sinopac.com/m/SinoCard/api/Accounting/OutstandingDetail",
+    );
+    expect(result.bankBalanceSnapshots).toEqual([]);
+    expect(result.bankAccounts).toEqual([]);
+    expect(result.creditCardBills).toEqual([]);
+    expect(result.bankTransactions).toEqual([]);
+    expect(JSON.parse(result.cursor ?? "{}")).toMatchObject({
+      sessionCookies,
+      protocol: "sinopac-mobile-app-json-v1",
+    });
+  });
+
   it("isolates App cookies and follows SinoCard cookie rotation", async () => {
     const authCookies = JSON.stringify([
       ...JSON.parse(sessionCookies),


### PR DESCRIPTION
## 摘要

- 將永豐最新消費 API 回傳「您沒有有效卡」視為成功的空信用卡結果
- 無有效卡時略過已請款明細查詢，並避免建立不存在的信用卡資料
- 同步失敗或需要處理時，持續顯示最後一次成功同步時間
- 補上永豐 connector 與 `SourceCard` 回歸測試

## 測試

- `npm exec -w @taiwan-fin-hub/worker -- vitest run tests/connectors/sinopac.test.ts`（12 tests）
- `npm exec -w @taiwan-fin-hub/web -- vitest run src/features/settings/components/SourceCard.test.ts`
- `npm run typecheck -w @taiwan-fin-hub/web`（0 errors、0 warnings）
- Svelte autofixer（0 issues、0 suggestions）
- `git diff --check origin/main...HEAD`