### PR TITLE
新增：帳戶互轉與信用卡年費減免自動配對

### DIFF
--- a/apps/web/src/data/bank/types.ts
+++ b/apps/web/src/data/bank/types.ts
@@ -40,7 +40,12 @@ export interface BankTransactionRow {
     categoryId: string;
     label: string;
     source:
-      "override" | "user_rule" | "system_rule" | "auto_transfer" | "fallback";
+      | "override"
+      | "user_rule"
+      | "system_rule"
+      | "auto_transfer"
+      | "auto_offset"
+      | "fallback";
     ruleId?: string;
     excludedFromCalculation?: boolean;
   };

--- a/apps/web/src/data/bank/types.ts
+++ b/apps/web/src/data/bank/types.ts
@@ -39,7 +39,8 @@ export interface BankTransactionRow {
   classification?: {
     categoryId: string;
     label: string;
-    source: "override" | "user_rule" | "system_rule" | "fallback";
+    source:
+      "override" | "user_rule" | "system_rule" | "auto_transfer" | "fallback";
     ruleId?: string;
     excludedFromCalculation?: boolean;
   };

--- a/apps/web/src/features/activity/model/types.ts
+++ b/apps/web/src/features/activity/model/types.ts
@@ -11,7 +11,8 @@ export interface ActivityItem {
   category: string;
   categoryId?: string;
   classificationPattern?: string;
-  classificationSource?: "override" | "user_rule" | "system_rule" | "fallback";
+  classificationSource?:
+    "override" | "user_rule" | "system_rule" | "auto_transfer" | "fallback";
   classificationRuleId?: string;
   transactionId?: string;
   excludedFromCalculation?: boolean;

--- a/apps/web/src/features/activity/model/types.ts
+++ b/apps/web/src/features/activity/model/types.ts
@@ -12,7 +12,12 @@ export interface ActivityItem {
   categoryId?: string;
   classificationPattern?: string;
   classificationSource?:
-    "override" | "user_rule" | "system_rule" | "auto_transfer" | "fallback";
+    | "override"
+    | "user_rule"
+    | "system_rule"
+    | "auto_transfer"
+    | "auto_offset"
+    | "fallback";
   classificationRuleId?: string;
   transactionId?: string;
   excludedFromCalculation?: boolean;

--- a/apps/worker/src/features/bank/repository.ts
+++ b/apps/worker/src/features/bank/repository.ts
@@ -130,6 +130,59 @@ export async function listBankTransactionsInRange(
   return rows.results;
 }
 
+export async function listBankTransactionsForTransferMatching(
+  db: D1Database,
+  transactions: Array<Pick<BankTransactionPageRow, "amount" | "currency">>,
+  days: string[] = [],
+) {
+  const amounts = [
+    ...new Set(
+      transactions
+        .filter(
+          (transaction) =>
+            Number.isFinite(transaction.amount) && transaction.amount !== 0,
+        )
+        .map((transaction) => Math.abs(transaction.amount)),
+    ),
+  ];
+  const currencies = [
+    ...new Set(
+      transactions
+        .map((transaction) => transaction.currency.trim().toUpperCase())
+        .filter(Boolean),
+    ),
+  ];
+  if (amounts.length === 0 || currencies.length === 0) return [];
+
+  const matchDays = [...new Set(days.filter(Boolean))];
+  const dayClause =
+    matchDays.length > 0
+      ? `
+         AND substr(COALESCE(txn.authorized_at, txn.posted_date), 1, 10) IN (
+           SELECT value FROM json_each(?)
+         )`
+      : "";
+  const values = [JSON.stringify(amounts), JSON.stringify(currencies)];
+  if (matchDays.length > 0) values.push(JSON.stringify(matchDays));
+
+  const rows = await db
+    .prepare(
+      `${BANK_TRANSACTION_SELECT}
+       WHERE account.canonical_account_id IS NULL
+         AND txn.status = 'posted'
+         AND txn.amount <> 0
+         AND ABS(txn.amount) IN (
+           SELECT CAST(value AS INTEGER) FROM json_each(?)
+         )
+         AND UPPER(TRIM(txn.currency)) IN (
+           SELECT UPPER(TRIM(value)) FROM json_each(?)
+         )${dayClause}`,
+    )
+    .bind(...values)
+    .all<BankTransactionPageRow>();
+  return rows.results;
+}
+
 export async function listCreditCardBills(
   db: D1Database,
   limit: number,

--- a/apps/worker/src/features/bank/service.ts
+++ b/apps/worker/src/features/bank/service.ts
@@ -1,6 +1,7 @@
 import {
   listBankAccounts,
   listBankTransactions,
+  listBankTransactionsForTransferMatching,
   listBankTransactionsInRange,
   listCreditCardBills,
   listCreditCardBillsInRange,
@@ -18,6 +19,10 @@ import {
   resolveClassifications,
   type ClassificationResult,
 } from "../classification/service";
+import {
+  findAutomaticTransferTransactionIds,
+  getAutomaticTransferDay,
+} from "./transfer-matching";
 
 export async function getBankPage(
   db: D1Database,
@@ -53,11 +58,17 @@ async function presentBankTransactions(
   db: D1Database,
   transactions: BankTransactionPageRow[],
 ) {
+  // The counterpart can be on another page, so expand the set before classifying.
+  const transactionsForClassification = await loadTransferCandidates(
+    db,
+    transactions,
+  );
   let classificationMap: Map<string, ClassificationResult>;
+  let classificationsReady = true;
   try {
     classificationMap = await resolveClassifications(
       db,
-      transactions.map((transaction) => ({
+      transactionsForClassification.map((transaction) => ({
         id: transaction.id,
         description: transaction.description,
         counterparty: transaction.counterparty,
@@ -67,26 +78,101 @@ async function presentBankTransactions(
   } catch (error) {
     console.error("[classify] resolveClassifications failed:", error);
     classificationMap = new Map();
+    classificationsReady = false;
   }
+
+  const automaticTransferIds = classificationsReady
+    ? findAutomaticTransferTransactionIds(
+        transactionsForClassification.filter((transaction) => {
+          const classification = classificationMap.get(transaction.id);
+          return (
+            // An explicit include preference or user classification wins.
+            transaction.calculationPreference !== 0 &&
+            classification?.source !== "override" &&
+            classification?.source !== "user_rule"
+          );
+        }),
+      )
+    : new Set<string>();
+
   return transactions.map(
     ({
       effectiveDate: _effectiveDate,
       updatedAt: _updatedAt,
       ...transaction
-    }) => ({
-      ...normalizeBankTransactionDisplay(transaction),
-      excludedFromCalculation: resolveCalculationExclusion({
-        accountType: transaction.accountType,
-        description: transaction.description,
-        counterparty: transaction.counterparty,
-        calculationPreference: transaction.calculationPreference,
-        classificationExcludedFromCalculation: classificationMap.get(
-          transaction.id,
-        )?.excludedFromCalculation,
-      }),
-      classification: classificationMap.get(transaction.id),
-    }),
+    }) => {
+      const classification = automaticTransferIds.has(transaction.id)
+        ? {
+            categoryId: "transfer",
+            label: "轉帳",
+            source: "auto_transfer" as const,
+            excludedFromCalculation: true,
+          }
+        : classificationMap.get(transaction.id);
+      return {
+        ...normalizeBankTransactionDisplay(transaction),
+        excludedFromCalculation: resolveCalculationExclusion({
+          accountType: transaction.accountType,
+          description: transaction.description,
+          counterparty: transaction.counterparty,
+          calculationPreference: transaction.calculationPreference,
+          classificationExcludedFromCalculation:
+            classification?.excludedFromCalculation,
+        }),
+        classification,
+      };
+    },
   );
+}
+
+async function loadTransferCandidates(
+  db: D1Database,
+  transactions: BankTransactionPageRow[],
+) {
+  if (transactions.length === 0) return transactions;
+
+  const visibleKeys = new Set(
+    transactions
+      .map(transferMatchKey)
+      .filter((key): key is string => key !== undefined),
+  );
+  if (visibleKeys.size === 0) return transactions;
+
+  let candidates: BankTransactionPageRow[];
+  try {
+    candidates = await listBankTransactionsForTransferMatching(
+      db,
+      transactions,
+      [
+        ...new Set(
+          transactions
+            .map(getAutomaticTransferDay)
+            .filter((day): day is string => day !== undefined),
+        ),
+      ],
+    );
+  } catch (error) {
+    console.error("[transfer] load transfer candidates failed:", error);
+    return transactions;
+  }
+
+  const byId = new Map(
+    transactions.map((transaction) => [transaction.id, transaction]),
+  );
+  for (const candidate of candidates) {
+    if (visibleKeys.has(transferMatchKey(candidate) ?? ""))
+      byId.set(candidate.id, candidate);
+  }
+  return [...byId.values()];
+}
+
+function transferMatchKey(transaction: BankTransactionPageRow) {
+  const day = getAutomaticTransferDay(transaction);
+  if (!day || !Number.isFinite(transaction.amount) || transaction.amount === 0)
+    return undefined;
+  const currency = transaction.currency.trim().toUpperCase();
+  if (!currency) return undefined;
+  return `${day}\u0000${currency}\u0000${Math.abs(transaction.amount)}`;
 }
 
 export async function getCreditCardBillPage(

--- a/apps/worker/src/features/bank/service.ts
+++ b/apps/worker/src/features/bank/service.ts
@@ -20,6 +20,7 @@ import {
   type ClassificationResult,
 } from "../classification/service";
 import {
+  findAutomaticCreditOffsetTransactionIds,
   findAutomaticTransferTransactionIds,
   getAutomaticTransferDay,
 } from "./transfer-matching";
@@ -81,18 +82,22 @@ async function presentBankTransactions(
     classificationsReady = false;
   }
 
+  const eligibleTransactions = transactionsForClassification.filter(
+    (transaction) => {
+      const classification = classificationMap.get(transaction.id);
+      return (
+        // An explicit include preference or user classification wins.
+        transaction.calculationPreference !== 0 &&
+        classification?.source !== "override" &&
+        classification?.source !== "user_rule"
+      );
+    },
+  );
   const automaticTransferIds = classificationsReady
-    ? findAutomaticTransferTransactionIds(
-        transactionsForClassification.filter((transaction) => {
-          const classification = classificationMap.get(transaction.id);
-          return (
-            // An explicit include preference or user classification wins.
-            transaction.calculationPreference !== 0 &&
-            classification?.source !== "override" &&
-            classification?.source !== "user_rule"
-          );
-        }),
-      )
+    ? findAutomaticTransferTransactionIds(eligibleTransactions)
+    : new Set<string>();
+  const automaticCreditOffsetIds = classificationsReady
+    ? findAutomaticCreditOffsetTransactionIds(eligibleTransactions)
     : new Set<string>();
 
   return transactions.map(
@@ -101,14 +106,21 @@ async function presentBankTransactions(
       updatedAt: _updatedAt,
       ...transaction
     }) => {
-      const classification = automaticTransferIds.has(transaction.id)
+      const classification = automaticCreditOffsetIds.has(transaction.id)
         ? {
-            categoryId: "transfer",
-            label: "轉帳",
-            source: "auto_transfer" as const,
+            categoryId: "fee",
+            label: "手續費",
+            source: "auto_offset" as const,
             excludedFromCalculation: true,
           }
-        : classificationMap.get(transaction.id);
+        : automaticTransferIds.has(transaction.id)
+          ? {
+              categoryId: "transfer",
+              label: "轉帳",
+              source: "auto_transfer" as const,
+              excludedFromCalculation: true,
+            }
+          : classificationMap.get(transaction.id);
       return {
         ...normalizeBankTransactionDisplay(transaction),
         excludedFromCalculation: resolveCalculationExclusion({

--- a/apps/worker/src/features/bank/transfer-matching.ts
+++ b/apps/worker/src/features/bank/transfer-matching.ts
@@ -1,0 +1,166 @@
+export type TransferMatchTransaction = {
+  id: string;
+  accountId: string;
+  amount: number;
+  currency: string;
+  accountType?: string | null;
+  authorizedAt?: string | null;
+  postedDate?: string | null;
+  status?: string | null;
+};
+
+type TransferCandidateGroup = {
+  positive: TransferMatchTransaction[];
+  negative: TransferMatchTransaction[];
+};
+
+/**
+ * Finds deterministic pairs of posted transactions that may represent a
+ * transfer between two accounts. A pair must share the stored financial date
+ * (using authorizedAt before postedDate, matching the date shown in Activity),
+ * currency, and absolute amount while having opposite signs and different
+ * accounts. The accounts may belong to the same bank. Credit-account
+ * transactions are ignored because their signed entries commonly represent
+ * card payments or refunds rather than account-to-account transfers.
+ *
+ * Same-account entries cannot form a transfer pair, so they are excluded from
+ * the candidate edges. Each group is then matched one-to-one as far as
+ * possible in a stable order; unmatched entries keep their existing
+ * classification and can be changed manually by the user.
+ */
+export function findAutomaticTransferPairs(
+  transactions: TransferMatchTransaction[],
+): Array<readonly [string, string]> {
+  const groups = new Map<string, TransferCandidateGroup>();
+
+  for (const transaction of transactions) {
+    if (transaction.status !== "posted") continue;
+    if (transaction.accountType === "credit") continue;
+    if (!Number.isFinite(transaction.amount) || transaction.amount === 0)
+      continue;
+
+    const day = getAutomaticTransferDay(transaction);
+    if (!day) continue;
+
+    const key = [
+      day,
+      transaction.currency.trim().toUpperCase(),
+      Math.abs(transaction.amount),
+    ].join("\u0000");
+    const group = groups.get(key) ?? { positive: [], negative: [] };
+    if (transaction.amount > 0) group.positive.push(transaction);
+    else group.negative.push(transaction);
+    groups.set(key, group);
+  }
+
+  return [...groups.values()].flatMap(({ positive, negative }) =>
+    pairCrossAccountCandidates(positive, negative),
+  );
+}
+
+export function getAutomaticTransferDay(
+  transaction: Pick<TransferMatchTransaction, "authorizedAt" | "postedDate">,
+) {
+  return storedFinancialDay(transaction.authorizedAt ?? transaction.postedDate);
+}
+
+export function findAutomaticTransferTransactionIds(
+  transactions: TransferMatchTransaction[],
+): Set<string> {
+  return new Set(
+    findAutomaticTransferPairs(transactions).flatMap(
+      ([positiveId, negativeId]) => [positiveId, negativeId],
+    ),
+  );
+}
+
+function storedFinancialDay(value?: string | null) {
+  if (!value) return undefined;
+
+  const dateOnly = value.trim().match(/^\d{4}-\d{2}-\d{2}/)?.[0];
+  // Bank connectors store the financial date in the timestamp prefix, and
+  // Activity groups rows by that same prefix. Do not reinterpret it through
+  // the runtime timezone: TDCC timestamps can represent a Taiwan local time
+  // while carrying a UTC-looking suffix.
+  if (dateOnly) return dateOnly;
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+
+  return parsed.toISOString().slice(0, 10);
+}
+
+function pairCrossAccountCandidates(
+  positive: TransferMatchTransaction[],
+  negative: TransferMatchTransaction[],
+): Array<readonly [string, string]> {
+  const orderedPositive = [...positive].sort(compareTransferCandidates);
+  const orderedNegative = [...negative].sort(compareTransferCandidates);
+  const matchedNegative = new Map<number, number>();
+
+  for (
+    let positiveIndex = 0;
+    positiveIndex < orderedPositive.length;
+    positiveIndex++
+  ) {
+    matchPositive(
+      positiveIndex,
+      new Set<number>(),
+      orderedPositive,
+      orderedNegative,
+      matchedNegative,
+    );
+  }
+
+  return [...matchedNegative.entries()]
+    .sort(([, leftPositive], [, rightPositive]) => leftPositive - rightPositive)
+    .map(([negativeIndex, positiveIndex]) => [
+      orderedPositive[positiveIndex].id,
+      orderedNegative[negativeIndex].id,
+    ]);
+}
+
+function matchPositive(
+  positiveIndex: number,
+  visitedNegative: Set<number>,
+  positive: TransferMatchTransaction[],
+  negative: TransferMatchTransaction[],
+  matchedNegative: Map<number, number>,
+): boolean {
+  for (
+    let negativeIndex = 0;
+    negativeIndex < negative.length;
+    negativeIndex++
+  ) {
+    const candidate = negative[negativeIndex];
+    if (
+      visitedNegative.has(negativeIndex) ||
+      positive[positiveIndex].accountId === candidate.accountId
+    )
+      continue;
+
+    visitedNegative.add(negativeIndex);
+    const previousPositive = matchedNegative.get(negativeIndex);
+    if (
+      previousPositive === undefined ||
+      matchPositive(
+        previousPositive,
+        visitedNegative,
+        positive,
+        negative,
+        matchedNegative,
+      )
+    ) {
+      matchedNegative.set(negativeIndex, positiveIndex);
+      return true;
+    }
+  }
+  return false;
+}
+
+function compareTransferCandidates(
+  left: TransferMatchTransaction,
+  right: TransferMatchTransaction,
+) {
+  return left.id.localeCompare(right.id);
+}

--- a/apps/worker/src/features/bank/transfer-matching.ts
+++ b/apps/worker/src/features/bank/transfer-matching.ts
@@ -7,12 +7,16 @@ export type TransferMatchTransaction = {
   authorizedAt?: string | null;
   postedDate?: string | null;
   status?: string | null;
+  description?: string | null;
+  counterparty?: string | null;
 };
 
 type TransferCandidateGroup = {
   positive: TransferMatchTransaction[];
   negative: TransferMatchTransaction[];
 };
+
+const CREDIT_FEE_REDUCTION_PATTERN = /減免|折抵|回饋|退回|退費/u;
 
 /**
  * Finds deterministic pairs of posted transactions that may represent a
@@ -67,10 +71,62 @@ export function getAutomaticTransferDay(
 export function findAutomaticTransferTransactionIds(
   transactions: TransferMatchTransaction[],
 ): Set<string> {
+  const pairs = findAutomaticTransferPairs(transactions);
   return new Set(
-    findAutomaticTransferPairs(transactions).flatMap(
-      ([positiveId, negativeId]) => [positiveId, negativeId],
-    ),
+    pairs.flatMap(([positiveId, negativeId]) => [positiveId, negativeId]),
+  );
+}
+
+export function findAutomaticCreditOffsetTransactionIds(
+  transactions: TransferMatchTransaction[],
+): Set<string> {
+  const pairs = findAutomaticCreditOffsetPairs(transactions);
+  return new Set(
+    pairs.flatMap(([positiveId, negativeId]) => [positiveId, negativeId]),
+  );
+}
+
+/**
+ * Finds same-card annual-fee reversals. These are not account transfers, but
+ * they are a deliberate same-day, same-amount offset that should not affect
+ * cash-flow calculations.
+ */
+export function findAutomaticCreditOffsetPairs(
+  transactions: TransferMatchTransaction[],
+): Array<readonly [string, string]> {
+  const groups = new Map<string, TransferCandidateGroup>();
+
+  for (const transaction of transactions) {
+    if (
+      transaction.status !== "posted" ||
+      transaction.accountType !== "credit" ||
+      !Number.isFinite(transaction.amount) ||
+      transaction.amount === 0
+    )
+      continue;
+
+    const day = getAutomaticTransferDay(transaction);
+    if (!day) continue;
+
+    const text = creditTransactionText(transaction);
+    const isReduction = CREDIT_FEE_REDUCTION_PATTERN.test(text);
+    if (!text.includes("年費") || transaction.amount > 0 !== isReduction)
+      continue;
+
+    const key = [
+      transaction.accountId,
+      day,
+      transaction.currency.trim().toUpperCase(),
+      Math.abs(transaction.amount),
+    ].join("\u0000");
+    const group = groups.get(key) ?? { positive: [], negative: [] };
+    if (transaction.amount > 0) group.positive.push(transaction);
+    else group.negative.push(transaction);
+    groups.set(key, group);
+  }
+
+  return [...groups.values()].flatMap(({ positive, negative }) =>
+    pairStableCandidates(positive, negative),
   );
 }
 
@@ -120,6 +176,20 @@ function pairCrossAccountCandidates(
     ]);
 }
 
+function pairStableCandidates(
+  positive: TransferMatchTransaction[],
+  negative: TransferMatchTransaction[],
+): Array<readonly [string, string]> {
+  const orderedPositive = [...positive].sort(compareTransferCandidates);
+  const orderedNegative = [...negative].sort(compareTransferCandidates);
+  const pairCount = Math.min(orderedPositive.length, orderedNegative.length);
+
+  return Array.from({ length: pairCount }, (_, index) => [
+    orderedPositive[index].id,
+    orderedNegative[index].id,
+  ]);
+}
+
 function matchPositive(
   positiveIndex: number,
   visitedNegative: Set<number>,
@@ -163,4 +233,10 @@ function compareTransferCandidates(
   right: TransferMatchTransaction,
 ) {
   return left.id.localeCompare(right.id);
+}
+
+function creditTransactionText(transaction: TransferMatchTransaction) {
+  return `${transaction.description ?? ""} ${transaction.counterparty ?? ""}`
+    .normalize("NFKC")
+    .replace(/\s+/gu, "");
 }

--- a/apps/worker/src/features/classification/service.ts
+++ b/apps/worker/src/features/classification/service.ts
@@ -1,7 +1,8 @@
 export type ClassificationResult = {
   categoryId: string;
   label: string;
-  source: "override" | "user_rule" | "system_rule" | "fallback";
+  source:
+    "override" | "user_rule" | "system_rule" | "auto_transfer" | "fallback";
   ruleId?: string;
   excludedFromCalculation?: boolean;
 };

--- a/apps/worker/src/features/classification/service.ts
+++ b/apps/worker/src/features/classification/service.ts
@@ -2,7 +2,12 @@ export type ClassificationResult = {
   categoryId: string;
   label: string;
   source:
-    "override" | "user_rule" | "system_rule" | "auto_transfer" | "fallback";
+    | "override"
+    | "user_rule"
+    | "system_rule"
+    | "auto_transfer"
+    | "auto_offset"
+    | "fallback";
   ruleId?: string;
   excludedFromCalculation?: boolean;
 };

--- a/apps/worker/tests/features/bank/repository.test.ts
+++ b/apps/worker/tests/features/bank/repository.test.ts
@@ -1,0 +1,105 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  listBankTransactionsForTransferMatching,
+  type BankTransactionPageRow,
+} from "../../../src/features/bank/repository";
+
+class SqliteD1 {
+  readonly database = new DatabaseSync(":memory:");
+
+  constructor() {
+    const migrationsDirectory = fileURLToPath(
+      new URL("../../../../../packages/db/migrations/", import.meta.url),
+    );
+    for (const file of readdirSync(migrationsDirectory)
+      .filter((name) => name.endsWith(".sql"))
+      .sort()) {
+      this.database.exec(
+        readFileSync(`${migrationsDirectory}/${file}`, "utf8"),
+      );
+    }
+  }
+
+  prepare(sql: string) {
+    let values: unknown[] = [];
+    const statement = {
+      bind(...nextValues: unknown[]) {
+        values = nextValues;
+        return statement;
+      },
+      async all<T>() {
+        return {
+          results: this.database
+            .prepare(sql)
+            .all(...(values as never[])) as T[],
+        };
+      },
+      database: this.database,
+    };
+    return statement;
+  }
+
+  close() {
+    this.database.close();
+  }
+}
+
+const databases: SqliteD1[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+function createDb() {
+  const db = new SqliteD1();
+  databases.push(db);
+  db.database.exec(`
+    INSERT INTO bank_accounts
+      (id, connector_id, source_id, account_type, currency, created_at, updated_at)
+    VALUES
+      ('account-a', 'tdcc', 'account-a', 'savings', 'TWD', '2026-08-22', '2026-08-22'),
+      ('account-b', 'tdcc', 'account-b', 'savings', 'TWD', '2026-08-22', '2026-08-22'),
+      ('account-c', 'tdcc', 'account-c', 'savings', 'TWD', '2026-08-22', '2026-08-22');
+
+    INSERT INTO bank_transactions
+      (id, connector_id, account_id, source_id, posted_date, amount, currency,
+       status, created_at, updated_at)
+    VALUES
+      ('out', 'tdcc', 'account-a', 'out', '2026-08-22', -10000, 'TWD', 'posted', '2026-08-22', '2026-08-22'),
+      ('in', 'tdcc', 'account-b', 'in', '2026-08-22', 10000, 'TWD', 'posted', '2026-08-22', '2026-08-22'),
+      ('late', 'tdcc', 'account-c', 'late', '2026-08-22T21:00:00.000Z', 10000, 'TWD', 'posted', '2026-08-22', '2026-08-22'),
+      ('other-day', 'tdcc', 'account-c', 'other-day', '2026-08-23', 10000, 'TWD', 'posted', '2026-08-23', '2026-08-23'),
+      ('pending', 'tdcc', 'account-c', 'pending', '2026-08-22', -10000, 'TWD', 'pending', '2026-08-22', '2026-08-22');
+  `);
+  return db;
+}
+
+describe("bank transaction transfer candidates", () => {
+  it("loads posted rows sharing a visible amount and currency", async () => {
+    const db = createDb();
+    const rows = await listBankTransactionsForTransferMatching(
+      db as unknown as D1Database,
+      [{ amount: -10_000, currency: "twd" }],
+      ["2026-08-22"],
+    );
+
+    expect(rows.map(({ id }: BankTransactionPageRow) => id).sort()).toEqual([
+      "in",
+      "late",
+      "out",
+    ]);
+  });
+
+  it("does not query when there are no usable visible amounts", async () => {
+    const db = createDb();
+    const rows = await listBankTransactionsForTransferMatching(
+      db as unknown as D1Database,
+      [{ amount: 0, currency: "TWD" }],
+    );
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/apps/worker/tests/features/bank/service.test.ts
+++ b/apps/worker/tests/features/bank/service.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import type { BankTransactionPageRow } from "../../../src/features/bank/repository";
+import { getBankRange } from "../../../src/features/bank/service";
+
+function transaction(
+  input: Partial<BankTransactionPageRow> &
+    Pick<BankTransactionPageRow, "id" | "accountId" | "amount">,
+): BankTransactionPageRow {
+  return {
+    connectorId: "tdcc",
+    accountSourceId: `account:${input.accountId}`,
+    accountName: null,
+    institutionName: null,
+    accountType: "savings",
+    bankCode: null,
+    accountLast4: null,
+    sourceId: input.id,
+    postedDate: "2026-08-22",
+    authorizedAt: null,
+    currency: "TWD",
+    description: null,
+    counterparty: null,
+    status: "posted",
+    effectiveDate: "2026-08-22",
+    updatedAt: "2026-08-22T12:00:00.000Z",
+    calculationPreference: null,
+    ...input,
+  };
+}
+
+function createDb(
+  visibleTransactions: BankTransactionPageRow[],
+  candidateTransactions: BankTransactionPageRow[],
+  classificationOverrides: Array<{
+    target_id: string;
+    category_id: string;
+    label: string;
+  }> = [],
+) {
+  const db = {
+    prepare(sql: string) {
+      let values: unknown[] = [];
+      const statement = {
+        bind(...nextValues: unknown[]) {
+          values = nextValues;
+          return statement;
+        },
+        async all() {
+          if (sql.includes("ABS(txn.amount)"))
+            return { results: candidateTransactions };
+          if (sql.includes("COALESCE(txn.authorized_at"))
+            return { results: visibleTransactions };
+          if (sql.includes("classification_overrides"))
+            return { results: classificationOverrides };
+          if (sql.includes("classification_rules")) return { results: [] };
+          if (sql.includes("FROM bank_accounts")) return { results: [] };
+          throw new Error(`Unexpected query: ${sql} (${values.join(",")})`);
+        },
+      };
+      return statement;
+    },
+  } as unknown as D1Database;
+  return db;
+}
+
+describe("bank transaction presentation", () => {
+  it("auto-classifies a same-day opposite transaction from another account", async () => {
+    const outgoing = transaction({
+      id: "outgoing",
+      accountId: "account-a",
+      amount: -20_000,
+      description: "808979118353",
+    });
+    const incoming = transaction({
+      id: "incoming",
+      accountId: "account-b",
+      amount: 20_000,
+      description: "812015117579",
+    });
+
+    const result = await getBankRange(
+      createDb([outgoing], [outgoing, incoming]),
+      { from: "2026-08-01", to: "2026-09-01" },
+    );
+
+    expect(result.transactions).toHaveLength(1);
+    expect(result.transactions[0]).toMatchObject({
+      id: "outgoing",
+      excludedFromCalculation: true,
+      classification: {
+        categoryId: "transfer",
+        label: "轉帳",
+        source: "auto_transfer",
+        excludedFromCalculation: true,
+      },
+    });
+  });
+
+  it("does not override an explicit classification override", async () => {
+    const outgoing = transaction({
+      id: "outgoing",
+      accountId: "account-a",
+      amount: -20_000,
+    });
+    const incoming = transaction({
+      id: "incoming",
+      accountId: "account-b",
+      amount: 20_000,
+    });
+
+    const db = createDb(
+      [outgoing],
+      [outgoing, incoming],
+      [
+        {
+          target_id: "outgoing",
+          category_id: "housing",
+          label: "居住",
+        },
+      ],
+    );
+
+    const result = await getBankRange(db, {
+      from: "2026-08-01",
+      to: "2026-09-01",
+    });
+
+    expect(result.transactions[0]).toMatchObject({
+      excludedFromCalculation: false,
+      classification: {
+        categoryId: "housing",
+        source: "override",
+      },
+    });
+  });
+
+  it("does not exclude a transaction with an explicit include preference", async () => {
+    const outgoing = transaction({
+      id: "outgoing",
+      accountId: "account-a",
+      amount: -20_000,
+      calculationPreference: 0,
+    });
+    const incoming = transaction({
+      id: "incoming",
+      accountId: "account-b",
+      amount: 20_000,
+    });
+
+    const result = await getBankRange(
+      createDb([outgoing], [outgoing, incoming]),
+      { from: "2026-08-01", to: "2026-09-01" },
+    );
+
+    expect(result.transactions[0]).toMatchObject({
+      excludedFromCalculation: false,
+      classification: { source: "fallback" },
+    });
+  });
+});

--- a/apps/worker/tests/features/bank/service.test.ts
+++ b/apps/worker/tests/features/bank/service.test.ts
@@ -96,6 +96,44 @@ describe("bank transaction presentation", () => {
     });
   });
 
+  it("auto-excludes a same-card annual-fee reduction", async () => {
+    const fee = transaction({
+      id: "fee",
+      accountId: "card-a",
+      accountType: "credit",
+      amount: -4_500,
+      description: "鈦金商務卡年費",
+    });
+    const reduction = transaction({
+      id: "reduction",
+      accountId: "card-a",
+      accountType: "credit",
+      amount: 4_500,
+      description: "鈦金商務卡年費減免",
+    });
+
+    const result = await getBankRange(
+      createDb([fee, reduction], [fee, reduction]),
+      {
+        from: "2026-08-01",
+        to: "2026-09-01",
+      },
+    );
+
+    expect(result.transactions).toHaveLength(2);
+    for (const transaction of result.transactions) {
+      expect(transaction).toMatchObject({
+        excludedFromCalculation: true,
+        classification: {
+          categoryId: "fee",
+          label: "手續費",
+          source: "auto_offset",
+          excludedFromCalculation: true,
+        },
+      });
+    }
+  });
+
   it("does not override an explicit classification override", async () => {
     const outgoing = transaction({
       id: "outgoing",

--- a/apps/worker/tests/features/bank/transfer-matching.test.ts
+++ b/apps/worker/tests/features/bank/transfer-matching.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  findAutomaticCreditOffsetPairs,
+  findAutomaticCreditOffsetTransactionIds,
   findAutomaticTransferPairs,
   findAutomaticTransferTransactionIds,
   getAutomaticTransferDay,
@@ -48,6 +50,55 @@ describe("automatic bank transfer matching", () => {
     expect(findAutomaticTransferPairs(transactions)).toEqual([
       ["same-bank-in", "same-bank-out"],
     ]);
+  });
+
+  it("pairs an annual fee with its same-card reduction", () => {
+    const transactions = [
+      transaction({
+        id: "fee",
+        accountId: "taishin:credit:main",
+        accountType: "credit",
+        amount: -4_500,
+        description: "鈦金商務卡年費",
+      }),
+      transaction({
+        id: "reduction",
+        accountId: "taishin:credit:main",
+        accountType: "credit",
+        amount: 4_500,
+        description: "鈦金商務卡年費減免",
+      }),
+    ];
+
+    expect(findAutomaticCreditOffsetPairs(transactions)).toEqual([
+      ["reduction", "fee"],
+    ]);
+    expect(findAutomaticCreditOffsetTransactionIds(transactions)).toEqual(
+      new Set(["reduction", "fee"]),
+    );
+  });
+
+  it("does not treat an ordinary credit refund as an annual-fee offset", () => {
+    const transactions = [
+      transaction({
+        id: "charge",
+        accountId: "card",
+        accountType: "credit",
+        amount: -4_500,
+        description: "一般消費",
+      }),
+      transaction({
+        id: "refund",
+        accountId: "card",
+        accountType: "credit",
+        amount: 4_500,
+        description: "消費退款",
+      }),
+    ];
+
+    expect(findAutomaticCreditOffsetTransactionIds(transactions)).toEqual(
+      new Set(),
+    );
   });
 
   it("uses the stored date prefix for connector timestamps", () => {

--- a/apps/worker/tests/features/bank/transfer-matching.test.ts
+++ b/apps/worker/tests/features/bank/transfer-matching.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+  findAutomaticTransferPairs,
+  findAutomaticTransferTransactionIds,
+  getAutomaticTransferDay,
+  type TransferMatchTransaction,
+} from "../../../src/features/bank/transfer-matching";
+
+function transaction(
+  input: Partial<TransferMatchTransaction> &
+    Pick<TransferMatchTransaction, "id" | "accountId" | "amount">,
+): TransferMatchTransaction {
+  return {
+    currency: "TWD",
+    postedDate: "2026-08-22",
+    status: "posted",
+    ...input,
+  };
+}
+
+describe("automatic bank transfer matching", () => {
+  it("pairs opposite posted amounts on the same stored financial day", () => {
+    const transactions = [
+      transaction({ id: "out", accountId: "account-a", amount: -10_000 }),
+      transaction({ id: "in", accountId: "account-b", amount: 10_000 }),
+    ];
+
+    expect(findAutomaticTransferPairs(transactions)).toEqual([["in", "out"]]);
+    expect(findAutomaticTransferTransactionIds(transactions)).toEqual(
+      new Set(["in", "out"]),
+    );
+  });
+
+  it("pairs different accounts at the same bank", () => {
+    const transactions = [
+      transaction({
+        id: "same-bank-out",
+        accountId: "tdcc:050:checking-01271",
+        amount: -20_000,
+      }),
+      transaction({
+        id: "same-bank-in",
+        accountId: "tdcc:050:savings-8888",
+        amount: 20_000,
+      }),
+    ];
+
+    expect(findAutomaticTransferPairs(transactions)).toEqual([
+      ["same-bank-in", "same-bank-out"],
+    ]);
+  });
+
+  it("uses the stored date prefix for connector timestamps", () => {
+    const transactions = [
+      transaction({
+        id: "out",
+        accountId: "account-a",
+        amount: -500,
+        postedDate: "2026-06-23T21:20:18.000Z",
+      }),
+      transaction({
+        id: "in",
+        accountId: "account-b",
+        amount: 500,
+        postedDate: "2026-06-23",
+      }),
+    ];
+
+    expect(findAutomaticTransferTransactionIds(transactions)).toEqual(
+      new Set(["in", "out"]),
+    );
+  });
+
+  it("uses authorizedAt before postedDate for the stored financial day", () => {
+    const transactions = [
+      transaction({
+        id: "out",
+        accountId: "account-a",
+        amount: -500,
+        authorizedAt: "2026-08-22T16:30:00.000Z",
+        postedDate: "2026-08-21",
+      }),
+      transaction({
+        id: "in",
+        accountId: "account-b",
+        amount: 500,
+        authorizedAt: "2026-08-22T07:00:00.000+08:00",
+        postedDate: "2026-08-22",
+      }),
+    ];
+
+    expect(getAutomaticTransferDay(transactions[0])).toBe("2026-08-22");
+    expect(findAutomaticTransferTransactionIds(transactions)).toEqual(
+      new Set(["in", "out"]),
+    );
+  });
+
+  it("pairs as many cross-account candidates as possible in stable order", () => {
+    const transactions = [
+      transaction({ id: "out-a", accountId: "account-a", amount: -100 }),
+      transaction({ id: "out-b", accountId: "account-b", amount: -100 }),
+      transaction({ id: "in-a", accountId: "account-c", amount: 100 }),
+      transaction({ id: "in-b", accountId: "account-c", amount: 100 }),
+    ];
+
+    expect(findAutomaticTransferPairs(transactions)).toEqual([
+      ["in-a", "out-b"],
+      ["in-b", "out-a"],
+    ]);
+  });
+
+  it("ignores same-account entries when one cross-account pair is unique", () => {
+    const transactions = [
+      transaction({ id: "out", accountId: "account-b", amount: -102 }),
+      transaction({ id: "in", accountId: "account-a", amount: 102 }),
+      transaction({ id: "interest-a", accountId: "account-b", amount: 102 }),
+      transaction({ id: "interest-b", accountId: "account-b", amount: 102 }),
+    ];
+
+    expect(findAutomaticTransferPairs(transactions)).toEqual([["in", "out"]]);
+  });
+
+  it.each([
+    {
+      name: "same account",
+      changes: {
+        positive: { accountId: "account-a" },
+        negative: { accountId: "account-a" },
+      },
+    },
+    {
+      name: "different currencies",
+      changes: {
+        positive: { currency: "USD" },
+        negative: { currency: "TWD" },
+      },
+    },
+    {
+      name: "pending transaction",
+      changes: {
+        positive: { status: "pending" },
+        negative: {},
+      },
+    },
+    {
+      name: "credit-account transaction",
+      changes: {
+        positive: { accountType: "credit" },
+        negative: {},
+      },
+    },
+    {
+      name: "zero amount",
+      changes: {
+        positive: { amount: 0 },
+        negative: { amount: 0 },
+      },
+    },
+    {
+      name: "different days",
+      changes: {
+        positive: { postedDate: "2026-08-23" },
+        negative: {},
+      },
+    },
+  ])("does not pair when the $name condition fails", ({ changes }) => {
+    const transactions = [
+      transaction({
+        id: "out",
+        accountId: "account-a",
+        amount: -100,
+        ...changes.negative,
+      }),
+      transaction({
+        id: "in",
+        accountId: "account-b",
+        amount: 100,
+        ...changes.positive,
+      }),
+    ];
+
+    expect(findAutomaticTransferTransactionIds(transactions)).toEqual(
+      new Set(),
+    );
+  });
+});


### PR DESCRIPTION
## 摘要

- 新增銀行帳戶互轉的自動配對，包含同銀行不同帳戶。
- 新增同一張信用卡的年費與減免自動沖銷。

## 規則

- 帳戶互轉：已入帳、同日、同幣別、同額、正負相反且屬不同帳戶；多筆時以穩定順序一對一配對。
- 信用卡年費：同一信用卡、同日、同幣別、同額、正負相反，且交易文字包含年費與減免相關字樣。
- 帳戶互轉分類為「轉帳」；信用卡年費／減免分類為既有的「手續費」。兩者都排除統計計算。
- 使用者既有的分類覆寫、使用者規則與明確納入計算設定優先；一般信用卡退款不會套用年費沖銷規則。

## 驗證

- `npm test -w @taiwan-fin-hub/worker`（45 個測試檔、353 項測試）
- `npm run typecheck`
- `npm run format:check`
- `git diff --check`