### PR TITLE
修正：恢復卡住的集保 Queue 同步

### DIFF
--- a/apps/worker/src/features/sync/route.ts
+++ b/apps/worker/src/features/sync/route.ts
@@ -418,13 +418,13 @@ async function queuedTdccSyncResponse(
       scope,
       overrides,
     });
-    if (created) {
-      try {
-        await enqueueTdccSyncChunk(c.env, run.id);
-      } catch (error) {
+    try {
+      await enqueueTdccSyncChunk(c.env, run.id);
+    } catch (error) {
+      if (created) {
         await cancelQueuedTdccSyncRun(c.env, run.id, error);
-        throw error;
       }
+      throw error;
     }
     return c.json(
       {

--- a/apps/worker/src/features/sync/scheduler.ts
+++ b/apps/worker/src/features/sync/scheduler.ts
@@ -107,16 +107,16 @@ async function runCustomScheduleJob(
       trigger: "scheduled",
       scope: "all",
     });
-    if (created) {
-      try {
-        await env.SYNC_QUEUE.send({
-          type: "run-tdcc-chunk",
-          runId: run.id,
-        });
-      } catch (error) {
+    try {
+      await env.SYNC_QUEUE.send({
+        type: "run-tdcc-chunk",
+        runId: run.id,
+      });
+    } catch (error) {
+      if (created) {
         await cancelQueuedTdccSyncRun(env, run.id, error);
-        throw error;
       }
+      throw error;
     }
     return true;
   }
@@ -155,16 +155,16 @@ async function runDefaultScheduleBatchJob(
       scope: "all",
       scheduledBatchId: batchId,
     });
-    if (created) {
-      try {
-        await env.SYNC_QUEUE.send({
-          type: "run-tdcc-chunk",
-          runId: run.id,
-        });
-      } catch (error) {
+    try {
+      await env.SYNC_QUEUE.send({
+        type: "run-tdcc-chunk",
+        runId: run.id,
+      });
+    } catch (error) {
+      if (created) {
         await cancelQueuedTdccSyncRun(env, run.id, error);
-        throw error;
       }
+      throw error;
     }
     return true;
   }

--- a/apps/worker/tests/features/sync/route.test.ts
+++ b/apps/worker/tests/features/sync/route.test.ts
@@ -21,11 +21,14 @@ import type { Env } from "../../../src/platform/env";
 
 const mocks = vi.hoisted(() => ({
   cancelQueuedEinvoiceSyncRun: vi.fn(),
+  cancelQueuedTdccSyncRun: vi.fn(),
   enqueueEinvoiceSyncChunk: vi.fn(),
+  enqueueTdccSyncChunk: vi.fn(),
   prepareTaishinCaptchaSession: vi.fn(),
   prepareHncbCaptchaSession: vi.fn(),
   prepareObankCaptchaSession: vi.fn(),
   startEinvoiceSyncRun: vi.fn(),
+  startTdccSyncRun: vi.fn(),
   syncCtbc: vi.fn(),
   syncCathaybk: vi.fn(),
   syncEsun: vi.fn(),
@@ -39,8 +42,14 @@ vi.mock("../../../src/features/sync/einvoice-sync-service", () => ({
   startEinvoiceSyncRun: mocks.startEinvoiceSyncRun,
 }));
 
+vi.mock("../../../src/features/sync/tdcc-sync-service", () => ({
+  cancelQueuedTdccSyncRun: mocks.cancelQueuedTdccSyncRun,
+  startTdccSyncRun: mocks.startTdccSyncRun,
+}));
+
 vi.mock("../../../src/features/sync/scheduler-queue", () => ({
   enqueueEinvoiceSyncChunk: mocks.enqueueEinvoiceSyncChunk,
+  enqueueTdccSyncChunk: mocks.enqueueTdccSyncChunk,
 }));
 
 vi.mock("../../../src/features/sync/service", () => ({
@@ -85,6 +94,12 @@ beforeEach(() => {
   });
   mocks.enqueueEinvoiceSyncChunk.mockResolvedValue(undefined);
   mocks.cancelQueuedEinvoiceSyncRun.mockResolvedValue(undefined);
+  mocks.startTdccSyncRun.mockResolvedValue({
+    run: { id: "tdcc-run-1" },
+    created: true,
+  });
+  mocks.enqueueTdccSyncChunk.mockResolvedValue(undefined);
+  mocks.cancelQueuedTdccSyncRun.mockResolvedValue(undefined);
   mocks.prepareTaishinCaptchaSession.mockResolvedValue({
     captchaImage: "data:image/jpeg;base64,AQID",
     expiresAt: "2026-07-23T12:02:00.000Z",
@@ -225,6 +240,76 @@ describe("e-invoice sync route", () => {
       "einvoice-run-1",
       error,
     );
+  });
+});
+
+describe("TDCC sync route", () => {
+  it("queues a newly-created manual durable run", async () => {
+    const response = await syncRoutes.request(
+      "/connectors/tdcc/sync",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      },
+      env,
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      connectorId: "tdcc",
+      scope: "all",
+      status: "queued",
+      runId: "tdcc-run-1",
+    });
+    expect(mocks.enqueueTdccSyncChunk).toHaveBeenCalledWith(env, "tdcc-run-1");
+  });
+
+  it("requeues a reused active run so an orphaned Queue chain can resume", async () => {
+    mocks.startTdccSyncRun.mockResolvedValueOnce({
+      run: { id: "tdcc-running" },
+      created: false,
+    });
+
+    const response = await syncRoutes.request(
+      "/connectors/tdcc/sync",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      },
+      env,
+    );
+
+    expect(response.status).toBe(202);
+    expect(mocks.enqueueTdccSyncChunk).toHaveBeenCalledWith(
+      env,
+      "tdcc-running",
+    );
+    expect(mocks.cancelQueuedTdccSyncRun).not.toHaveBeenCalled();
+  });
+
+  it("does not fail a reused run when its recovery enqueue fails", async () => {
+    mocks.startTdccSyncRun.mockResolvedValueOnce({
+      run: { id: "tdcc-running" },
+      created: false,
+    });
+    mocks.enqueueTdccSyncChunk.mockRejectedValueOnce(
+      new Error("Queue unavailable"),
+    );
+
+    const response = await syncRoutes.request(
+      "/connectors/tdcc/sync",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      },
+      env,
+    );
+
+    expect(response.status).toBe(500);
+    expect(mocks.cancelQueuedTdccSyncRun).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/worker/tests/features/sync/scheduler-queue.test.ts
+++ b/apps/worker/tests/features/sync/scheduler-queue.test.ts
@@ -3,8 +3,10 @@ import type { Env, ScheduledSyncQueueMessage } from "../../../src/platform/env";
 
 const mocks = vi.hoisted(() => ({
   failEinvoiceSyncRun: vi.fn(),
+  failTdccSyncRun: vi.fn(),
   isEinvoiceUserActionError: vi.fn(),
   processEinvoiceSyncChunk: vi.fn(),
+  processTdccSyncChunk: vi.fn(),
   runSchedulerTick: vi.fn(),
 }));
 
@@ -18,9 +20,15 @@ vi.mock("../../../src/features/sync/einvoice-sync-service", () => ({
   processEinvoiceSyncChunk: mocks.processEinvoiceSyncChunk,
 }));
 
+vi.mock("../../../src/features/sync/tdcc-sync-service", () => ({
+  failTdccSyncRun: mocks.failTdccSyncRun,
+  processTdccSyncChunk: mocks.processTdccSyncChunk,
+}));
+
 import {
   consumeScheduledSyncQueue,
   enqueueScheduledSync,
+  enqueueTdccSyncChunk,
 } from "../../../src/features/sync/scheduler-queue";
 
 function queueMessage(body: ScheduledSyncQueueMessage) {
@@ -62,6 +70,55 @@ describe("scheduled sync queue", () => {
     await enqueueScheduledSync(env(send));
 
     expect(send).toHaveBeenCalledWith({ type: "run-next-scheduled-sync" });
+  });
+
+  it("enqueues a TDCC chunk message", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+
+    await enqueueTdccSyncChunk(env(send), "tdcc-run-1");
+
+    expect(send).toHaveBeenCalledWith({
+      type: "run-tdcc-chunk",
+      runId: "tdcc-run-1",
+    });
+  });
+
+  it("dispatches a TDCC chunk and sends its continuation before ack", async () => {
+    const order: string[] = [];
+    const send = vi.fn(async () => order.push("send"));
+    const message = queueMessage({
+      type: "run-tdcc-chunk",
+      runId: "tdcc-run-1",
+    });
+    message.ack = vi.fn(() => order.push("ack"));
+    mocks.processTdccSyncChunk.mockResolvedValue({ status: "continue" });
+
+    await consumeScheduledSyncQueue(queueBatch(message), env(send));
+
+    expect(mocks.processTdccSyncChunk).toHaveBeenCalledWith(
+      expect.anything(),
+      "tdcc-run-1",
+      "message-1",
+    );
+    expect(send).toHaveBeenCalledWith(
+      { type: "run-tdcc-chunk", runId: "tdcc-run-1" },
+      { delaySeconds: 1 },
+    );
+    expect(order).toEqual(["send", "ack"]);
+  });
+
+  it("retries a transient TDCC chunk failure", async () => {
+    const message = queueMessage({
+      type: "run-tdcc-chunk",
+      runId: "tdcc-run-1",
+    });
+    mocks.processTdccSyncChunk.mockRejectedValue(new Error("HTTP 503"));
+
+    await consumeScheduledSyncQueue(queueBatch(message), env());
+
+    expect(message.retry).toHaveBeenCalledWith({ delaySeconds: 15 });
+    expect(message.ack).not.toHaveBeenCalled();
+    expect(mocks.failTdccSyncRun).not.toHaveBeenCalled();
   });
 
   it("delays the next invocation after processing a job", async () => {

--- a/apps/worker/tests/features/sync/scheduler.test.ts
+++ b/apps/worker/tests/features/sync/scheduler.test.ts
@@ -6,6 +6,7 @@ import type { Env } from "../../../src/platform/env";
 const mocks = vi.hoisted(() => ({
   acquireSyncJobLock: vi.fn(),
   cancelQueuedEinvoiceSyncRun: vi.fn(),
+  cancelQueuedTdccSyncRun: vi.fn(),
   claimCompletedDefaultScheduleBatch: vi.fn(),
   completeSyncJob: vi.fn(),
   ensureDefaultScheduleBatch: vi.fn(),
@@ -19,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   safelySendScheduledSyncSummary: vi.fn(),
   safelySendSyncNotification: vi.fn(),
   startEinvoiceSyncRun: vi.fn(),
+  startTdccSyncRun: vi.fn(),
   startSyncLockHeartbeat: vi.fn(),
   syncCathaybk: vi.fn(),
   syncEsun: vi.fn(),
@@ -28,6 +30,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../../../src/features/sync/einvoice-sync-service", () => ({
   cancelQueuedEinvoiceSyncRun: mocks.cancelQueuedEinvoiceSyncRun,
   startEinvoiceSyncRun: mocks.startEinvoiceSyncRun,
+}));
+
+vi.mock("../../../src/features/sync/tdcc-sync-service", () => ({
+  cancelQueuedTdccSyncRun: mocks.cancelQueuedTdccSyncRun,
+  startTdccSyncRun: mocks.startTdccSyncRun,
 }));
 
 vi.mock("@taiwan-fin-hub/db", () => ({
@@ -132,6 +139,11 @@ beforeEach(() => {
     created: true,
   });
   mocks.cancelQueuedEinvoiceSyncRun.mockResolvedValue(undefined);
+  mocks.startTdccSyncRun.mockResolvedValue({
+    run: { id: "tdcc-run-1" },
+    created: true,
+  });
+  mocks.cancelQueuedTdccSyncRun.mockResolvedValue(undefined);
   mocks.syncEsun.mockResolvedValue({
     connectorId: "esun",
     scope: "all",
@@ -325,6 +337,27 @@ describe("scheduled sync rounds", () => {
 
     expect(send).not.toHaveBeenCalled();
     expect(mocks.cancelQueuedEinvoiceSyncRun).not.toHaveBeenCalled();
+  });
+
+  it("requeues a reused custom TDCC run", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const job = syncJob("custom", "tdcc");
+    mocks.findOpenDefaultScheduleBatchId.mockResolvedValue(null);
+    mocks.findNextDueSyncJob.mockResolvedValue(job);
+    mocks.startTdccSyncRun.mockResolvedValueOnce({
+      run: { id: "tdcc-running" },
+      created: false,
+    });
+
+    await expect(
+      runSchedulerTick(env(send), scheduledController),
+    ).resolves.toBe(true);
+
+    expect(send).toHaveBeenCalledWith({
+      type: "run-tdcc-chunk",
+      runId: "tdcc-running",
+    });
+    expect(mocks.cancelQueuedTdccSyncRun).not.toHaveBeenCalled();
   });
 
   it("preserves the default batch ID when starting an e-invoice durable run", async () => {


### PR DESCRIPTION
## 問題

TDCC durable run 的第一筆 Queue 訊息若在跨版本部署期間被舊 consumer 確認掉，run 會停在 active 狀態。後續手動同步或排程取得既有 run 時，因 `created=false` 不會再次 enqueue，導致 23 筆工作永久停留在 pending。

## 修正

- 手動同步取得既有 TDCC active run 時，重新送出 chunk 訊息以恢復 Queue chain
- 自訂與預設排程取得既有 active run 時，同樣重新 enqueue
- 只有新建 run 的 enqueue 失敗才終止該 run，避免誤傷可能仍在執行的既有 run
- 補上 TDCC Queue dispatch、continuation、retry 與 active-run recovery 測試

## 驗證

- `npm exec vitest -- run apps/worker/tests/features/sync/scheduler-queue.test.ts apps/worker/tests/features/sync/route.test.ts apps/worker/tests/features/sync/scheduler.test.ts`（50 tests passed）
- `npm run typecheck -w @taiwan-fin-hub/worker`
- Prettier targeted check
- `git diff --check`

## 正式環境處理

已在 Queue backlog=0、run 無 lease 且 23 筆全 pending 的前提下，僅補送原 run 的一筆 `run-tdcc-chunk`。新版 consumer 已接手並將過期 session 正確標示為需要重新驗證。