### PR TITLE
更新：設定頁顯示系統自動規則

### DIFF
--- a/apps/web/src/features/settings/SettingsPage.svelte
+++ b/apps/web/src/features/settings/SettingsPage.svelte
@@ -116,11 +116,16 @@
       ? "失敗與重新驗證時通知"
       : "前往同步與通知開啟",
   );
+  const customRuleCount = $derived(
+    ($rules.data ?? []).filter((rule) => !rule.isSystem).length,
+  );
   const rulesSummary = $derived(
-    $rules.isPending ? "載入中…" : `${$rules.data?.length ?? 0} 條銀行交易規則`,
+    $rules.isPending
+      ? "載入中…"
+      : `${customRuleCount} 條自訂規則 · 含自動分類與配對`,
   );
   const enabledRuleCount = $derived(
-    ($rules.data ?? []).filter((rule) => rule.enabled).length,
+    ($rules.data ?? []).filter((rule) => !rule.isSystem && rule.enabled).length,
   );
   const recentJobs = $derived(getConfiguredSyncJobs($jobs.data ?? []));
   const recentSuccessCount = $derived(
@@ -409,7 +414,7 @@
         <div>
           <h2 class="text-2xl font-bold tracking-tight">分類規則</h2>
           <p class="mt-1 text-sm text-muted-foreground">
-            依照優先順序，自動為銀行交易套用分類與計算設定。
+            管理自訂分類，也會自動處理帳戶互轉、信用卡年費減免與發票配對。
           </p>
         </div>
         <span class="rounded-lg bg-steel px-4 py-2 text-sm font-bold text-white"
@@ -422,11 +427,11 @@
         class="hidden min-w-0 gap-3 md:grid md:grid-cols-2"
       >
         <div class="rounded-xl border border-border bg-card p-3.5 shadow-xs">
-          <p class="text-sm font-semibold text-muted-foreground">規則總數</p>
-          <p class="mt-1 text-lg font-bold">{$rules.data?.length ?? 0}</p>
+          <p class="text-sm font-semibold text-muted-foreground">自訂規則</p>
+          <p class="mt-1 text-lg font-bold">{customRuleCount}</p>
         </div>
         <div class="rounded-xl border border-border bg-card p-3.5 shadow-xs">
-          <p class="text-sm font-semibold text-muted-foreground">已啟用</p>
+          <p class="text-sm font-semibold text-muted-foreground">已啟用自訂</p>
           <p class="mt-1 text-lg font-bold text-moss">{enabledRuleCount}</p>
         </div>
       </section>

--- a/apps/web/src/features/settings/components/ClassificationRulesPanel.svelte
+++ b/apps/web/src/features/settings/components/ClassificationRulesPanel.svelte
@@ -43,6 +43,23 @@
     starts_with: "開頭為",
     regex: "符合正規表示式",
   };
+  const systemAutoRules = [
+    {
+      title: "帳戶互轉",
+      description:
+        "同日、同幣別、同金額且方向相反的已入帳交易，會在不同帳戶間自動配對，分類為「轉帳」並排除收支計算；相同銀行的不同帳戶也適用。",
+    },
+    {
+      title: "信用卡年費減免",
+      description:
+        "同一張信用卡同日出現同幣別、同金額、方向相反的「年費」與減免相關交易時，會自動互相沖銷，分類為「手續費」並排除收支計算；一般退款不套用。",
+    },
+    {
+      title: "電子發票配對",
+      description:
+        "電子發票與同日、同金額的 TWD 銀行／信用卡支出會自動配對；一筆發票與交易只配對一次，已配對發票不會重複計入支出。手動連結或「解除並保持分開」優先。",
+    },
+  ] as const;
   const rules = createQuery(classificationRulesQuery(() => api));
   const categories = createQuery(classificationCategoriesQuery(() => api));
   const qc = useQueryClient();
@@ -169,7 +186,7 @@
     <div>
       <h2 class="text-lg font-semibold">分類規則</h2>
       <p class="text-sm text-muted-foreground">
-        讓銀行交易依條件自動分類，也可選擇不計入收支
+        管理自訂分類規則；系統也會自動處理帳戶互轉、信用卡年費減免與電子發票配對
       </p>
     </div>
     <div class="flex flex-wrap items-center gap-2">
@@ -182,11 +199,48 @@
         <Plus class="size-4" />新增分類
       </Button>
       <Badge class="text-sm" variant="secondary"
-        >{$rules.data?.length ?? 0} 條</Badge
+        >{editableRuleCount} 條自訂規則</Badge
       >
     </div>
   </CardHeader>
   <CardContent>
+    <section
+      aria-label="系統自動分類與配對"
+      class="mb-6 border-b border-border pb-6"
+    >
+      <div class="mb-3 flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h3 class="text-base font-semibold">系統自動分類與配對</h3>
+          <p class="mt-1 text-sm text-muted-foreground">
+            以下為系統內建規則，不佔用自訂規則順序；符合條件時會自動套用。
+          </p>
+        </div>
+        <Badge variant="secondary">內建</Badge>
+      </div>
+      <div class="grid gap-3 md:grid-cols-3">
+        {#each systemAutoRules as rule (rule.title)}
+          <article class="rounded-lg border border-border bg-muted/30 p-4">
+            <h4 class="text-sm font-semibold">{rule.title}</h4>
+            <p class="mt-2 text-sm leading-relaxed text-muted-foreground">
+              {rule.description}
+            </p>
+          </article>
+        {/each}
+      </div>
+      <p class="mt-3 text-sm leading-relaxed text-muted-foreground">
+        已手動分類或自行設定計算方式的交易，以你的設定為準；發票配對可在活動明細中管理或解除。
+      </p>
+    </section>
+
+    <div class="mb-3 flex flex-wrap items-end justify-between gap-2">
+      <div>
+        <h3 class="text-base font-semibold">自訂分類規則</h3>
+        <p class="mt-1 text-sm text-muted-foreground">
+          建立、排序與編輯自己的關鍵字分類規則。
+        </p>
+      </div>
+    </div>
+
     {#if showCategoryForm}
       <form
         class="mb-4 grid gap-3 rounded-lg border border-border bg-background p-4 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-end"

--- a/apps/web/src/features/settings/components/ClassificationRulesPanel.svelte
+++ b/apps/web/src/features/settings/components/ClassificationRulesPanel.svelte
@@ -182,42 +182,33 @@
 </script>
 
 <Card class="w-full min-w-0">
-  <CardHeader class="gap-4 sm:flex-row sm:items-start sm:justify-between">
+  <CardHeader class="gap-4">
     <div>
       <h2 class="text-lg font-semibold">分類規則</h2>
       <p class="text-sm text-muted-foreground">
         管理自訂分類規則；系統也會自動處理帳戶互轉、信用卡年費減免與電子發票配對
       </p>
     </div>
-    <div class="flex flex-wrap items-center gap-2">
-      <Button
-        size="sm"
-        variant="outline"
-        aria-expanded={showCategoryForm}
-        onclick={() => (showCategoryForm = !showCategoryForm)}
-      >
-        <Plus class="size-4" />新增分類
-      </Button>
-      <Badge class="text-sm" variant="secondary"
-        >{editableRuleCount} 條自訂規則</Badge
-      >
-    </div>
   </CardHeader>
   <CardContent>
-    <section
-      aria-label="系統自動分類與配對"
-      class="mb-6 border-b border-border pb-6"
-    >
-      <div class="mb-3 flex flex-wrap items-start justify-between gap-2">
-        <div>
-          <h3 class="text-base font-semibold">系統自動分類與配對</h3>
+    <details class="group mb-6 border-b border-border pb-5">
+      <summary
+        class="flex cursor-pointer list-none items-start justify-between gap-3 rounded-lg py-1 outline-none focus-visible:ring-2 focus-visible:ring-steel"
+      >
+        <div class="min-w-0">
+          <div class="flex flex-wrap items-center gap-2">
+            <h3 class="text-base font-semibold">系統自動分類與配對</h3>
+            <Badge variant="secondary">內建 3 項</Badge>
+          </div>
           <p class="mt-1 text-sm text-muted-foreground">
-            以下為系統內建規則，不佔用自訂規則順序；符合條件時會自動套用。
+            查看帳戶互轉、信用卡年費減免與電子發票配對的判斷方式。
           </p>
         </div>
-        <Badge variant="secondary">內建</Badge>
-      </div>
-      <div class="grid gap-3 md:grid-cols-3">
+        <ChevronDown
+          class="mt-1 size-5 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
+        />
+      </summary>
+      <div class="mt-3 grid gap-3 md:grid-cols-3">
         {#each systemAutoRules as rule (rule.title)}
           <article class="rounded-lg border border-border bg-muted/30 p-4">
             <h4 class="text-sm font-semibold">{rule.title}</h4>
@@ -230,14 +221,27 @@
       <p class="mt-3 text-sm leading-relaxed text-muted-foreground">
         已手動分類或自行設定計算方式的交易，以你的設定為準；發票配對可在活動明細中管理或解除。
       </p>
-    </section>
+    </details>
 
-    <div class="mb-3 flex flex-wrap items-end justify-between gap-2">
+    <div class="mb-3 flex flex-wrap items-start justify-between gap-3">
       <div>
         <h3 class="text-base font-semibold">自訂分類規則</h3>
         <p class="mt-1 text-sm text-muted-foreground">
           建立、排序與編輯自己的關鍵字分類規則。
         </p>
+      </div>
+      <div class="flex shrink-0 flex-wrap items-center gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          aria-expanded={showCategoryForm}
+          onclick={() => (showCategoryForm = !showCategoryForm)}
+        >
+          <Plus class="size-4" />新增分類
+        </Button>
+        <Badge class="text-sm" variant="secondary"
+          >{editableRuleCount} 條自訂規則</Badge
+        >
       </div>
     </div>
 

--- a/apps/web/src/features/settings/components/MobileMore.svelte
+++ b/apps/web/src/features/settings/components/MobileMore.svelte
@@ -32,6 +32,9 @@
   const configuredSources = $derived(
     jobs.filter((job) => job.configured && job.scope === "all"),
   );
+  const customRuleCount = $derived(
+    rules.filter((rule) => !rule.isSystem).length,
+  );
   const unhealthy = $derived(getActionableSyncJobs(jobs));
 </script>
 
@@ -102,10 +105,10 @@
             ><Settings class="size-5" /></span
           ><span class="flex-1"
             ><span class="block font-semibold">分類規則</span><span
-              class="block text-sm text-ink/45">銀行交易自動分類</span
+              class="block text-sm text-ink/45">自訂分類與自動配對</span
             ></span
           ><span class="text-sm font-semibold text-steel"
-            >{rules.length} 條　›</span
+            >{customRuleCount} 條自訂　›</span
           ></button
         >
       </div></Card


### PR DESCRIPTION
## 摘要

- 在設定的「分類規則」頁面新增系統自動分類與配對說明。
- 顯示帳戶互轉、信用卡年費減免、電子發票配對三項內建規則。
- 將自訂規則數量與系統內建規則分開呈現，避免混淆可編輯規則與固定邏輯。

## 介面文案

- 帳戶互轉：同日、同幣別、同金額、方向相反的已入帳交易自動配對，分類為「轉帳」並排除收支計算。
- 信用卡年費減免：同卡同日同額的年費與減免交易自動沖銷，分類為「手續費」並排除收支計算。
- 電子發票配對：同日同額的 TWD 銀行／信用卡支出自動配對，避免發票重複計入。

## 驗證

- `npm run typecheck -w @taiwan-fin-hub/web`
- `npm run test:unit -w @taiwan-fin-hub/web`（22 個測試檔、88 項測試）
- `npm run build -w @taiwan-fin-hub/web`
- `npm run format:check`
- `git diff --check`