### PR TITLE
修正：集保同步改為 durable Queue 分頁處理

### DIFF
--- a/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
+++ b/apps/web/src/features/settings/connectors/ConnectorPanel.svelte
@@ -81,6 +81,11 @@
   let einvoiceSyncPolling = $state<"awaiting-active" | "active" | null>(null);
   let einvoiceSyncPreviousLastRunAt = $state<string | null>(null);
   let einvoiceSyncPollingTimer: ReturnType<typeof setTimeout> | undefined;
+  let tdccSyncQueued = $state(false);
+  let tdccSyncQueuedTimer: ReturnType<typeof setTimeout> | undefined;
+  let tdccSyncPolling = $state<"awaiting-active" | "active" | null>(null);
+  let tdccSyncPreviousLastRunAt = $state<string | null>(null);
+  let tdccSyncPollingTimer: ReturnType<typeof setTimeout> | undefined;
   let destroyed = false;
   const job = $derived(
     ($jobs.data ?? []).find(
@@ -175,6 +180,8 @@
     destroyed = true;
     clearTimeout(einvoiceSyncQueuedTimer);
     stopEinvoiceSyncPolling();
+    clearTimeout(tdccSyncQueuedTimer);
+    stopTdccSyncPolling();
   });
 
   const save = createMutation({
@@ -210,7 +217,7 @@
           : `/api/connectors/${connectorId}/sync`;
       pendingSyncTarget = target;
       const runSync = () =>
-        connectorId === "einvoice"
+        connectorId === "einvoice" || connectorId === "tdcc"
           ? api.post<QueuedSyncResponse>(path, {})
           : api.post(path);
       try {
@@ -240,8 +247,13 @@
         startEinvoiceSyncPolling();
         return;
       }
+      if (connectorId === "tdcc") {
+        showTdccSyncQueued();
+        startTdccSyncPolling();
+        tdccSetupStep = "complete";
+        return;
+      }
       invalidateLatestSyncReport();
-      if (connectorId === "tdcc") tdccSetupStep = "complete";
       qc.invalidateQueries({ queryKey: queryKeys.syncJobs });
       qc.invalidateQueries({ queryKey: queryKeys.summary });
       if (
@@ -556,6 +568,8 @@
     qc.invalidateQueries({ queryKey: queryKeys.investments });
     qc.invalidateQueries({ queryKey: queryKeys.investmentTransactions });
     qc.invalidateQueries({ queryKey: queryKeys.bank });
+    showTdccSyncQueued();
+    startTdccSyncPolling();
   }
 
   function buildConfig() {
@@ -577,6 +591,14 @@
     clearTimeout(einvoiceSyncQueuedTimer);
     einvoiceSyncQueuedTimer = setTimeout(() => {
       einvoiceSyncQueued = false;
+    }, 5_000);
+  }
+
+  function showTdccSyncQueued() {
+    tdccSyncQueued = true;
+    clearTimeout(tdccSyncQueuedTimer);
+    tdccSyncQueuedTimer = setTimeout(() => {
+      tdccSyncQueued = false;
     }, 5_000);
   }
   function startEinvoiceSyncPolling() {
@@ -618,6 +640,50 @@
       void pollEinvoiceSyncJob();
     }, 2_000);
   }
+  function startTdccSyncPolling() {
+    tdccSyncPolling = "awaiting-active";
+    tdccSyncPreviousLastRunAt = job?.lastRunAt ?? null;
+    clearTimeout(tdccSyncPollingTimer);
+    void pollTdccSyncJob();
+  }
+  function stopTdccSyncPolling() {
+    tdccSyncPolling = null;
+    clearTimeout(tdccSyncPollingTimer);
+    tdccSyncPollingTimer = undefined;
+  }
+  async function pollTdccSyncJob() {
+    const syncJobs = await qc
+      .fetchQuery({ ...syncJobsQuery(() => api), staleTime: 0 })
+      .catch(() => undefined);
+    if (!tdccSyncPolling || destroyed) return;
+    const tdccJob = syncJobs?.find(
+      (syncJob) => syncJob.connectorId === "tdcc" && syncJob.scope === "all",
+    );
+    if (tdccJob?.running) {
+      tdccSyncPolling = "active";
+    } else if (
+      tdccJob &&
+      (tdccSyncPolling === "active" ||
+        tdccJob.lastRunAt !== tdccSyncPreviousLastRunAt)
+    ) {
+      const status = tdccJob?.lastStatus;
+      stopTdccSyncPolling();
+      if (status === "success") {
+        invalidateLatestSyncReport();
+        qc.invalidateQueries({ queryKey: queryKeys.summary });
+        qc.invalidateQueries({ queryKey: queryKeys.connectorSettings("tdcc") });
+        qc.invalidateQueries({ queryKey: queryKeys.investments });
+        qc.invalidateQueries({ queryKey: queryKeys.investmentTransactions });
+        qc.invalidateQueries({ queryKey: queryKeys.bank });
+      } else if (status === "failed" || status === "needs_user_action") {
+        error = tdccJob?.lastError ?? "集保同步失敗，請重新驗證。";
+      }
+      return;
+    }
+    tdccSyncPollingTimer = setTimeout(() => {
+      void pollTdccSyncJob();
+    }, 2_000);
+  }
   function invalidateLatestSyncReport() {
     qc.invalidateQueries({ queryKey: queryKeys.latestSyncReport });
   }
@@ -656,11 +722,20 @@
       {#if connectorId === "tdcc" && tdccConnectionReady}
         <Button
           size="sm"
-          disabled={demoMode || $sync.isPending || $verifyOtp.isPending}
+          disabled={demoMode ||
+            $sync.isPending ||
+            $verifyOtp.isPending ||
+            tdccSyncPolling !== null}
           onclick={() => $sync.mutate("default")}
           ><RefreshCw
             class={$sync.isPending ? "size-4 animate-spin" : "size-4"}
-          />{$sync.isPending ? "同步中…" : "同步"}</Button
+          />{$sync.isPending
+            ? "同步中…"
+            : tdccSyncQueued
+              ? "已排入同步"
+              : tdccSyncPolling
+                ? "同步中…"
+                : "同步"}</Button
         >
       {:else if connectorId === "tdcc"}
         <span

--- a/apps/worker/src/features/sync/persistence.ts
+++ b/apps/worker/src/features/sync/persistence.ts
@@ -321,6 +321,86 @@ export function emptySyncNewRecordCounts(): SyncNewRecordCounts {
   return { invoices: 0, bankTransactions: 0, investmentTransactions: 0 };
 }
 
+/**
+ * Append normalized records to a durable staging run without promoting them.
+ *
+ * Durable Queue based syncs use this between invocations.  The existing
+ * `persistStagedSyncWrite` helper below remains the one-shot compatibility
+ * path for connectors that still complete in a single invocation.
+ */
+export async function stageSyncWriteRecords(
+  db: D1Database,
+  runId: string,
+  records: SyncWriteRecord[],
+) {
+  if (records.length === 0) return;
+  const createdAt = new Date().toISOString();
+  for (let offset = 0; offset < records.length; offset += STAGING_CHUNK_SIZE) {
+    const chunk = records.slice(offset, offset + STAGING_CHUNK_SIZE);
+    await db
+      .prepare(
+        `INSERT INTO sync_write_staging (run_id, entity_type, record_key, payload, created_at)
+       SELECT
+         ?1,
+         json_extract(value, '$.entityType'),
+         json_extract(value, '$.recordKey'),
+         json_extract(value, '$.payload'),
+         ?2
+       FROM json_each(?3)
+       WHERE 1
+       ON CONFLICT(run_id, entity_type, record_key) DO UPDATE SET
+         payload = excluded.payload,
+         created_at = excluded.created_at`,
+      )
+      .bind(runId, createdAt, JSON.stringify(chunk))
+      .run();
+  }
+}
+
+export async function promoteStagedSyncWrite(
+  db: D1Database,
+  input: {
+    runId: string;
+    entityTypes: readonly SyncEntityType[];
+    beforePromoteStatements?: D1PreparedStatement[];
+    afterPromoteStatements?: D1PreparedStatement[];
+    finalizeStatements?: D1PreparedStatement[];
+  },
+) {
+  const entityTypes = new Set(input.entityTypes);
+  const promotionStatements = ENTITY_ORDER.filter((entityType) =>
+    entityTypes.has(entityType),
+  ).map((entityType) => promotionStatement(db, input.runId, entityType));
+  const newRecordCountStatements = Object.entries(NEW_RECORD_ENTITIES)
+    .filter(([entityType]) => entityTypes.has(entityType as SyncEntityType))
+    .map(([entityType, resultKey]) => ({
+      resultKey,
+      statement: newRecordCountStatement(
+        db,
+        input.runId,
+        entityType as keyof typeof NEW_RECORD_ENTITIES,
+      ),
+    }));
+  const countResultOffset = input.beforePromoteStatements?.length ?? 0;
+  const batchResults = await db.batch([
+    ...(input.beforePromoteStatements ?? []),
+    ...newRecordCountStatements.map(({ statement }) => statement),
+    ...promotionStatements,
+    ...(input.afterPromoteStatements ?? []),
+    ...(input.finalizeStatements ?? []),
+    db
+      .prepare("DELETE FROM sync_write_staging WHERE run_id = ?")
+      .bind(input.runId),
+  ]);
+  const newRecords = emptySyncNewRecordCounts();
+  for (const [index, { resultKey }] of newRecordCountStatements.entries()) {
+    const result = batchResults[countResultOffset + index] as
+      { results?: Array<{ count?: number }> } | undefined;
+    newRecords[resultKey] = result?.results?.[0]?.count ?? 0;
+  }
+  return newRecords;
+}
+
 export async function persistStagedSyncWrite(
   db: D1Database,
   input: {
@@ -331,70 +411,20 @@ export async function persistStagedSyncWrite(
   },
 ) {
   const runId = crypto.randomUUID();
-  const createdAt = new Date().toISOString();
   await db
     .prepare("DELETE FROM sync_write_staging WHERE created_at < ?")
     .bind(new Date(Date.now() - STAGING_RETENTION_MS).toISOString())
     .run();
 
   try {
-    for (
-      let offset = 0;
-      offset < input.records.length;
-      offset += STAGING_CHUNK_SIZE
-    ) {
-      const chunk = input.records.slice(offset, offset + STAGING_CHUNK_SIZE);
-      await db
-        .prepare(
-          `INSERT INTO sync_write_staging (run_id, entity_type, record_key, payload, created_at)
-         SELECT
-           ?1,
-           json_extract(value, '$.entityType'),
-           json_extract(value, '$.recordKey'),
-           json_extract(value, '$.payload'),
-           ?2
-         FROM json_each(?3)
-         WHERE 1
-         ON CONFLICT(run_id, entity_type, record_key) DO UPDATE SET
-           payload = excluded.payload,
-           created_at = excluded.created_at`,
-        )
-        .bind(runId, createdAt, JSON.stringify(chunk))
-        .run();
-    }
-
-    const entityTypes = new Set(
-      input.records.map((record) => record.entityType),
-    );
-    const promotionStatements = ENTITY_ORDER.filter((entityType) =>
-      entityTypes.has(entityType),
-    ).map((entityType) => promotionStatement(db, runId, entityType));
-    const newRecordCountStatements = Object.entries(NEW_RECORD_ENTITIES)
-      .filter(([entityType]) => entityTypes.has(entityType as SyncEntityType))
-      .map(([entityType, resultKey]) => ({
-        resultKey,
-        statement: newRecordCountStatement(
-          db,
-          runId,
-          entityType as keyof typeof NEW_RECORD_ENTITIES,
-        ),
-      }));
-    const countResultOffset = input.beforePromoteStatements?.length ?? 0;
-    const batchResults = await db.batch([
-      ...(input.beforePromoteStatements ?? []),
-      ...newRecordCountStatements.map(({ statement }) => statement),
-      ...promotionStatements,
-      ...(input.afterPromoteStatements ?? []),
-      ...(input.finalizeStatements ?? []),
-      db.prepare("DELETE FROM sync_write_staging WHERE run_id = ?").bind(runId),
-    ]);
-    const newRecords = emptySyncNewRecordCounts();
-    for (const [index, { resultKey }] of newRecordCountStatements.entries()) {
-      const result = batchResults[countResultOffset + index] as
-        { results?: Array<{ count?: number }> } | undefined;
-      newRecords[resultKey] = result?.results?.[0]?.count ?? 0;
-    }
-    return newRecords;
+    await stageSyncWriteRecords(db, runId, input.records);
+    return await promoteStagedSyncWrite(db, {
+      runId,
+      entityTypes: input.records.map((record) => record.entityType),
+      beforePromoteStatements: input.beforePromoteStatements,
+      afterPromoteStatements: input.afterPromoteStatements,
+      finalizeStatements: input.finalizeStatements,
+    });
   } catch (error) {
     await db
       .prepare("DELETE FROM sync_write_staging WHERE run_id = ?")

--- a/apps/worker/src/features/sync/route.ts
+++ b/apps/worker/src/features/sync/route.ts
@@ -42,6 +42,9 @@ import {
   type SyncOutcome,
 } from "./service";
 import { prepareConnectorChallenge, runConnectorSync } from "./registry";
+import { cancelQueuedTdccSyncRun, startTdccSyncRun } from "./tdcc-sync-service";
+import { enqueueTdccSyncChunk } from "./scheduler-queue";
+import type { TdccRunScope } from "./tdcc-run-repository";
 
 const tdccSyncBodySchema = z.object({
   otp: z.string().min(1).optional(),
@@ -131,12 +134,7 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
     ),
     async (c) => {
       const overrides = c.req.valid("json");
-      return syncRouteResponse(
-        c,
-        withManualSyncLock(c.env, "tdcc", SYNC_SCOPE_ALL, () =>
-          runConnectorSync(c.env, "tdcc", "manual", SYNC_SCOPE_ALL, overrides),
-        ),
-      );
+      return queuedTdccSyncResponse(c, "all", overrides);
     },
   );
 
@@ -149,18 +147,7 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
     ),
     async (c) => {
       const overrides = c.req.valid("json");
-      return syncRouteResponse(
-        c,
-        withManualSyncLock(c.env, "tdcc", TDCC_SCOPE_INVESTMENTS, () =>
-          runConnectorSync(
-            c.env,
-            "tdcc",
-            "manual",
-            TDCC_SCOPE_INVESTMENTS,
-            overrides,
-          ),
-        ),
-      );
+      return queuedTdccSyncResponse(c, "investments", overrides);
     },
   );
 
@@ -173,12 +160,7 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
     ),
     async (c) => {
       const overrides = c.req.valid("json");
-      return syncRouteResponse(
-        c,
-        withManualSyncLock(c.env, "tdcc", TDCC_SCOPE_BANK, () =>
-          runConnectorSync(c.env, "tdcc", "manual", TDCC_SCOPE_BANK, overrides),
-        ),
-      );
+      return queuedTdccSyncResponse(c, "bank", overrides);
     },
   );
 
@@ -191,18 +173,7 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
     ),
     async (c) => {
       const overrides = c.req.valid("json");
-      return syncRouteResponse(
-        c,
-        withManualSyncLock(c.env, "tdcc", TDCC_SCOPE_TRADES, () =>
-          runConnectorSync(
-            c.env,
-            "tdcc",
-            "manual",
-            TDCC_SCOPE_TRADES,
-            overrides,
-          ),
-        ),
-      );
+      return queuedTdccSyncResponse(c, "trades", overrides);
     },
   );
 
@@ -434,6 +405,40 @@ function registerSyncRoutes(api: Hono<AppBindings>) {
       );
     },
   );
+}
+
+async function queuedTdccSyncResponse(
+  c: Context<AppBindings>,
+  scope: TdccRunScope,
+  overrides: Record<string, unknown>,
+) {
+  try {
+    const { run, created } = await startTdccSyncRun(c.env, {
+      trigger: "manual",
+      scope,
+      overrides,
+    });
+    if (created) {
+      try {
+        await enqueueTdccSyncChunk(c.env, run.id);
+      } catch (error) {
+        await cancelQueuedTdccSyncRun(c.env, run.id, error);
+        throw error;
+      }
+    }
+    return c.json(
+      {
+        success: true as const,
+        connectorId: "tdcc" as const,
+        scope,
+        status: "queued" as const,
+        runId: run.id,
+      },
+      202,
+    );
+  } catch (error) {
+    return syncRouteResponse(c, Promise.reject(error) as Promise<SyncOutcome>);
+  }
 }
 
 async function syncRouteResponse(

--- a/apps/worker/src/features/sync/scheduler-queue.ts
+++ b/apps/worker/src/features/sync/scheduler-queue.ts
@@ -5,6 +5,8 @@ import {
   isEinvoiceUserActionError,
   processEinvoiceSyncChunk,
 } from "./einvoice-sync-service";
+import { failTdccSyncRun, processTdccSyncChunk } from "./tdcc-sync-service";
+import { isUserActionError } from "./service";
 
 const queueController = {
   cron: "queue:scheduled-sync",
@@ -12,7 +14,9 @@ const queueController = {
 
 export const SCHEDULED_SYNC_CHAIN_DELAY_SECONDS = 20;
 export const EINVOICE_SYNC_CHAIN_DELAY_SECONDS = 1;
+export const TDCC_SYNC_CHAIN_DELAY_SECONDS = 1;
 const EINVOICE_MAX_QUEUE_ATTEMPTS = 3;
+const TDCC_MAX_QUEUE_ATTEMPTS = 3;
 
 export async function enqueueScheduledSync(env: Env, delaySeconds = 0) {
   const message = { type: "run-next-scheduled-sync" } as const;
@@ -36,6 +40,19 @@ export async function enqueueEinvoiceSyncChunk(
   await env.SYNC_QUEUE.send(message);
 }
 
+export async function enqueueTdccSyncChunk(
+  env: Env,
+  runId: string,
+  delaySeconds = 0,
+) {
+  const message = { type: "run-tdcc-chunk", runId } as const;
+  if (delaySeconds > 0) {
+    await env.SYNC_QUEUE.send(message, { delaySeconds });
+    return;
+  }
+  await env.SYNC_QUEUE.send(message);
+}
+
 export async function consumeScheduledSyncQueue(
   batch: MessageBatch<ScheduledSyncQueueMessage>,
   env: Env,
@@ -43,6 +60,10 @@ export async function consumeScheduledSyncQueue(
   for (const message of batch.messages) {
     if (message.body.type === "run-einvoice-chunk") {
       await consumeEinvoiceChunkMessage(message, env);
+      continue;
+    }
+    if (message.body.type === "run-tdcc-chunk") {
+      await consumeTdccChunkMessage(message, env);
       continue;
     }
     if (message.body.type !== "run-next-scheduled-sync") {
@@ -61,6 +82,56 @@ export async function consumeScheduledSyncQueue(
       await enqueueScheduledSync(env, SCHEDULED_SYNC_CHAIN_DELAY_SECONDS);
     }
     message.ack();
+  }
+}
+
+async function consumeTdccChunkMessage(
+  message: Message<ScheduledSyncQueueMessage>,
+  env: Env,
+) {
+  if (message.body.type !== "run-tdcc-chunk") return;
+  try {
+    const result = await processTdccSyncChunk(
+      env,
+      message.body.runId,
+      message.id,
+    );
+    if (result.status === "busy") {
+      try {
+        await enqueueTdccSyncChunk(
+          env,
+          message.body.runId,
+          result.retryAfterSeconds,
+        );
+        message.ack();
+      } catch {
+        message.retry({ delaySeconds: result.retryAfterSeconds });
+      }
+      return;
+    }
+    if (result.status === "continue") {
+      await enqueueTdccSyncChunk(
+        env,
+        message.body.runId,
+        TDCC_SYNC_CHAIN_DELAY_SECONDS,
+      );
+    }
+    message.ack();
+  } catch (error) {
+    if (
+      isUserActionError(error) ||
+      message.attempts >= TDCC_MAX_QUEUE_ATTEMPTS
+    ) {
+      await failTdccSyncRun(
+        env,
+        message.body.runId,
+        error,
+        !isUserActionError(error),
+      );
+      message.ack();
+      return;
+    }
+    message.retry({ delaySeconds: retryDelaySeconds(message.attempts) });
   }
 }
 

--- a/apps/worker/src/features/sync/scheduler.ts
+++ b/apps/worker/src/features/sync/scheduler.ts
@@ -28,6 +28,7 @@ import {
   cancelQueuedEinvoiceSyncRun,
   startEinvoiceSyncRun,
 } from "./einvoice-sync-service";
+import { cancelQueuedTdccSyncRun, startTdccSyncRun } from "./tdcc-sync-service";
 import {
   claimCompletedDefaultScheduleBatch,
   ensureDefaultScheduleBatch,
@@ -101,6 +102,24 @@ async function runCustomScheduleJob(
     }
     return true;
   }
+  if (job.connector_id === "tdcc") {
+    const { run, created } = await startTdccSyncRun(env, {
+      trigger: "scheduled",
+      scope: "all",
+    });
+    if (created) {
+      try {
+        await env.SYNC_QUEUE.send({
+          type: "run-tdcc-chunk",
+          runId: run.id,
+        });
+      } catch (error) {
+        await cancelQueuedTdccSyncRun(env, run.id, error);
+        throw error;
+      }
+    }
+    return true;
+  }
   const notification = await runScheduledJob(env, controller, job);
   if (notification) await safelySendSyncNotification(env, notification);
   return notification !== undefined;
@@ -125,6 +144,25 @@ async function runDefaultScheduleBatchJob(
         });
       } catch (error) {
         await cancelQueuedEinvoiceSyncRun(env, run.id, error);
+        throw error;
+      }
+    }
+    return true;
+  }
+  if (job.connector_id === "tdcc") {
+    const { run, created } = await startTdccSyncRun(env, {
+      trigger: "scheduled",
+      scope: "all",
+      scheduledBatchId: batchId,
+    });
+    if (created) {
+      try {
+        await env.SYNC_QUEUE.send({
+          type: "run-tdcc-chunk",
+          runId: run.id,
+        });
+      } catch (error) {
+        await cancelQueuedTdccSyncRun(env, run.id, error);
         throw error;
       }
     }

--- a/apps/worker/src/features/sync/tdcc-run-repository.ts
+++ b/apps/worker/src/features/sync/tdcc-run-repository.ts
@@ -1,0 +1,893 @@
+/**
+ * Durable state for TDCC's paginated provider work.
+ *
+ * The repository deliberately only owns run/item state.  The sync service is
+ * responsible for mapping a completed item into `sync_write_staging` and for
+ * promoting that staging data after every item is done.
+ */
+
+export type TdccRunStatus =
+  | "queued"
+  | "initializing"
+  | "processing"
+  | "promoting"
+  | "completed"
+  | "failed"
+  | "needs_user_action";
+
+export type TdccRunPhase =
+  | "initialize"
+  | "snapshot"
+  | "positions"
+  | "bank"
+  | "investments"
+  | "trades"
+  | "promote"
+  | "finalize";
+
+export type TdccRunTrigger = "manual" | "scheduled";
+export type TdccRunScope = "all" | "investments" | "bank" | "trades";
+export type TdccRunItemStatus = "pending" | "processing" | "done" | "failed";
+
+export type TdccRunRow = {
+  id: string;
+  connector_id: "tdcc";
+  trigger: TdccRunTrigger;
+  scope: TdccRunScope;
+  sync_job_id: string | null;
+  scheduled_batch_id: string | null;
+  settings_version: string | null;
+  phase: TdccRunPhase;
+  status: TdccRunStatus;
+  encrypted_config: string | null;
+  encrypted_session: string | null;
+  session_json: string | null;
+  total_item_count: number;
+  pending_item_count: number;
+  processing_item_count: number;
+  done_item_count: number;
+  failed_item_count: number;
+  session_refresh_count: number;
+  last_error: string | null;
+  lease_owner: string | null;
+  lease_expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+  promoted_at: string | null;
+  completed_at: string | null;
+};
+
+export type TdccRunItemRow = {
+  id: string;
+  run_id: string;
+  task_type: string;
+  task_key: string;
+  account_id: string | null;
+  page_cursor: string;
+  next_page_cursor: string | null;
+  page_number: number;
+  task_json: string;
+  payload_json: string | null;
+  status: TdccRunItemStatus;
+  attempt_count: number;
+  last_error: string | null;
+  lease_token: string | null;
+  lease_expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+};
+
+export type CreateTdccRunInput = {
+  id?: string;
+  trigger: TdccRunTrigger;
+  scope?: TdccRunScope;
+  syncJobId?: string | null;
+  scheduledBatchId?: string | null;
+  settingsVersion?: string | null;
+  encryptedConfig?: string | null;
+  encryptedSession?: string | null;
+  session?: unknown;
+  phase?: TdccRunPhase;
+  now?: string;
+};
+
+export type UpsertTdccRunItemInput = {
+  id?: string;
+  taskType: string;
+  taskKey?: string;
+  accountId?: string | null;
+  pageCursor?: string;
+  nextPageCursor?: string | null;
+  pageNumber?: number;
+  task?: unknown;
+  payload?: unknown;
+  status?: TdccRunItemStatus;
+  lastError?: string | null;
+  now?: string;
+};
+
+export type UpdateTdccRunItemInput = {
+  runId: string;
+  itemId?: string;
+  taskType?: string;
+  taskKey?: string;
+  pageCursor?: string;
+  claimToken?: string;
+  status?: TdccRunItemStatus;
+  accountId?: string | null;
+  nextPageCursor?: string | null;
+  pageNumber?: number;
+  task?: unknown;
+  payload?: unknown;
+  error?: string | null;
+  completedAt?: string | null;
+  now?: string;
+};
+
+export type TdccRunLeaseInput = {
+  runId: string;
+  owner: string;
+  leaseMs: number;
+  now?: Date;
+};
+
+const ACTIVE_RUN_STATUSES: TdccRunStatus[] = [
+  "queued",
+  "initializing",
+  "processing",
+  "promoting",
+];
+
+const TERMINAL_RUN_STATUSES: TdccRunStatus[] = [
+  "completed",
+  "failed",
+  "needs_user_action",
+];
+
+/** Creates the connector's only active run, or returns the existing one. */
+export async function createOrGetActiveTdccRun(
+  db: D1Database,
+  input: CreateTdccRunInput,
+): Promise<{ run: TdccRunRow; created: boolean }> {
+  const now = input.now ?? new Date().toISOString();
+  const id = input.id ?? `tdcc:${crypto.randomUUID()}`;
+  const scope = input.scope ?? "all";
+  try {
+    await db
+      .prepare(
+        `INSERT INTO tdcc_sync_runs (
+           id, connector_id, trigger, scope, sync_job_id, scheduled_batch_id,
+           settings_version, phase, status, encrypted_config,
+           encrypted_session, session_json, created_at, updated_at
+         ) VALUES (?, 'tdcc', ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        id,
+        input.trigger,
+        scope,
+        input.syncJobId ?? null,
+        input.scheduledBatchId ?? null,
+        input.settingsVersion ?? null,
+        input.phase ?? "initialize",
+        input.encryptedConfig ?? null,
+        input.encryptedSession ?? null,
+        // Never persist a provider token in plaintext. `session` is retained
+        // in the input type for callers migrating from an early prototype;
+        // callers must provide encryptedSession instead.
+        null,
+        now,
+        now,
+      )
+      .run();
+  } catch (error) {
+    const active = await getActiveTdccRun(db);
+    if (!active) throw error;
+    return { run: active, created: false };
+  }
+  const run = await getTdccRun(db, id);
+  if (!run) throw new Error(`TDCC run ${id} was not found after creation`);
+  return { run, created: true };
+}
+
+export async function getActiveTdccRun(
+  db: D1Database,
+): Promise<TdccRunRow | null> {
+  return (
+    (await db
+      .prepare(
+        `SELECT * FROM tdcc_sync_runs
+         WHERE connector_id = 'tdcc'
+           AND status IN ('queued', 'initializing', 'processing', 'promoting')
+         ORDER BY created_at ASC
+         LIMIT 1`,
+      )
+      .first<TdccRunRow>()) ?? null
+  );
+}
+
+export async function getTdccRun(
+  db: D1Database,
+  runId: string,
+): Promise<TdccRunRow | null> {
+  return (
+    (await db
+      .prepare("SELECT * FROM tdcc_sync_runs WHERE id = ?")
+      .bind(runId)
+      .first<TdccRunRow>()) ?? null
+  );
+}
+
+/**
+ * Changes a run state with compare-and-set semantics.  Omitting `from` means
+ * any active state is accepted, which is useful for an idempotent Queue retry.
+ */
+export async function transitionTdccRun(
+  db: D1Database,
+  input: {
+    runId: string;
+    from?: TdccRunStatus | TdccRunStatus[];
+    to: TdccRunStatus;
+    phase?: TdccRunPhase;
+    error?: string | null;
+    now?: string;
+  },
+) {
+  const fromStatuses = input.from
+    ? Array.isArray(input.from)
+      ? input.from
+      : [input.from]
+    : ACTIVE_RUN_STATUSES;
+  const placeholders = fromStatuses.map(() => "?").join(", ");
+  const now = input.now ?? new Date().toISOString();
+  const result = await db
+    .prepare(
+      `UPDATE tdcc_sync_runs
+       SET status = ?,
+           phase = COALESCE(?, phase),
+           last_error = CASE WHEN ? IS NULL THEN last_error ELSE ? END,
+           updated_at = ?
+       WHERE id = ? AND status IN (${placeholders})`,
+    )
+    .bind(
+      input.to,
+      input.phase ?? null,
+      input.error ?? null,
+      input.error ?? null,
+      now,
+      input.runId,
+      ...fromStatuses,
+    )
+    .run();
+  return result.meta.changes === 1;
+}
+
+/** Alias matching the e-invoice repository's explicit function name. */
+export async function transitionTdccRunStatus(
+  db: D1Database,
+  input: Parameters<typeof transitionTdccRun>[1],
+) {
+  return transitionTdccRun(db, input);
+}
+
+/** Acquires a run lease; an expired delivery may safely take it over. */
+export async function acquireTdccRunLease(
+  db: D1Database,
+  input: TdccRunLeaseInput,
+) {
+  const now = input.now ?? new Date();
+  const nowIso = now.toISOString();
+  const expiresAt = new Date(now.getTime() + input.leaseMs).toISOString();
+  const result = await db
+    .prepare(
+      `UPDATE tdcc_sync_runs
+       SET lease_owner = ?, lease_expires_at = ?, updated_at = ?
+       WHERE id = ?
+         AND status IN ('queued', 'initializing', 'processing', 'promoting')
+         AND (
+           lease_owner IS NULL
+           OR lease_expires_at IS NULL
+           OR lease_expires_at < ?
+         )`,
+    )
+    .bind(input.owner, expiresAt, nowIso, input.runId, nowIso)
+    .run();
+  return result.meta.changes === 1;
+}
+
+export async function renewTdccRunLease(
+  db: D1Database,
+  input: TdccRunLeaseInput,
+) {
+  const now = input.now ?? new Date();
+  const nowIso = now.toISOString();
+  const expiresAt = new Date(now.getTime() + input.leaseMs).toISOString();
+  const result = await db
+    .prepare(
+      `UPDATE tdcc_sync_runs
+       SET lease_expires_at = ?, updated_at = ?
+       WHERE id = ?
+         AND status IN ('queued', 'initializing', 'processing', 'promoting')
+         AND lease_owner = ?`,
+    )
+    .bind(expiresAt, nowIso, input.runId, input.owner)
+    .run();
+  return result.meta.changes === 1;
+}
+
+export async function releaseTdccRunLease(
+  db: D1Database,
+  input: { runId: string; owner: string; now?: string },
+) {
+  const result = await db
+    .prepare(
+      `UPDATE tdcc_sync_runs
+       SET lease_owner = NULL, lease_expires_at = NULL, updated_at = ?
+       WHERE id = ? AND lease_owner = ?`,
+    )
+    .bind(input.now ?? new Date().toISOString(), input.runId, input.owner)
+    .run();
+  return result.meta.changes === 1;
+}
+
+// Keep the terminology used by the e-invoice Queue consumer available to
+// callers while using one TDCC run-level lease internally.
+export const acquireTdccRunChunkLease = acquireTdccRunLease;
+export const renewTdccRunChunkLease = renewTdccRunLease;
+export const releaseTdccRunChunkLease = releaseTdccRunLease;
+
+/** Writes encrypted state captured during initialization with a run guard. */
+export async function updateTdccRunState(
+  db: D1Database,
+  input: {
+    runId: string;
+    settingsVersion?: string | null;
+    encryptedConfig?: string | null;
+    encryptedSession?: string | null;
+    session?: unknown;
+    phase?: TdccRunPhase;
+    status?: TdccRunStatus;
+    now?: string;
+  },
+) {
+  const assignments: string[] = [];
+  const values: unknown[] = [];
+  if (input.settingsVersion !== undefined) {
+    assignments.push("settings_version = ?");
+    values.push(input.settingsVersion);
+  }
+  if (input.encryptedConfig !== undefined) {
+    assignments.push("encrypted_config = ?");
+    values.push(input.encryptedConfig);
+  }
+  if (input.encryptedSession !== undefined) {
+    assignments.push("encrypted_session = ?");
+    values.push(input.encryptedSession);
+  }
+  // `session` is intentionally not written: TDCC session tokens are secrets.
+  // Keep the optional input for source compatibility with the initialization
+  // helper; encryptedSession is the only persisted representation.
+  if (input.phase !== undefined) {
+    assignments.push("phase = ?");
+    values.push(input.phase);
+  }
+  if (input.status !== undefined) {
+    assignments.push("status = ?");
+    values.push(input.status);
+  }
+  if (assignments.length === 0) return false;
+  const now = input.now ?? new Date().toISOString();
+  assignments.push("updated_at = ?");
+  values.push(now, input.runId);
+  const result = await db
+    .prepare(`UPDATE tdcc_sync_runs SET ${assignments.join(", ")} WHERE id = ?`)
+    .bind(...values)
+    .run();
+  return result.meta.changes === 1;
+}
+
+export const updateTdccRunSession = updateTdccRunState;
+
+/** Bounds automatic session rebuilds so an expired TDCC session cannot loop. */
+export async function claimTdccRunSessionRefresh(
+  db: D1Database,
+  input: { runId: string; maxRefreshes?: number; now?: string },
+) {
+  const result = await db
+    .prepare(
+      `UPDATE tdcc_sync_runs
+       SET session_refresh_count = session_refresh_count + 1, updated_at = ?
+       WHERE id = ?
+         AND status IN ('queued', 'initializing', 'processing', 'promoting')
+         AND session_refresh_count < ?`,
+    )
+    .bind(
+      input.now ?? new Date().toISOString(),
+      input.runId,
+      Math.max(1, Math.floor(input.maxRefreshes ?? 1)),
+    )
+    .run();
+  return result.meta.changes === 1;
+}
+
+/** Adds or refreshes a page item without resetting a claimed/completed item. */
+export async function upsertTdccRunItem(
+  db: D1Database,
+  runId: string,
+  input: UpsertTdccRunItemInput,
+): Promise<TdccRunItemRow> {
+  const now = input.now ?? new Date().toISOString();
+  const taskKey = input.taskKey ?? "";
+  const pageCursor = input.pageCursor ?? "";
+  const id =
+    input.id ??
+    `${runId}:${input.taskType}:${taskKey}:${pageCursor || "first"}`;
+  const taskJson = json(input.task ?? {});
+  const payloadJson = input.payload === undefined ? null : json(input.payload);
+  const status = input.status ?? "pending";
+  await db
+    .prepare(
+      `INSERT INTO tdcc_sync_run_items (
+         id, run_id, task_type, task_key, account_id, page_cursor,
+         next_page_cursor, page_number, task_json, payload_json, status,
+         last_error, created_at, updated_at, completed_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(run_id, task_type, task_key, page_cursor) DO UPDATE SET
+         account_id = COALESCE(excluded.account_id, tdcc_sync_run_items.account_id),
+         next_page_cursor = COALESCE(
+           excluded.next_page_cursor, tdcc_sync_run_items.next_page_cursor
+         ),
+         page_number = excluded.page_number,
+         task_json = CASE
+           WHEN tdcc_sync_run_items.status IN ('processing', 'done')
+             THEN tdcc_sync_run_items.task_json
+           ELSE excluded.task_json
+         END,
+         payload_json = CASE
+           WHEN tdcc_sync_run_items.status = 'done'
+             THEN tdcc_sync_run_items.payload_json
+           ELSE COALESCE(excluded.payload_json, tdcc_sync_run_items.payload_json)
+         END,
+         status = CASE
+           WHEN tdcc_sync_run_items.status IN ('processing', 'done')
+             THEN tdcc_sync_run_items.status
+           ELSE excluded.status
+         END,
+         last_error = CASE
+           WHEN excluded.status = 'pending' THEN excluded.last_error
+           ELSE tdcc_sync_run_items.last_error
+         END,
+         completed_at = CASE
+           WHEN tdcc_sync_run_items.status = 'done'
+             THEN tdcc_sync_run_items.completed_at
+           WHEN excluded.status = 'done' THEN excluded.completed_at
+           ELSE NULL
+         END,
+         updated_at = excluded.updated_at`,
+    )
+    .bind(
+      id,
+      runId,
+      input.taskType,
+      taskKey,
+      input.accountId ?? null,
+      pageCursor,
+      input.nextPageCursor ?? null,
+      Math.max(0, Math.floor(input.pageNumber ?? 0)),
+      taskJson,
+      payloadJson,
+      status,
+      input.lastError ?? null,
+      now,
+      now,
+      status === "done" ? now : null,
+    )
+    .run();
+  await refreshTdccRunCounts(db, runId, now);
+  const item = await getTdccRunItem(db, runId, id, input);
+  if (!item) throw new Error(`TDCC run item ${id} was not found after upsert`);
+  return item;
+}
+
+export async function insertTdccRunItem(
+  db: D1Database,
+  runId: string,
+  input: UpsertTdccRunItemInput,
+) {
+  return upsertTdccRunItem(db, runId, input);
+}
+
+/** Inserts the next provider page; repeated Queue deliveries are idempotent. */
+export async function insertNextTdccRunItem(
+  db: D1Database,
+  runId: string,
+  input: UpsertTdccRunItemInput,
+) {
+  return upsertTdccRunItem(db, runId, input);
+}
+
+export async function getTdccRunItem(
+  db: D1Database,
+  runId: string,
+  itemId: string,
+  identity?: Pick<
+    UpsertTdccRunItemInput,
+    "taskType" | "taskKey" | "pageCursor"
+  >,
+) {
+  const clause = identity
+    ? " AND task_type = ? AND task_key = ? AND page_cursor = ?"
+    : "";
+  const bindings: unknown[] = [runId, itemId];
+  if (identity) {
+    bindings.push(
+      identity.taskType,
+      identity.taskKey ?? "",
+      identity.pageCursor ?? "",
+    );
+  }
+  return (
+    (await db
+      .prepare(
+        `SELECT * FROM tdcc_sync_run_items
+         WHERE run_id = ? AND id = ?${clause}`,
+      )
+      .bind(...bindings)
+      .first<TdccRunItemRow>()) ?? null
+  );
+}
+
+/** Claims a bounded page set using an owner-scoped rolling lease. */
+export async function claimTdccRunItems(
+  db: D1Database,
+  input: {
+    runId: string;
+    claimToken?: string;
+    limit?: number;
+    leaseMs: number;
+    taskType?: string;
+    now?: Date;
+  },
+): Promise<TdccRunItemRow[]> {
+  const now = input.now ?? new Date();
+  const nowIso = now.toISOString();
+  const claimToken = input.claimToken ?? crypto.randomUUID();
+  const leaseExpiresAt = new Date(now.getTime() + input.leaseMs).toISOString();
+  const limit = Math.max(1, Math.floor(input.limit ?? 1));
+  const taskTypeClause = input.taskType ? " AND task_type = ?" : "";
+  const taskTypeBindings = input.taskType ? [input.taskType] : [];
+  await db.batch([
+    db
+      .prepare(
+        `UPDATE tdcc_sync_run_items
+         SET status = 'processing',
+             lease_token = ?, lease_expires_at = ?,
+             attempt_count = attempt_count + 1,
+             last_error = NULL, updated_at = ?
+         WHERE id IN (
+           SELECT id FROM tdcc_sync_run_items
+           WHERE run_id = ?${taskTypeClause}
+             AND (
+               status = 'pending'
+               OR (status = 'processing' AND (
+                 lease_expires_at IS NULL OR lease_expires_at < ?
+               ))
+             )
+           ORDER BY created_at ASC, task_type ASC, task_key ASC, page_number ASC
+           LIMIT ?
+         )`,
+      )
+      .bind(
+        claimToken,
+        leaseExpiresAt,
+        nowIso,
+        input.runId,
+        ...taskTypeBindings,
+        nowIso,
+        limit,
+      ),
+    refreshTdccRunCountsStatement(db, input.runId, nowIso),
+  ]);
+  return (
+    await db
+      .prepare(
+        `SELECT * FROM tdcc_sync_run_items
+         WHERE run_id = ? AND lease_token = ? AND status = 'processing'
+         ORDER BY created_at ASC, task_type ASC, task_key ASC, page_number ASC`,
+      )
+      .bind(input.runId, claimToken)
+      .all<TdccRunItemRow>()
+  ).results;
+}
+
+/** Generic CAS item update for a page worker. */
+export async function updateTdccRunItem(
+  db: D1Database,
+  input: UpdateTdccRunItemInput,
+) {
+  if (
+    input.itemId === undefined &&
+    input.taskType === undefined &&
+    input.taskKey === undefined &&
+    input.pageCursor === undefined
+  ) {
+    return false;
+  }
+  const assignments: string[] = [];
+  const values: unknown[] = [];
+  if (input.status !== undefined) {
+    assignments.push("status = ?");
+    values.push(input.status);
+    if (input.status === "done") {
+      assignments.push(
+        "lease_token = NULL",
+        "lease_expires_at = NULL",
+        "last_error = NULL",
+      );
+      if (input.completedAt === undefined) {
+        assignments.push("completed_at = ?");
+        values.push(input.now ?? new Date().toISOString());
+      }
+    } else if (input.status !== "processing") {
+      assignments.push("lease_token = NULL", "lease_expires_at = NULL");
+    }
+  }
+  if (input.accountId !== undefined) {
+    assignments.push("account_id = ?");
+    values.push(input.accountId);
+  }
+  if (input.nextPageCursor !== undefined) {
+    assignments.push("next_page_cursor = ?");
+    values.push(input.nextPageCursor);
+  }
+  if (input.pageNumber !== undefined) {
+    assignments.push("page_number = ?");
+    values.push(Math.max(0, Math.floor(input.pageNumber)));
+  }
+  if (input.task !== undefined) {
+    assignments.push("task_json = ?");
+    values.push(json(input.task));
+  }
+  if (input.payload !== undefined) {
+    assignments.push("payload_json = ?");
+    values.push(json(input.payload));
+  }
+  if (input.error !== undefined) {
+    assignments.push("last_error = ?");
+    values.push(input.error);
+  }
+  if (input.completedAt !== undefined) {
+    assignments.push("completed_at = ?");
+    values.push(input.completedAt);
+  }
+  if (assignments.length === 0) return false;
+  const now = input.now ?? new Date().toISOString();
+  assignments.push("updated_at = ?");
+  values.push(now, input.runId);
+  const where: string[] = ["run_id = ?"];
+  if (input.itemId !== undefined) {
+    where.push("id = ?");
+    values.push(input.itemId);
+  }
+  if (input.taskType !== undefined) {
+    where.push("task_type = ?");
+    values.push(input.taskType);
+  }
+  if (input.taskKey !== undefined) {
+    where.push("task_key = ?");
+    values.push(input.taskKey);
+  }
+  if (input.pageCursor !== undefined) {
+    where.push("page_cursor = ?");
+    values.push(input.pageCursor);
+  }
+  if (input.claimToken !== undefined) {
+    where.push("status = 'processing'");
+    where.push("lease_token = ?");
+    values.push(input.claimToken);
+  }
+  const result = await db
+    .prepare(
+      `UPDATE tdcc_sync_run_items SET ${assignments.join(", ")}
+       WHERE ${where.join(" AND ")}`,
+    )
+    .bind(...values)
+    .run();
+  await refreshTdccRunCounts(db, input.runId, now);
+  return result.meta.changes === 1;
+}
+
+/** Completes a claimed page; a stale delivery cannot overwrite a new lease. */
+export async function markTdccRunItemSucceeded(
+  db: D1Database,
+  input: {
+    runId: string;
+    itemId: string;
+    claimToken: string;
+    payload?: unknown;
+    nextPageCursor?: string | null;
+    now?: string;
+  },
+) {
+  const now = input.now ?? new Date().toISOString();
+  const nextCursorExpression =
+    input.nextPageCursor === undefined ? "next_page_cursor" : "?";
+  const nextCursorBindings =
+    input.nextPageCursor === undefined ? [] : [input.nextPageCursor];
+  const result = await db
+    .prepare(
+      `UPDATE tdcc_sync_run_items
+       SET payload_json = CASE
+             WHEN ? IS NULL THEN payload_json ELSE ? END,
+           next_page_cursor = ${nextCursorExpression},
+           status = 'done', lease_token = NULL, lease_expires_at = NULL,
+           last_error = NULL, completed_at = ?, updated_at = ?
+       WHERE run_id = ? AND id = ?
+         AND status = 'processing' AND lease_token = ?`,
+    )
+    .bind(
+      input.payload === undefined ? null : json(input.payload),
+      input.payload === undefined ? null : json(input.payload),
+      ...nextCursorBindings,
+      now,
+      now,
+      input.runId,
+      input.itemId,
+      input.claimToken,
+    )
+    .run();
+  await refreshTdccRunCounts(db, input.runId, now);
+  return result.meta.changes === 1;
+}
+
+/** Releases a claimed page for Queue retry while retaining the error. */
+export async function releaseTdccRunItemForRetry(
+  db: D1Database,
+  input: {
+    runId: string;
+    itemId: string;
+    claimToken: string;
+    error: string;
+    now?: string;
+  },
+) {
+  const now = input.now ?? new Date().toISOString();
+  const result = await db
+    .prepare(
+      `UPDATE tdcc_sync_run_items
+       SET status = 'pending', lease_token = NULL, lease_expires_at = NULL,
+           last_error = ?, updated_at = ?
+       WHERE run_id = ? AND id = ?
+         AND status = 'processing' AND lease_token = ?`,
+    )
+    .bind(input.error, now, input.runId, input.itemId, input.claimToken)
+    .run();
+  await refreshTdccRunCounts(db, input.runId, now);
+  return result.meta.changes === 1;
+}
+
+export const releaseTdccRunItem = releaseTdccRunItemForRetry;
+
+/** Terminal run transition. Completion is allowed only when every item is done. */
+export async function finalizeTdccRun(
+  db: D1Database,
+  input: {
+    runId: string;
+    status: Extract<
+      TdccRunStatus,
+      "completed" | "failed" | "needs_user_action"
+    >;
+    error?: string | null;
+    phase?: TdccRunPhase;
+    promotedAt?: string | null;
+    now?: string;
+  },
+) {
+  const now = input.now ?? new Date().toISOString();
+  const result = await db
+    .prepare(
+      `UPDATE tdcc_sync_runs
+       SET status = ?,
+           phase = COALESCE(?, phase),
+           last_error = ?,
+           lease_owner = NULL,
+           lease_expires_at = NULL,
+           promoted_at = COALESCE(?, promoted_at),
+           completed_at = ?,
+           updated_at = ?
+       WHERE id = ?
+         AND status IN ('queued', 'initializing', 'processing', 'promoting')
+         AND (
+           ? != 'completed'
+           OR NOT EXISTS (
+             SELECT 1 FROM tdcc_sync_run_items
+             WHERE run_id = tdcc_sync_runs.id AND status != 'done'
+           )
+         )`,
+    )
+    .bind(
+      input.status,
+      input.phase ?? null,
+      input.error ?? null,
+      input.promotedAt ?? null,
+      now,
+      now,
+      input.runId,
+      input.status,
+    )
+    .run();
+  return result.meta.changes === 1;
+}
+
+export async function listPendingTdccRunItems(db: D1Database, runId: string) {
+  return (
+    await db
+      .prepare(
+        `SELECT * FROM tdcc_sync_run_items
+         WHERE run_id = ? AND status != 'done'
+         ORDER BY created_at ASC, task_type ASC, task_key ASC, page_number ASC`,
+      )
+      .bind(runId)
+      .all<TdccRunItemRow>()
+  ).results;
+}
+
+export async function listCompletedTdccRunItems(db: D1Database, runId: string) {
+  return (
+    await db
+      .prepare(
+        `SELECT * FROM tdcc_sync_run_items
+         WHERE run_id = ? AND status = 'done'
+         ORDER BY created_at ASC, task_type ASC, task_key ASC, page_number ASC`,
+      )
+      .bind(runId)
+      .all<TdccRunItemRow>()
+  ).results;
+}
+
+function refreshTdccRunCountsStatement(
+  db: D1Database,
+  runId: string,
+  now: string,
+) {
+  return db
+    .prepare(
+      `UPDATE tdcc_sync_runs
+       SET total_item_count = (
+             SELECT COUNT(*) FROM tdcc_sync_run_items WHERE run_id = ?
+           ),
+           pending_item_count = (
+             SELECT COUNT(*) FROM tdcc_sync_run_items
+             WHERE run_id = ? AND status = 'pending'
+           ),
+           processing_item_count = (
+             SELECT COUNT(*) FROM tdcc_sync_run_items
+             WHERE run_id = ? AND status = 'processing'
+           ),
+           done_item_count = (
+             SELECT COUNT(*) FROM tdcc_sync_run_items
+             WHERE run_id = ? AND status = 'done'
+           ),
+           failed_item_count = (
+             SELECT COUNT(*) FROM tdcc_sync_run_items
+             WHERE run_id = ? AND status = 'failed'
+           ),
+           updated_at = ?
+       WHERE id = ?`,
+    )
+    .bind(runId, runId, runId, runId, runId, now, runId);
+}
+
+async function refreshTdccRunCounts(
+  db: D1Database,
+  runId: string,
+  now: string,
+) {
+  await refreshTdccRunCountsStatement(db, runId, now).run();
+}
+
+function json(value: unknown) {
+  return JSON.stringify(value) ?? "null";
+}
+
+export { ACTIVE_RUN_STATUSES, TERMINAL_RUN_STATUSES };

--- a/apps/worker/src/features/sync/tdcc-sync-service.ts
+++ b/apps/worker/src/features/sync/tdcc-sync-service.ts
@@ -1,0 +1,1042 @@
+import {
+  createTdccClient,
+  EPassbookError,
+  ensureTdccSession,
+  initializeTdccSnapshot,
+  normalizeBankTransactionDetails,
+  normalizeTdccSnapshot,
+  parseTdccConfig,
+  parseTdccTradePageItems,
+  type BankTransactionDetail,
+  type TdccConfig,
+  type TdccCursorState,
+  type TdccSnapshotInitialization,
+  type TdccStockAccount,
+} from "@taiwan-fin-hub/connectors";
+import type {
+  SyncNewRecordCounts,
+  SyncNotificationStatus,
+} from "@taiwan-fin-hub/core";
+import { getConnectorSettings, nextSyncRunAt } from "@taiwan-fin-hub/db";
+import { configEncryptionKey } from "../../platform/config";
+import { decryptJson, encryptJson } from "../../platform/crypto";
+import type { Env } from "../../platform/env";
+import { rebuildBankDepositHistory, dateFromIso } from "../net-worth/service";
+import {
+  safelySendScheduledSyncSummary,
+  safelySendSyncNotification,
+} from "../notifications/service";
+import { claimCompletedDefaultScheduleBatch } from "./notification-batch-repository";
+import {
+  acquireTdccRunLease,
+  claimTdccRunItems,
+  createOrGetActiveTdccRun,
+  finalizeTdccRun,
+  getTdccRun,
+  insertNextTdccRunItem,
+  markTdccRunItemSucceeded,
+  releaseTdccRunItemForRetry,
+  releaseTdccRunLease,
+  transitionTdccRun,
+  updateTdccRunState,
+  type TdccRunItemRow,
+  type TdccRunRow,
+  type TdccRunScope,
+  type TdccRunTrigger,
+} from "./tdcc-run-repository";
+import { findSyncJob } from "./schedule-repository";
+import { recoverLatestScheduledSyncSource } from "./report-repository";
+import {
+  bankAccountRecord,
+  bankBalanceSnapshotRecord,
+  bankTransactionRecord,
+  investmentPositionRecord,
+  investmentTransactionRecord,
+  netWorthHistoryRecord,
+} from "./record-mapper";
+import {
+  linkCanonicalBankAccountsStatement,
+  connectorStateStatement,
+} from "./repository";
+import {
+  isUserActionError,
+  NeedsUserActionError,
+  safeErrorMessage,
+  SyncAlreadyRunningError,
+  SYNC_LOCK_LEASE_MS,
+} from "./service";
+import {
+  serializePublicConnectorConfig,
+  splitConnectorCursorState,
+} from "./connector-state";
+import { promoteStagedSyncWrite, stageSyncWriteRecords } from "./persistence";
+
+const TDCC_JOB_ID = "tdcc:all";
+const TDCC_RUN_LEASE_MS = 3 * 60 * 1000;
+const TDCC_MAX_BANK_PAGES = 1_000;
+const TDCC_MAX_QUEUE_ITEMS_PER_CHUNK = 1;
+const TDCC_SESSION_EXPIRED_CODES = new Set([
+  "D0006",
+  "D0007",
+  "A0001",
+  "A0002",
+  "T8000",
+]);
+
+export type TdccChunkResult =
+  | { status: "continue" }
+  | { status: "completed" }
+  | { status: "terminal" }
+  | { status: "busy"; retryAfterSeconds: number };
+
+export type StartTdccSyncRunResult = {
+  run: TdccRunRow;
+  created: boolean;
+};
+
+/** Start a durable TDCC run. Manual starts initialize the bounded snapshot
+ * inline so OTP/device errors retain the existing immediate UX. */
+export async function startTdccSyncRun(
+  env: Env,
+  input: {
+    trigger: TdccRunTrigger;
+    scope: TdccRunScope;
+    overrides?: Record<string, unknown>;
+    scheduledBatchId?: string | null;
+  },
+): Promise<StartTdccSyncRunResult> {
+  const settings = await getConnectorSettings(env.DB, "tdcc");
+  if (!settings) {
+    throw new NeedsUserActionError("請先儲存集保 e 存摺設定，再開始同步。");
+  }
+  const storedConfig = await decryptJson<Record<string, unknown>>(
+    settings.encrypted_config,
+    configEncryptionKey(env),
+  );
+  const config = parseTdccConfig({
+    ...storedConfig,
+    ...(input.overrides ?? {}),
+    requestOtp: input.trigger === "manual",
+  });
+  requireTdccCredentials(config);
+  const encryptedConfig = await encryptJson(config, configEncryptionKey(env));
+  const result = await createOrGetActiveTdccRun(env.DB, {
+    trigger: input.trigger,
+    scope: input.scope,
+    syncJobId: TDCC_JOB_ID,
+    scheduledBatchId: input.scheduledBatchId,
+    settingsVersion: settings.updated_at,
+    encryptedConfig,
+  });
+  const { run, created } = result;
+  if (
+    run.trigger !== input.trigger ||
+    run.scope !== input.scope ||
+    (input.scheduledBatchId &&
+      run.scheduled_batch_id !== input.scheduledBatchId)
+  ) {
+    throw new SyncAlreadyRunningError("tdcc");
+  }
+  if (!created) return result;
+
+  if (!(await holdTdccRunLock(env.DB, run.id, input.trigger, input.scope))) {
+    await failTdccSyncRun(
+      env,
+      run.id,
+      new SyncAlreadyRunningError("tdcc"),
+      true,
+    );
+    throw new SyncAlreadyRunningError("tdcc");
+  }
+
+  try {
+    if (input.trigger === "manual") {
+      await initializeTdccRun(env, run, config, settings.sync_cursor);
+    }
+  } catch (error) {
+    await failTdccSyncRun(env, run.id, error);
+    throw error;
+  }
+  return {
+    run: (await getTdccRun(env.DB, run.id)) ?? run,
+    created: true,
+  };
+}
+
+export async function processTdccSyncChunk(
+  env: Env,
+  runId: string,
+  chunkOwner: string = crypto.randomUUID(),
+): Promise<TdccChunkResult> {
+  let run = await getTdccRun(env.DB, runId);
+  if (!run || isTerminal(run)) return { status: "terminal" };
+  if (
+    !(await acquireTdccRunLease(env.DB, {
+      runId,
+      owner: chunkOwner,
+      leaseMs: TDCC_RUN_LEASE_MS,
+    }))
+  ) {
+    return { status: "busy", retryAfterSeconds: 5 };
+  }
+  try {
+    run = (await getTdccRun(env.DB, runId)) ?? run;
+    if (!(await holdTdccRunLock(env.DB, run.id, run.trigger, run.scope))) {
+      throw new SyncAlreadyRunningError("tdcc");
+    }
+    if (run.status === "queued" || run.phase === "initialize") {
+      const settings = await requireTdccSettings(env);
+      const config = await loadRunConfig(env, run);
+      await initializeTdccRun(env, run, config, settings.sync_cursor);
+      run = (await getTdccRun(env.DB, runId)) ?? run;
+    }
+
+    const claimToken = crypto.randomUUID();
+    const claimed = await claimTdccRunItems(env.DB, {
+      runId,
+      claimToken,
+      limit: TDCC_MAX_QUEUE_ITEMS_PER_CHUNK,
+      leaseMs: TDCC_RUN_LEASE_MS,
+    });
+    if (claimed.length > 0) {
+      try {
+        await processTdccRunItem(env, run, claimed[0]!, claimToken);
+      } catch (error) {
+        await releaseTdccRunItemForRetry(env.DB, {
+          runId,
+          itemId: claimed[0]!.id,
+          claimToken,
+          error: safeErrorMessage(error),
+        }).catch(() => undefined);
+        throw error;
+      }
+      run = (await getTdccRun(env.DB, runId)) ?? run;
+    }
+
+    if (run.pending_item_count > 0 || run.processing_item_count > 0) {
+      return { status: "continue" };
+    }
+    if (run.status !== "promoting" && !run.promoted_at) {
+      await promoteTdccRun(env, run);
+      run = (await getTdccRun(env.DB, runId)) ?? run;
+    }
+    const finalized = await finalizeTdccRunOutcome(env, run);
+    return finalized ? { status: "completed" } : { status: "terminal" };
+  } finally {
+    await releaseTdccRunLease(env.DB, {
+      runId,
+      owner: chunkOwner,
+    }).catch(() => undefined);
+  }
+}
+
+export async function failTdccSyncRun(
+  env: Env,
+  runId: string,
+  error: unknown,
+  forceFailed = false,
+) {
+  const run = await getTdccRun(env.DB, runId);
+  if (!run || isTerminal(run)) return false;
+  const status: Exclude<SyncNotificationStatus, "success"> =
+    !forceFailed && isUserActionError(error) ? "needs_user_action" : "failed";
+  const errorMessage = safeErrorMessage(error);
+  await finalizeTdccRun(env.DB, {
+    runId,
+    status,
+    error: errorMessage,
+  });
+  await clearTdccStaging(env, runId);
+  await finishTdccJob(env, run, status, errorMessage, emptyNewRecords());
+  return true;
+}
+
+export async function cancelQueuedTdccSyncRun(
+  env: Env,
+  runId: string,
+  error: unknown,
+) {
+  const run = await getTdccRun(env.DB, runId);
+  if (
+    !run ||
+    isTerminal(run) ||
+    !["queued", "initializing", "processing", "promoting"].includes(run.status)
+  )
+    return false;
+  return failTdccSyncRun(env, runId, error, true);
+}
+
+async function initializeTdccRun(
+  env: Env,
+  run: TdccRunRow,
+  config: TdccConfig,
+  persistedCursor: string | null,
+) {
+  if (run.status !== "queued" && run.phase !== "initialize") return;
+  const transitioned = await transitionTdccRun(env.DB, {
+    runId: run.id,
+    from: "queued",
+    to: "initializing",
+    phase: "initialize",
+  });
+  if (!transitioned && run.status === "queued") {
+    const current = await getTdccRun(env.DB, run.id);
+    if (current?.status !== "initializing") return;
+  }
+
+  const initialized = await initializeTdccSnapshot(
+    config,
+    persistedCursor ?? undefined,
+  );
+  const now = new Date().toISOString();
+  const cursor = JSON.stringify({
+    deviceId: initialized.identity.deviceId,
+    devType: initialized.identity.devType,
+    devModel: initialized.identity.devModel,
+    session: initialized.session,
+    tradeCursors: initialized.previous?.tradeCursors,
+  });
+  const records = snapshotRecords(env, run.scope, initialized, now);
+  await stageSyncWriteRecords(env.DB, run.id, records);
+  await createTdccPageItems(env, run, initialized, config.tradeHistoryMaxPages);
+  const session = JSON.parse(cursor) as TdccCursorState;
+  const phase = firstPendingPhase(run.scope, initialized);
+  await updateTdccRunState(env.DB, {
+    runId: run.id,
+    encryptedSession: await encryptJson(session, configEncryptionKey(env)),
+    phase,
+    status: "processing",
+  });
+}
+
+async function processTdccRunItem(
+  env: Env,
+  run: TdccRunRow,
+  item: TdccRunItemRow,
+  claimToken: string,
+) {
+  const config = await loadRunConfig(env, run);
+  const sessionState = await loadRunSession(env, run);
+  if (!sessionState?.session?.tokenId) {
+    throw new NeedsUserActionError("集保登入狀態已失效，請重新驗證。");
+  }
+  const cursor = JSON.stringify(sessionState);
+  const clientState = createTdccClient(
+    { ...config, session: sessionState.session },
+    cursor,
+  );
+  await ensureTdccSession(clientState.client, {
+    ...config,
+    session: sessionState.session,
+  });
+  const task = parseTask(item.task_json);
+  try {
+    if (item.task_type === "bank_page") {
+      await processBankPage(
+        env,
+        run,
+        item,
+        claimToken,
+        clientState,
+        task as BankPageTask,
+      );
+      return;
+    }
+    if (item.task_type === "trade_page") {
+      await processTradePage(
+        env,
+        run,
+        item,
+        claimToken,
+        clientState,
+        task as TradePageTask,
+        sessionState,
+      );
+      return;
+    }
+  } catch (error) {
+    if (
+      error instanceof EPassbookError &&
+      TDCC_SESSION_EXPIRED_CODES.has(error.code)
+    ) {
+      throw new NeedsUserActionError("集保登入狀態已失效，請重新驗證。");
+    }
+    throw error;
+  }
+  throw new Error(`Unsupported TDCC task type: ${item.task_type}`);
+}
+
+async function processBankPage(
+  env: Env,
+  run: TdccRunRow,
+  item: TdccRunItemRow,
+  claimToken: string,
+  clientState: ReturnType<typeof createTdccClient>,
+  task: BankPageTask,
+) {
+  if (item.page_number >= TDCC_MAX_BANK_PAGES) {
+    throw new Error(
+      `TDCC bank transaction pagination exceeded ${TDCC_MAX_BANK_PAGES} pages.`,
+    );
+  }
+  const page = await clientState.client.getBankTransactionsPage(
+    task.bankId,
+    task.accountNo,
+    task.currency,
+    item.page_cursor,
+  );
+  const payload = {
+    details: page.details,
+    pageToken: page.pageToken,
+    nextPageToken: page.nextPageToken,
+    totalCount: page.totalCount,
+    pageRecordCount: page.pageRecordCount,
+  };
+  if (page.nextPageToken) {
+    await assertTdccPageNotSeen(
+      env,
+      run.id,
+      "bank_page",
+      item.task_key,
+      page.nextPageToken,
+    );
+    await insertNextTdccRunItem(env.DB, run.id, {
+      taskType: "bank_page",
+      taskKey: item.task_key,
+      accountId: item.account_id,
+      pageCursor: page.nextPageToken,
+      pageNumber: item.page_number + 1,
+      task,
+    });
+  }
+  await markTdccRunItemSucceeded(env.DB, {
+    runId: run.id,
+    itemId: item.id,
+    claimToken,
+    payload,
+    nextPageCursor: page.nextPageToken ?? null,
+  });
+  await persistClientSession(env, run.id, clientState);
+}
+
+async function processTradePage(
+  env: Env,
+  run: TdccRunRow,
+  item: TdccRunItemRow,
+  claimToken: string,
+  clientState: ReturnType<typeof createTdccClient>,
+  task: TradePageTask,
+  sessionState: TdccCursorState,
+) {
+  const page = await clientState.client.getTradeDetailPage({
+    brokerNo: task.brokerNo,
+    brokerAccount: task.brokerAccount,
+    txnSerNo: task.txnSerNo,
+    updateType: task.updateType,
+  });
+  const transactions = parseTdccTradePageItems(page, task);
+  const now = new Date().toISOString();
+  await stageSyncWriteRecords(
+    env.DB,
+    run.id,
+    transactions.map((transaction) =>
+      investmentTransactionRecord("tdcc", transaction, now),
+    ),
+  );
+
+  const next = tradeTaskAfterPage(task, transactions, page.returnCode);
+  const cursorKey = `${task.brokerNo}:${task.brokerAccount}`;
+  const tradeCursors = { ...(sessionState.tradeCursors ?? {}) };
+  tradeCursors[cursorKey] = {
+    newest: next.newest,
+    oldest: next.oldest,
+    backfillComplete: next.backfillComplete,
+  };
+  const nextSession = {
+    ...sessionState,
+    session: clientState.client.exportSession(),
+    tradeCursors,
+  };
+  await updateTdccRunState(env.DB, {
+    runId: run.id,
+    encryptedSession: await encryptJson(nextSession, configEncryptionKey(env)),
+  });
+
+  const maxPages = task.maxPages;
+  const canContinue =
+    next.nextTxnSerNo &&
+    next.nextTxnSerNo !== (task.txnSerNo ?? "") &&
+    page.returnCode !== "D0002" &&
+    transactions.length > 0 &&
+    item.page_number + 1 < maxPages;
+  if (canContinue) {
+    await assertTdccPageNotSeen(
+      env,
+      run.id,
+      "trade_page",
+      item.task_key,
+      next.nextTxnSerNo,
+    );
+    await insertNextTdccRunItem(env.DB, run.id, {
+      taskType: "trade_page",
+      taskKey: item.task_key,
+      accountId: item.account_id,
+      pageCursor: next.nextTxnSerNo,
+      pageNumber: item.page_number + 1,
+      task: {
+        ...task,
+        txnSerNo: next.nextTxnSerNo,
+        newest: next.newest,
+        oldest: next.oldest,
+        backfillComplete: next.backfillComplete,
+      },
+    });
+  }
+  await markTdccRunItemSucceeded(env.DB, {
+    runId: run.id,
+    itemId: item.id,
+    claimToken,
+    payload: { returnCode: page.returnCode, itemCount: transactions.length },
+    nextPageCursor: canContinue ? next.nextTxnSerNo : null,
+  });
+}
+
+async function promoteTdccRun(env: Env, run: TdccRunRow) {
+  if (run.pending_item_count > 0 || run.processing_item_count > 0) {
+    throw new Error("TDCC run is not ready for promotion.");
+  }
+  const settings = await requireTdccSettings(env);
+  if (run.settings_version && settings.updated_at !== run.settings_version) {
+    throw new NeedsUserActionError(
+      "集保設定已在同步期間更新，請重新啟動同步。",
+    );
+  }
+  const config = await loadRunConfig(env, run);
+  const session = await loadRunSession(env, run);
+  if (!session)
+    throw new NeedsUserActionError("集保登入狀態已失效，請重新驗證。");
+  const now = new Date().toISOString();
+  const bankTransactions = await bankTransactionsFromRun(env, run);
+  await stageSyncWriteRecords(
+    env.DB,
+    run.id,
+    bankTransactions.map((transaction) =>
+      bankTransactionRecord("tdcc", transaction, now),
+    ),
+  );
+
+  const cursor = JSON.stringify(session);
+  const cursorState = splitConnectorCursorState("tdcc", cursor);
+  const {
+    otp: _otp,
+    otpChannel: _otpChannel,
+    requestOtp: _requestOtp,
+    ...reusableConfig
+  } = config;
+  const encryptedConfig = await encryptJson(
+    {
+      ...reusableConfig,
+      ...cursorState.secretState,
+    },
+    configEncryptionKey(env),
+  );
+  const job = await findSyncJob(env.DB, "tdcc", "all");
+  const finalizeStatements: D1PreparedStatement[] = [
+    connectorStateStatement(
+      env.DB,
+      "tdcc",
+      encryptedConfig,
+      serializePublicConnectorConfig("tdcc", reusableConfig),
+      cursorState.safeCursor,
+      now,
+    ),
+  ];
+  if (job) {
+    const nextRunAt = nextSyncRunAt(
+      job.interval_minutes,
+      job.preferred_time,
+      new Date(now),
+      job.next_run_at,
+      job.preferred_weekday,
+    );
+    finalizeStatements.push(
+      env.DB.prepare(
+        `UPDATE sync_jobs
+           SET last_status = 'success', last_error = NULL,
+               last_run_at = ?, last_success_at = ?, next_run_at = ?,
+               locked_by = NULL, locked_until = NULL,
+               lock_trigger = NULL, lock_scope = NULL, updated_at = ?
+           WHERE id = ? AND locked_by = ?`,
+      ).bind(now, now, nextRunAt, now, job.id, run.id),
+    );
+  }
+  const entityTypes = entityTypesForScope(run.scope);
+  const newRecords = await promoteStagedSyncWrite(env.DB, {
+    runId: run.id,
+    entityTypes,
+    afterPromoteStatements: includesBank(run.scope)
+      ? [linkCanonicalBankAccountsStatement(env.DB)]
+      : [],
+    finalizeStatements,
+  });
+  if (includesBank(run.scope)) {
+    await rebuildBankDepositHistory(env.DB, [dateFromIso(now)]);
+  }
+  await updateTdccRunState(env.DB, {
+    runId: run.id,
+    encryptedConfig: null,
+    encryptedSession: null,
+    phase: "promote",
+    status: "promoting",
+  });
+  await finishTdccJobAfterPromotion(env, run, newRecords);
+}
+
+async function finalizeTdccRunOutcome(env: Env, run: TdccRunRow) {
+  return finalizeTdccRun(env.DB, {
+    runId: run.id,
+    status: "completed",
+    phase: "promote",
+    promotedAt: run.promoted_at ?? new Date().toISOString(),
+  });
+}
+
+async function finishTdccJobAfterPromotion(
+  env: Env,
+  run: TdccRunRow,
+  newRecords: SyncNewRecordCounts,
+) {
+  if (run.trigger === "manual" && run.scope === "all") {
+    await recoverLatestScheduledSyncSource(env.DB, {
+      connectorId: "tdcc",
+      newRecords,
+    }).catch((error) =>
+      console.error("[sync] failed to recover latest TDCC report", error),
+    );
+  }
+  if (run.scheduled_batch_id) {
+    const job = await findSyncJob(env.DB, "tdcc", "all");
+    if (job) {
+      await env.DB.prepare(
+        `UPDATE scheduled_sync_batch_results
+           SET connector_id = 'tdcc', status = 'success', completed_at = ?,
+               new_invoices = 0, new_bank_transactions = ?,
+               new_investment_transactions = ?
+           WHERE batch_id = ? AND job_id = ? AND completed_at IS NULL`,
+      )
+        .bind(
+          new Date().toISOString(),
+          newRecords.bankTransactions,
+          newRecords.investmentTransactions,
+          run.scheduled_batch_id,
+          job.id,
+        )
+        .run();
+    }
+    const summary = await claimCompletedDefaultScheduleBatch(
+      env.DB,
+      run.scheduled_batch_id,
+    );
+    if (summary) await safelySendScheduledSyncSummary(env, summary);
+  } else if (run.trigger === "scheduled") {
+    await safelySendSyncNotification(env, {
+      connectorId: "tdcc",
+      status: "success",
+    });
+  }
+}
+
+async function finishTdccJob(
+  env: Env,
+  run: TdccRunRow,
+  status: Exclude<SyncNotificationStatus, "success">,
+  error: string,
+  newRecords: SyncNewRecordCounts,
+) {
+  const job = await findSyncJob(env.DB, "tdcc", "all");
+  if (job) {
+    const now = new Date().toISOString();
+    const nextRunAt =
+      status === "failed"
+        ? nextSyncRunAt(
+            job.interval_minutes,
+            job.preferred_time,
+            new Date(now),
+            job.next_run_at,
+            job.preferred_weekday,
+          )
+        : job.next_run_at;
+    await env.DB.prepare(
+      `UPDATE sync_jobs
+         SET last_status = ?, last_error = ?, last_run_at = ?, next_run_at = ?,
+             locked_by = NULL, locked_until = NULL,
+             lock_trigger = NULL, lock_scope = NULL, updated_at = ?
+         WHERE id = ? AND locked_by = ?`,
+    )
+      .bind(status, error, now, nextRunAt, now, job.id, run.id)
+      .run();
+    if (run.scheduled_batch_id) {
+      await env.DB.prepare(
+        `UPDATE scheduled_sync_batch_results
+           SET connector_id = 'tdcc', status = ?, completed_at = ?,
+               new_invoices = 0, new_bank_transactions = ?,
+               new_investment_transactions = ?
+           WHERE batch_id = ? AND job_id = ? AND completed_at IS NULL`,
+      )
+        .bind(
+          status,
+          now,
+          newRecords.bankTransactions,
+          newRecords.investmentTransactions,
+          run.scheduled_batch_id,
+          job.id,
+        )
+        .run();
+    }
+  }
+  if (run.scheduled_batch_id) {
+    const summary = await claimCompletedDefaultScheduleBatch(
+      env.DB,
+      run.scheduled_batch_id,
+    );
+    if (summary) await safelySendScheduledSyncSummary(env, summary);
+  } else if (run.trigger === "scheduled") {
+    await safelySendSyncNotification(env, { connectorId: "tdcc", status });
+  }
+}
+
+async function requireTdccSettings(env: Env) {
+  const settings = await getConnectorSettings(env.DB, "tdcc");
+  if (!settings) throw new NeedsUserActionError("請先儲存集保 e 存摺設定。");
+  return settings;
+}
+
+async function loadRunConfig(env: Env, run: TdccRunRow) {
+  if (!run.encrypted_config) {
+    throw new NeedsUserActionError("集保同步設定已遺失，請重新啟動同步。");
+  }
+  return parseTdccConfig(
+    await decryptJson<Record<string, unknown>>(
+      run.encrypted_config,
+      configEncryptionKey(env),
+    ),
+  );
+}
+
+async function loadRunSession(env: Env, run: TdccRunRow) {
+  if (run.encrypted_session) {
+    return decryptJson<TdccCursorState>(
+      run.encrypted_session,
+      configEncryptionKey(env),
+    );
+  }
+  if (!run.session_json) return null;
+  return JSON.parse(run.session_json) as TdccCursorState;
+}
+
+async function persistClientSession(
+  env: Env,
+  runId: string,
+  state: ReturnType<typeof createTdccClient>,
+) {
+  const sessionState: TdccCursorState = {
+    ...state.identity,
+    session: state.client.exportSession(),
+    tradeCursors: state.previous?.tradeCursors,
+  };
+  await updateTdccRunState(env.DB, {
+    runId,
+    encryptedSession: await encryptJson(sessionState, configEncryptionKey(env)),
+  });
+}
+
+async function bankTransactionsFromRun(env: Env, run: TdccRunRow) {
+  const items = await listCompletedItems(env, run.id, "bank_page");
+  const transactions = [] as Array<{
+    accountId: string;
+    sourceId: string;
+    postedDate?: string;
+    amount: number;
+    currency: string;
+    description?: string;
+    raw: unknown;
+  }>;
+  const detailsByAccount = new Map<
+    string,
+    { task: BankPageTask; details: BankTransactionDetail[] }
+  >();
+  for (const item of items) {
+    const payload = parseJson<{ details?: BankTransactionDetail[] }>(
+      item.payload_json,
+    );
+    const task = parseTask(item.task_json) as BankPageTask;
+    const accountId = `settlement:${task.bankId}:${task.accountNo}:${task.currency}`;
+    const current = detailsByAccount.get(accountId) ?? { task, details: [] };
+    current.details.push(...(payload.details ?? []));
+    detailsByAccount.set(accountId, current);
+  }
+  for (const { task, details } of detailsByAccount.values()) {
+    const normalized = normalizeBankTransactionDetails(details);
+    const accountId = `settlement:${task.bankId}:${task.accountNo}:${task.currency}`;
+    for (const transaction of normalized) {
+      const amount = Number(transaction.amount);
+      transactions.push({
+        accountId,
+        sourceId: transaction.txnId,
+        postedDate: transaction.occurredAt,
+        amount: Number.isFinite(amount) ? amount : 0,
+        currency: task.currency,
+        ...(transaction.memo ? { description: transaction.memo } : {}),
+        raw: transaction,
+      });
+    }
+  }
+  return transactions;
+}
+
+async function listCompletedItems(env: Env, runId: string, taskType: string) {
+  return (
+    await env.DB.prepare(
+      `SELECT * FROM tdcc_sync_run_items
+         WHERE run_id = ? AND task_type = ? AND status = 'done'`,
+    )
+      .bind(runId, taskType)
+      .all<TdccRunItemRow>()
+  ).results;
+}
+
+async function assertTdccPageNotSeen(
+  env: Env,
+  runId: string,
+  taskType: string,
+  taskKey: string,
+  pageCursor: string,
+) {
+  const existing = await env.DB.prepare(
+    `SELECT status FROM tdcc_sync_run_items
+       WHERE run_id = ? AND task_type = ? AND task_key = ? AND page_cursor = ?`,
+  )
+    .bind(runId, taskType, taskKey, pageCursor)
+    .first<{ status: string }>();
+  if (existing?.status === "done") {
+    throw new Error("TDCC pagination returned a repeated page cursor.");
+  }
+}
+
+function snapshotRecords(
+  _env: Env,
+  scope: TdccRunScope,
+  initialized: TdccSnapshotInitialization,
+  now: string,
+) {
+  const snapshot = initialized.snapshot ?? normalizeTdccSnapshot(initialized);
+  return [
+    ...(includesBank(scope)
+      ? snapshot.bankAccounts.map((record) =>
+          bankAccountRecord("tdcc", record, now),
+        )
+      : []),
+    ...(includesBank(scope)
+      ? snapshot.bankBalanceSnapshots.map((record) =>
+          bankBalanceSnapshotRecord("tdcc", record, now),
+        )
+      : []),
+    ...(includesInvestments(scope)
+      ? snapshot.investmentPositions.map((record) =>
+          investmentPositionRecord("tdcc", record, now),
+        )
+      : []),
+    ...(scope !== "trades"
+      ? snapshot.netWorthHistory.map((record) =>
+          netWorthHistoryRecord("tdcc", record, now),
+        )
+      : []),
+  ];
+}
+
+async function createTdccPageItems(
+  env: Env,
+  run: TdccRunRow,
+  initialized: TdccSnapshotInitialization,
+  tradeHistoryMaxPages: number,
+) {
+  const previous = initialized.previous;
+  if (includesBank(run.scope)) {
+    for (const entry of initialized.bankEntries) {
+      const taskKey = `${entry.bankId}:${entry.accountNo}:${entry.currency}`;
+      await insertNextTdccRunItem(env.DB, run.id, {
+        taskType: "bank_page",
+        taskKey,
+        accountId: taskKey,
+        pageCursor: "",
+        pageNumber: 0,
+        task: {
+          bankId: entry.bankId,
+          accountNo: entry.accountNo,
+          currency: entry.currency,
+        } satisfies BankPageTask,
+      });
+    }
+  }
+  if (includesTrades(run.scope)) {
+    for (const account of initialized.stockAccounts) {
+      const cursorKey = `${account.brokerNo}:${account.brokerAccount}`;
+      const saved = previous?.tradeCursors?.[cursorKey] ?? {};
+      const updateType: "B" | "F" = saved.backfillComplete ? "F" : "B";
+      const txnSerNo =
+        updateType === "F" ? (saved.newest ?? "") : (saved.oldest ?? "");
+      await insertNextTdccRunItem(env.DB, run.id, {
+        taskType: "trade_page",
+        taskKey: cursorKey,
+        accountId: cursorKey,
+        pageCursor: txnSerNo,
+        pageNumber: 0,
+        task: {
+          brokerNo: account.brokerNo,
+          brokerAccount: account.brokerAccount,
+          brokerName: account.brokerName,
+          updateType,
+          txnSerNo,
+          newest: saved.newest,
+          oldest: saved.oldest,
+          backfillComplete: saved.backfillComplete,
+          maxPages: tradeHistoryMaxPages,
+        } satisfies TradePageTask,
+      });
+    }
+  }
+}
+
+function tradeTaskAfterPage(
+  task: TradePageTask,
+  transactions: ReturnType<typeof parseTdccTradePageItems>,
+  returnCode: string,
+) {
+  let newest = task.newest;
+  let oldest = task.oldest;
+  let backfillComplete = task.backfillComplete ?? false;
+  if (transactions.length > 0) {
+    newest = newest ?? transactions[0]?.sourceId;
+    oldest = transactions.at(-1)?.sourceId ?? oldest;
+  } else if (task.updateType === "B" || returnCode === "D0002") {
+    backfillComplete = task.updateType === "B" ? true : backfillComplete;
+  }
+  return {
+    newest,
+    oldest,
+    backfillComplete,
+    nextTxnSerNo: task.updateType === "F" ? (newest ?? "") : (oldest ?? ""),
+  };
+}
+
+function firstPendingPhase(
+  scope: TdccRunScope,
+  initialized: TdccSnapshotInitialization,
+) {
+  if (includesBank(scope) && initialized.bankEntries.length > 0)
+    return "bank" as const;
+  if (includesTrades(scope) && initialized.stockAccounts.length > 0)
+    return "trades" as const;
+  return "promote" as const;
+}
+
+function entityTypesForScope(scope: TdccRunScope) {
+  return [
+    ...(includesBank(scope)
+      ? (["bank_account", "bank_balance_snapshot", "bank_transaction"] as const)
+      : []),
+    ...(includesInvestments(scope) ? (["investment_position"] as const) : []),
+    ...(includesTrades(scope) ? (["investment_transaction"] as const) : []),
+    ...(scope !== "trades" ? (["net_worth_history"] as const) : []),
+  ];
+}
+
+function includesBank(scope: TdccRunScope) {
+  return scope === "all" || scope === "bank";
+}
+
+function includesInvestments(scope: TdccRunScope) {
+  return scope === "all" || scope === "investments";
+}
+
+function includesTrades(scope: TdccRunScope) {
+  return scope === "all" || scope === "trades";
+}
+
+function parseTask(value: string) {
+  return JSON.parse(value) as BankPageTask | TradePageTask;
+}
+
+function parseJson<T>(value: string | null): T {
+  return value ? (JSON.parse(value) as T) : ({} as T);
+}
+
+function emptyNewRecords(): SyncNewRecordCounts {
+  return { invoices: 0, bankTransactions: 0, investmentTransactions: 0 };
+}
+
+async function clearTdccStaging(env: Env, runId: string) {
+  await env.DB.prepare("DELETE FROM sync_write_staging WHERE run_id = ?")
+    .bind(runId)
+    .run()
+    .catch(() => undefined);
+}
+
+async function holdTdccRunLock(
+  db: D1Database,
+  runId: string,
+  trigger: TdccRunTrigger,
+  scope: TdccRunScope,
+) {
+  const now = new Date();
+  const result = await db
+    .prepare(
+      `UPDATE sync_jobs
+       SET locked_by = ?, locked_until = ?, lock_trigger = ?, lock_scope = ?,
+           updated_at = ?
+       WHERE id = ?
+         AND (locked_until IS NULL OR locked_until < ? OR locked_by = ?)`,
+    )
+    .bind(
+      runId,
+      new Date(now.getTime() + SYNC_LOCK_LEASE_MS).toISOString(),
+      trigger,
+      scope,
+      now.toISOString(),
+      TDCC_JOB_ID,
+      now.toISOString(),
+      runId,
+    )
+    .run();
+  return result.meta.changes === 1;
+}
+
+function requireTdccCredentials(config: {
+  userId?: string;
+  password?: string;
+}) {
+  if (!config.userId || !config.password) {
+    throw new NeedsUserActionError(
+      "請重新輸入身分證字號與集保 App 密碼，再開始連線。",
+    );
+  }
+}
+
+function isTerminal(run: TdccRunRow) {
+  return ["completed", "failed", "needs_user_action"].includes(run.status);
+}
+
+type BankPageTask = {
+  bankId: string;
+  accountNo: string;
+  currency: string;
+};
+
+type TradePageTask = TdccStockAccount & {
+  updateType: "B" | "F";
+  txnSerNo?: string;
+  newest?: string;
+  oldest?: string;
+  backfillComplete?: boolean;
+  maxPages: number;
+};

--- a/apps/worker/src/platform/env.ts
+++ b/apps/worker/src/platform/env.ts
@@ -2,7 +2,8 @@ import type { ConnectorId } from "@taiwan-fin-hub/core";
 
 export type ScheduledSyncQueueMessage =
   | { type: "run-next-scheduled-sync" }
-  | { type: "run-einvoice-chunk"; runId: string };
+  | { type: "run-einvoice-chunk"; runId: string }
+  | { type: "run-tdcc-chunk"; runId: string };
 
 export interface Env {
   DB: D1Database;

--- a/apps/worker/tests/features/sync/tdcc-run-repository.test.ts
+++ b/apps/worker/tests/features/sync/tdcc-run-repository.test.ts
@@ -1,0 +1,369 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  acquireTdccRunLease,
+  claimTdccRunItems,
+  createOrGetActiveTdccRun,
+  finalizeTdccRun,
+  getActiveTdccRun,
+  getTdccRun,
+  insertNextTdccRunItem,
+  markTdccRunItemSucceeded,
+  releaseTdccRunItemForRetry,
+  releaseTdccRunLease,
+  renewTdccRunLease,
+  transitionTdccRun,
+  updateTdccRunItem,
+  updateTdccRunState,
+  upsertTdccRunItem,
+} from "../../../src/features/sync/tdcc-run-repository";
+
+class SqliteStatement {
+  private values: unknown[] = [];
+
+  constructor(
+    private readonly database: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: unknown[]) {
+    this.values = values;
+    return this;
+  }
+
+  async run() {
+    const result = this.database
+      .prepare(this.sql)
+      .run(...(this.values as never[]));
+    return {
+      success: true,
+      meta: { changes: Number(result.changes) },
+      results: [],
+    };
+  }
+
+  async first<T>() {
+    return (
+      (this.database.prepare(this.sql).get(...(this.values as never[])) as T) ??
+      null
+    );
+  }
+
+  async all<T>() {
+    return {
+      success: true,
+      meta: {},
+      results: this.database
+        .prepare(this.sql)
+        .all(...(this.values as never[])) as T[],
+    };
+  }
+}
+
+const databases: DatabaseSync[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+function createDb() {
+  const database = new DatabaseSync(":memory:");
+  database.exec("PRAGMA foreign_keys = ON");
+  const migrationsDirectory = fileURLToPath(
+    new URL("../../../../../packages/db/migrations/", import.meta.url),
+  );
+  for (const file of readdirSync(migrationsDirectory)
+    .filter((name) => name.endsWith(".sql"))
+    .sort()) {
+    database.exec(readFileSync(`${migrationsDirectory}/${file}`, "utf8"));
+  }
+  databases.push(database);
+  const db = {
+    prepare(sql: string) {
+      return new SqliteStatement(database, sql);
+    },
+    async batch(statements: D1PreparedStatement[]) {
+      database.exec("BEGIN");
+      try {
+        const results = [];
+        for (const statement of statements) {
+          results.push(await (statement as unknown as SqliteStatement).run());
+        }
+        database.exec("COMMIT");
+        return results;
+      } catch (error) {
+        database.exec("ROLLBACK");
+        throw error;
+      }
+    },
+  } as unknown as D1Database;
+  return { database, db };
+}
+
+describe("durable TDCC sync runs", () => {
+  it("keeps one active run across partial scopes", async () => {
+    const { db } = createDb();
+    const first = await createOrGetActiveTdccRun(db, {
+      id: "run-1",
+      trigger: "manual",
+      scope: "bank",
+      now: "2026-08-23T00:00:00.000Z",
+    });
+    const second = await createOrGetActiveTdccRun(db, {
+      id: "run-2",
+      trigger: "scheduled",
+      scope: "all",
+      now: "2026-08-23T00:01:00.000Z",
+    });
+
+    expect(first).toMatchObject({
+      created: true,
+      run: { id: "run-1", scope: "bank", sync_job_id: null },
+    });
+    expect(second).toMatchObject({
+      created: false,
+      run: { id: "run-1", trigger: "manual" },
+    });
+    expect(await getActiveTdccRun(db)).toMatchObject({ id: "run-1" });
+  });
+
+  it("pins encrypted state and transitions with compare-and-set", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveTdccRun(db, {
+      id: "run-1",
+      trigger: "manual",
+      settingsVersion: "v1",
+      encryptedConfig: "config-v1",
+      encryptedSession: "session-v1",
+      session: { cookie: "redacted" },
+    });
+    expect(
+      await updateTdccRunState(db, {
+        runId: run.id,
+        settingsVersion: "v2",
+        encryptedSession: "session-v2",
+        phase: "bank",
+        status: "processing",
+        now: "2026-08-23T00:02:00.000Z",
+      }),
+    ).toBe(true);
+    expect(await getTdccRun(db, run.id)).toMatchObject({
+      settings_version: "v2",
+      encrypted_config: "config-v1",
+      encrypted_session: "session-v2",
+      phase: "bank",
+      status: "processing",
+      session_json: null,
+    });
+    expect(
+      await transitionTdccRun(db, {
+        runId: run.id,
+        from: "queued",
+        to: "processing",
+      }),
+    ).toBe(false);
+    expect(
+      await transitionTdccRun(db, {
+        runId: run.id,
+        from: "processing",
+        to: "promoting",
+        phase: "promote",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows only the current owner to renew or release a run lease", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveTdccRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    const startedAt = new Date("2026-08-23T00:00:00.000Z");
+    await expect(
+      acquireTdccRunLease(db, {
+        runId: run.id,
+        owner: "consumer-a",
+        leaseMs: 60_000,
+        now: startedAt,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      renewTdccRunLease(db, {
+        runId: run.id,
+        owner: "consumer-b",
+        leaseMs: 60_000,
+        now: startedAt,
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      releaseTdccRunLease(db, { runId: run.id, owner: "consumer-b" }),
+    ).resolves.toBe(false);
+    await expect(
+      acquireTdccRunLease(db, {
+        runId: run.id,
+        owner: "consumer-b",
+        leaseMs: 60_000,
+        now: new Date("2026-08-23T00:01:01.000Z"),
+      }),
+    ).resolves.toBe(true);
+    expect(await getTdccRun(db, run.id)).toMatchObject({
+      lease_owner: "consumer-b",
+      lease_expires_at: "2026-08-23T00:02:01.000Z",
+    });
+  });
+
+  it("claims pages, preserves retries, and rejects stale completion", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveTdccRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    const item = await upsertTdccRunItem(db, run.id, {
+      taskType: "bank_transactions",
+      taskKey: "bank-1",
+      accountId: "bank-1",
+      task: { accountId: "bank-1" },
+      pageCursor: "first",
+      now: "2026-08-23T00:00:00.000Z",
+    });
+    const claimed = await claimTdccRunItems(db, {
+      runId: run.id,
+      claimToken: "claim-a",
+      leaseMs: 60_000,
+      now: new Date("2026-08-23T00:01:00.000Z"),
+    });
+    expect(claimed).toHaveLength(1);
+    expect(claimed[0]).toMatchObject({
+      id: item.id,
+      status: "processing",
+      attempt_count: 1,
+      lease_token: "claim-a",
+    });
+    await expect(
+      releaseTdccRunItemForRetry(db, {
+        runId: run.id,
+        itemId: item.id,
+        claimToken: "wrong-claim",
+        error: "transient",
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      releaseTdccRunItemForRetry(db, {
+        runId: run.id,
+        itemId: item.id,
+        claimToken: "claim-a",
+        error: "transient",
+      }),
+    ).resolves.toBe(true);
+    const reclaimed = await claimTdccRunItems(db, {
+      runId: run.id,
+      claimToken: "claim-b",
+      leaseMs: 60_000,
+      now: new Date("2026-08-23T00:02:00.000Z"),
+    });
+    expect(reclaimed[0]).toMatchObject({ attempt_count: 2 });
+    await expect(
+      markTdccRunItemSucceeded(db, {
+        runId: run.id,
+        itemId: item.id,
+        claimToken: "claim-a",
+        payload: [{ sourceId: "stale" }],
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      markTdccRunItemSucceeded(db, {
+        runId: run.id,
+        itemId: item.id,
+        claimToken: "claim-b",
+        payload: [{ sourceId: "bank-tx-1" }],
+        nextPageCursor: null,
+      }),
+    ).resolves.toBe(true);
+    expect(await getTdccRun(db, run.id)).toMatchObject({
+      total_item_count: 1,
+      done_item_count: 1,
+      pending_item_count: 0,
+    });
+  });
+
+  it("upserts the next page and only completes after every item is done", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveTdccRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    await insertNextTdccRunItem(db, run.id, {
+      taskType: "trades",
+      taskKey: "broker-1",
+      pageCursor: "cursor-2",
+      pageNumber: 2,
+      task: { broker: "broker-1" },
+    });
+    expect(
+      await finalizeTdccRun(db, {
+        runId: run.id,
+        status: "completed",
+        now: "2026-08-23T00:03:00.000Z",
+      }),
+    ).toBe(false);
+    const claimed = await claimTdccRunItems(db, {
+      runId: run.id,
+      claimToken: "claim-a",
+      leaseMs: 60_000,
+      now: new Date("2026-08-23T00:03:30.000Z"),
+    });
+    await markTdccRunItemSucceeded(db, {
+      runId: run.id,
+      itemId: claimed[0]!.id,
+      claimToken: "claim-a",
+      payload: { rows: [] },
+      now: "2026-08-23T00:04:00.000Z",
+    });
+    expect(
+      await finalizeTdccRun(db, {
+        runId: run.id,
+        status: "completed",
+        phase: "promote",
+        promotedAt: "2026-08-23T00:04:30.000Z",
+        now: "2026-08-23T00:04:30.000Z",
+      }),
+    ).toBe(true);
+    expect(await getTdccRun(db, run.id)).toMatchObject({
+      status: "completed",
+      phase: "promote",
+      promoted_at: "2026-08-23T00:04:30.000Z",
+      completed_at: "2026-08-23T00:04:30.000Z",
+    });
+  });
+
+  it("updates a claimed item through the generic item API", async () => {
+    const { db } = createDb();
+    const { run } = await createOrGetActiveTdccRun(db, {
+      id: "run-1",
+      trigger: "manual",
+    });
+    const item = await upsertTdccRunItem(db, run.id, {
+      taskType: "positions",
+      taskKey: "account-1",
+    });
+    const [claimed] = await claimTdccRunItems(db, {
+      runId: run.id,
+      claimToken: "claim-a",
+      leaseMs: 60_000,
+    });
+    expect(
+      await updateTdccRunItem(db, {
+        runId: run.id,
+        itemId: item.id,
+        claimToken: "claim-a",
+        payload: { quantity: 1 },
+        status: "done",
+        completedAt: "2026-08-23T00:05:00.000Z",
+      }),
+    ).toBe(true);
+    expect(claimed?.id).toBe(item.id);
+    expect(await getTdccRun(db, run.id)).toMatchObject({ done_item_count: 1 });
+  });
+});

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -25,6 +25,17 @@ export {
   createTdccConnector,
   tdccConfigSchema,
   parseTdccConfig,
+  parseTdccCursor,
+  createTdccClient,
+  ensureTdccSession,
+  initializeTdccSnapshot,
+  normalizeTdccSnapshot,
+  stockAccountsFromPayload,
+  parseTdccStockAccounts,
+  parseTdccStockHoldings,
+  parseTdccFundHoldings,
+  toInvestmentTransaction,
+  parseTdccTradePageItems,
   syncTdccTradeHistory,
   TdccConnectionError,
   TdccOtpExpiredError,
@@ -36,7 +47,27 @@ export type {
   TdccCashBalance,
   TdccCashMovement,
   TdccClient,
+  TdccCursorState,
+  TdccTradeCursor,
+  TdccIdentity,
+  TdccStockAccount,
+  TdccBankEntry,
+  TdccSnapshotInitialization,
+  TdccSnapshotRecords,
 } from "./tdcc";
+export {
+  EPassbookClient,
+  EPassbookError,
+  normalizeBankTransactionDetails,
+} from "./tdcc-epassbook-client";
+export type {
+  EPassbookClientOptions,
+  EPassbookSession,
+  BankTransaction,
+  BankTransactionDetail,
+  BankTransactionPage,
+  TradeDetailPage,
+} from "./tdcc-epassbook-client";
 import { tdccConfigSchema } from "./tdcc";
 
 export { esunConfigSchema, parseEsunConfig } from "./esun";

--- a/packages/connectors/src/tdcc-epassbook-client.ts
+++ b/packages/connectors/src/tdcc-epassbook-client.ts
@@ -1,6 +1,6 @@
 // Ported from the TDCC ePassbook Android app's mobile API (reverse-engineered).
-// Trimmed to login/OTP + stock & fund holdings — bank balances, trade detail
-// drill-down, and asset trend charts are out of scope per docs/002-tdcc-connector.md.
+// Trimmed to the ePassbook login/OTP and snapshot/page APIs used by the
+// connector. Durable callers own pagination and promotion of staged pages.
 const BASE_URL = "https://epassbooksys.tdcc.com.tw/MPSBKV2/rest/";
 const APP_INFO = "tw.com.tdcc.epassbook:3.3.4";
 const API_VER = "20250220";
@@ -10,13 +10,53 @@ const MAX_BANK_TRANSACTION_PAGES = 1_000;
 const AES_IV = new TextEncoder().encode("0000000000000000");
 const encoder = new TextEncoder();
 
-type BankTransactionDetail = {
+export type BankTransactionDetail = {
   stan?: string;
   txnDateTime?: string;
   transferInAmount?: string;
   transferOutAmount?: string;
   summary?: string;
   memo?: string;
+};
+
+/** A normalized transaction returned by the TSP007 bank transaction API. */
+export type BankTransaction = {
+  txnId: string;
+  occurredAt: string;
+  amount: string;
+  memo?: string;
+};
+
+/**
+ * One TSP007 page. `pageToken` is the token used for this request (the first
+ * page uses an empty string); `nextPageToken` is omitted when the API reports
+ * that there are no more pages.
+ *
+ * `details` is intentionally kept alongside the normalized transactions. A
+ * durable Queue consumer can persist the raw page and re-run normalization at
+ * finalization, which preserves duplicate-STAN handling across page boundaries.
+ */
+export type BankTransactionPage = {
+  pageToken: string;
+  nextPageToken?: string;
+  totalCount?: number;
+  pageRecordCount: number;
+  details: BankTransactionDetail[];
+  transactions: BankTransaction[];
+};
+
+export type TradeDetailPage = {
+  brokerNo?: string;
+  brokerAccount?: string;
+  exchangeRates?: Record<string, unknown>;
+  items: unknown[];
+  lastServerTime?: string;
+  /** Canonical response code; `D0002` means no more records. */
+  returnCode: string;
+  returnMsg?: string;
+  /** Kept for backwards compatibility with the existing full-sync caller. */
+  _returnCode?: string;
+  _returnMsg?: string;
 };
 
 export class EPassbookError extends Error {
@@ -33,7 +73,7 @@ export type EPassbookSession = {
   richUrl: string | null;
 };
 
-type EPassbookClientOptions = {
+export type EPassbookClientOptions = {
   devId: string;
   devType: string;
   devModel: string;
@@ -320,12 +360,7 @@ export class EPassbookClient {
     acctNo: string,
     currency: string,
   ): Promise<{
-    transactions: Array<{
-      txnId: string;
-      occurredAt: string;
-      amount: string;
-      memo?: string;
-    }>;
+    transactions: BankTransaction[];
   }> {
     const details: BankTransactionDetail[] = [];
     const seenPageTokens = new Set<string>();
@@ -339,28 +374,23 @@ export class EPassbookClient {
           `TSP007 exceeded ${MAX_BANK_TRANSACTION_PAGES} pages.`,
         );
       }
+      if (seenPageTokens.has(pageToken)) {
+        throw new EPassbookError(
+          "PAGINATION_LOOP",
+          "TSP007 returned a repeated page token.",
+        );
+      }
       seenPageTokens.add(pageToken);
 
-      const raw = await this.post<{
-        transactionDetails?: BankTransactionDetail[];
-        pageToken?: string | null;
-        totalCount?: number | string;
-      }>("tsp/TSP007", {
-        bankId: bankNo,
-        accountNo: acctNo,
+      const pageResult = await this.getBankTransactionsPage(
+        bankNo,
+        acctNo,
         currency,
-        limitsInPage: BANK_TRANSACTION_PAGE_SIZE,
         pageToken,
-      });
-
-      const pageDetails = raw.transactionDetails ?? [];
-      details.push(...pageDetails);
-      const parsedTotal =
-        typeof raw.totalCount === "number" || typeof raw.totalCount === "string"
-          ? Number(raw.totalCount)
-          : Number.NaN;
-      if (Number.isFinite(parsedTotal) && parsedTotal >= 0)
-        expectedTotal = parsedTotal;
+      );
+      details.push(...pageResult.details);
+      if (pageResult.totalCount !== undefined)
+        expectedTotal = pageResult.totalCount;
 
       console.log(
         JSON.stringify({
@@ -369,15 +399,14 @@ export class EPassbookClient {
           account: maskAccountNumber(acctNo),
           currency,
           page,
-          records: pageDetails.length,
+          records: pageResult.pageRecordCount,
           totalCount: expectedTotal ?? null,
         }),
       );
 
       if (expectedTotal !== undefined && details.length >= expectedTotal) break;
 
-      const nextPageToken =
-        typeof raw.pageToken === "string" ? raw.pageToken : "";
+      const nextPageToken = pageResult.nextPageToken ?? "";
       if (!nextPageToken) {
         if (expectedTotal !== undefined && details.length < expectedTotal) {
           throw new EPassbookError(
@@ -396,47 +425,71 @@ export class EPassbookClient {
       pageToken = nextPageToken;
     }
 
-    // ponytail: some banks reuse the same stan for recurring/batch entries (e.g. interest).
-    // Count occurrences so duplicates get a compound key that includes date+amounts.
-    const stanCount = new Map<string, number>();
-    for (const d of details) {
-      if (d.stan) stanCount.set(d.stan, (stanCount.get(d.stan) ?? 0) + 1);
-    }
-
-    const transactions = details.map((d) => {
-      const dt = d.txnDateTime ?? "";
-      const occurredAt =
-        dt.length >= 14
-          ? `${dt.slice(0, 4)}-${dt.slice(4, 6)}-${dt.slice(6, 8)}T${dt.slice(8, 10)}:${dt.slice(10, 12)}:${dt.slice(12, 14)}`
-          : new Date().toISOString();
-      const isDupStan = d.stan && (stanCount.get(d.stan) ?? 0) > 1;
-      const txnId = isDupStan
-        ? `${d.stan}:${occurredAt}:${d.transferInAmount ?? "0"}:${d.transferOutAmount ?? "0"}`
-        : (d.stan ?? occurredAt);
-      return {
-        txnId,
-        occurredAt,
-        amount: String(
-          Number(d.transferInAmount ?? "0") -
-            Number(d.transferOutAmount ?? "0"),
-        ),
-        ...(d.memo?.trim() || d.summary?.trim()
-          ? { memo: d.memo?.trim() || d.summary?.trim() }
-          : {}),
-      };
-    });
+    const transactions = normalizeBankTransactionDetails(details);
 
     return { transactions };
   }
 
-  async getTradeDetail(input: {
+  /**
+   * Fetch exactly one TSP007 page. The caller owns the cursor and can enqueue
+   * the returned `nextPageToken` as a separate Queue message.
+   */
+  async getBankTransactionsPage(
+    bankNo: string,
+    acctNo: string,
+    currency: string,
+    pageToken = "",
+  ): Promise<BankTransactionPage> {
+    const raw = await this.post<{
+      transactionDetails?: BankTransactionDetail[];
+      pageToken?: string | null;
+      totalCount?: number | string;
+    }>("tsp/TSP007", {
+      bankId: bankNo,
+      accountNo: acctNo,
+      currency,
+      limitsInPage: BANK_TRANSACTION_PAGE_SIZE,
+      pageToken,
+    });
+    const details = Array.isArray(raw.transactionDetails)
+      ? raw.transactionDetails
+      : [];
+    const parsedTotal =
+      typeof raw.totalCount === "number" || typeof raw.totalCount === "string"
+        ? Number(raw.totalCount)
+        : Number.NaN;
+    const totalCount =
+      Number.isFinite(parsedTotal) && parsedTotal >= 0
+        ? parsedTotal
+        : undefined;
+    const nextPageToken =
+      typeof raw.pageToken === "string" && raw.pageToken.length > 0
+        ? raw.pageToken
+        : undefined;
+    if (nextPageToken === pageToken && nextPageToken) {
+      throw new EPassbookError(
+        "PAGINATION_LOOP",
+        "TSP007 returned a repeated page token.",
+      );
+    }
+    return {
+      pageToken,
+      ...(nextPageToken ? { nextPageToken } : {}),
+      ...(totalCount !== undefined ? { totalCount } : {}),
+      pageRecordCount: details.length,
+      details,
+      transactions: normalizeBankTransactionDetails(details),
+    };
+  }
+
+  async getTradeDetailPage(input: {
     brokerNo: string;
     brokerAccount: string;
     postDate?: string;
     txnSerNo?: string;
     updateType: "B" | "F";
-  }) {
-    return this.post<{
+  }): Promise<TradeDetailPage> {
+    const payload = await this.post<{
       brokerNo?: string;
       brokerAccount?: string;
       exchangeRates?: Record<string, unknown>;
@@ -453,7 +506,71 @@ export class EPassbookClient {
       },
       { allowedReturnCodes: ["D0002"] },
     );
+    const items = Array.isArray(payload.items) ? payload.items : [];
+    const returnCode = payload._returnCode ?? "0000";
+    return {
+      brokerNo: payload.brokerNo,
+      brokerAccount: payload.brokerAccount,
+      exchangeRates: payload.exchangeRates,
+      items,
+      lastServerTime: payload.lastServerTime,
+      returnCode,
+      returnMsg: payload._returnMsg,
+      _returnCode: returnCode,
+      _returnMsg: payload._returnMsg,
+    };
   }
+
+  async getTradeDetail(input: {
+    brokerNo: string;
+    brokerAccount: string;
+    postDate?: string;
+    txnSerNo?: string;
+    updateType: "B" | "F";
+  }) {
+    return this.getTradeDetailPage(input);
+  }
+}
+
+/**
+ * Normalize raw TSP007 rows. Keeping this outside the client makes it usable
+ * by durable consumers when staged pages are finalized together (duplicate
+ * STAN values are only detectable after all pages have been collected).
+ */
+export function normalizeBankTransactionDetails(
+  details: BankTransactionDetail[],
+): BankTransaction[] {
+  // ponytail: some banks reuse the same stan for recurring/batch entries (e.g.
+  // interest). Count occurrences so duplicates get a compound key that
+  // includes date+amounts.
+  const stanCount = new Map<string, number>();
+  for (const detail of details) {
+    if (detail.stan)
+      stanCount.set(detail.stan, (stanCount.get(detail.stan) ?? 0) + 1);
+  }
+
+  return details.map((detail) => {
+    const dt = detail.txnDateTime ?? "";
+    const occurredAt =
+      dt.length >= 14
+        ? `${dt.slice(0, 4)}-${dt.slice(4, 6)}-${dt.slice(6, 8)}T${dt.slice(8, 10)}:${dt.slice(10, 12)}:${dt.slice(12, 14)}`
+        : new Date().toISOString();
+    const isDupStan = detail.stan && (stanCount.get(detail.stan) ?? 0) > 1;
+    const txnId = isDupStan
+      ? `${detail.stan}:${occurredAt}:${detail.transferInAmount ?? "0"}:${detail.transferOutAmount ?? "0"}`
+      : (detail.stan ?? occurredAt);
+    return {
+      txnId,
+      occurredAt,
+      amount: String(
+        Number(detail.transferInAmount ?? "0") -
+          Number(detail.transferOutAmount ?? "0"),
+      ),
+      ...(detail.memo?.trim() || detail.summary?.trim()
+        ? { memo: detail.memo?.trim() || detail.summary?.trim() }
+        : {}),
+    };
+  });
 }
 
 function maskAccountNumber(value: string) {

--- a/packages/connectors/src/tdcc.ts
+++ b/packages/connectors/src/tdcc.ts
@@ -12,6 +12,7 @@ import {
   EPassbookClient,
   EPassbookError,
   type EPassbookSession,
+  type TradeDetailPage,
 } from "./tdcc-epassbook-client";
 
 const tdccHoldingSchema = z.object({
@@ -160,7 +161,7 @@ export function createTdccConnector(
 
 export const tdccConnector = createTdccConnector();
 
-type TdccCursorState = {
+export type TdccCursorState = {
   deviceId: string;
   devType: string;
   devModel: string;
@@ -168,13 +169,13 @@ type TdccCursorState = {
   tradeCursors?: Record<string, TdccTradeCursor>;
 };
 
-type TdccTradeCursor = {
+export type TdccTradeCursor = {
   newest?: string;
   oldest?: string;
   backfillComplete?: boolean;
 };
 
-function readTdccCursor(
+export function parseTdccCursor(
   cursor: string | undefined,
 ): TdccCursorState | undefined {
   if (!cursor) return undefined;
@@ -184,6 +185,10 @@ function readTdccCursor(
     return undefined;
   }
 }
+
+// Keep the old private name local to this module while callers migrate to the
+// durable-sync helper above.
+const readTdccCursor = parseTdccCursor;
 
 // ponytail: TDCC signals "new/unrecognized device" two ways — a successful
 // login response with isDiffDevice/isEmailValid flags, or these error codes
@@ -230,12 +235,189 @@ export class TdccVerificationRequiredError extends Error {
   }
 }
 
-type TdccIdentity = {
+export type TdccIdentity = {
   deviceId: string;
   devType: string;
   devModel: string;
   session?: EPassbookSession;
 };
+
+export type TdccBankEntry = {
+  bankId: string;
+  accountNo: string;
+  accountType?: string;
+  currency: string;
+  balanceAmt: string;
+  availableBalance?: string;
+};
+
+/**
+ * Build the client and identity for a Queue chunk without performing a
+ * network request. The returned `previous` cursor is safe to persist again;
+ * it contains only device/session metadata and trade cursors.
+ */
+export function createTdccClient(
+  config: TdccConfig,
+  cursor?: string,
+): {
+  client: EPassbookClient;
+  identity: TdccIdentity;
+  previous?: TdccCursorState;
+} {
+  const previous = parseTdccCursor(cursor);
+  const identity: TdccIdentity = {
+    deviceId:
+      config.deviceId ??
+      previous?.deviceId ??
+      crypto.randomUUID().replace(/-/g, "").slice(0, 16),
+    devType: config.devType ?? previous?.devType ?? "Android:14",
+    devModel: config.devModel ?? previous?.devModel ?? "SM-G991B",
+    session: config.session ?? previous?.session,
+  };
+  return {
+    client: new EPassbookClient({
+      devId: identity.deviceId,
+      devType: identity.devType,
+      devModel: identity.devModel,
+      session: identity.session,
+    }),
+    identity,
+    previous,
+  };
+}
+
+/** Ensure a client has a trusted TDCC session, preserving OTP error classes. */
+export async function ensureTdccSession(
+  client: EPassbookClient,
+  config: TdccConfig,
+): Promise<EPassbookSession> {
+  if (!client.exportSession().tokenId) {
+    try {
+      await client.getInitialToken();
+      await loginWithDeviceVerification(client, config);
+    } catch (error) {
+      wrapTdccError(error);
+    }
+  }
+  return client.exportSession();
+}
+
+export type TdccSnapshotInitialization = {
+  client: EPassbookClient;
+  identity: TdccIdentity;
+  previous?: TdccCursorState;
+  session: EPassbookSession;
+  stockPayload: Record<string, unknown>;
+  fundPayload: Record<string, unknown>;
+  bankBalancesPayload: Awaited<ReturnType<EPassbookClient["getBankBalances"]>>;
+  trendPayload: Awaited<ReturnType<EPassbookClient["getAssetTrend"]>>;
+  stockAccounts: TdccStockAccount[];
+  bankEntries: TdccBankEntry[];
+  snapshot: TdccSnapshotRecords;
+};
+
+export type TdccSnapshotRecords = {
+  holdings: TdccHolding[];
+  investmentPositions: Array<Omit<InvestmentPosition, "id" | "connectorId">>;
+  cashBalances: TdccCashBalance[];
+  bankAccounts: Array<Omit<BankAccount, "id" | "connectorId">>;
+  bankBalanceSnapshots: Array<Omit<BankBalanceSnapshot, "id" | "connectorId">>;
+  netWorthHistory: NetWorthHistoryPoint[];
+};
+
+type TdccSnapshotPayload = Omit<
+  TdccSnapshotInitialization,
+  "client" | "identity" | "previous" | "session"
+>;
+
+async function fetchTdccSnapshot(
+  client: EPassbookClient,
+): Promise<TdccSnapshotPayload> {
+  const [stockPayload, fundPayload, bankBalancesPayload, trendPayload] =
+    await Promise.all([
+      client.getPositions(),
+      client.getFundPositions(),
+      client.getBankBalances(),
+      client.getAssetTrend("1Y").catch(() => null),
+    ]);
+  const tspInfos = bankBalancesPayload.tspAccountInfos ?? [];
+  const bankEntries: TdccBankEntry[] = tspInfos.flatMap((info) =>
+    (info.tspAccount ?? [])
+      .filter((account) => account.isShow !== false)
+      .map((account) => ({
+        bankId: info.bankId,
+        accountNo: account.accountNo,
+        accountType: account.accountType,
+        currency: account.currency || "TWD",
+        balanceAmt: account.balanceAmt,
+        availableBalance: account.availableBalance,
+      })),
+  );
+  const snapshot = normalizeTdccSnapshot({
+    stockPayload,
+    fundPayload,
+    bankBalancesPayload,
+    trendPayload,
+    bankEntries,
+  });
+  return {
+    stockPayload,
+    fundPayload,
+    bankBalancesPayload,
+    trendPayload,
+    stockAccounts: stockAccountsFromPayload(stockPayload),
+    bankEntries,
+    snapshot,
+  };
+}
+
+/**
+ * Login/restore a session and fetch only the bounded TDCC snapshot endpoints.
+ * TSP007/TR002 pagination is deliberately left to Queue chunks.
+ */
+export async function initializeTdccSnapshot(
+  config: TdccConfig,
+  cursor?: string,
+): Promise<TdccSnapshotInitialization> {
+  const state = createTdccClient(config, cursor);
+  try {
+    await ensureTdccSession(state.client, config);
+    const snapshot = await fetchTdccSnapshot(state.client);
+    return {
+      ...state,
+      session: state.client.exportSession(),
+      ...snapshot,
+    };
+  } catch (error) {
+    // A persisted token can expire between Queue chunks. Retry the bounded
+    // initialization once with a fresh login, matching syncTdccLive behavior.
+    const isStaleSession =
+      error instanceof EPassbookError &&
+      SESSION_EXPIRED_CODES.has(error.code) &&
+      Boolean(state.identity.session?.tokenId);
+    if (!isStaleSession) return wrapTdccError(error);
+    const fresh = createTdccClient(
+      { ...config, session: undefined },
+      JSON.stringify({
+        ...(state.previous ?? {}),
+        deviceId: state.identity.deviceId,
+        devType: state.identity.devType,
+        devModel: state.identity.devModel,
+        session: undefined,
+      }),
+    );
+    await ensureTdccSession(fresh.client, {
+      ...config,
+      session: undefined,
+    });
+    const snapshot = await fetchTdccSnapshot(fresh.client);
+    return {
+      ...fresh,
+      session: fresh.client.exportSession(),
+      ...snapshot,
+    };
+  }
+}
 
 async function syncTdccLive(config: TdccConfig, cursor?: string) {
   const previous = readTdccCursor(cursor);
@@ -614,13 +796,13 @@ function wrapTdccError(error: unknown): never {
   throw error;
 }
 
-type TdccStockAccount = {
+export type TdccStockAccount = {
   brokerNo: string;
   brokerAccount: string;
   brokerName?: string;
 };
 
-function stockAccountsFromPayload(
+export function stockAccountsFromPayload(
   payload: Record<string, unknown>,
 ): TdccStockAccount[] {
   const accounts = Array.isArray(payload.accounts) ? payload.accounts : [];
@@ -646,7 +828,10 @@ function stockAccountsFromPayload(
   return Array.from(byId.values());
 }
 
-function toInvestmentTransaction(
+/** Descriptive alias for callers that do not need the legacy function name. */
+export const parseTdccStockAccounts = stockAccountsFromPayload;
+
+export function toInvestmentTransaction(
   row: unknown[],
   account: TdccStockAccount,
 ): Omit<InvestmentTransaction, "id" | "connectorId"> {
@@ -723,6 +908,17 @@ function toInvestmentTransaction(
   };
 }
 
+/** Parse and normalize one TR002 page for a single stock account. */
+export function parseTdccTradePageItems(
+  page: Pick<TradeDetailPage, "items"> | { items?: unknown[] },
+  account: TdccStockAccount,
+): Array<Omit<InvestmentTransaction, "id" | "connectorId">> {
+  const rows = Array.isArray(page.items)
+    ? page.items.filter((item): item is unknown[] => Array.isArray(item))
+    : [];
+  return rows.map((row) => toInvestmentTransaction(row, account));
+}
+
 function parseStockHoldings(payload: Record<string, unknown>): TdccHolding[] {
   const accounts = Array.isArray(payload.accounts) ? payload.accounts : [];
   const holdings: TdccHolding[] = [];
@@ -784,6 +980,8 @@ function parseStockHoldings(payload: Record<string, unknown>): TdccHolding[] {
   return holdings;
 }
 
+export const parseTdccStockHoldings = parseStockHoldings;
+
 function marketValueFromTradeItem(item: unknown[]) {
   const quantity = Number(stringField(item[7]) || "0");
   const price = Number(stringField(item[17]) || "0");
@@ -826,6 +1024,94 @@ function parseFundHoldings(payload: Record<string, unknown>): TdccHolding[] {
         raw: fund,
       };
     });
+}
+
+export const parseTdccFundHoldings = parseFundHoldings;
+
+/**
+ * Convert the bounded snapshot endpoints into the same normalized records
+ * used by the legacy full sync. No TSP007/TR002 request is made here; cash
+ * movements and investment transactions are intentionally left to Queue page
+ * chunks.
+ */
+export function normalizeTdccSnapshot(input: {
+  stockPayload: Record<string, unknown>;
+  fundPayload: Record<string, unknown>;
+  bankBalancesPayload: Awaited<ReturnType<EPassbookClient["getBankBalances"]>>;
+  trendPayload: Awaited<ReturnType<EPassbookClient["getAssetTrend"]>>;
+  bankEntries?: TdccBankEntry[];
+  asOfAt?: string;
+}): TdccSnapshotRecords {
+  const holdings = [
+    ...parseStockHoldings(input.stockPayload),
+    ...parseFundHoldings(input.fundPayload),
+  ];
+  const bankEntries =
+    input.bankEntries ??
+    (input.bankBalancesPayload.tspAccountInfos ?? []).flatMap((info) =>
+      (info.tspAccount ?? [])
+        .filter((account) => account.isShow !== false)
+        .map((account) => ({
+          bankId: info.bankId,
+          accountNo: account.accountNo,
+          accountType: account.accountType,
+          currency: account.currency || "TWD",
+          balanceAmt: account.balanceAmt,
+          availableBalance: account.availableBalance,
+        })),
+    );
+  const asOfAt = input.asOfAt ?? new Date().toISOString();
+  const cashBalances: TdccCashBalance[] = bankEntries.map((entry) => ({
+    accountId: `${entry.bankId}:${entry.accountNo}:${entry.currency}`,
+    brokerName: entry.accountType || undefined,
+    balance: entry.balanceAmt,
+    availableBalance: entry.availableBalance || undefined,
+    currency: entry.currency.toUpperCase(),
+    asOfAt,
+    raw: entry,
+  }));
+
+  const toDate = (value: string) =>
+    `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
+  const trendPayload = input.trendPayload;
+  const netWorthHistory: NetWorthHistoryPoint[] = trendPayload
+    ? [
+        ...trendPayload.chartDate.map((date, index) => ({
+          date: toDate(date),
+          netWorth: trendPayload.chartVal[index] ?? 0,
+          assetType: "total" as const,
+        })),
+        ...trendPayload.chartDate.map((date, index) => ({
+          date: toDate(date),
+          netWorth:
+            (trendPayload.chartVal[index] ?? 0) -
+            (trendPayload.fundChartVal[index] ?? 0),
+          assetType: "stock" as const,
+        })),
+        ...trendPayload.fundChartDate.map((date, index) => ({
+          date: toDate(date),
+          netWorth: trendPayload.fundChartVal[index] ?? 0,
+          assetType: "fund" as const,
+        })),
+      ]
+    : [];
+
+  return {
+    holdings,
+    investmentPositions: dedupeBySourceId(holdings.map(toInvestmentPosition)),
+    cashBalances,
+    bankAccounts: dedupeBySourceId([
+      ...holdings
+        .filter((holding) => holding.cashBalance !== undefined)
+        .map(toSettlementBankAccount),
+      ...cashBalances.map(toSettlementBankAccount),
+    ]),
+    bankBalanceSnapshots: dedupeByAccountAndSourceId([
+      ...holdings.flatMap(toSettlementBalanceSnapshot),
+      ...cashBalances.map(toBankBalanceSnapshot),
+    ]),
+    netWorthHistory,
+  };
 }
 
 function stringField(value: unknown): string {

--- a/packages/connectors/tests/selfcheck/tdcc.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/tdcc.selfcheck.ts
@@ -4,10 +4,12 @@
 import assert from "node:assert/strict";
 import {
   createTdccConnector,
+  parseTdccTradePageItems,
   parseTdccConfig,
   TdccOtpExpiredError,
   TdccVerificationRequiredError,
 } from "../../src/tdcc";
+import { EPassbookClient } from "../../src/tdcc-epassbook-client";
 
 const calls: string[] = [];
 const tspPageTokens: string[] = [];
@@ -16,7 +18,8 @@ let mode:
   | "error_code_otp"
   | "stale_session"
   | "otp_expired"
-  | "pagination_incomplete" = "flag_otp";
+  | "pagination_incomplete"
+  | "pagination_loop" = "flag_otp";
 let fundUpdateTime = "20240615090000";
 
 function errorResponse(returnCode: string) {
@@ -173,6 +176,13 @@ function errorResponse(returnCode: string) {
   if (endpoint === "tsp/TSP007") {
     const pageToken = String(body.requestBody.pageToken ?? "");
     tspPageTokens.push(pageToken);
+    if (mode === "pagination_loop") {
+      return respond("0000", {
+        transactionDetails: [],
+        pageToken: "LOOP",
+        totalCount: 1,
+      });
+    }
     if (mode === "pagination_incomplete") {
       return respond("0000", {
         transactionDetails: [
@@ -214,6 +224,36 @@ function errorResponse(returnCode: string) {
       ],
       pageToken: "NEXT-1",
       totalCount: 2,
+    });
+  }
+  if (endpoint === "TR002") {
+    return respond("0000", {
+      items: [
+        [
+          "20240615",
+          "TXN-1",
+          "2330",
+          "TSMC",
+          "TW",
+          "",
+          "11",
+          "",
+          "11",
+          "20240614",
+          "B",
+          "買進",
+          "2",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "500",
+          "20240615",
+          "TWD",
+        ],
+      ],
+      lastServerTime: "20240615120000",
     });
   }
   throw new Error(`unexpected endpoint ${endpoint}`);
@@ -289,6 +329,59 @@ async function main() {
     "bank transactions should follow pageToken until exhausted",
   );
   assert.equal(JSON.parse(result.cursor!).session.tokenId, "TKN-1");
+
+  // The durable TDCC worker consumes one TSP007 page at a time. Verify the
+  // page contract and the TR002 page parser independently of full-sync loops.
+  const pageClient = new EPassbookClient({
+    devId: "dev-page",
+    devType: "Android:14",
+    devModel: "SM-G991B",
+    session: { tokenId: "TKN-1", richUrl: null },
+  });
+  mode = "flag_otp";
+  const firstPage = await pageClient.getBankTransactionsPage(
+    "004",
+    "1234567890",
+    "TWD",
+    "",
+  );
+  assert.equal(firstPage.pageToken, "");
+  assert.equal(firstPage.pageRecordCount, 1);
+  assert.equal(firstPage.totalCount, 2);
+  assert.equal(firstPage.nextPageToken, "NEXT-1");
+  assert.equal(firstPage.transactions[0]?.txnId, "live-cash-move-1");
+  const secondPage = await pageClient.getBankTransactionsPage(
+    "004",
+    "1234567890",
+    "TWD",
+    firstPage.nextPageToken,
+  );
+  assert.equal(secondPage.pageRecordCount, 1);
+  assert.equal(secondPage.nextPageToken, undefined);
+
+  const tradePage = await pageClient.getTradeDetailPage({
+    brokerNo: "9A92",
+    brokerAccount: "1234567",
+    updateType: "B",
+  });
+  assert.equal(tradePage.returnCode, "0000");
+  assert.equal(tradePage.items.length, 1);
+  const tradeRows = parseTdccTradePageItems(tradePage, {
+    brokerNo: "9A92",
+    brokerAccount: "1234567",
+    brokerName: "Test Broker",
+  });
+  assert.equal(tradeRows.length, 1);
+  assert.equal(tradeRows[0]?.sourceId, "2024061420240615TXN-1");
+  assert.equal(tradeRows[0]?.amount, 1000);
+
+  mode = "pagination_loop";
+  await assert.rejects(
+    pageClient.getBankTransactionsPage("004", "1234567890", "TWD", "LOOP"),
+    /PAGINATION_LOOP/,
+    "a page API must reject an immediately repeated page token",
+  );
+  mode = "flag_otp";
 
   const manualWithMovement = parseTdccConfig({
     holdings: [

--- a/packages/db/migrations/0031_tdcc_durable_runs.sql
+++ b/packages/db/migrations/0031_tdcc_durable_runs.sql
@@ -1,0 +1,79 @@
+-- TDCC can return one page per bank or investment account.  Keep the
+-- provider work durable so a Queue delivery only has to process a bounded
+-- number of pages and can safely resume after a retry.
+CREATE TABLE IF NOT EXISTS tdcc_sync_runs (
+  id TEXT PRIMARY KEY,
+  connector_id TEXT NOT NULL DEFAULT 'tdcc'
+    CHECK (connector_id = 'tdcc'),
+  trigger TEXT NOT NULL CHECK (trigger IN ('manual', 'scheduled')),
+  scope TEXT NOT NULL DEFAULT 'all'
+    CHECK (scope IN ('all', 'investments', 'bank', 'trades')),
+  sync_job_id TEXT REFERENCES sync_jobs(id) ON DELETE SET NULL,
+  scheduled_batch_id TEXT REFERENCES scheduled_sync_batches(id) ON DELETE SET NULL,
+  settings_version TEXT,
+  phase TEXT NOT NULL DEFAULT 'initialize'
+    CHECK (phase IN (
+      'initialize', 'snapshot', 'positions', 'bank', 'investments',
+      'trades', 'promote', 'finalize'
+    )),
+  status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN (
+    'queued', 'initializing', 'processing', 'promoting',
+    'completed', 'failed', 'needs_user_action'
+  )),
+  -- The run retains the encrypted provider state it was initialized with.
+  -- It is never exposed in an API response or log.
+  encrypted_config TEXT,
+  encrypted_session TEXT,
+  session_json TEXT CHECK (session_json IS NULL OR json_valid(session_json)),
+  total_item_count INTEGER NOT NULL DEFAULT 0,
+  pending_item_count INTEGER NOT NULL DEFAULT 0,
+  processing_item_count INTEGER NOT NULL DEFAULT 0,
+  done_item_count INTEGER NOT NULL DEFAULT 0,
+  failed_item_count INTEGER NOT NULL DEFAULT 0,
+  session_refresh_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  lease_owner TEXT,
+  lease_expires_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  promoted_at TEXT,
+  completed_at TEXT
+);
+
+-- TDCC scopes share one connector session/cursor.  Only one active run may
+-- exist at a time, including when a partial manual scope races tdcc:all.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tdcc_sync_runs_one_active
+  ON tdcc_sync_runs (connector_id)
+  WHERE status IN ('queued', 'initializing', 'processing', 'promoting');
+
+CREATE INDEX IF NOT EXISTS idx_tdcc_sync_runs_completed
+  ON tdcc_sync_runs (completed_at DESC);
+
+CREATE TABLE IF NOT EXISTS tdcc_sync_run_items (
+  id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES tdcc_sync_runs(id) ON DELETE CASCADE,
+  task_type TEXT NOT NULL,
+  task_key TEXT NOT NULL DEFAULT '',
+  account_id TEXT,
+  page_cursor TEXT NOT NULL DEFAULT '',
+  next_page_cursor TEXT,
+  page_number INTEGER NOT NULL DEFAULT 0,
+  task_json TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(task_json)),
+  payload_json TEXT CHECK (payload_json IS NULL OR json_valid(payload_json)),
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'processing', 'done', 'failed')),
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  lease_token TEXT,
+  lease_expires_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT,
+  UNIQUE (run_id, task_type, task_key, page_cursor)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tdcc_sync_run_items_claim
+  ON tdcc_sync_run_items (run_id, status, lease_expires_at, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_tdcc_sync_run_items_account
+  ON tdcc_sync_run_items (run_id, account_id, task_type, page_number);


### PR DESCRIPTION
## 摘要

將集保 e 存摺同步改為 durable Queue 分頁流程，避免單次 Worker invocation 因 TSP007/TR002 分頁過多而超過 subrequest 限制。

## 內容

- 新增 TDCC durable run/item repository 與 0031 D1 migration。
- Snapshot 維持有界呼叫，銀行交易與投資交易改為每次 Queue 只處理一頁。
- 加入 staging、分頁 cursor、lease、retry、重複頁面防護與加密 session 保存。
- 手動同步 API 改為 202 queued，設定頁加入 TDCC 同步輪詢。
- 保留既有同步結果的 promotion 與排程通知流程。

## 驗證

- Worker：46 個測試檔、359 個測試通過。
- Web：22 個測試檔、88 個測試通過。
- Connector self-check、workspace typecheck、format check 與 git diff check 通過。
- 0031 migration 已套用至目前遠端 D1；尚未部署 Worker，也未執行金融同步。

## 注意

既有 TDCC source_id 漂移造成的歷史重複資料不在本 PR 內清理，需另行受控 reconcile。