### PR TITLE
修正國泰首次 OTP 驗證與同步流程

### DIFF
--- a/apps/web/src/data/connectors/types.ts
+++ b/apps/web/src/data/connectors/types.ts
@@ -11,6 +11,9 @@ export interface ConnectorSettings {
   publicConfig?: Record<string, unknown> | null;
   credentialsComplete?: boolean;
   sessionAvailable?: boolean;
+  verificationPending?: boolean;
+  verificationChannel?: "email" | "sms" | null;
+  verificationExpiresAt?: string | null;
 }
 
 export interface SyncJobRow {

--- a/apps/web/src/features/settings/connectors/ConnectionProgress.svelte
+++ b/apps/web/src/features/settings/connectors/ConnectionProgress.svelte
@@ -4,15 +4,19 @@
   let {
     step,
     connectionReady,
+    source,
   }: {
     step: "credentials" | "email" | "sms" | "complete";
     connectionReady: boolean;
+    source: "tdcc" | "cathaybk";
   } = $props();
+
+  const sourceName = $derived(source === "tdcc" ? "集保" : "國泰世華");
 </script>
 
 <div
   class="mt-4 grid overflow-hidden rounded-xl border border-ink/10 bg-paper sm:grid-cols-3"
-  aria-label="集保連線進度"
+  aria-label={`${sourceName}連線進度`}
 >
   <div
     class={`flex items-center gap-3 px-3 py-3 ${step === "credentials" && !connectionReady ? "bg-steel/[0.07] text-steel" : "text-ink/55"}`}
@@ -21,7 +25,9 @@
       class="grid size-7 shrink-0 place-items-center rounded-full border border-current/20 text-sm font-bold"
       >1</span
     >
-    <span class="text-sm font-semibold">確認集保帳密</span>
+    <span class="text-sm font-semibold"
+      >{source === "tdcc" ? "確認集保帳密" : "確認網銀帳密"}</span
+    >
   </div>
   <div
     class={`flex items-center gap-3 border-t border-ink/10 px-3 py-3 sm:border-l sm:border-t-0 ${step === "email" || step === "sms" ? "bg-steel/[0.07] text-steel" : "text-ink/55"}`}
@@ -52,9 +58,16 @@
     >使用說明</summary
   >
   <ol class="list-decimal space-y-1.5 px-3 pb-3 pt-1 pl-8">
-    <li>先在手機下載並登入「集保e存摺」，確認可看到股票與基金資料。</li>
-    <li>填入身分證字號與集保 App 密碼，再按「連線並取得驗證碼」。</li>
-    <li>系統只會在集保要求時寄出 Email；部分帳號還需要簡訊驗證。</li>
-    <li>驗證成功後會自動執行首次同步，日後通常不需重新輸入驗證碼。</li>
+    {#if source === "tdcc"}
+      <li>先在手機下載並登入「集保e存摺」，確認可看到股票與基金資料。</li>
+      <li>填入身分證字號與集保 App 密碼，再按「連線並取得驗證碼」。</li>
+      <li>系統只會在集保要求時寄出 Email；部分帳號還需要簡訊驗證。</li>
+      <li>驗證成功後會自動執行首次同步，日後通常不需重新輸入驗證碼。</li>
+    {:else}
+      <li>先儲存國泰世華網路銀行帳密，再按上方的「同步」。</li>
+      <li>首次同步若銀行要求額外驗證，可選擇 Email 或簡訊接收驗證碼。</li>
+      <li>驗證成功後會加入「ALL SET 同步」信任裝置並完成首次同步。</li>
+      <li>日後通常不需重新輸入驗證碼；銀行仍可能視安全狀態要求重新驗證。</li>
+    {/if}
   </ol>
 </details>

--- a/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
+++ b/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
@@ -15,7 +15,7 @@
     Smartphone,
   } from "@lucide/svelte";
   import BrowserBankConnectionHelp from "./BrowserBankConnectionHelp.svelte";
-  import TdccConnectionProgress from "./TdccConnectionProgress.svelte";
+  import ConnectionProgress from "./ConnectionProgress.svelte";
   import Card from "@/shared/ui/Card.svelte";
   import Button from "@/shared/ui/Button.svelte";
   import Input from "@/shared/ui/Input.svelte";
@@ -65,6 +65,12 @@
   let tdccSetupStep = $state<"credentials" | "email" | "sms" | "complete">(
     "credentials",
   );
+  let cathayVerificationStep = $state<
+    "idle" | "choose" | "email" | "sms" | "complete"
+  >("idle");
+  let cathayOtpChannel = $state<"email" | "sms" | null>(null);
+  let cathayVerificationExpiresAt = $state<string | null>(null);
+  let cathayVerificationSecondsRemaining = $state<number | null>(null);
   let bankCaptchaImage = $state("");
   let bankCaptcha = $state("");
   let bankCaptchaDigitCount = $state(6);
@@ -96,6 +102,25 @@
   const tdccCredentialsComplete = $derived(
     connectorId === "tdcc" && Boolean($settings.data?.credentialsComplete),
   );
+  const cathayConnectionReady = $derived(
+    connectorId === "cathaybk" && Boolean($settings.data?.sessionAvailable),
+  );
+  const cathayVerificationExpired = $derived(
+    cathayVerificationSecondsRemaining !== null &&
+      cathayVerificationSecondsRemaining <= 0,
+  );
+  const cathayProgressStep = $derived(
+    cathayConnectionReady || cathayVerificationStep === "complete"
+      ? "complete"
+      : cathayVerificationExpired
+        ? "credentials"
+        : cathayVerificationStep === "sms"
+          ? "sms"
+          : cathayVerificationStep === "choose" ||
+              cathayVerificationStep === "email"
+            ? "email"
+            : "credentials",
+  );
   const intervalOptions = [
     { label: "每小時", minutes: 60 },
     { label: "每 6 小時", minutes: 360 },
@@ -120,8 +145,32 @@
       )) {
         if (values[key] === undefined) values[key] = String(value);
       }
+      if (connectorId === "cathaybk" && result.data) {
+        if (result.data.sessionAvailable) {
+          cathayVerificationStep = "complete";
+          cathayVerificationExpiresAt = null;
+          cathayVerificationSecondsRemaining = null;
+        } else if (result.data.verificationPending) {
+          cathayOtpChannel = result.data.verificationChannel ?? null;
+          cathayVerificationStep = cathayOtpChannel ?? "choose";
+          cathayVerificationExpiresAt =
+            result.data.verificationExpiresAt ?? null;
+          updateCathayVerificationCountdown();
+        } else if (result.data.verificationExpiresAt) {
+          cathayOtpChannel = null;
+          cathayVerificationStep = "choose";
+          cathayVerificationExpiresAt = result.data.verificationExpiresAt;
+          updateCathayVerificationCountdown();
+        } else if (cathayVerificationStep === "complete") {
+          cathayVerificationStep = "idle";
+        }
+      }
     }),
   );
+  onMount(() => {
+    const timer = setInterval(updateCathayVerificationCountdown, 1_000);
+    return () => clearInterval(timer);
+  });
   onDestroy(() => {
     destroyed = true;
     clearTimeout(einvoiceSyncQueuedTimer);
@@ -135,6 +184,7 @@
     },
     onSuccess: () => {
       error = "";
+      if (connectorId === "cathaybk") resetCathayVerification();
       for (const field of fields) {
         if (field.type === "text" || field.type === "password")
           values[field.key] = "";
@@ -152,19 +202,39 @@
     onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.syncJobs }),
   });
   const sync = createMutation({
-    mutationFn: (target: SyncTarget) => {
+    mutationFn: async (target: SyncTarget) => {
       if (demoMode) throw new Error("Demo site 已停用連接器同步。");
       const path =
         connectorId === "tdcc" && target !== "default"
           ? `/api/connectors/${connectorId}/sync/${target}`
           : `/api/connectors/${connectorId}/sync`;
       pendingSyncTarget = target;
-      return connectorId === "einvoice"
-        ? api.post<QueuedSyncResponse>(path, {})
-        : api.post(path);
+      const runSync = () =>
+        connectorId === "einvoice"
+          ? api.post<QueuedSyncResponse>(path, {})
+          : api.post(path);
+      try {
+        return await runSync();
+      } catch (errorValue) {
+        if (
+          connectorId === "cathaybk" &&
+          errorValue instanceof ApiRequestError &&
+          errorValue.code === "CATHAY_OTP_SESSION_EXPIRED"
+        ) {
+          return runSync();
+        }
+        throw errorValue;
+      }
     },
     onSuccess: () => {
       error = "";
+      if (connectorId === "cathaybk") {
+        resetCathayVerification();
+        cathayVerificationStep = "complete";
+        qc.invalidateQueries({
+          queryKey: queryKeys.connectorSettings(connectorId),
+        });
+      }
       if (connectorId === "einvoice") {
         showEinvoiceSyncQueued();
         startEinvoiceSyncPolling();
@@ -202,6 +272,7 @@
     },
     onError: (e) => {
       if (handleTdccVerificationRequired(e)) return;
+      if (handleCathayVerificationRequired(e)) return;
       error = e instanceof Error ? e.message : "同步失敗";
       if (browserBank)
         qc.invalidateQueries({
@@ -325,6 +396,44 @@
     },
   });
 
+  const requestCathayOtp = createMutation({
+    mutationFn: (channel: "email" | "sms") => {
+      if (demoMode) throw new Error("Demo site 已停用連接器同步。");
+      cathayOtpChannel = channel;
+      return api.post(`/api/connectors/${connectorId}/sync`, {
+        otpChannel: channel,
+      });
+    },
+    onSuccess: () => {
+      if (cathayOtpChannel) cathayVerificationStep = cathayOtpChannel;
+      error = "";
+    },
+    onError: (e) => {
+      if (handleCathayVerificationRequired(e)) return;
+      error = e instanceof Error ? e.message : "寄送驗證碼失敗";
+    },
+  });
+
+  const verifyCathayOtp = createMutation({
+    mutationFn: () => {
+      if (demoMode) throw new Error("Demo site 已停用連接器同步。");
+      if (!otp.trim()) throw new Error("請先輸入驗證碼。");
+      if (!cathayOtpChannel) throw new Error("請先選擇驗證方式。");
+      return api.post(`/api/connectors/${connectorId}/sync`, {
+        otp: otp.trim(),
+        otpChannel: cathayOtpChannel,
+      });
+    },
+    onSuccess: () => finishCathayVerification(),
+    onError: (e) => {
+      if (handleCathayVerificationRequired(e)) {
+        otp = "";
+        return;
+      }
+      error = e instanceof Error ? e.message : "驗證失敗";
+    },
+  });
+
   function handleTdccVerificationRequired(errorValue: unknown) {
     if (!(errorValue instanceof ApiRequestError)) return false;
     if (errorValue.code === "TDCC_EMAIL_OTP_REQUIRED") {
@@ -341,6 +450,92 @@
       return true;
     }
     return false;
+  }
+
+  function handleCathayVerificationRequired(errorValue: unknown) {
+    if (!(errorValue instanceof ApiRequestError)) return false;
+    if (errorValue.code === "CATHAY_OTP_CHANNEL_REQUIRED") {
+      error = "";
+      otp = "";
+      cathayOtpChannel = null;
+      cathayVerificationStep = "choose";
+      qc.invalidateQueries({
+        queryKey: queryKeys.connectorSettings(connectorId),
+      });
+      return true;
+    }
+    if (
+      errorValue.code === "CATHAY_EMAIL_OTP_REQUIRED" ||
+      errorValue.code === "CATHAY_SMS_OTP_REQUIRED"
+    ) {
+      error = "";
+      otp = "";
+      cathayOtpChannel =
+        errorValue.code === "CATHAY_SMS_OTP_REQUIRED" ? "sms" : "email";
+      cathayVerificationStep = cathayOtpChannel;
+      qc.invalidateQueries({
+        queryKey: queryKeys.connectorSettings(connectorId),
+      });
+      return true;
+    }
+    if (errorValue.code === "CATHAY_OTP_SESSION_EXPIRED") {
+      resetCathayVerification();
+      error = errorValue.message;
+      return true;
+    }
+    if (errorValue.code === "CATHAY_OTP_INVALID") {
+      otp = "";
+      error = errorValue.message;
+      return true;
+    }
+    return false;
+  }
+
+  function resetCathayVerification() {
+    if (connectorId !== "cathaybk") return;
+    otp = "";
+    cathayOtpChannel = null;
+    cathayVerificationExpiresAt = null;
+    cathayVerificationSecondsRemaining = null;
+    cathayVerificationStep = "idle";
+    $requestCathayOtp.reset();
+    $verifyCathayOtp.reset();
+  }
+
+  function finishCathayVerification() {
+    error = "";
+    resetCathayVerification();
+    cathayVerificationStep = "complete";
+    qc.invalidateQueries({
+      queryKey: queryKeys.connectorSettings(connectorId),
+    });
+    qc.invalidateQueries({ queryKey: queryKeys.syncJobs });
+    qc.invalidateQueries({ queryKey: queryKeys.summary });
+    invalidateLatestSyncReport();
+    qc.invalidateQueries({ queryKey: queryKeys.bank });
+    qc.invalidateQueries({ queryKey: queryKeys.bills });
+  }
+
+  function updateCathayVerificationCountdown() {
+    if (!cathayVerificationExpiresAt) {
+      cathayVerificationSecondsRemaining = null;
+      return;
+    }
+    const expiresAt = Date.parse(cathayVerificationExpiresAt);
+    cathayVerificationSecondsRemaining = Number.isFinite(expiresAt)
+      ? Math.max(0, Math.ceil((expiresAt - Date.now()) / 1_000))
+      : 0;
+  }
+
+  function cathayCountdownLabel(seconds: number) {
+    const minutes = Math.floor(seconds / 60);
+    return `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
+  }
+
+  function restartCathayVerification() {
+    resetCathayVerification();
+    error = "";
+    $sync.mutate("default");
   }
 
   function finishTdccConnection() {
@@ -538,7 +733,12 @@
           size="sm"
           disabled={demoMode ||
             $sync.isPending ||
-            (connectorId === "einvoice" && einvoiceSyncPolling !== null)}
+            (connectorId === "einvoice" && einvoiceSyncPolling !== null) ||
+            (connectorId === "cathaybk" &&
+              !cathayVerificationExpired &&
+              (cathayVerificationStep === "choose" ||
+                cathayVerificationStep === "email" ||
+                cathayVerificationStep === "sms"))}
           onclick={() => {
             error = "";
             $sync.mutate("default");
@@ -562,9 +762,16 @@
       Demo site 已停用同步；你仍可查看示範資料與介面互動。
     </p>{/if}
   {#if connectorId === "tdcc"}
-    <TdccConnectionProgress
+    <ConnectionProgress
       step={tdccSetupStep}
       connectionReady={tdccConnectionReady}
+      source="tdcc"
+    />
+  {:else if connectorId === "cathaybk"}
+    <ConnectionProgress
+      step={cathayProgressStep}
+      connectionReady={cathayConnectionReady}
+      source="cathaybk"
     />
   {:else if browserBank}
     <BrowserBankConnectionHelp
@@ -590,7 +797,7 @@
     />
   {/if}
   <div
-    class={`mt-3 rounded-xl border border-ink/10 bg-paper p-3 text-sm ${connectorId === "tdcc" && !tdccConnectionReady ? "hidden" : ""}`}
+    class={`mt-3 rounded-xl border border-ink/10 bg-paper p-3 text-sm ${(connectorId === "tdcc" && !tdccConnectionReady) || (connectorId === "cathaybk" && !cathayConnectionReady && cathayVerificationStep !== "complete") ? "hidden" : ""}`}
   >
     <div class="flex flex-wrap items-start justify-between gap-3">
       <div>
@@ -903,7 +1110,141 @@
           >{/if}
       </div>
     </div>{/if}
-  {#if connectorId === "tdcc" && error}<p
+  {#if connectorId === "cathaybk" && (cathayVerificationStep === "choose" || cathayVerificationStep === "email" || cathayVerificationStep === "sms")}
+    <div
+      class="mt-3 overflow-hidden rounded-xl border border-steel/20 bg-steel/[0.055]"
+    >
+      <div class="flex items-start gap-3 border-b border-steel/15 px-4 py-3">
+        <span
+          class="grid size-9 shrink-0 place-items-center rounded-full bg-steel/10 text-steel"
+        >
+          {#if cathayVerificationStep === "sms"}<Smartphone
+              class="size-4.5"
+            />{:else}<Mail class="size-4.5" />{/if}
+        </span>
+        <div>
+          <p class="text-sm font-semibold text-ink">
+            {cathayVerificationExpired
+              ? "驗證工作階段已逾時"
+              : cathayVerificationStep === "choose"
+                ? "需要額外驗證"
+                : cathayVerificationStep === "sms"
+                  ? "簡訊驗證碼已寄出"
+                  : "Email 驗證碼已寄出"}
+          </p>
+          <p class="mt-0.5 text-sm leading-relaxed text-ink/60">
+            {cathayVerificationExpired
+              ? "為避免持續占用 Browser Run，驗證工作階段已關閉，請重新同步。"
+              : cathayVerificationStep === "choose"
+                ? "國泰世華要求額外驗證，請選擇驗證碼寄送方式。"
+                : cathayVerificationStep === "sms"
+                  ? "請輸入國泰世華寄到手機的驗證碼。"
+                  : "請查看國泰世華帳號登記的電子信箱，也別忘了檢查垃圾郵件匣。"}
+          </p>
+          {#if !cathayVerificationExpired && cathayVerificationSecondsRemaining !== null}
+            <p class="mt-1 text-xs font-semibold text-steel" aria-live="polite">
+              請於 {cathayCountdownLabel(cathayVerificationSecondsRemaining)}
+              內完成驗證
+            </p>
+          {/if}
+        </div>
+      </div>
+      {#if cathayVerificationExpired}
+        <div class="p-4">
+          <Button
+            size="sm"
+            disabled={$sync.isPending}
+            onclick={restartCathayVerification}
+            ><RefreshCw
+              class={$sync.isPending ? "size-4 animate-spin" : "size-4"}
+            />{$sync.isPending ? "重新連線中…" : "重新開始驗證"}</Button
+          >
+        </div>
+      {:else if cathayVerificationStep === "choose"}
+        <div class="flex flex-wrap gap-2 p-4">
+          <Button
+            size="sm"
+            disabled={$requestCathayOtp.isPending || $verifyCathayOtp.isPending}
+            onclick={() => {
+              error = "";
+              $requestCathayOtp.mutate("email");
+            }}
+            ><Mail class="size-4" />{$requestCathayOtp.isPending &&
+            cathayOtpChannel === "email"
+              ? "寄送中…"
+              : "使用 Email"}</Button
+          >
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={$requestCathayOtp.isPending || $verifyCathayOtp.isPending}
+            onclick={() => {
+              error = "";
+              $requestCathayOtp.mutate("sms");
+            }}
+            ><Smartphone class="size-4" />{$requestCathayOtp.isPending &&
+            cathayOtpChannel === "sms"
+              ? "寄送中…"
+              : "使用簡訊"}</Button
+          >
+        </div>
+      {:else}
+        <div class="grid gap-3 p-4 sm:grid-cols-[minmax(0,1fr)_auto]">
+          <label class="grid gap-1.5 text-sm font-medium">
+            驗證碼後 6 位數字
+            <Input
+              class="bg-white/80 tracking-[0.2em]"
+              inputmode="numeric"
+              autocomplete="one-time-code"
+              placeholder="例如 310307（不含英文前綴）"
+              bind:value={otp}
+            />
+          </label>
+          <Button
+            class="self-end"
+            size="sm"
+            disabled={$verifyCathayOtp.isPending || !otp.trim()}
+            onclick={() => {
+              error = "";
+              $verifyCathayOtp.mutate();
+            }}
+            ><ShieldCheck class="size-4" />{$verifyCathayOtp.isPending
+              ? "驗證與同步中…"
+              : "驗證並完成首次同步"}</Button
+          >
+        </div>
+        <div
+          class="flex flex-wrap items-center justify-between gap-2 border-t border-steel/15 px-4 py-2.5"
+        >
+          <button
+            type="button"
+            class="text-sm font-semibold text-ink/55 underline-offset-4 hover:text-ink hover:underline"
+            onclick={() => {
+              otp = "";
+              cathayOtpChannel = null;
+              cathayVerificationStep = "choose";
+              $requestCathayOtp.reset();
+            }}>返回選擇驗證方式</button
+          >
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={$requestCathayOtp.isPending || !cathayOtpChannel}
+            onclick={() => {
+              error = "";
+              $requestCathayOtp.mutate(cathayOtpChannel!);
+            }}
+            ><RefreshCw class="size-4" />{$requestCathayOtp.isPending
+              ? "重新寄送中…"
+              : cathayOtpChannel === "sms"
+                ? "重新寄送簡訊"
+                : "重新寄送 Email"}</Button
+          >
+        </div>
+      {/if}
+    </div>
+  {/if}
+  {#if (connectorId === "tdcc" || connectorId === "cathaybk") && error}<p
       class="mt-3 rounded-lg border border-coral/20 bg-coral/[0.06] px-3 py-2 text-sm font-medium text-coral"
     >
       {error}
@@ -915,6 +1256,8 @@
         ? "王道手動與排程同步都會在必要時接管其他登入中的裝置；同步會直接使用 App API，並由 Gemma 4 自動辨識四位英數驗證碼。"
         : connectorId === "tdcc"
           ? "排程同步不會在背景寄送驗證碼；登入失效時會標記為需要重新驗證。"
-          : "輸入完帳號密碼後，請先按「儲存設定」，再按「同步」。"}
+          : connectorId === "cathaybk"
+            ? "首次驗證會加入信任裝置；信任失效時需在手動同步中重新取得驗證碼。"
+            : "輸入完帳號密碼後，請先按「儲存設定」，再按「同步」。"}
   </p>
 </Card>

--- a/apps/web/src/features/settings/connectors/ConnectorPanel.test.ts
+++ b/apps/web/src/features/settings/connectors/ConnectorPanel.test.ts
@@ -1,9 +1,9 @@
-import { fireEvent, render } from "@testing-library/svelte";
+import { fireEvent, render, waitFor, within } from "@testing-library/svelte";
 import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
 import { describe, expect, it, vi } from "vitest";
 import { connectorFields } from "@/data/connectors/definitions";
 import type { ConnectorField, SyncJobRow } from "@/data/connectors/types";
-import type { ApiClient } from "@/shared/api/client";
+import { ApiRequestError, type ApiClient } from "@/shared/api/client";
 import ConnectorPanel from "./ConnectorPanel.svelte";
 
 function syncJob(overrides: Partial<SyncJobRow> = {}): SyncJobRow {
@@ -62,6 +62,47 @@ function renderEinvoicePanel(syncJobs: SyncJobRow[][]) {
         demoMode: false,
         title: "電子發票",
         fields: connectorFields.einvoice as ConnectorField[],
+      },
+    },
+    {
+      wrapper: QueryClientProvider,
+      wrapperProps: { client: queryClient },
+    },
+  );
+  return { ...result, api, queryClient };
+}
+
+function renderCathayPanel(
+  post: ReturnType<typeof vi.fn>,
+  connectorSettings: Record<string, unknown> = {},
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 30_000 } },
+  });
+  const api = {
+    get: vi.fn((path: string) => {
+      if (path === "/api/sync-jobs")
+        return Promise.resolve([
+          syncJob({
+            id: "cathaybk:all",
+            connectorId: "cathaybk",
+          }),
+        ]);
+      if (path === "/api/connectors/cathaybk/settings")
+        return Promise.resolve(connectorSettings);
+      return Promise.resolve({});
+    }),
+    post,
+  } as unknown as ApiClient;
+  const result = render(
+    ConnectorPanel,
+    {
+      props: {
+        api,
+        connectorId: "cathaybk",
+        demoMode: false,
+        title: "國泰世華銀行",
+        fields: connectorFields.cathaybk as ConnectorField[],
       },
     },
     {
@@ -184,5 +225,162 @@ describe("ConnectorPanel", () => {
       ),
     ).toHaveLength(syncJobRequestsBeforeUnmount);
     vi.useRealTimers();
+  });
+
+  it("guides Cathay through channel selection and OTP verification", async () => {
+    const post = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new ApiRequestError(
+          "CATHAY_OTP_CHANNEL_REQUIRED",
+          "需要選擇驗證方式。",
+          400,
+        ),
+      )
+      .mockRejectedValueOnce(
+        new ApiRequestError(
+          "CATHAY_EMAIL_OTP_REQUIRED",
+          "Email 驗證碼已寄出。",
+          400,
+        ),
+      )
+      .mockResolvedValueOnce({ success: true });
+    const { getByLabelText, getByRole, findByText, getByPlaceholderText } =
+      renderCathayPanel(post);
+    const progress = getByLabelText("國泰世華連線進度");
+
+    expect(
+      within(progress).getByText("確認網銀帳密").parentElement,
+    ).toHaveClass("bg-steel/[0.07]");
+
+    await fireEvent.click(getByRole("button", { name: "同步" }));
+    expect(await findByText("需要額外驗證")).toBeInTheDocument();
+    expect(
+      within(progress).getByText("驗證這台裝置").parentElement,
+    ).toHaveClass("bg-steel/[0.07]");
+    expect(getByRole("button", { name: "使用 Email" })).toBeInTheDocument();
+    expect(getByRole("button", { name: "使用簡訊" })).toBeInTheDocument();
+
+    await fireEvent.click(getByRole("button", { name: "使用 Email" }));
+    expect(await findByText("Email 驗證碼已寄出")).toBeInTheDocument();
+    expect(post).toHaveBeenNthCalledWith(2, "/api/connectors/cathaybk/sync", {
+      otpChannel: "email",
+    });
+
+    await fireEvent.input(getByPlaceholderText("例如 310307（不含英文前綴）"), {
+      target: { value: "123456" },
+    });
+    await fireEvent.click(getByRole("button", { name: "驗證並完成首次同步" }));
+    expect(post).toHaveBeenNthCalledWith(3, "/api/connectors/cathaybk/sync", {
+      otp: "123456",
+      otpChannel: "email",
+    });
+    await waitFor(() =>
+      expect(
+        within(progress).getByText("完成首次同步").parentElement,
+      ).toHaveClass("bg-moss/[0.07]"),
+    );
+  });
+
+  it("restores a pending Cathay Email verification after remount", async () => {
+    const { findByText, getByPlaceholderText } = renderCathayPanel(vi.fn(), {
+      connectorId: "cathaybk",
+      configured: true,
+      credentialsComplete: true,
+      sessionAvailable: false,
+      verificationPending: true,
+      verificationChannel: "email",
+      verificationExpiresAt: "2099-08-22T08:08:00.000Z",
+    });
+
+    expect(await findByText("Email 驗證碼已寄出")).toBeInTheDocument();
+    expect(
+      getByPlaceholderText("例如 310307（不含英文前綴）"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the Cathay Email step open after an incorrect OTP", async () => {
+    const post = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new ApiRequestError(
+          "CATHAY_OTP_INVALID",
+          "國泰世華驗證碼錯誤或已逾時，請重新輸入或取得驗證碼。",
+          400,
+        ),
+      );
+    const {
+      findByPlaceholderText,
+      findByText,
+      getByPlaceholderText,
+      getByRole,
+    } = renderCathayPanel(post, {
+      connectorId: "cathaybk",
+      configured: true,
+      credentialsComplete: true,
+      sessionAvailable: false,
+      verificationPending: true,
+      verificationChannel: "email",
+      verificationExpiresAt: "2099-08-22T08:08:00.000Z",
+    });
+
+    const input = await findByPlaceholderText("例如 310307（不含英文前綴）");
+    await fireEvent.input(input, { target: { value: "123456" } });
+    await fireEvent.click(getByRole("button", { name: "驗證並完成首次同步" }));
+
+    expect(
+      await findByText("國泰世華驗證碼錯誤或已逾時，請重新輸入或取得驗證碼。"),
+    ).toBeInTheDocument();
+    expect(
+      getByPlaceholderText("例如 310307（不含英文前綴）"),
+    ).toBeInTheDocument();
+    expect(getByRole("button", { name: "重新寄送 Email" })).toBeInTheDocument();
+  });
+
+  it("closes an expired Cathay verification flow and restarts it", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-22T08:00:00.000Z"));
+    const post = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new ApiRequestError(
+          "CATHAY_OTP_SESSION_EXPIRED",
+          "驗證工作階段已逾時，請重新同步。",
+          400,
+        ),
+      )
+      .mockRejectedValueOnce(
+        new ApiRequestError(
+          "CATHAY_OTP_CHANNEL_REQUIRED",
+          "需要選擇驗證方式。",
+          400,
+        ),
+      );
+
+    try {
+      const { getByRole, getByText } = renderCathayPanel(post, {
+        connectorId: "cathaybk",
+        configured: true,
+        credentialsComplete: true,
+        sessionAvailable: false,
+        verificationPending: true,
+        verificationChannel: "email",
+        verificationExpiresAt: "2026-08-22T08:02:00.000Z",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(getByText("請於 2:00 內完成驗證")).toBeInTheDocument();
+
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(getByText("驗證工作階段已逾時")).toBeInTheDocument();
+
+      await fireEvent.click(getByRole("button", { name: "重新開始驗證" }));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(post).toHaveBeenCalledTimes(2);
+      expect(getByText("需要額外驗證")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/worker/src/connectors/cathaybk.ts
+++ b/apps/worker/src/connectors/cathaybk.ts
@@ -1,4 +1,8 @@
-import puppeteer, { type Page } from "@cloudflare/puppeteer";
+import puppeteer, {
+  type Browser,
+  type CookieParam,
+  type Page,
+} from "@cloudflare/puppeteer";
 import type {
   BankAccount,
   BankBalanceSnapshot,
@@ -20,6 +24,57 @@ const CREDIT_CARD_BILL_URL =
   "https://www.cathaybk.com.tw/OnlineBanking/CQuery/C0102_BillInq";
 
 const API_DEPOSIT_TX = "B_ACCT_Q_TransferDetail";
+const OTP_SESSION_TTL_MS = 2 * 60 * 1000;
+const TRUSTED_DEVICE_NAME = "ALL SET 同步";
+const OTP_SUBMIT_LABEL_PATTERN = /驗證|確認|確定|送出|登入/;
+const TRUST_DEVICE_CONTEXT_PATTERN =
+  /登入安全再升級|立即啟用|信任裝置|設定裝置名稱|裝置名稱|裝置暱稱|確定加入/;
+const TRUST_DEVICE_CONFIRM_PATTERN =
+  /確定加入|確認加入|完成設定|^確定$|^確認$|^完成$/;
+
+export class CathayVerificationRequiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CathayVerificationRequiredError";
+  }
+}
+
+export class CathayOtpChannelRequiredError extends CathayVerificationRequiredError {
+  constructor(
+    message: string,
+    readonly browserSessionId: string,
+    readonly browserSessionExpiresAt: string,
+  ) {
+    super(message);
+    this.name = "CathayOtpChannelRequiredError";
+  }
+}
+
+export class CathayOtpRequiredError extends CathayVerificationRequiredError {
+  constructor(
+    message: string,
+    readonly channel: "email" | "sms",
+  ) {
+    super(message);
+    this.name = "CathayOtpRequiredError";
+  }
+}
+
+export class CathayOtpInvalidError extends CathayVerificationRequiredError {
+  constructor(
+    message = "國泰世華驗證碼錯誤或已逾時，請重新輸入或取得驗證碼。",
+  ) {
+    super(message);
+    this.name = "CathayOtpInvalidError";
+  }
+}
+
+export class CathayOtpSessionExpiredError extends CathayVerificationRequiredError {
+  constructor() {
+    super("國泰世華驗證工作階段已逾時，請重新同步後再取得驗證碼。");
+    this.name = "CathayOtpSessionExpiredError";
+  }
+}
 
 function maskAccountNumber(value: string) {
   const suffix = value.slice(-4);
@@ -58,9 +113,8 @@ export function createCathaybkConnector(browser?: Fetcher) {
         bankTransactions,
         creditCardBills,
         freshCookies,
+        sessionExpiresAt,
       } = await scrapeWithBrowser(browser, config);
-
-      const expiresAt = new Date(Date.now() + 8 * 60 * 1000).toISOString();
 
       return {
         records: [],
@@ -70,7 +124,7 @@ export function createCathaybkConnector(browser?: Fetcher) {
         creditCardBills,
         cursor: JSON.stringify({
           sessionCookies: freshCookies,
-          sessionExpiresAt: expiresAt,
+          sessionExpiresAt,
           syncedAt: new Date().toISOString(),
         }),
       };
@@ -82,16 +136,88 @@ async function scrapeWithBrowser(
   browserBinding: Fetcher,
   config: CathaybkConfig,
 ) {
-  console.log("[cathaybk] launching browser");
-  const b = await puppeteer.launch(browserBinding);
-  const page = await b.newPage();
+  const reconnecting = Boolean(config.browserSessionId);
+  if (
+    reconnecting &&
+    (!config.browserSessionExpiresAt ||
+      new Date(config.browserSessionExpiresAt) <= new Date())
+  ) {
+    throw new CathayOtpSessionExpiredError();
+  }
+
   const syncWindowDays = BANK_SYNC_MONTHS * 30;
+  let b: Browser | undefined;
+  let page: Page | undefined;
+  let preserveSession = false;
+  let loggedOut = false;
 
   try {
+    console.log(
+      reconnecting
+        ? "[cathaybk] reconnecting to verification session"
+        : "[cathaybk] launching browser",
+    );
+    b = reconnecting
+      ? await connectCathayBrowser(browserBinding, config.browserSessionId!)
+      : await puppeteer.launch(browserBinding, {
+          keep_alive: OTP_SESSION_TTL_MS,
+        });
+    const pages = await b.pages();
+    page = pages[0] ?? (await b.newPage());
+
     await page.setViewport({ width: 1280, height: 800 });
 
-    // ponytail: session cookie reuse disabled — bank fingerprints the browser (citrix_bot_id)
-    await login(page, config);
+    if (config.browserSessionId) {
+      if (!config.otpChannel) {
+        await b.disconnect();
+        preserveSession = true;
+        throw new CathayOtpChannelRequiredError(
+          "請選擇以 Email 或簡訊接收國泰世華驗證碼。",
+          config.browserSessionId,
+          config.browserSessionExpiresAt!,
+        );
+      }
+      if (!config.otp) {
+        await sendCathayOtp(page, config.otpChannel);
+        await b.disconnect();
+        preserveSession = true;
+        throw new CathayOtpRequiredError(
+          config.otpChannel === "email"
+            ? "國泰世華 Email 驗證碼已寄出，請輸入驗證碼。"
+            : "國泰世華簡訊驗證碼已寄出，請輸入驗證碼。",
+          config.otpChannel,
+        );
+      }
+      try {
+        await submitCathayOtp(page, config.otp);
+      } catch (error) {
+        if (!(error instanceof CathayOtpInvalidError)) throw error;
+        await b.disconnect();
+        preserveSession = true;
+        throw error;
+      }
+    } else {
+      const restoredState = await restoreCathayTrustedState(page, config);
+      if (restoredState) {
+        console.log("[cathaybk] restored trusted browser state");
+      }
+      try {
+        await loginCathay(page, config);
+      } catch (error) {
+        if (!(error instanceof CathayVerificationRequiredError)) throw error;
+        const sessionId = b.sessionId();
+        const expiresAt = new Date(
+          Date.now() + OTP_SESSION_TTL_MS,
+        ).toISOString();
+        await b.disconnect();
+        preserveSession = true;
+        throw new CathayOtpChannelRequiredError(
+          "國泰世華要求額外驗證，請選擇 Email 或簡訊接收驗證碼。",
+          sessionId,
+          expiresAt,
+        );
+      }
+    }
 
     console.log("[cathaybk] collecting deposit accounts");
     const deposits = await scrapeDeposits(page, syncWindowDays);
@@ -99,7 +225,9 @@ async function scrapeWithBrowser(
     console.log("[cathaybk] collecting credit cards");
     const cards = await scrapeCreditCards(page);
 
-    const freshCookies = JSON.stringify(await page.cookies());
+    const trustedState = await captureCathayTrustedState(page);
+    await logoutCathay(page);
+    loggedOut = true;
 
     return {
       bankAccounts: [...deposits.bankAccounts, ...cards.bankAccounts],
@@ -112,7 +240,8 @@ async function scrapeWithBrowser(
         ...cards.bankTransactions,
       ],
       creditCardBills: cards.creditCardBills,
-      freshCookies,
+      freshCookies: trustedState.sessionCookies,
+      sessionExpiresAt: trustedState.sessionExpiresAt,
     };
   } catch (error) {
     console.error(
@@ -123,19 +252,586 @@ async function scrapeWithBrowser(
     );
     throw error;
   } finally {
-    // Always logout so next run doesn't hit the "未完成正常的登出" interstitial
-    console.log("[cathaybk] logging out");
-    await page
-      .goto("https://www.cathaybk.com.tw/OnlineBanking/Logout/Index", {
-        waitUntil: "networkidle2",
-        timeout: 30000,
-      })
-      .catch(() => null);
-    await b.close();
+    if (!preserveSession && b) {
+      try {
+        if (!loggedOut && page) {
+          // Always logout so next run doesn't hit the "未完成正常的登出" interstitial
+          await logoutCathay(page);
+        }
+      } finally {
+        await b.close();
+      }
+    }
   }
 }
 
-async function dismissInterstitialIfPresent(page: Page): Promise<boolean> {
+async function logoutCathay(page: Pick<Page, "goto">) {
+  console.log("[cathaybk] logging out");
+  await page
+    .goto("https://www.cathaybk.com.tw/OnlineBanking/Logout/Index", {
+      waitUntil: "networkidle2",
+      timeout: 30_000,
+    })
+    .catch(() => null);
+}
+
+type CathayTrustedStatePage = Pick<Page, "setCookie">;
+
+export async function restoreCathayTrustedState(
+  page: CathayTrustedStatePage,
+  config: Pick<CathaybkConfig, "sessionCookies">,
+) {
+  const cookies = parseCathayCookies(config.sessionCookies);
+  if (cookies.length === 0) return false;
+
+  await page.setCookie(...cookies);
+
+  return true;
+}
+
+export async function captureCathayTrustedState(page: Pick<Page, "cookies">) {
+  const cookies = (
+    await page.cookies(
+      LOGIN_URL,
+      DEPOSIT_OVERVIEW_URL,
+      CREDIT_CARD_OVERVIEW_URL,
+    )
+  ).filter(isCathayCookie);
+  const expires = cookies
+    .map((cookie) => cookie.expires)
+    .filter((value): value is number => typeof value === "number" && value > 0);
+
+  return {
+    sessionCookies: JSON.stringify(cookies),
+    sessionExpiresAt:
+      expires.length > 0
+        ? new Date(Math.max(...expires) * 1000).toISOString()
+        : undefined,
+  };
+}
+
+function parseCathayCookies(value: string | undefined): CookieParam[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isCathayCookie).map((cookie) => ({ ...cookie }));
+  } catch {
+    return [];
+  }
+}
+
+function isCathayCookie(value: unknown): value is CookieParam {
+  if (!value || typeof value !== "object") return false;
+  const cookie = value as Partial<CookieParam>;
+  if (typeof cookie.name !== "string" || typeof cookie.value !== "string") {
+    return false;
+  }
+  const domain = String(cookie.domain ?? "")
+    .replace(/^\./, "")
+    .toLowerCase();
+  return (
+    cookie.name === "CUB.eBank.DeviceId" &&
+    (domain === "cathaybk.com.tw" || domain.endsWith(".cathaybk.com.tw"))
+  );
+}
+
+async function connectCathayBrowser(
+  browserBinding: Fetcher,
+  sessionId: string,
+): Promise<Browser> {
+  const sessions = await puppeteer.sessions(browserBinding).catch(() => []);
+  const session = sessions.find(
+    (candidate) => candidate.sessionId === sessionId,
+  );
+  if (!session) throw new CathayOtpSessionExpiredError();
+  try {
+    return await puppeteer.connect(browserBinding, sessionId);
+  } catch {
+    throw new CathayOtpSessionExpiredError();
+  }
+}
+
+export async function sendCathayOtp(
+  page: Pick<Page, "click" | "evaluate" | "waitForSelector">,
+  channel: "email" | "sms",
+) {
+  const selector = channel === "email" ? "#js-otp-email-send" : "#js-otp-send";
+  await page.evaluate((selectedChannel) => {
+    const selector =
+      selectedChannel === "email" ? "#js-otp-email-send" : "#js-otp-send";
+    const target = document.querySelector<HTMLElement>(selector);
+    if (!target) return;
+    const rect = target.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) return;
+    const expectedText =
+      selectedChannel === "email" ? /Email|電子信箱/i : /簡訊|手機/;
+    const toggles = Array.from(
+      document.querySelectorAll<HTMLElement>(".js-otp-change-view"),
+    );
+    (
+      toggles.find((toggle) => expectedText.test(toggle.innerText)) ??
+      toggles[0]
+    )?.click();
+  }, channel);
+  await page.waitForSelector(selector, { visible: true, timeout: 15_000 });
+  await page.click(selector);
+  await page.waitForSelector(
+    '.js-otp-view input:not([type="hidden"]), .login-otp input:not([type="hidden"]), input[autocomplete="one-time-code"], input[inputmode="numeric"], input[name*="otp" i], input[id*="otp" i], input[placeholder*="後6位數字"]',
+    { timeout: 15_000 },
+  );
+}
+
+export async function submitCathayOtp(
+  page: Pick<
+    Page,
+    | "click"
+    | "evaluate"
+    | "type"
+    | "url"
+    | "waitForFunction"
+    | "waitForNavigation"
+  >,
+  otp: string,
+) {
+  const otpMatch = otp
+    .trim()
+    .toUpperCase()
+    .match(/^(?:[A-Z]{2,8}-)?(\d{4,8})$/);
+  if (!otpMatch) {
+    throw new CathayOtpInvalidError(
+      "請輸入驗證碼後 4 至 8 位數字；英文前綴可省略。",
+    );
+  }
+  const normalizedOtp = otpMatch[1];
+
+  const selectors = await page.evaluate((submitLabelPatternSource) => {
+    const submitLabelPattern = new RegExp(submitLabelPatternSource);
+    const visible = (element: HTMLElement) => {
+      const rect = element.getBoundingClientRect();
+      return !element.hidden && rect.width > 0 && rect.height > 0;
+    };
+    const inputs = Array.from(
+      document.querySelectorAll<HTMLInputElement>(
+        '.js-otp-view input:not([type="hidden"]), .login-otp input:not([type="hidden"]), input[autocomplete="one-time-code"], input[inputmode="numeric"], input[name*="otp" i], input[id*="otp" i], input[name*="code" i], input[placeholder*="後6位數字"]',
+      ),
+    );
+    const input =
+      inputs.find(
+        (candidate) =>
+          visible(candidate) && /後\s*6\s*位數字/.test(candidate.placeholder),
+      ) ??
+      inputs.find(
+        (candidate) =>
+          visible(candidate) &&
+          candidate.maxLength >= 4 &&
+          candidate.maxLength <= 8,
+      ) ??
+      inputs.find(visible);
+    if (input) input.dataset.cathayOtpInput = "true";
+
+    const verificationRoot =
+      input?.closest<HTMLElement>("form, [role='dialog'], main, section") ??
+      document;
+    const controls = Array.from(
+      verificationRoot.querySelectorAll<HTMLElement>(
+        'button, input[type="submit"], input[type="button"], [role="button"]',
+      ),
+    );
+    const submit = controls.find((candidate) => {
+      const text = `${candidate.textContent ?? ""} ${candidate.getAttribute("value") ?? ""}`;
+      return visible(candidate) && submitLabelPattern.test(text);
+    });
+    if (submit) submit.dataset.cathayOtpSubmit = "true";
+
+    const trustCheckbox = Array.from(
+      document.querySelectorAll<HTMLInputElement>(
+        'input[type="checkbox"], input[type="radio"]',
+      ),
+    ).find((candidate) => {
+      const explicitLabel = candidate.id
+        ? document.querySelector<HTMLLabelElement>(
+            `label[for="${CSS.escape(candidate.id)}"]`,
+          )?.innerText
+        : "";
+      const context = `${explicitLabel ?? ""} ${candidate.parentElement?.innerText ?? ""}`;
+      return (
+        /加入.*信任|信任.*裝置|常用.*裝置|記住.*裝置/.test(context) &&
+        !/不要|取消|移除/.test(context)
+      );
+    });
+    if (trustCheckbox && !trustCheckbox.checked) trustCheckbox.click();
+    return { hasInput: Boolean(input), hasSubmit: Boolean(submit) };
+  }, OTP_SUBMIT_LABEL_PATTERN.source);
+
+  if (!selectors.hasInput) {
+    throw new CathayVerificationRequiredError(
+      "國泰世華驗證頁面格式已變更，找不到驗證碼輸入欄。",
+    );
+  }
+  if (!selectors.hasSubmit) {
+    throw new CathayVerificationRequiredError(
+      "國泰世華驗證頁面格式已變更，找不到「確定」按鈕。",
+    );
+  }
+
+  await page.click('[data-cathay-otp-input="true"]', { clickCount: 3 });
+  await page.type('[data-cathay-otp-input="true"]', normalizedOtp);
+  const verificationResult = Promise.race([
+    page
+      .waitForNavigation({
+        waitUntil: "domcontentloaded",
+        timeout: 45_000,
+      })
+      .catch(() => null),
+    page
+      .waitForFunction(
+        () =>
+          (window.location.href.includes("/OnlineBanking/") &&
+            document.querySelector('[data-cathay-otp-input="true"]') ===
+              null) ||
+          /登入安全再升級|立即啟用|信任裝置|設定裝置名稱|確定加入|啟用成功/.test(
+            (document.body?.innerText ?? "").replace(/\s+/g, ""),
+          ) ||
+          /驗證碼.*(錯誤|失敗|逾時)/.test(document.body?.innerText ?? ""),
+        { timeout: 45_000 },
+      )
+      .catch(() => null),
+  ]);
+  await page.click('[data-cathay-otp-submit="true"]');
+  await verificationResult;
+  const verified = await page.evaluate(() => {
+    const normalizedText = (document.body?.innerText ?? "").replace(/\s+/g, "");
+    return (
+      (window.location.href.includes("/OnlineBanking/") &&
+        document.querySelector('[data-cathay-otp-input="true"]') === null) ||
+      /登入安全再升級|立即啟用|信任裝置|設定裝置名稱|確定加入|啟用成功/.test(
+        normalizedText,
+      )
+    );
+  });
+  if (!verified) {
+    throw new CathayOtpInvalidError();
+  }
+  const trustedDeviceReady = await completeCathayTrustedDeviceSetup(page);
+  if (!trustedDeviceReady) {
+    throw new CathayVerificationRequiredError(
+      "國泰世華已通過 OTP，但未完成加入信任裝置。",
+    );
+  }
+}
+
+export async function completeCathayTrustedDeviceSetup(
+  page: Pick<Page, "click" | "evaluate" | "type" | "waitForFunction">,
+) {
+  await page
+    .waitForFunction(
+      () =>
+        document.cookie.includes("CUB.eBank.DeviceId=") ||
+        /登入安全再升級|立即啟用|信任裝置|設定裝置名稱|裝置名稱|確定加入|啟用成功/.test(
+          (document.body?.innerText ?? "").replace(/\s+/g, ""),
+        ),
+      { timeout: 15_000 },
+    )
+    .catch(() => null);
+
+  const findStep = () =>
+    page.evaluate(
+      (patterns) => {
+        const trustContextPattern = new RegExp(patterns.context);
+        const trustConfirmPattern = new RegExp(patterns.confirm);
+        const visible = (element: HTMLElement) => {
+          const rect = element.getBoundingClientRect();
+          return !element.hidden && rect.width > 0 && rect.height > 0;
+        };
+        const trustDialog = Array.from(
+          document.querySelectorAll<HTMLElement>(
+            '[role="dialog"], [aria-modal="true"]',
+          ),
+        ).find(
+          (dialog) =>
+            visible(dialog) &&
+            trustContextPattern.test(
+              (dialog.innerText ?? "").replace(/\s+/g, ""),
+            ),
+        );
+        const trustRoot =
+          trustDialog ??
+          (trustContextPattern.test(
+            (document.body?.innerText ?? "").replace(/\s+/g, ""),
+          )
+            ? document.body
+            : null);
+        const controls = Array.from(
+          trustRoot?.querySelectorAll<HTMLElement>(
+            'button, a, input[type="button"], input[type="submit"], [role="button"]',
+          ) ?? [],
+        );
+        const textOf = (element: HTMLElement) =>
+          `${element.textContent ?? ""} ${element.getAttribute("value") ?? ""}`
+            .replace(/\s+/g, "")
+            .trim();
+        const next = controls.find(
+          (control) =>
+            visible(control) &&
+            /立即啟用|啟用信任裝置|加入信任裝置|設定信任裝置/.test(
+              textOf(control),
+            ),
+        );
+        if (next) next.dataset.cathayTrustNext = "true";
+
+        const inputs = Array.from(
+          trustRoot?.querySelectorAll<HTMLInputElement>(
+            'input:not([type="hidden"]):not([type="password"])',
+          ) ?? [],
+        );
+        const nameInput = inputs.find((input) => {
+          const explicitLabel = input.id
+            ? document.querySelector<HTMLLabelElement>(
+                `label[for="${CSS.escape(input.id)}"]`,
+              )?.innerText
+            : "";
+          const context = [
+            input.name,
+            input.placeholder,
+            input.getAttribute("aria-label"),
+            explicitLabel,
+            input.parentElement?.innerText,
+          ]
+            .filter(Boolean)
+            .join(" ");
+          return (
+            visible(input) &&
+            /裝置名稱|裝置暱稱|方便記憶的裝置名稱/.test(context)
+          );
+        });
+        if (nameInput) nameInput.dataset.cathayTrustName = "true";
+
+        const confirm = controls.find(
+          (control) =>
+            visible(control) && trustConfirmPattern.test(textOf(control)),
+        );
+        if (confirm) confirm.dataset.cathayTrustConfirm = "true";
+
+        return {
+          hasNext: Boolean(next),
+          hasNameInput: Boolean(nameInput),
+          hasConfirm: Boolean(confirm),
+          success:
+            document.cookie.includes("CUB.eBank.DeviceId=") ||
+            /啟用成功|已加入信任裝置/.test(
+              (document.body?.innerText ?? "").replace(/\s+/g, ""),
+            ),
+        };
+      },
+      {
+        context: TRUST_DEVICE_CONTEXT_PATTERN.source,
+        confirm: TRUST_DEVICE_CONFIRM_PATTERN.source,
+      },
+    );
+
+  let step = await findStep();
+  if (step.hasNext) {
+    await page.click('[data-cathay-trust-next="true"]');
+    await page
+      .waitForFunction(
+        () =>
+          /設定裝置名稱|裝置名稱|確定加入/.test(
+            (document.body?.innerText ?? "").replace(/\s+/g, ""),
+          ),
+        { timeout: 15_000 },
+      )
+      .catch(() => null);
+    step = await findStep();
+  }
+
+  if (!step.hasNameInput && !step.hasConfirm) return step.success;
+  if (!step.hasNameInput || !step.hasConfirm) {
+    console.warn(
+      JSON.stringify({
+        event: "cathaybk_trusted_device_controls_missing",
+        hasNext: step.hasNext,
+        hasNameInput: step.hasNameInput,
+        hasConfirm: step.hasConfirm,
+      }),
+    );
+    throw new CathayVerificationRequiredError(
+      "國泰世華已通過 OTP，但無法完成信任裝置設定。",
+    );
+  }
+
+  await page.click('[data-cathay-trust-name="true"]', { clickCount: 3 });
+  await page.type('[data-cathay-trust-name="true"]', TRUSTED_DEVICE_NAME);
+  await page.click('[data-cathay-trust-confirm="true"]');
+  await page
+    .waitForFunction(
+      () =>
+        document.cookie.includes("CUB.eBank.DeviceId=") ||
+        /啟用成功|已加入信任裝置/.test(
+          (document.body?.innerText ?? "").replace(/\s+/g, ""),
+        ),
+      { timeout: 15_000 },
+    )
+    .catch(() => null);
+  return page.evaluate(() => {
+    const normalizedText = (document.body?.innerText ?? "").replace(/\s+/g, "");
+    return (
+      document.cookie.includes("CUB.eBank.DeviceId=") ||
+      /啟用成功|已加入信任裝置/.test(normalizedText)
+    );
+  });
+}
+
+export type CathayLoginPage = Pick<
+  Page,
+  | "$"
+  | "click"
+  | "evaluate"
+  | "goto"
+  | "on"
+  | "type"
+  | "url"
+  | "waitForFunction"
+  | "waitForSelector"
+>;
+
+function safeCathayDiagnosticUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return "invalid-url";
+  }
+}
+
+function safeCathayDiagnosticOrigin(value: string) {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return "invalid-origin";
+  }
+}
+
+function safeCathayDiagnosticMessage(value: string, secrets: string[] = []) {
+  let sanitized = value
+    .replace(/https?:\/\/[^\s"'<>]+/gi, (url) => safeCathayDiagnosticUrl(url))
+    .replace(/[A-Za-z0-9_-]{16,}/g, "[redacted]");
+  for (const secret of secrets) {
+    if (secret) sanitized = sanitized.split(secret).join("[redacted]");
+  }
+  return sanitized.slice(0, 240);
+}
+
+function attachCathaySafeDiagnostics(
+  page: CathayLoginPage,
+  config: CathaybkConfig,
+) {
+  const ignoredAbortedOrigins = new Set([
+    "https://ad.doubleclick.net",
+    "https://analytics.google.com",
+    "https://cathayunitedbank.tt.omtrdc.net",
+    "https://faro-collector-prod-ap-southeast-1.grafana.net",
+    "https://www.google.com",
+  ]);
+  const recordedResponses = new Set<string>();
+  const recordedFailures = new Set<string>();
+  const secrets = [
+    config.userId,
+    config.account,
+    config.password,
+    config.otp,
+  ].filter((value): value is string => Boolean(value));
+
+  page.on("pageerror", (error) => {
+    const diagnostic = JSON.stringify({
+      event: "cathaybk_page_error",
+      errorType: error.name,
+      message: safeCathayDiagnosticMessage(error.message, secrets),
+    });
+    if (error.name === "ReferenceError" && error.message.includes("getMbox")) {
+      console.warn(diagnostic);
+      return;
+    }
+    console.error(diagnostic);
+  });
+  page.on("requestfailed", (request) => {
+    const origin = safeCathayDiagnosticOrigin(request.url());
+    const errorText = safeCathayDiagnosticMessage(
+      request.failure()?.errorText ?? "unknown",
+      secrets,
+    );
+    if (errorText === "net::ERR_ABORTED" && ignoredAbortedOrigins.has(origin)) {
+      return;
+    }
+    const key = `${origin}:${errorText}`;
+    if (recordedFailures.size >= 20 || recordedFailures.has(key)) return;
+    recordedFailures.add(key);
+    console.warn(
+      JSON.stringify({
+        event: "cathaybk_request_failed",
+        origin,
+        errorText,
+      }),
+    );
+  });
+  page.on("response", (response) => {
+    const status = response.status();
+    if (status < 400) return;
+    const origin = safeCathayDiagnosticOrigin(response.url());
+    const key = `${origin}:${status}`;
+    if (recordedResponses.size >= 20 || recordedResponses.has(key)) return;
+    recordedResponses.add(key);
+    console.warn(
+      JSON.stringify({
+        event: "cathaybk_http_error",
+        origin,
+        status,
+      }),
+    );
+  });
+}
+
+async function logCathayLoginTimeout(page: CathayLoginPage, error: unknown) {
+  const state = await page
+    .evaluate(() => ({
+      customerIdCleared:
+        (document.querySelector<HTMLInputElement>("#CustID")?.value ?? "") ===
+        "",
+      userIdCleared:
+        (document.querySelector<HTMLInputElement>("#UserIdKeyin")?.value ??
+          "") === "",
+      passwordCleared:
+        (document.querySelector<HTMLInputElement>("#PasswordKeyin")?.value ??
+          "") === "",
+      encryptedUserIdReady: Boolean(
+        document.querySelector<HTMLInputElement>("#UserId")?.value,
+      ),
+      encryptedPasswordReady: Boolean(
+        document.querySelector<HTMLInputElement>("#Password")?.value,
+      ),
+      formMarkedSubmitting:
+        (window as typeof window & { blnSubmit?: boolean }).blnSubmit === true,
+      hasVisibleValidation: Array.from(
+        document.querySelectorAll<HTMLElement>(
+          ".control-group.was-validated .error-msg",
+        ),
+      ).some((element) => element.innerText.trim() !== ""),
+    }))
+    .catch(() => null);
+
+  console.error(
+    JSON.stringify({
+      event: "cathaybk_login_wait_failed",
+      errorType: error instanceof Error ? error.name : "UNKNOWN_ERROR",
+      currentUrl: safeCathayDiagnosticUrl(page.url()),
+      state,
+    }),
+  );
+}
+
+async function dismissInterstitialIfPresent(
+  page: CathayLoginPage,
+): Promise<boolean> {
   const hasWarning = await page
     .evaluate(() => document.body.innerText.includes("未完成正常的登出程序"))
     .catch(() => false);
@@ -152,7 +848,42 @@ async function dismissInterstitialIfPresent(page: Page): Promise<boolean> {
   return hasWarning as boolean;
 }
 
-async function login(page: Page, config: CathaybkConfig) {
+export async function dismissCathaySystemMessageIfPresent(
+  page: Pick<CathayLoginPage, "$" | "waitForSelector">,
+): Promise<boolean> {
+  const dismissButton = await page.$(
+    "#divSystemLoginMsgList.show button.btn-fill",
+  );
+  if (!dismissButton) return false;
+
+  console.log("[cathaybk] dismissing system message modal");
+  await dismissButton.click();
+  await page.waitForSelector("#divSystemLoginMsgList.show", {
+    hidden: true,
+    timeout: 5000,
+  });
+  return true;
+}
+
+export async function submitCathayLoginForm(
+  page: Pick<CathayLoginPage, "click" | "evaluate">,
+) {
+  const invokedBankHandler = await page.evaluate(() => {
+    const normalDataCheck = (
+      window as typeof window & { NormalDataCheck?: () => boolean }
+    ).NormalDataCheck;
+    if (typeof normalDataCheck !== "function") return false;
+    normalDataCheck();
+    return true;
+  });
+  if (!invokedBankHandler) await page.click(".js-login");
+}
+
+export async function loginCathay(
+  page: CathayLoginPage,
+  config: CathaybkConfig,
+) {
+  attachCathaySafeDiagnostics(page, config);
   console.log("[cathaybk] navigating to login page");
   await page.goto(LOGIN_URL, { waitUntil: "networkidle2", timeout: 60000 });
 
@@ -160,6 +891,7 @@ async function login(page: Page, config: CathaybkConfig) {
   // if a prior session didn't log out — retry up to 3 times
   for (let attempt = 1; attempt <= 3; attempt++) {
     await dismissInterstitialIfPresent(page);
+    await dismissCathaySystemMessageIfPresent(page);
     await page.waitForSelector("#CustID", { timeout: 15000 });
 
     await page.click("#CustID", { clickCount: 3 });
@@ -170,20 +902,83 @@ async function login(page: Page, config: CathaybkConfig) {
     await page.type("#PasswordKeyin", config.password!);
 
     console.log(`[cathaybk] submitting login form (attempt ${attempt}/3)`);
-    await page.click(".js-login");
+    const loginResult = page.waitForFunction(
+      () => {
+        const controlsText = Array.from(
+          document.querySelectorAll<HTMLElement>(
+            'a, button, input[type="button"], input[type="submit"], [role="button"]',
+          ),
+        )
+          .map((element) =>
+            [
+              element.textContent,
+              element.getAttribute("aria-label"),
+              element.getAttribute("value"),
+            ]
+              .filter(Boolean)
+              .join(" "),
+          )
+          .join(" ");
+        const pageText = `${document.body?.innerText ?? ""} ${controlsText}`;
+        const normalizedText = pageText.replace(/\s+/g, "");
 
-    await page.waitForFunction(
-      () =>
-        window.location.href.includes("/OnlineBanking/") ||
-        document.body.innerText.includes("未完成正常的登出程序") ||
-        document.body.innerText.includes("登入失敗") ||
-        document.body.innerText.includes("錯誤"),
-      { timeout: 60000 },
+        return (
+          window.location.href.includes("/OnlineBanking/") ||
+          document.querySelector(
+            ".js-otp-view, #js-otp-send, #js-otp-email-send",
+          ) !== null ||
+          normalizedText.includes("未完成正常的登出程序") ||
+          normalizedText.includes("登入失敗") ||
+          normalizedText.includes("錯誤") ||
+          (normalizedText.includes("Email驗證") &&
+            normalizedText.includes("簡訊驗證"))
+        );
+      },
+      { timeout: 45000 },
     );
+    await submitCathayLoginForm(page);
+    try {
+      await loginResult;
+    } catch (error) {
+      await logCathayLoginTimeout(page, error);
+      throw error;
+    }
 
     if (page.url().includes("/OnlineBanking/")) {
       console.log("[cathaybk] login succeeded");
       return;
+    }
+
+    const requiresAdditionalVerification = await page.evaluate(() => {
+      const controlsText = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          'a, button, input[type="button"], input[type="submit"], [role="button"]',
+        ),
+      )
+        .map((element) =>
+          [
+            element.textContent,
+            element.getAttribute("aria-label"),
+            element.getAttribute("value"),
+          ]
+            .filter(Boolean)
+            .join(" "),
+        )
+        .join(" ");
+      const normalizedText =
+        `${document.body?.innerText ?? ""} ${controlsText}`.replace(/\s+/g, "");
+      return (
+        document.querySelector(
+          ".js-otp-view, #js-otp-send, #js-otp-email-send",
+        ) !== null ||
+        (normalizedText.includes("Email驗證") &&
+          normalizedText.includes("簡訊驗證"))
+      );
+    });
+    if (requiresAdditionalVerification) {
+      throw new CathayVerificationRequiredError(
+        "國泰世華要求 Email 或簡訊額外驗證，請先完成人工驗證。",
+      );
     }
 
     const bodyText = await page
@@ -548,7 +1343,7 @@ interface MonthDetail {
   sections: BillDetailSection[];
 }
 
-async function scrapeCreditCards(page: Page): Promise<Scraped> {
+export async function scrapeCreditCards(page: Page): Promise<Scraped> {
   const bankAccounts: Scraped["bankAccounts"] = [];
   const bankBalanceSnapshots: Scraped["bankBalanceSnapshots"] = [];
   const bankTransactions: Scraped["bankTransactions"] = [];
@@ -585,6 +1380,7 @@ async function scrapeCreditCards(page: Page): Promise<Scraped> {
         )
       : null;
     return {
+      cardDetected: Boolean(last4Match),
       last4: last4Match?.[1] ?? "",
       cardName: last4Match
         ? `國泰信用卡 末四碼 ${last4Match[1]}`
@@ -600,11 +1396,23 @@ async function scrapeCreditCards(page: Page): Promise<Scraped> {
   console.log(
     JSON.stringify({
       event: "cathaybk_card_overview_parsed",
-      cardDetected: Boolean(cardOverview.last4),
+      cardDetected: cardOverview.cardDetected,
       paymentDueDateAvailable: Boolean(cardOverview.paymentDueDate),
       noPaymentNeeded: cardOverview.noPaymentNeeded,
     }),
   );
+
+  if (!cardOverview.cardDetected) {
+    console.log(
+      "[cathaybk] no credit card detected; skipping card account and bills",
+    );
+    return {
+      bankAccounts,
+      bankBalanceSnapshots,
+      bankTransactions,
+      creditCardBills,
+    };
+  }
 
   // ponytail: always use main — CathayBK pools limit across all cards
   const sourceId = "credit:cathaybk:main";

--- a/apps/worker/src/features/connectors/service.ts
+++ b/apps/worker/src/features/connectors/service.ts
@@ -9,6 +9,33 @@ import { findConnectorSettings, saveConnectorSettings } from "./repository";
 export class ConnectorConfigMissingError extends Error {}
 export class InvalidConnectorConfigError extends Error {}
 
+function hasValidCathayTrustedDevice(value: unknown) {
+  if (typeof value !== "string") return false;
+  try {
+    const cookies = JSON.parse(value) as unknown;
+    return (
+      Array.isArray(cookies) &&
+      cookies.some((cookie) => {
+        if (!cookie || typeof cookie !== "object") return false;
+        const candidate = cookie as Record<string, unknown>;
+        const domain = String(candidate.domain ?? "")
+          .replace(/^\./, "")
+          .toLowerCase();
+        return (
+          candidate.name === "CUB.eBank.DeviceId" &&
+          typeof candidate.value === "string" &&
+          candidate.value.length > 0 &&
+          typeof candidate.expires === "number" &&
+          candidate.expires > Date.now() / 1000 &&
+          (domain === "cathaybk.com.tw" || domain.endsWith(".cathaybk.com.tw"))
+        );
+      })
+    );
+  } catch {
+    return false;
+  }
+}
+
 export async function getConnectorSettingsView(
   env: Env,
   connectorId: ConnectorId,
@@ -16,6 +43,9 @@ export async function getConnectorSettingsView(
   const settings = await findConnectorSettings(env.DB, connectorId);
   let sessionAvailable = false;
   let credentialsComplete = false;
+  let verificationPending = false;
+  let verificationChannel: "email" | "sms" | null = null;
+  let verificationExpiresAt: string | null = null;
   if (settings) {
     const stored = await decryptJson<Record<string, unknown>>(
       settings.encrypted_config,
@@ -44,6 +74,23 @@ export async function getConnectorSettingsView(
         stored.sessionCookies.length > 0 &&
         (connectorId !== "sinopac" ||
           stored.protocol === "sinopac-mobile-app-json-v1");
+    } else if (connectorId === "cathaybk") {
+      sessionAvailable = hasValidCathayTrustedDevice(stored.sessionCookies);
+      verificationExpiresAt =
+        typeof stored.browserSessionExpiresAt === "string"
+          ? stored.browserSessionExpiresAt
+          : null;
+      verificationPending =
+        credentialsComplete &&
+        typeof stored.browserSessionId === "string" &&
+        stored.browserSessionId.length > 0 &&
+        verificationExpiresAt !== null &&
+        new Date(verificationExpiresAt) > new Date();
+      verificationChannel =
+        verificationPending &&
+        (stored.otpChannel === "email" || stored.otpChannel === "sms")
+          ? stored.otpChannel
+          : null;
     }
   }
   return {
@@ -58,6 +105,9 @@ export async function getConnectorSettingsView(
       : null,
     credentialsComplete,
     sessionAvailable,
+    verificationPending,
+    verificationChannel,
+    verificationExpiresAt,
   };
 }
 

--- a/apps/worker/src/features/sync/registry.ts
+++ b/apps/worker/src/features/sync/registry.ts
@@ -25,6 +25,7 @@ import {
   type HncbSyncOverrides,
   type TaishinSyncOverrides,
   type TdccSyncOverrides,
+  type CathaySyncOverrides,
 } from "./service";
 
 type ConnectorRuntimeDefinition = {
@@ -61,7 +62,8 @@ export const connectorRuntimeRegistry: Record<
     run: (env, trigger) => syncEsun(env, trigger),
   },
   cathaybk: {
-    run: (env, trigger) => syncCathaybk(env, trigger),
+    run: (env, trigger, _scope, overrides) =>
+      syncCathaybk(env, trigger, overrides as CathaySyncOverrides),
   },
   ctbc: {
     run: (env, trigger) => syncCtbc(env, trigger),

--- a/apps/worker/src/features/sync/route.ts
+++ b/apps/worker/src/features/sync/route.ts
@@ -14,6 +14,13 @@ import {
   HncbConnectionError,
   HncbVerificationRequiredError,
 } from "../../connectors/hncb";
+import {
+  CathayOtpChannelRequiredError,
+  CathayOtpInvalidError,
+  CathayOtpRequiredError,
+  CathayOtpSessionExpiredError,
+  CathayVerificationRequiredError,
+} from "../../connectors/cathaybk";
 import { SinopacBrowserCapacityError } from "../../connectors/sinopac";
 import {
   TaishinBrowserCapacityError,
@@ -67,6 +74,11 @@ const obankSyncBodySchema = z.object({
     .string()
     .regex(/^[A-Za-z0-9]{4}$/)
     .optional(),
+});
+
+const cathaySyncBodySchema = z.object({
+  otp: z.string().min(1).optional(),
+  otpChannel: z.enum(["email", "sms"]).optional(),
 });
 
 export const syncRoutes = honoFactory.createApp();
@@ -203,14 +215,29 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
     );
   });
 
-  api.post("/connectors/cathaybk/sync", async (c) => {
-    return syncRouteResponse(
-      c,
-      withManualSyncLock(c.env, "cathaybk", SYNC_SCOPE_ALL, () =>
-        runConnectorSync(c.env, "cathaybk", "manual"),
-      ),
-    );
-  });
+  api.post(
+    "/connectors/cathaybk/sync",
+    zValidator(
+      "json",
+      cathaySyncBodySchema,
+      validationHook("INVALID_REQUEST", "Cathay sync options are invalid."),
+    ),
+    async (c) => {
+      const overrides = c.req.valid("json");
+      return syncRouteResponse(
+        c,
+        withManualSyncLock(c.env, "cathaybk", SYNC_SCOPE_ALL, () =>
+          runConnectorSync(
+            c.env,
+            "cathaybk",
+            "manual",
+            SYNC_SCOPE_ALL,
+            overrides,
+          ),
+        ),
+      );
+    },
+  );
 
   api.post("/connectors/ctbc/sync", async (c) => {
     return syncRouteResponse(
@@ -418,6 +445,35 @@ async function syncRouteResponse(
   } catch (error) {
     if (error instanceof SyncAlreadyRunningError) {
       return jsonError("SYNC_ALREADY_RUNNING", safeErrorMessage(error), 409);
+    }
+    if (error instanceof CathayOtpChannelRequiredError) {
+      return jsonError(
+        "CATHAY_OTP_CHANNEL_REQUIRED",
+        safeErrorMessage(error),
+        400,
+      );
+    }
+    if (error instanceof CathayOtpRequiredError) {
+      return jsonError(
+        error.channel === "sms"
+          ? "CATHAY_SMS_OTP_REQUIRED"
+          : "CATHAY_EMAIL_OTP_REQUIRED",
+        safeErrorMessage(error),
+        400,
+      );
+    }
+    if (error instanceof CathayOtpSessionExpiredError) {
+      return jsonError(
+        "CATHAY_OTP_SESSION_EXPIRED",
+        safeErrorMessage(error),
+        400,
+      );
+    }
+    if (error instanceof CathayOtpInvalidError) {
+      return jsonError("CATHAY_OTP_INVALID", safeErrorMessage(error), 400);
+    }
+    if (error instanceof CathayVerificationRequiredError) {
+      return jsonError("USER_ACTION_REQUIRED", safeErrorMessage(error), 400);
     }
     if (error instanceof TdccVerificationRequiredError) {
       return jsonError(

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -19,7 +19,14 @@ import {
   TdccVerificationRequiredError,
   prepareObankCaptcha,
 } from "@taiwan-fin-hub/connectors";
-import { createCathaybkConnector } from "../../connectors/cathaybk";
+import {
+  CathayOtpChannelRequiredError,
+  CathayOtpInvalidError,
+  CathayOtpRequiredError,
+  CathayOtpSessionExpiredError,
+  CathayVerificationRequiredError,
+  createCathaybkConnector,
+} from "../../connectors/cathaybk";
 import { createCtbcFetch } from "../../connectors/ctbc";
 import { createEsunConnector } from "../../connectors/esun";
 import {
@@ -154,6 +161,11 @@ export type TaishinSyncOverrides = {
 
 export type ObankSyncOverrides = {
   captcha?: string;
+};
+
+export type CathaySyncOverrides = {
+  otp?: string;
+  otpChannel?: "email" | "sms";
 };
 
 export type TdccSyncOverrides = {
@@ -454,6 +466,7 @@ export async function syncEsun(
 export async function syncCathaybk(
   env: Env,
   trigger: SyncTrigger,
+  overrides: CathaySyncOverrides = {},
 ): Promise<SyncOutcome> {
   const connectorId = "cathaybk";
   const scope = "all";
@@ -465,15 +478,89 @@ export async function syncCathaybk(
   const config = parseCathaybkConfig({
     ...stored,
     ...parsePublicConnectorConfig(connectorId, settings.public_config),
+    ...(trigger === "manual" ? overrides : {}),
   });
+
+  if (trigger !== "manual" && config.browserSessionId) {
+    throw new NeedsUserActionError(
+      "國泰世華正在等待一次性驗證碼，排程同步不會在背景寄送驗證碼。",
+    );
+  }
 
   console.log(
     `[sync] ${connectorId}/${scope}: starting trigger=${trigger} (cursor=${settings.sync_cursor ? "set" : "none"})`,
   );
-  const result = await createCathaybkConnector(env.BROWSER).sync(
-    config,
-    settings.sync_cursor ?? undefined,
-  );
+  let result: Awaited<
+    ReturnType<ReturnType<typeof createCathaybkConnector>["sync"]>
+  >;
+  try {
+    result = await createCathaybkConnector(env.BROWSER).sync(
+      config,
+      settings.sync_cursor ?? undefined,
+    );
+  } catch (error) {
+    const cleaned = { ...stored };
+
+    if (error instanceof CathayOtpChannelRequiredError) {
+      delete cleaned.sessionCookies;
+      delete cleaned.sessionExpiresAt;
+      cleaned.browserSessionId = error.browserSessionId;
+      cleaned.browserSessionExpiresAt = error.browserSessionExpiresAt;
+      delete cleaned.otp;
+      delete cleaned.otpChannel;
+      await updateConnectorEncryptedConfig(
+        env.DB,
+        connectorId,
+        await encryptJson(cleaned, configEncryptionKey(env)),
+      );
+      throw error;
+    }
+
+    if (error instanceof CathayOtpRequiredError) {
+      cleaned.otpChannel = error.channel;
+      delete cleaned.otp;
+      await updateConnectorEncryptedConfig(
+        env.DB,
+        connectorId,
+        await encryptJson(cleaned, configEncryptionKey(env)),
+      );
+      throw error;
+    }
+
+    if (error instanceof CathayOtpInvalidError) {
+      delete cleaned.otp;
+      await updateConnectorEncryptedConfig(
+        env.DB,
+        connectorId,
+        await encryptJson(cleaned, configEncryptionKey(env)),
+      );
+      throw error;
+    }
+
+    // OTP submission, session expiry, and all other failures invalidate the
+    // transient Browser session. A subsequent manual sync starts a new login.
+    delete cleaned.browserSessionId;
+    delete cleaned.browserSessionExpiresAt;
+    delete cleaned.otp;
+    delete cleaned.otpChannel;
+    if (error instanceof CathayVerificationRequiredError) {
+      delete cleaned.sessionCookies;
+      delete cleaned.sessionExpiresAt;
+    }
+    await updateConnectorEncryptedConfig(
+      env.DB,
+      connectorId,
+      await encryptJson(cleaned, configEncryptionKey(env)),
+    );
+
+    if (error instanceof CathayOtpSessionExpiredError) {
+      throw error;
+    }
+    if (error instanceof CathayVerificationRequiredError) {
+      throw new NeedsUserActionError(error.message);
+    }
+    throw error;
+  }
 
   const bankAccounts = result.bankAccounts ?? [];
   const bankBalanceSnapshots = result.bankBalanceSnapshots ?? [];
@@ -504,12 +591,19 @@ export async function syncCathaybk(
   if (result.cursor) {
     const cursorState = splitConnectorCursorState(connectorId, result.cursor);
     persistedCursor = cursorState.safeCursor;
+    const {
+      browserSessionId: _browserSessionId,
+      browserSessionExpiresAt: _browserSessionExpiresAt,
+      otp: _otp,
+      otpChannel: _otpChannel,
+      ...reusableConfig
+    } = config;
     finalizeStatements.push(
       connectorStateStatement(
         env.DB,
         connectorId,
         await encryptConnectorConfig(env, connectorId, {
-          ...config,
+          ...reusableConfig,
           ...cursorState.secretState,
         }),
         serializePublicConfig(connectorId, config),
@@ -1700,6 +1794,10 @@ function serializePublicConfig(connectorId: ConnectorId, config: object) {
 export function isUserActionError(error: unknown) {
   if (
     error instanceof NeedsUserActionError ||
+    error instanceof CathayOtpChannelRequiredError ||
+    error instanceof CathayOtpRequiredError ||
+    error instanceof CathayOtpSessionExpiredError ||
+    error instanceof CathayVerificationRequiredError ||
     error instanceof TdccOtpExpiredError ||
     error instanceof TdccVerificationRequiredError ||
     error instanceof EInvoiceProtocolUnavailableError ||

--- a/apps/worker/tests/connectors/cathaybk-session.test.ts
+++ b/apps/worker/tests/connectors/cathaybk-session.test.ts
@@ -1,0 +1,612 @@
+import { describe, expect, it, vi } from "vitest";
+
+const puppeteerMock = vi.hoisted(() => ({
+  connect: vi.fn(),
+  launch: vi.fn(),
+  sessions: vi.fn(),
+}));
+
+vi.mock("@cloudflare/puppeteer", () => ({ default: puppeteerMock }));
+
+import {
+  CathayOtpInvalidError,
+  CathayOtpChannelRequiredError,
+  CathayOtpRequiredError,
+  CathayVerificationRequiredError,
+  captureCathayTrustedState,
+  completeCathayTrustedDeviceSetup,
+  createCathaybkConnector,
+  dismissCathaySystemMessageIfPresent,
+  loginCathay,
+  restoreCathayTrustedState,
+  sendCathayOtp,
+  scrapeCreditCards,
+  submitCathayLoginForm,
+  submitCathayOtp,
+} from "../../src/connectors/cathaybk";
+
+const credentials = {
+  userId: "A123456789",
+  account: "test-user",
+  password: "test-password",
+};
+
+function verificationPage() {
+  return {
+    click: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockImplementation(async (fn: unknown) => {
+      const source = String(fn);
+      if (source.includes("hasInput")) {
+        return { hasInput: true, hasSubmit: true };
+      }
+      if (source.includes("normalizedText")) return false;
+      return undefined;
+    }),
+    setViewport: vi.fn().mockResolvedValue(undefined),
+    type: vi.fn().mockResolvedValue(undefined),
+    waitForFunction: vi.fn().mockResolvedValue(undefined),
+    waitForNavigation: vi.fn().mockResolvedValue(undefined),
+    waitForSelector: vi.fn().mockResolvedValue(undefined),
+    url: vi
+      .fn()
+      .mockReturnValue("https://www.cathaybk.com.tw/MyBank/verification"),
+  };
+}
+
+function browserForPage(page: ReturnType<typeof verificationPage>) {
+  return {
+    close: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    newPage: vi.fn().mockResolvedValue(page),
+    pages: vi.fn().mockResolvedValue([page]),
+    sessionId: vi.fn().mockReturnValue("cathay-session"),
+  };
+}
+
+describe("Cathay system message modal", () => {
+  it("dismisses the visible login message before continuing", async () => {
+    const dismissButton = {
+      click: vi.fn().mockResolvedValue(undefined),
+    };
+    const page = {
+      $: vi.fn().mockResolvedValue(dismissButton),
+      waitForSelector: vi.fn().mockResolvedValue(null),
+    };
+
+    await expect(dismissCathaySystemMessageIfPresent(page)).resolves.toBe(true);
+
+    expect(page.$).toHaveBeenCalledWith(
+      "#divSystemLoginMsgList.show button.btn-fill",
+    );
+    expect(dismissButton.click).toHaveBeenCalledOnce();
+    expect(page.waitForSelector).toHaveBeenCalledWith(
+      "#divSystemLoginMsgList.show",
+      { hidden: true, timeout: 5000 },
+    );
+  });
+
+  it("does nothing when the login message is not visible", async () => {
+    const page = {
+      $: vi.fn().mockResolvedValue(null),
+      waitForSelector: vi.fn(),
+    };
+
+    await expect(dismissCathaySystemMessageIfPresent(page)).resolves.toBe(
+      false,
+    );
+
+    expect(page.waitForSelector).not.toHaveBeenCalled();
+  });
+});
+
+describe("Cathay browser session lifecycle", () => {
+  it("attempts to reconnect when the session list still has a connection id", async () => {
+    const page = verificationPage();
+    const browser = browserForPage(page);
+    puppeteerMock.sessions.mockResolvedValueOnce([
+      {
+        sessionId: "cathay-session",
+        connectionId: "stale-connection",
+      },
+    ]);
+    puppeteerMock.connect.mockResolvedValueOnce(browser);
+
+    await expect(
+      createCathaybkConnector({} as Fetcher).sync({
+        ...credentials,
+        browserSessionId: "cathay-session",
+        browserSessionExpiresAt: new Date(Date.now() + 120_000).toISOString(),
+      }),
+    ).rejects.toBeInstanceOf(CathayOtpChannelRequiredError);
+
+    expect(puppeteerMock.connect).toHaveBeenCalledWith({}, "cathay-session");
+    expect(browser.disconnect).toHaveBeenCalledOnce();
+    expect(browser.close).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "pages",
+      (browser: ReturnType<typeof browserForPage>) => {
+        browser.pages.mockRejectedValue(new Error("pages failed"));
+      },
+    ],
+    [
+      "newPage",
+      (browser: ReturnType<typeof browserForPage>) => {
+        browser.pages.mockResolvedValue([]);
+        browser.newPage.mockRejectedValue(new Error("new page failed"));
+      },
+    ],
+  ] as const)(
+    "closes a launched browser when %s setup fails",
+    async (_stage, fail) => {
+      const page = verificationPage();
+      const browser = browserForPage(page);
+      fail(browser);
+      puppeteerMock.launch.mockResolvedValueOnce(browser);
+
+      await expect(
+        createCathaybkConnector({} as Fetcher).sync(credentials),
+      ).rejects.toThrow();
+
+      expect(puppeteerMock.launch).toHaveBeenCalledWith(
+        {},
+        { keep_alive: 120_000 },
+      );
+      expect(browser.close).toHaveBeenCalledOnce();
+      expect(browser.disconnect).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    [
+      "missing OTP channel",
+      { browserSessionId: "cathay-session" },
+      CathayOtpChannelRequiredError,
+    ],
+    [
+      "missing OTP",
+      { browserSessionId: "cathay-session", otpChannel: "email" as const },
+      CathayOtpRequiredError,
+    ],
+    [
+      "invalid OTP",
+      {
+        browserSessionId: "cathay-session",
+        otpChannel: "email" as const,
+        otp: "123456",
+      },
+      CathayOtpInvalidError,
+    ],
+  ] as const)(
+    "disconnects instead of closing for %s",
+    async (_stage, options, errorType) => {
+      const page = verificationPage();
+      const browser = browserForPage(page);
+      puppeteerMock.sessions.mockResolvedValueOnce([
+        { sessionId: "cathay-session" },
+      ]);
+      puppeteerMock.connect.mockResolvedValueOnce(browser);
+
+      await expect(
+        createCathaybkConnector({} as Fetcher).sync({
+          ...credentials,
+          ...options,
+          browserSessionExpiresAt: new Date(Date.now() + 120_000).toISOString(),
+        }),
+      ).rejects.toBeInstanceOf(errorType);
+
+      expect(browser.disconnect).toHaveBeenCalledOnce();
+      expect(browser.close).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe("Cathay login result", () => {
+  it("invokes the bank login handler directly", async () => {
+    const page = {
+      click: vi.fn(),
+      evaluate: vi.fn().mockResolvedValue(true),
+    };
+
+    await submitCathayLoginForm(page);
+
+    expect(page.evaluate).toHaveBeenCalledOnce();
+    expect(page.click).not.toHaveBeenCalled();
+  });
+
+  it("falls back to clicking the login button when the handler is unavailable", async () => {
+    const page = {
+      click: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue(false),
+    };
+
+    await submitCathayLoginForm(page);
+
+    expect(page.click).toHaveBeenCalledWith(".js-login");
+  });
+
+  it("reports additional email or SMS verification without requiring a navigation event", async () => {
+    const page = {
+      $: vi.fn().mockResolvedValue(null),
+      click: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true),
+      goto: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+      type: vi.fn().mockResolvedValue(undefined),
+      url: vi
+        .fn()
+        .mockReturnValue(
+          "https://www.cathaybk.com.tw/MyBank/Quicklinks/Home/NormalSignin",
+        ),
+      waitForNavigation: vi
+        .fn()
+        .mockRejectedValue(
+          new Error("Navigation timeout of 60000 ms exceeded"),
+        ),
+      waitForFunction: vi.fn().mockResolvedValue(undefined),
+      waitForSelector: vi.fn().mockResolvedValue(null),
+    };
+
+    await expect(loginCathay(page, credentials)).rejects.toMatchObject({
+      name: CathayVerificationRequiredError.name,
+      message: "國泰世華要求 Email 或簡訊額外驗證，請先完成人工驗證。",
+    });
+
+    expect(page.click).not.toHaveBeenCalledWith(".js-login");
+    expect(page.waitForNavigation).not.toHaveBeenCalled();
+    expect(page.waitForFunction).toHaveBeenCalledWith(expect.any(Function), {
+      timeout: 45000,
+    });
+  });
+
+  it("logs only sanitized page state when the login result times out", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const page = {
+      $: vi.fn().mockResolvedValue(null),
+      click: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce({
+          customerIdCleared: false,
+          userIdCleared: true,
+          passwordCleared: true,
+          encryptedUserIdReady: true,
+          encryptedPasswordReady: true,
+          formMarkedSubmitting: true,
+          hasVisibleValidation: false,
+        }),
+      goto: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+      type: vi.fn().mockResolvedValue(undefined),
+      url: vi
+        .fn()
+        .mockReturnValue(
+          "https://www.cathaybk.com.tw/MyBank/Quicklinks/Home/NormalSignin?token=secret",
+        ),
+      waitForFunction: vi
+        .fn()
+        .mockRejectedValue(new Error("Waiting failed: 45000ms exceeded")),
+      waitForSelector: vi.fn().mockResolvedValue(null),
+    };
+
+    await expect(loginCathay(page, credentials)).rejects.toThrow(
+      "Waiting failed: 45000ms exceeded",
+    );
+
+    const diagnostic = String(consoleError.mock.calls.at(-1)?.[0]);
+    expect(diagnostic).toContain('"event":"cathaybk_login_wait_failed"');
+    expect(diagnostic).toContain(
+      '"currentUrl":"https://www.cathaybk.com.tw/MyBank/Quicklinks/Home/NormalSignin"',
+    );
+    expect(diagnostic).not.toContain("token=secret");
+    expect(diagnostic).not.toContain(credentials.userId);
+    expect(diagnostic).not.toContain(credentials.account);
+    expect(diagnostic).not.toContain(credentials.password);
+
+    const pageErrorHandler = page.on.mock.calls.find(
+      ([event]) => event === "pageerror",
+    )?.[1] as ((error: Error) => void) | undefined;
+    expect(pageErrorHandler).toBeTypeOf("function");
+    pageErrorHandler?.(
+      new Error(
+        `Login failed for ${credentials.account}/${credentials.password} at https://www.cathaybk.com.tw/MyBank/?token=secret`,
+      ),
+    );
+    const pageErrorDiagnostic = String(consoleError.mock.calls.at(-1)?.[0]);
+    expect(pageErrorDiagnostic).toContain('"event":"cathaybk_page_error"');
+    expect(pageErrorDiagnostic).not.toContain("token=secret");
+    expect(pageErrorDiagnostic).not.toContain(credentials.account);
+    expect(pageErrorDiagnostic).not.toContain(credentials.password);
+  });
+});
+
+describe("Cathay additional verification", () => {
+  it.each([
+    ["email", "#js-otp-email-send"],
+    ["sms", "#js-otp-send"],
+  ] as const)(
+    "sends the %s OTP with the bank's dedicated control",
+    async (channel, selector) => {
+      const page = {
+        click: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockResolvedValue(undefined),
+        waitForSelector: vi.fn().mockResolvedValue(null),
+      };
+
+      await sendCathayOtp(page, channel);
+
+      expect(page.waitForSelector).toHaveBeenNthCalledWith(1, selector, {
+        visible: true,
+        timeout: 15_000,
+      });
+      expect(page.click).toHaveBeenCalledWith(selector);
+      expect(page.waitForSelector).toHaveBeenNthCalledWith(
+        2,
+        '.js-otp-view input:not([type="hidden"]), .login-otp input:not([type="hidden"]), input[autocomplete="one-time-code"], input[inputmode="numeric"], input[name*="otp" i], input[id*="otp" i], input[placeholder*="後6位數字"]',
+        { timeout: 15_000 },
+      );
+    },
+  );
+
+  it("types a numeric OTP and submits the visible verification form", async () => {
+    const page = {
+      click: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce({
+          hasInput: true,
+          hasSubmit: true,
+        })
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce({
+          hasNext: false,
+          hasNameInput: false,
+          hasConfirm: false,
+          success: true,
+        }),
+      type: vi.fn().mockResolvedValue(undefined),
+      url: vi
+        .fn()
+        .mockReturnValue("https://www.cathaybk.com.tw/OnlineBanking/Home"),
+      waitForFunction: vi.fn().mockResolvedValue(undefined),
+      waitForNavigation: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await submitCathayOtp(page, " 123456 ");
+
+    expect(page.evaluate).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Function),
+      "驗證|確認|確定|送出|登入",
+    );
+    expect(page.click).toHaveBeenNthCalledWith(
+      1,
+      '[data-cathay-otp-input="true"]',
+      { clickCount: 3 },
+    );
+    expect(page.type).toHaveBeenCalledWith(
+      '[data-cathay-otp-input="true"]',
+      "123456",
+    );
+    expect(page.click).toHaveBeenNthCalledWith(
+      2,
+      '[data-cathay-otp-submit="true"]',
+    );
+  });
+
+  it("strips the bank's English prefix before typing the OTP suffix", async () => {
+    const page = {
+      click: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce({ hasInput: true, hasSubmit: true })
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce({
+          hasNext: false,
+          hasNameInput: false,
+          hasConfirm: false,
+          success: true,
+        }),
+      type: vi.fn().mockResolvedValue(undefined),
+      url: vi
+        .fn()
+        .mockReturnValue("https://www.cathaybk.com.tw/OnlineBanking/Home"),
+      waitForFunction: vi.fn().mockResolvedValue(undefined),
+      waitForNavigation: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await submitCathayOtp(page, "DAKY-310307");
+
+    expect(page.type).toHaveBeenCalledWith(
+      '[data-cathay-otp-input="true"]',
+      "310307",
+    );
+  });
+
+  it("rejects malformed OTP values before operating the bank page", async () => {
+    const page = {
+      click: vi.fn(),
+      evaluate: vi.fn(),
+      type: vi.fn(),
+      url: vi.fn(),
+      waitForFunction: vi.fn(),
+      waitForNavigation: vi.fn(),
+    };
+
+    await expect(submitCathayOtp(page, "12AB")).rejects.toThrow(
+      "請輸入驗證碼後 4 至 8 位數字；英文前綴可省略。",
+    );
+    await expect(submitCathayOtp(page, "12AB")).rejects.toBeInstanceOf(
+      CathayOtpInvalidError,
+    );
+    expect(page.evaluate).not.toHaveBeenCalled();
+  });
+
+  it("classifies a rejected bank OTP as retryable", async () => {
+    const page = {
+      click: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce({ hasInput: true, hasSubmit: true })
+        .mockResolvedValueOnce(false),
+      type: vi.fn().mockResolvedValue(undefined),
+      url: vi
+        .fn()
+        .mockReturnValue("https://www.cathaybk.com.tw/OnlineBanking/"),
+      waitForFunction: vi.fn().mockResolvedValue(undefined),
+      waitForNavigation: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(submitCathayOtp(page, "123456")).rejects.toBeInstanceOf(
+      CathayOtpInvalidError,
+    );
+  });
+});
+
+describe("Cathay credit cards", () => {
+  it("returns no card data when the overview has no card number", async () => {
+    vi.useFakeTimers();
+    const page = {
+      evaluate: vi.fn().mockResolvedValue({
+        cardDetected: false,
+        last4: "",
+        cardName: "國泰信用卡",
+        creditLimit: 0,
+        availableCredit: 0,
+        unpaidAmount: 0,
+        paymentDueDate: null,
+        noPaymentNeeded: false,
+      }),
+      goto: vi.fn().mockResolvedValue(undefined),
+    };
+
+    try {
+      const pending = scrapeCreditCards(
+        page as unknown as Parameters<typeof scrapeCreditCards>[0],
+      );
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      await expect(pending).resolves.toEqual({
+        bankAccounts: [],
+        bankBalanceSnapshots: [],
+        bankTransactions: [],
+        creditCardBills: [],
+      });
+      expect(page.goto).toHaveBeenCalledOnce();
+      expect(page.evaluate).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("Cathay trusted device state", () => {
+  it("restores only the Cathay trusted-device cookie", async () => {
+    const page = {
+      setCookie: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(
+      restoreCathayTrustedState(page, {
+        sessionCookies: JSON.stringify([
+          {
+            name: "CUB.eBank.DeviceId",
+            value: "device-1",
+            domain: ".cathaybk.com.tw",
+          },
+          { name: "active-session", value: "no", domain: ".cathaybk.com.tw" },
+          { name: "foreign", value: "no", domain: ".example.com" },
+        ]),
+      }),
+    ).resolves.toBe(true);
+
+    expect(page.setCookie).toHaveBeenCalledWith({
+      name: "CUB.eBank.DeviceId",
+      value: "device-1",
+      domain: ".cathaybk.com.tw",
+    });
+  });
+
+  it("captures encrypted cursor state without OTP fields", async () => {
+    const page = {
+      cookies: vi.fn().mockResolvedValue([
+        {
+          name: "CUB.eBank.DeviceId",
+          value: "device-1",
+          domain: ".cathaybk.com.tw",
+          expires: 1_800_000_000,
+        },
+      ]),
+    };
+
+    await expect(captureCathayTrustedState(page)).resolves.toEqual({
+      sessionCookies: JSON.stringify([
+        {
+          name: "CUB.eBank.DeviceId",
+          value: "device-1",
+          domain: ".cathaybk.com.tw",
+          expires: 1_800_000_000,
+        },
+      ]),
+      sessionExpiresAt: new Date(1_800_000_000 * 1000).toISOString(),
+    });
+  });
+
+  it("names and confirms a detected trusted-device setup step", async () => {
+    const page = {
+      click: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce({
+          hasNext: false,
+          hasNameInput: true,
+          hasConfirm: true,
+          success: false,
+        })
+        .mockResolvedValueOnce(true),
+      type: vi.fn().mockResolvedValue(undefined),
+      waitForFunction: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(completeCathayTrustedDeviceSetup(page)).resolves.toBe(true);
+    expect(page.evaluate).toHaveBeenNthCalledWith(1, expect.any(Function), {
+      context:
+        "登入安全再升級|立即啟用|信任裝置|設定裝置名稱|裝置名稱|裝置暱稱|確定加入",
+      confirm: "確定加入|確認加入|完成設定|^確定$|^確認$|^完成$",
+    });
+    expect(page.type).toHaveBeenCalledWith(
+      '[data-cathay-trust-name="true"]',
+      "ALL SET 同步",
+    );
+    expect(page.click).toHaveBeenLastCalledWith(
+      '[data-cathay-trust-confirm="true"]',
+    );
+  });
+
+  it("does not claim success when no trusted-device result is present", async () => {
+    const page = {
+      click: vi.fn(),
+      evaluate: vi.fn().mockResolvedValue({
+        hasNext: false,
+        hasNameInput: false,
+        hasConfirm: false,
+        success: false,
+      }),
+      type: vi.fn(),
+      waitForFunction: vi.fn().mockRejectedValue(new Error("timeout")),
+    };
+
+    await expect(completeCathayTrustedDeviceSetup(page)).resolves.toBe(false);
+    expect(page.click).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/tests/features/connectors/service.test.ts
+++ b/apps/worker/tests/features/connectors/service.test.ts
@@ -173,6 +173,97 @@ describe("connector settings state boundaries", () => {
     });
   });
 
+  it("reports Cathay trusted-device availability only for its device cookie", async () => {
+    mocks.findConnectorSettings.mockResolvedValue({
+      id: "cathay-settings",
+      connector_id: "cathaybk",
+      encrypted_config: JSON.stringify({
+        userId: "A123456789",
+        account: "user",
+        password: "password",
+        sessionCookies: JSON.stringify([
+          {
+            name: "CUB.eBank.DeviceId",
+            value: "trusted-device",
+            domain: ".cathaybk.com.tw",
+            expires: 2_000_000_000,
+          },
+        ]),
+      }),
+      public_config: null,
+      sync_cursor: null,
+      created_at: "2026-08-22T08:00:00.000Z",
+      updated_at: "2026-08-22T08:00:00.000Z",
+    });
+
+    await expect(
+      getConnectorSettingsView(env, "cathaybk"),
+    ).resolves.toMatchObject({
+      connectorId: "cathaybk",
+      credentialsComplete: true,
+      sessionAvailable: true,
+    });
+  });
+
+  it("reports a resumable Cathay Email verification session", async () => {
+    mocks.findConnectorSettings.mockResolvedValue({
+      id: "cathay-settings",
+      connector_id: "cathaybk",
+      encrypted_config: JSON.stringify({
+        userId: "A123456789",
+        account: "user",
+        password: "password",
+        browserSessionId: "pending-session",
+        browserSessionExpiresAt: "2099-08-22T08:08:00.000Z",
+        otpChannel: "email",
+      }),
+      public_config: null,
+      sync_cursor: null,
+      created_at: "2026-08-22T08:00:00.000Z",
+      updated_at: "2026-08-22T08:00:00.000Z",
+    });
+
+    await expect(
+      getConnectorSettingsView(env, "cathaybk"),
+    ).resolves.toMatchObject({
+      verificationPending: true,
+      verificationChannel: "email",
+      verificationExpiresAt: "2099-08-22T08:08:00.000Z",
+    });
+  });
+
+  it("clears Cathay trusted-device state when credentials change", async () => {
+    mocks.findConnectorSettings.mockResolvedValue({
+      id: "cathay-settings",
+      connector_id: "cathaybk",
+      encrypted_config: JSON.stringify({
+        userId: "A123456789",
+        account: "old-user",
+        password: "old-password",
+        sessionCookies: '[{"name":"CUB.eBank.DeviceId"}]',
+        sessionExpiresAt: "2027-09-26T08:00:00.000Z",
+      }),
+      public_config: null,
+      sync_cursor: JSON.stringify({ syncedAt: "2026-08-22T08:00:00.000Z" }),
+      created_at: "2026-08-22T07:00:00.000Z",
+      updated_at: "2026-08-22T08:00:00.000Z",
+    });
+
+    await updateConnectorSettings(env, "cathaybk", { account: "new-user" });
+
+    const saved = mocks.saveConnectorSettings.mock.calls[0]![1];
+    expect(JSON.parse(saved.encryptedConfig)).toEqual({
+      userId: "A123456789",
+      account: "new-user",
+      password: "old-password",
+    });
+    expect(mocks.clearConnectorCursor).toHaveBeenCalledWith(
+      env.DB,
+      "cathaybk",
+      expect.any(String),
+    );
+  });
+
   it("clears HNCB session state when credentials change", async () => {
     mocks.findConnectorSettings.mockResolvedValue({
       id: "hncb-settings",

--- a/apps/worker/tests/features/sync/connector-state.test.ts
+++ b/apps/worker/tests/features/sync/connector-state.test.ts
@@ -94,6 +94,25 @@ describe("connector state boundaries", () => {
     });
   });
 
+  it("removes Cathay trusted browser state from the cursor", () => {
+    expect(
+      splitConnectorCursorState(
+        "cathaybk",
+        JSON.stringify({
+          sessionCookies: "cathay-cookies",
+          sessionExpiresAt: "2026-08-22T12:00:00.000Z",
+          syncedAt: "2026-08-22T08:01:00.000Z",
+        }),
+      ),
+    ).toEqual({
+      safeCursor: JSON.stringify({ syncedAt: "2026-08-22T08:01:00.000Z" }),
+      secretState: {
+        sessionCookies: "cathay-cookies",
+        sessionExpiresAt: "2026-08-22T12:00:00.000Z",
+      },
+    });
+  });
+
   it("keeps TDCC trade watermarks while encrypting device session state", () => {
     expect(
       splitConnectorCursorState(

--- a/apps/worker/tests/features/sync/error-details.test.ts
+++ b/apps/worker/tests/features/sync/error-details.test.ts
@@ -1,10 +1,34 @@
 import { describe, expect, it } from "vitest";
 import {
+  CathayOtpChannelRequiredError,
+  CathayOtpInvalidError,
+  CathayOtpRequiredError,
+  CathayOtpSessionExpiredError,
+} from "../../../src/connectors/cathaybk";
+import {
+  isUserActionError,
   safeErrorLogDetails,
   safeErrorMessage,
 } from "../../../src/features/sync/service";
 
 describe("sync error details", () => {
+  it("classifies Cathay OTP states as user actions", () => {
+    expect(
+      isUserActionError(
+        new CathayOtpChannelRequiredError(
+          "choose channel",
+          "pending-session",
+          "2026-08-22T12:00:00.000Z",
+        ),
+      ),
+    ).toBe(true);
+    expect(isUserActionError(new CathayOtpRequiredError("sent", "email"))).toBe(
+      true,
+    );
+    expect(isUserActionError(new CathayOtpSessionExpiredError())).toBe(true);
+    expect(isUserActionError(new CathayOtpInvalidError())).toBe(true);
+  });
+
   it("uses a non-empty fallback when Error.message is blank", () => {
     expect(safeErrorMessage(new Error("  \n  "))).toBe(
       "同步失敗，但未取得錯誤原因。",

--- a/apps/worker/tests/features/sync/route.test.ts
+++ b/apps/worker/tests/features/sync/route.test.ts
@@ -8,6 +8,12 @@ import {
   HncbConnectionError,
 } from "../../../src/connectors/hncb";
 import {
+  CathayOtpChannelRequiredError,
+  CathayOtpInvalidError,
+  CathayOtpRequiredError,
+  CathayOtpSessionExpiredError,
+} from "../../../src/connectors/cathaybk";
+import {
   TaishinBrowserCapacityError,
   TaishinConnectionError,
 } from "../../../src/connectors/taishin";
@@ -21,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   prepareObankCaptchaSession: vi.fn(),
   startEinvoiceSyncRun: vi.fn(),
   syncCtbc: vi.fn(),
+  syncCathaybk: vi.fn(),
   syncEsun: vi.fn(),
   syncObank: vi.fn(),
   syncHncb: vi.fn(),
@@ -44,7 +51,7 @@ vi.mock("../../../src/features/sync/service", () => ({
   prepareObankCaptchaSession: mocks.prepareObankCaptchaSession,
   safeErrorMessage: (error: unknown) =>
     error instanceof Error ? error.message : String(error),
-  syncCathaybk: vi.fn(),
+  syncCathaybk: mocks.syncCathaybk,
   syncCtbc: mocks.syncCtbc,
   syncEinvoice: vi.fn(),
   syncEsun: mocks.syncEsun,
@@ -270,6 +277,88 @@ describe("E.SUN sync route", () => {
         message:
           "E.SUN browser login: duplicate-login dialog kept reappearing.",
       },
+    });
+  });
+});
+
+describe("Cathay sync routes", () => {
+  it("dispatches a manual sync without OTP overrides", async () => {
+    const response = await syncRoutes.request(
+      "/connectors/cathaybk/sync",
+      { method: "POST" },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.syncCathaybk).toHaveBeenCalledWith(env, "manual", {});
+  });
+
+  it("passes the selected OTP channel and code to the sync service", async () => {
+    const response = await syncRoutes.request(
+      "/connectors/cathaybk/sync",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ otpChannel: "email", otp: "123456" }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.syncCathaybk).toHaveBeenCalledWith(env, "manual", {
+      otpChannel: "email",
+      otp: "123456",
+    });
+  });
+
+  it("rejects a malformed OTP channel before dispatch", async () => {
+    const response = await syncRoutes.request(
+      "/connectors/cathaybk/sync",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ otpChannel: "push" }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "INVALID_REQUEST" },
+    });
+    expect(mocks.syncCathaybk).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      new CathayOtpChannelRequiredError(
+        "請選擇驗證方式。",
+        "pending-session",
+        "2026-08-22T12:00:00.000Z",
+      ),
+      "CATHAY_OTP_CHANNEL_REQUIRED",
+    ],
+    [
+      new CathayOtpRequiredError("Email 驗證碼已寄出。", "email"),
+      "CATHAY_EMAIL_OTP_REQUIRED",
+    ],
+    [
+      new CathayOtpRequiredError("簡訊驗證碼已寄出。", "sms"),
+      "CATHAY_SMS_OTP_REQUIRED",
+    ],
+    [new CathayOtpSessionExpiredError(), "CATHAY_OTP_SESSION_EXPIRED"],
+    [new CathayOtpInvalidError(), "CATHAY_OTP_INVALID"],
+  ])("maps %s to %s", async (error, code) => {
+    mocks.syncCathaybk.mockRejectedValueOnce(error);
+    const response = await syncRoutes.request(
+      "/connectors/cathaybk/sync",
+      { method: "POST" },
+      env,
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code },
     });
   });
 });

--- a/apps/worker/tests/features/sync/scheduler.test.ts
+++ b/apps/worker/tests/features/sync/scheduler.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   safelySendSyncNotification: vi.fn(),
   startEinvoiceSyncRun: vi.fn(),
   startSyncLockHeartbeat: vi.fn(),
+  syncCathaybk: vi.fn(),
   syncEsun: vi.fn(),
   syncTaishin: vi.fn(),
 }));
@@ -54,7 +55,7 @@ vi.mock("../../../src/features/sync/service", () => ({
       ? error.message.trim()
       : "同步失敗，但未取得錯誤原因。",
   startSyncLockHeartbeat: mocks.startSyncLockHeartbeat,
-  syncCathaybk: vi.fn(),
+  syncCathaybk: mocks.syncCathaybk,
   syncEinvoice: vi.fn(),
   syncEsun: mocks.syncEsun,
   syncSinopac: vi.fn(),
@@ -143,6 +144,16 @@ beforeEach(() => {
   });
   mocks.syncTaishin.mockResolvedValue({
     connectorId: "taishin",
+    scope: "all",
+    records: 2,
+    newRecords: {
+      invoices: 0,
+      bankTransactions: 2,
+      investmentTransactions: 0,
+    },
+  });
+  mocks.syncCathaybk.mockResolvedValue({
+    connectorId: "cathaybk",
     scope: "all",
     records: 2,
     newRecords: {
@@ -259,6 +270,20 @@ describe("scheduled sync rounds", () => {
     await runSchedulerTick(env(), scheduledController);
 
     expect(mocks.syncTaishin).toHaveBeenCalledWith(
+      expect.anything(),
+      "scheduled",
+      {},
+    );
+  });
+
+  it("dispatches a scheduled Cathay job without OTP overrides", async () => {
+    const job = syncJob("custom", "cathaybk");
+    mocks.findOpenDefaultScheduleBatchId.mockResolvedValue(null);
+    mocks.findNextDueSyncJob.mockResolvedValue(job);
+
+    await runSchedulerTick(env(), scheduledController);
+
+    expect(mocks.syncCathaybk).toHaveBeenCalledWith(
       expect.anything(),
       "scheduled",
       {},

--- a/packages/connectors/src/cathaybk.ts
+++ b/packages/connectors/src/cathaybk.ts
@@ -6,6 +6,10 @@ export const cathaybkConfigSchema = z.object({
   password: z.string().min(1).optional(),
   sessionCookies: z.string().optional(),
   sessionExpiresAt: z.string().optional(),
+  browserSessionId: z.string().min(1).optional(),
+  browserSessionExpiresAt: z.string().optional(),
+  otp: z.string().min(1).optional(),
+  otpChannel: z.enum(["email", "sms"]).optional(),
 });
 
 export type CathaybkConfig = z.infer<typeof cathaybkConfigSchema>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -409,8 +409,21 @@ export const connectorCatalog = {
     ],
     publicFields: [],
     credentialFields: ["userId", "account", "password"],
-    secretStateFields: ["sessionCookies", "sessionExpiresAt"],
-    resetOnCredentialChangeFields: ["sessionCookies", "sessionExpiresAt"],
+    secretStateFields: [
+      "sessionCookies",
+      "sessionExpiresAt",
+      "browserSessionId",
+      "browserSessionExpiresAt",
+      "otpChannel",
+    ],
+    resetOnCredentialChangeFields: [
+      "sessionCookies",
+      "sessionExpiresAt",
+      "browserSessionId",
+      "browserSessionExpiresAt",
+      "otp",
+      "otpChannel",
+    ],
   },
   sinopac: {
     id: "sinopac",

--- a/scripts/dev-worker.mjs
+++ b/scripts/dev-worker.mjs
@@ -78,6 +78,8 @@ const wrangler = spawn(
     "dev",
     "-c",
     "wrangler.local.toml",
+    "--port",
+    "8787",
     "--var",
     `CTBC_API_RELAY_URL:http://127.0.0.1:${address.port}/ctbc`,
     "--var",
@@ -87,6 +89,7 @@ const wrangler = spawn(
     cwd: workerDirectory,
     env: {
       ...process.env,
+      X_BROWSER_HEADFUL: process.env.X_BROWSER_HEADFUL ?? "true",
       XDG_CONFIG_HOME: path.join(projectRoot, ".wrangler-config"),
     },
     stdio: "inherit",


### PR DESCRIPTION
## 摘要

- 補上國泰首次登入的 Email／簡訊 OTP 選擇、輸入、信任裝置與前端進度流程
- 將 Browser 驗證 session 限制為 120 秒，並補齊成功、失敗及初始化異常的關閉處理
- 支援新版國泰登入、OTP 與信任裝置頁面格式，加入去識別化診斷
- 未偵測到信用卡時不建立零額 placeholder 卡片、空帳單或卡片交易
- 本機開發固定使用 local D1，並支援 headful Browser 除錯

## 驗證

- npm run typecheck
- Worker：42 個測試檔、333 項測試通過
- ConnectorPanel.test.ts：8 項測試通過
- Svelte autofixer：無問題
- Prettier check 與 git diff --check 通過

## 注意事項

- 未修改或清理 demo seed
- PR 不包含本機 D1 中既有 placeholder 資料的一次性清理
- 未執行遠端部署或正式環境同步