### PR TITLE
修正：穩定集保銀行交易識別碼並清理重複資料

### DIFF
--- a/apps/worker/tests/features/sync/tdcc-transaction-identity-migration.test.ts
+++ b/apps/worker/tests/features/sync/tdcc-transaction-identity-migration.test.ts
@@ -25,9 +25,22 @@ function createDatabase() {
     .prepare(
       `INSERT INTO bank_accounts
         (id, connector_id, source_id, account_type, currency, created_at, updated_at)
-       VALUES (?, 'tdcc', ?, 'settlement_cash', 'TWD', ?, ?)`,
+       VALUES
+         ('account-a', 'tdcc', 'settlement:bank-a:account-a:TWD',
+          'settlement_cash', 'TWD', ?, ?),
+         ('account-b', 'tdcc', 'settlement:bank-b:account-b:TWD',
+          'settlement_cash', 'TWD', ?, ?),
+         ('account-external', 'ctbc', 'bank:external',
+          'savings', 'TWD', ?, ?)`,
     )
-    .run("account-1", "settlement:004:test:TWD", "2026-08-20", "2026-08-20");
+    .run(
+      "2026-04-01",
+      "2026-04-01",
+      "2026-04-01",
+      "2026-04-01",
+      "2026-04-01",
+      "2026-04-01",
+    );
   databases.push(database);
   return database;
 }
@@ -41,31 +54,37 @@ function insertTransaction(
     occurredAt?: string;
     amount?: number;
     memo?: string;
+    accountId?: string;
+    connectorId?: string;
+    currency?: string;
   },
 ) {
-  const occurredAt = input.occurredAt ?? "2026-08-21T00:00:00";
-  const amount = input.amount ?? 102;
+  const occurredAt = input.occurredAt ?? "2026-04-15T08:30:45";
+  const amount = input.amount ?? 375;
   database
     .prepare(
       `INSERT INTO bank_transactions
         (id, connector_id, account_id, source_id, posted_date, amount, currency,
          description, raw_payload, created_at, updated_at)
-       VALUES (?, 'tdcc', 'account-1', ?, ?, ?, 'TWD', ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       input.id,
+      input.connectorId ?? "tdcc",
+      input.accountId ?? "account-a",
       input.sourceId,
       occurredAt,
       amount,
-      input.memo ?? "利息102稅額0健保費0",
+      input.currency ?? "TWD",
+      input.memo ?? "Provider adjustment",
       JSON.stringify({
         txnId: input.txnId,
         occurredAt,
         amount: String(amount),
-        memo: input.memo ?? "利息102稅額0健保費0",
+        memo: input.memo ?? "Provider adjustment",
       }),
-      "2026-08-20",
-      "2026-08-23",
+      "2026-04-01",
+      "2026-04-16",
     );
 }
 
@@ -76,9 +95,9 @@ function applyMigration(database: DatabaseSync) {
 }
 
 describe("TDCC bank transaction identity migration", () => {
-  it("merges uniquely matched legacy rows and preserves user preferences", () => {
+  it("merges generic legacy identities with one canonical transaction", () => {
     const database = createDatabase();
-    const canonicalSourceId = "00000:2026-08-21T00:00:00:102.0:0.0";
+    const canonicalSourceId = "batch:2026-04-15T08:30:45:375.0:0.0";
     insertTransaction(database, {
       id: "canonical",
       sourceId: canonicalSourceId,
@@ -86,29 +105,29 @@ describe("TDCC bank transaction identity migration", () => {
     });
     insertTransaction(database, {
       id: "legacy-1",
-      sourceId: "settlement:004:test:TWD:2026-08-21:102:TWD:interest-a",
+      sourceId: "settlement:bank-a:account-a:TWD:legacy-a",
       txnId: "",
-      memo: "利息 102稅額 0健保費 0",
+      memo: "Provider  adjustment",
     });
     insertTransaction(database, {
       id: "legacy-2",
-      sourceId: "settlement:004:test:TWD:2026-08-21:102:TWD:interest-b",
+      sourceId: "settlement:bank-a:account-a:TWD:legacy-b",
       txnId: " ",
     });
     database.exec(`
       INSERT INTO bank_transaction_preferences
         (transaction_id, excluded_from_calculation, created_at, updated_at)
       VALUES
-        ('canonical', 0, '2026-08-23', '2026-08-23'),
-        ('legacy-1', 1, '2026-08-20', '2026-08-21');
+        ('canonical', 0, '2026-04-16', '2026-04-16'),
+        ('legacy-1', 1, '2026-04-01', '2026-04-15');
       INSERT INTO classification_overrides
         (id, target_type, target_id, category_id, created_at, updated_at)
       VALUES
         ('legacy-override', 'bank_transaction', 'legacy-2', 'insurance',
-         '2026-08-20', '2026-08-21');
+         '2026-04-01', '2026-04-15');
       INSERT INTO invoice_transaction_preferences
         (invoice_id, transaction_id, decision, created_at, updated_at)
-      VALUES ('invoice-1', 'legacy-1', 'linked', '2026-08-20', '2026-08-21');
+      VALUES ('invoice-1', 'legacy-1', 'linked', '2026-04-01', '2026-04-15');
     `);
 
     applyMigration(database);
@@ -151,7 +170,7 @@ describe("TDCC bank transaction identity migration", () => {
     const database = createDatabase();
     insertTransaction(database, {
       id: "ambiguous-legacy",
-      sourceId: "settlement:004:test:TWD:ambiguous",
+      sourceId: "settlement:bank-a:account-a:TWD:ambiguous",
       txnId: "",
     });
     insertTransaction(database, {
@@ -167,44 +186,44 @@ describe("TDCC bank transaction identity migration", () => {
 
     insertTransaction(database, {
       id: "invoice-legacy",
-      sourceId: "settlement:004:test:TWD:invoice",
+      sourceId: "settlement:bank-a:account-a:TWD:invoice",
       txnId: "",
-      occurredAt: "2026-08-22T00:00:00",
+      occurredAt: "2026-04-16T08:30:45",
     });
     insertTransaction(database, {
       id: "invoice-canonical",
       sourceId: "invoice-canonical-id",
       txnId: "invoice-canonical-id",
-      occurredAt: "2026-08-22T00:00:00",
+      occurredAt: "2026-04-16T08:30:45",
     });
     database.exec(`
       INSERT INTO invoice_transaction_preferences
         (invoice_id, transaction_id, decision, created_at, updated_at)
       VALUES
-        ('invoice-legacy-pref', 'invoice-legacy', 'linked', '2026-08-20', '2026-08-20'),
-        ('invoice-canonical-pref', 'invoice-canonical', 'linked', '2026-08-20', '2026-08-20');
+        ('invoice-legacy-pref', 'invoice-legacy', 'linked', '2026-04-01', '2026-04-01'),
+        ('invoice-canonical-pref', 'invoice-canonical', 'linked', '2026-04-01', '2026-04-01');
     `);
 
     insertTransaction(database, {
       id: "classification-legacy",
-      sourceId: "settlement:004:test:TWD:classification",
+      sourceId: "settlement:bank-a:account-a:TWD:classification",
       txnId: "",
-      occurredAt: "2026-08-23T00:00:00",
+      occurredAt: "2026-04-17T08:30:45",
     });
     insertTransaction(database, {
       id: "classification-canonical",
       sourceId: "classification-canonical-id",
       txnId: "classification-canonical-id",
-      occurredAt: "2026-08-23T00:00:00",
+      occurredAt: "2026-04-17T08:30:45",
     });
     database.exec(`
       INSERT INTO classification_overrides
         (id, target_type, target_id, category_id, created_at, updated_at)
       VALUES
         ('classification-legacy-override', 'bank_transaction',
-         'classification-legacy', 'tax', '2026-08-20', '2026-08-20'),
+         'classification-legacy', 'tax', '2026-04-01', '2026-04-01'),
         ('classification-canonical-override', 'bank_transaction',
-         'classification-canonical', 'insurance', '2026-08-20', '2026-08-20');
+         'classification-canonical', 'insurance', '2026-04-01', '2026-04-01');
     `);
 
     applyMigration(database);
@@ -219,6 +238,92 @@ describe("TDCC bank transaction identity migration", () => {
         .all()
         .map((row) => row.id),
     ).toEqual(["ambiguous-legacy", "classification-legacy", "invoice-legacy"]);
+    expect(
+      database
+        .prepare(
+          "SELECT invoice_id, transaction_id FROM invoice_transaction_preferences ORDER BY invoice_id",
+        )
+        .all(),
+    ).toEqual([
+      {
+        invoice_id: "invoice-canonical-pref",
+        transaction_id: "invoice-canonical",
+      },
+      {
+        invoice_id: "invoice-legacy-pref",
+        transaction_id: "invoice-legacy",
+      },
+    ]);
+    expect(
+      database
+        .prepare(
+          `SELECT target_id, category_id FROM classification_overrides
+           WHERE target_id LIKE 'classification-%' ORDER BY target_id`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        target_id: "classification-canonical",
+        category_id: "insurance",
+      },
+      { target_id: "classification-legacy", category_id: "tax" },
+    ]);
+  });
+
+  it("does not cross account, connector, timestamp, memo, or valid provider ids", () => {
+    const database = createDatabase();
+    const canonicalSourceId = "batch:2026-04-15T08:30:45:375.0:0.0";
+    insertTransaction(database, {
+      id: "canonical",
+      sourceId: canonicalSourceId,
+      txnId: canonicalSourceId,
+    });
+    insertTransaction(database, {
+      id: "other-account",
+      accountId: "account-b",
+      sourceId: "settlement:bank-b:account-b:TWD:legacy",
+      txnId: "",
+    });
+    insertTransaction(database, {
+      id: "other-connector",
+      accountId: "account-external",
+      connectorId: "ctbc",
+      sourceId: "settlement:external:legacy",
+      txnId: "",
+    });
+    insertTransaction(database, {
+      id: "valid-provider-id",
+      sourceId: "opaque-provider-id",
+      txnId: "opaque-provider-id",
+    });
+    insertTransaction(database, {
+      id: "different-time",
+      sourceId: "settlement:bank-a:account-a:TWD:different-time",
+      txnId: "",
+      occurredAt: "2026-04-15T08:30:46",
+    });
+    insertTransaction(database, {
+      id: "different-memo",
+      sourceId: "settlement:bank-a:account-a:TWD:different-memo",
+      txnId: "",
+      memo: "Another adjustment",
+    });
+
+    applyMigration(database);
+
+    expect(
+      database
+        .prepare("SELECT id FROM bank_transactions ORDER BY id")
+        .all()
+        .map((row) => row.id),
+    ).toEqual([
+      "canonical",
+      "different-memo",
+      "different-time",
+      "other-account",
+      "other-connector",
+      "valid-provider-id",
+    ]);
   });
 
   it("re-keys an empty durable source id without changing its transaction id", () => {
@@ -227,12 +332,12 @@ describe("TDCC bank transaction identity migration", () => {
       id: "empty-source-id",
       sourceId: "",
       txnId: "",
-      memo: "利息 102稅額 0健保費 0",
+      memo: "Provider adjustment",
     });
     database.exec(`
       INSERT INTO bank_transaction_preferences
         (transaction_id, excluded_from_calculation, created_at, updated_at)
-      VALUES ('empty-source-id', 1, '2026-08-20', '2026-08-20');
+      VALUES ('empty-source-id', 1, '2026-04-01', '2026-04-01');
     `);
 
     applyMigration(database);
@@ -245,7 +350,7 @@ describe("TDCC bank transaction identity migration", () => {
         .get(),
     ).toEqual({
       id: "empty-source-id",
-      source_id: "missing:2026-08-21T00:00:00:102:利息102稅額0健保費0",
+      source_id: "missing:2026-04-15T08:30:45:375:Provideradjustment",
     });
     expect(
       database

--- a/apps/worker/tests/features/sync/tdcc-transaction-identity-migration.test.ts
+++ b/apps/worker/tests/features/sync/tdcc-transaction-identity-migration.test.ts
@@ -7,17 +7,18 @@ const migrationsDirectory = fileURLToPath(
   new URL("../../../../../packages/db/migrations/", import.meta.url),
 );
 const migrationFile = "0032_tdcc_bank_transaction_identity_cleanup.sql";
+const staleIdentityMigrationFile = "0033_tdcc_stale_identity_cleanup.sql";
 const databases: DatabaseSync[] = [];
 
 afterEach(() => {
   for (const database of databases.splice(0)) database.close();
 });
 
-function createDatabase() {
+function createDatabase(beforeMigration = migrationFile) {
   const database = new DatabaseSync(":memory:");
   database.exec("PRAGMA foreign_keys = ON");
   for (const file of readdirSync(migrationsDirectory)
-    .filter((name) => name.endsWith(".sql") && name < migrationFile)
+    .filter((name) => name.endsWith(".sql") && name < beforeMigration)
     .sort()) {
     database.exec(readFileSync(`${migrationsDirectory}/${file}`, "utf8"));
   }
@@ -88,10 +89,8 @@ function insertTransaction(
     );
 }
 
-function applyMigration(database: DatabaseSync) {
-  database.exec(
-    readFileSync(`${migrationsDirectory}/${migrationFile}`, "utf8"),
-  );
+function applyMigration(database: DatabaseSync, migration = migrationFile) {
+  database.exec(readFileSync(`${migrationsDirectory}/${migration}`, "utf8"));
 }
 
 describe("TDCC bank transaction identity migration", () => {
@@ -359,5 +358,69 @@ describe("TDCC bank transaction identity migration", () => {
         )
         .get(),
     ).toEqual({ transaction_id: "empty-source-id" });
+  });
+
+  it("merges an older opaque provider id into a newer compound identity", () => {
+    const database = createDatabase(staleIdentityMigrationFile);
+    const canonicalSourceId = "batch:2026-04-15T08:30:45:375.0:0.0";
+    insertTransaction(database, {
+      id: "compound-canonical",
+      sourceId: canonicalSourceId,
+      txnId: canonicalSourceId,
+    });
+    insertTransaction(database, {
+      id: "opaque-legacy",
+      sourceId: "opaque-provider-id",
+      txnId: "opaque-provider-id",
+    });
+    database.exec(`
+      UPDATE bank_transactions
+      SET created_at = CASE id
+        WHEN 'opaque-legacy' THEN '2026-04-01T00:00:00.000Z'
+        WHEN 'compound-canonical' THEN '2026-04-16T00:00:00.000Z'
+      END
+      WHERE id IN ('opaque-legacy', 'compound-canonical');
+      INSERT INTO bank_transaction_preferences
+        (transaction_id, excluded_from_calculation, created_at, updated_at)
+      VALUES ('opaque-legacy', 1, '2026-04-01', '2026-04-15');
+      INSERT INTO classification_overrides
+        (id, target_type, target_id, category_id, created_at, updated_at)
+      VALUES ('opaque-legacy-override', 'bank_transaction', 'opaque-legacy',
+              'other', '2026-04-01', '2026-04-15');
+      INSERT INTO invoice_transaction_preferences
+        (invoice_id, transaction_id, decision, created_at, updated_at)
+      VALUES ('opaque-invoice', 'opaque-legacy', 'linked',
+              '2026-04-01', '2026-04-15');
+    `);
+
+    applyMigration(database, staleIdentityMigrationFile);
+
+    expect(
+      database
+        .prepare("SELECT id, source_id FROM bank_transactions ORDER BY id")
+        .all(),
+    ).toEqual([{ id: "compound-canonical", source_id: canonicalSourceId }]);
+    expect(
+      database
+        .prepare(
+          "SELECT transaction_id, excluded_from_calculation FROM bank_transaction_preferences",
+        )
+        .get(),
+    ).toEqual({
+      transaction_id: "compound-canonical",
+      excluded_from_calculation: 1,
+    });
+    expect(
+      database
+        .prepare("SELECT target_id, category_id FROM classification_overrides")
+        .get(),
+    ).toEqual({ target_id: "compound-canonical", category_id: "other" });
+    expect(
+      database
+        .prepare(
+          "SELECT transaction_id FROM invoice_transaction_preferences WHERE invoice_id = 'opaque-invoice'",
+        )
+        .get(),
+    ).toEqual({ transaction_id: "compound-canonical" });
   });
 });

--- a/apps/worker/tests/features/sync/tdcc-transaction-identity-migration.test.ts
+++ b/apps/worker/tests/features/sync/tdcc-transaction-identity-migration.test.ts
@@ -1,0 +1,258 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+const migrationsDirectory = fileURLToPath(
+  new URL("../../../../../packages/db/migrations/", import.meta.url),
+);
+const migrationFile = "0032_tdcc_bank_transaction_identity_cleanup.sql";
+const databases: DatabaseSync[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+function createDatabase() {
+  const database = new DatabaseSync(":memory:");
+  database.exec("PRAGMA foreign_keys = ON");
+  for (const file of readdirSync(migrationsDirectory)
+    .filter((name) => name.endsWith(".sql") && name < migrationFile)
+    .sort()) {
+    database.exec(readFileSync(`${migrationsDirectory}/${file}`, "utf8"));
+  }
+  database
+    .prepare(
+      `INSERT INTO bank_accounts
+        (id, connector_id, source_id, account_type, currency, created_at, updated_at)
+       VALUES (?, 'tdcc', ?, 'settlement_cash', 'TWD', ?, ?)`,
+    )
+    .run("account-1", "settlement:004:test:TWD", "2026-08-20", "2026-08-20");
+  databases.push(database);
+  return database;
+}
+
+function insertTransaction(
+  database: DatabaseSync,
+  input: {
+    id: string;
+    sourceId: string;
+    txnId: string;
+    occurredAt?: string;
+    amount?: number;
+    memo?: string;
+  },
+) {
+  const occurredAt = input.occurredAt ?? "2026-08-21T00:00:00";
+  const amount = input.amount ?? 102;
+  database
+    .prepare(
+      `INSERT INTO bank_transactions
+        (id, connector_id, account_id, source_id, posted_date, amount, currency,
+         description, raw_payload, created_at, updated_at)
+       VALUES (?, 'tdcc', 'account-1', ?, ?, ?, 'TWD', ?, ?, ?, ?)`,
+    )
+    .run(
+      input.id,
+      input.sourceId,
+      occurredAt,
+      amount,
+      input.memo ?? "利息102稅額0健保費0",
+      JSON.stringify({
+        txnId: input.txnId,
+        occurredAt,
+        amount: String(amount),
+        memo: input.memo ?? "利息102稅額0健保費0",
+      }),
+      "2026-08-20",
+      "2026-08-23",
+    );
+}
+
+function applyMigration(database: DatabaseSync) {
+  database.exec(
+    readFileSync(`${migrationsDirectory}/${migrationFile}`, "utf8"),
+  );
+}
+
+describe("TDCC bank transaction identity migration", () => {
+  it("merges uniquely matched legacy rows and preserves user preferences", () => {
+    const database = createDatabase();
+    const canonicalSourceId = "00000:2026-08-21T00:00:00:102.0:0.0";
+    insertTransaction(database, {
+      id: "canonical",
+      sourceId: canonicalSourceId,
+      txnId: canonicalSourceId,
+    });
+    insertTransaction(database, {
+      id: "legacy-1",
+      sourceId: "settlement:004:test:TWD:2026-08-21:102:TWD:interest-a",
+      txnId: "",
+      memo: "利息 102稅額 0健保費 0",
+    });
+    insertTransaction(database, {
+      id: "legacy-2",
+      sourceId: "settlement:004:test:TWD:2026-08-21:102:TWD:interest-b",
+      txnId: " ",
+    });
+    database.exec(`
+      INSERT INTO bank_transaction_preferences
+        (transaction_id, excluded_from_calculation, created_at, updated_at)
+      VALUES
+        ('canonical', 0, '2026-08-23', '2026-08-23'),
+        ('legacy-1', 1, '2026-08-20', '2026-08-21');
+      INSERT INTO classification_overrides
+        (id, target_type, target_id, category_id, created_at, updated_at)
+      VALUES
+        ('legacy-override', 'bank_transaction', 'legacy-2', 'insurance',
+         '2026-08-20', '2026-08-21');
+      INSERT INTO invoice_transaction_preferences
+        (invoice_id, transaction_id, decision, created_at, updated_at)
+      VALUES ('invoice-1', 'legacy-1', 'linked', '2026-08-20', '2026-08-21');
+    `);
+
+    applyMigration(database);
+
+    expect(
+      database
+        .prepare("SELECT id FROM bank_transactions ORDER BY id")
+        .all()
+        .map((row) => row.id),
+    ).toEqual(["canonical"]);
+    expect(
+      database
+        .prepare(
+          "SELECT excluded_from_calculation FROM bank_transaction_preferences WHERE transaction_id = 'canonical'",
+        )
+        .get(),
+    ).toEqual({ excluded_from_calculation: 1 });
+    expect(
+      database
+        .prepare(
+          "SELECT target_id, category_id FROM classification_overrides WHERE target_type = 'bank_transaction'",
+        )
+        .get(),
+    ).toEqual({ target_id: "canonical", category_id: "insurance" });
+    expect(
+      database
+        .prepare(
+          "SELECT transaction_id FROM invoice_transaction_preferences WHERE invoice_id = 'invoice-1'",
+        )
+        .get(),
+    ).toEqual({ transaction_id: "canonical" });
+
+    applyMigration(database);
+    expect(
+      database.prepare("SELECT COUNT(*) AS count FROM bank_transactions").get(),
+    ).toEqual({ count: 1 });
+  });
+
+  it("keeps ambiguous matches and conflicting user decisions untouched", () => {
+    const database = createDatabase();
+    insertTransaction(database, {
+      id: "ambiguous-legacy",
+      sourceId: "settlement:004:test:TWD:ambiguous",
+      txnId: "",
+    });
+    insertTransaction(database, {
+      id: "ambiguous-canonical-1",
+      sourceId: "canonical-1",
+      txnId: "canonical-1",
+    });
+    insertTransaction(database, {
+      id: "ambiguous-canonical-2",
+      sourceId: "canonical-2",
+      txnId: "canonical-2",
+    });
+
+    insertTransaction(database, {
+      id: "invoice-legacy",
+      sourceId: "settlement:004:test:TWD:invoice",
+      txnId: "",
+      occurredAt: "2026-08-22T00:00:00",
+    });
+    insertTransaction(database, {
+      id: "invoice-canonical",
+      sourceId: "invoice-canonical-id",
+      txnId: "invoice-canonical-id",
+      occurredAt: "2026-08-22T00:00:00",
+    });
+    database.exec(`
+      INSERT INTO invoice_transaction_preferences
+        (invoice_id, transaction_id, decision, created_at, updated_at)
+      VALUES
+        ('invoice-legacy-pref', 'invoice-legacy', 'linked', '2026-08-20', '2026-08-20'),
+        ('invoice-canonical-pref', 'invoice-canonical', 'linked', '2026-08-20', '2026-08-20');
+    `);
+
+    insertTransaction(database, {
+      id: "classification-legacy",
+      sourceId: "settlement:004:test:TWD:classification",
+      txnId: "",
+      occurredAt: "2026-08-23T00:00:00",
+    });
+    insertTransaction(database, {
+      id: "classification-canonical",
+      sourceId: "classification-canonical-id",
+      txnId: "classification-canonical-id",
+      occurredAt: "2026-08-23T00:00:00",
+    });
+    database.exec(`
+      INSERT INTO classification_overrides
+        (id, target_type, target_id, category_id, created_at, updated_at)
+      VALUES
+        ('classification-legacy-override', 'bank_transaction',
+         'classification-legacy', 'tax', '2026-08-20', '2026-08-20'),
+        ('classification-canonical-override', 'bank_transaction',
+         'classification-canonical', 'insurance', '2026-08-20', '2026-08-20');
+    `);
+
+    applyMigration(database);
+
+    expect(
+      database
+        .prepare(
+          `SELECT id FROM bank_transactions
+           WHERE id IN ('ambiguous-legacy', 'invoice-legacy', 'classification-legacy')
+           ORDER BY id`,
+        )
+        .all()
+        .map((row) => row.id),
+    ).toEqual(["ambiguous-legacy", "classification-legacy", "invoice-legacy"]);
+  });
+
+  it("re-keys an empty durable source id without changing its transaction id", () => {
+    const database = createDatabase();
+    insertTransaction(database, {
+      id: "empty-source-id",
+      sourceId: "",
+      txnId: "",
+      memo: "利息 102稅額 0健保費 0",
+    });
+    database.exec(`
+      INSERT INTO bank_transaction_preferences
+        (transaction_id, excluded_from_calculation, created_at, updated_at)
+      VALUES ('empty-source-id', 1, '2026-08-20', '2026-08-20');
+    `);
+
+    applyMigration(database);
+
+    expect(
+      database
+        .prepare(
+          "SELECT id, source_id FROM bank_transactions WHERE id = 'empty-source-id'",
+        )
+        .get(),
+    ).toEqual({
+      id: "empty-source-id",
+      source_id: "missing:2026-08-21T00:00:00:102:利息102稅額0健保費0",
+    });
+    expect(
+      database
+        .prepare(
+          "SELECT transaction_id FROM bank_transaction_preferences WHERE transaction_id = 'empty-source-id'",
+        )
+        .get(),
+    ).toEqual({ transaction_id: "empty-source-id" });
+  });
+});

--- a/packages/connectors/src/tdcc-epassbook-client.ts
+++ b/packages/connectors/src/tdcc-epassbook-client.ts
@@ -545,30 +545,33 @@ export function normalizeBankTransactionDetails(
   // includes date+amounts.
   const stanCount = new Map<string, number>();
   for (const detail of details) {
-    if (detail.stan)
-      stanCount.set(detail.stan, (stanCount.get(detail.stan) ?? 0) + 1);
+    const stan = detail.stan?.trim();
+    if (stan) stanCount.set(stan, (stanCount.get(stan) ?? 0) + 1);
   }
 
   return details.map((detail) => {
-    const dt = detail.txnDateTime ?? "";
-    const occurredAt =
-      dt.length >= 14
-        ? `${dt.slice(0, 4)}-${dt.slice(4, 6)}-${dt.slice(6, 8)}T${dt.slice(8, 10)}:${dt.slice(10, 12)}:${dt.slice(12, 14)}`
-        : new Date().toISOString();
-    const isDupStan = detail.stan && (stanCount.get(detail.stan) ?? 0) > 1;
+    const stan = detail.stan?.trim();
+    const dt = detail.txnDateTime?.trim() ?? "";
+    const hasValidDateTime = /^\d{14}$/.test(dt);
+    const occurredAt = hasValidDateTime
+      ? `${dt.slice(0, 4)}-${dt.slice(4, 6)}-${dt.slice(6, 8)}T${dt.slice(8, 10)}:${dt.slice(10, 12)}:${dt.slice(12, 14)}`
+      : "1970-01-01T00:00:00";
+    const transferInAmount = detail.transferInAmount?.trim() || "0";
+    const transferOutAmount = detail.transferOutAmount?.trim() || "0";
+    const memo = detail.memo?.trim() || detail.summary?.trim();
+    const amount = String(Number(transferInAmount) - Number(transferOutAmount));
+    const isDupStan = stan && (stanCount.get(stan) ?? 0) > 1;
     const txnId = isDupStan
-      ? `${detail.stan}:${occurredAt}:${detail.transferInAmount ?? "0"}:${detail.transferOutAmount ?? "0"}`
-      : (detail.stan ?? occurredAt);
+      ? `${stan}:${occurredAt}:${transferInAmount}:${transferOutAmount}`
+      : stan ||
+        ["missing", occurredAt, amount, memo?.replace(/\s+/g, "") || "-"].join(
+          ":",
+        );
     return {
       txnId,
       occurredAt,
-      amount: String(
-        Number(detail.transferInAmount ?? "0") -
-          Number(detail.transferOutAmount ?? "0"),
-      ),
-      ...(detail.memo?.trim() || detail.summary?.trim()
-        ? { memo: detail.memo?.trim() || detail.summary?.trim() }
-        : {}),
+      amount,
+      ...(memo ? { memo } : {}),
     };
   });
 }

--- a/packages/connectors/tests/selfcheck/tdcc.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/tdcc.selfcheck.ts
@@ -9,7 +9,10 @@ import {
   TdccOtpExpiredError,
   TdccVerificationRequiredError,
 } from "../../src/tdcc";
-import { EPassbookClient } from "../../src/tdcc-epassbook-client";
+import {
+  EPassbookClient,
+  normalizeBankTransactionDetails,
+} from "../../src/tdcc-epassbook-client";
 
 const calls: string[] = [];
 const tspPageTokens: string[] = [];
@@ -260,6 +263,73 @@ function errorResponse(returnCode: string) {
 }) as typeof fetch;
 
 async function main() {
+  const missingStanDetails = [
+    {
+      stan: " ",
+      txnDateTime: "20260821000000",
+      transferInAmount: "102.0",
+      transferOutAmount: "0.0",
+      memo: "利息 102稅額 0健保費 0",
+    },
+    {
+      stan: "",
+      txnDateTime: "20260821000000",
+      transferInAmount: "102.0",
+      transferOutAmount: "0.0",
+      memo: "利息102稅額0健保費0",
+    },
+  ];
+  const normalizedMissingStan =
+    normalizeBankTransactionDetails(missingStanDetails);
+  assert.ok(normalizedMissingStan[0]?.txnId);
+  assert.equal(
+    normalizedMissingStan[0]?.txnId,
+    normalizedMissingStan[1]?.txnId,
+    "blank STAN rows with whitespace-only memo differences need the same stable id",
+  );
+  assert.deepEqual(
+    normalizeBankTransactionDetails(missingStanDetails),
+    normalizedMissingStan,
+    "blank STAN ids must remain stable across syncs",
+  );
+
+  const duplicateStan = normalizeBankTransactionDetails([
+    {
+      stan: "00000",
+      txnDateTime: "20260821000000",
+      transferInAmount: "102.0",
+      transferOutAmount: "0.0",
+    },
+    {
+      stan: "00000",
+      txnDateTime: "20260620000000",
+      transferInAmount: "103.0",
+      transferOutAmount: "0.0",
+    },
+  ]);
+  assert.equal(
+    duplicateStan[0]?.txnId,
+    "00000:2026-08-21T00:00:00:102.0:0.0",
+    "existing compound ids for duplicate non-empty STAN values must stay compatible",
+  );
+
+  const malformedDate = normalizeBankTransactionDetails([
+    {
+      stan: "",
+      txnDateTime: "invalid",
+      transferInAmount: "1",
+    },
+  ]);
+  assert.equal(malformedDate[0]?.occurredAt, "1970-01-01T00:00:00");
+  assert.equal(malformedDate[0]?.txnId, "missing:1970-01-01T00:00:00:1:-");
+  assert.equal(
+    malformedDate[0]?.txnId,
+    normalizeBankTransactionDetails([
+      { stan: "", txnDateTime: "invalid", transferInAmount: "1" },
+    ])[0]?.txnId,
+    "malformed dates must not use the current wall-clock time in their id",
+  );
+
   const connector = createTdccConnector();
   const config = parseTdccConfig({ userId: "A123456789", password: "secret" });
 

--- a/packages/db/migrations/0032_tdcc_bank_transaction_identity_cleanup.sql
+++ b/packages/db/migrations/0032_tdcc_bank_transaction_identity_cleanup.sql
@@ -1,0 +1,222 @@
+CREATE TABLE migration_0032_tdcc_transaction_matches (
+  legacy_id TEXT PRIMARY KEY,
+  canonical_id TEXT NOT NULL
+);
+
+INSERT INTO migration_0032_tdcc_transaction_matches (legacy_id, canonical_id)
+WITH normalized AS (
+  SELECT
+    id,
+    connector_id,
+    account_id,
+    source_id,
+    amount,
+    currency,
+    trim(CAST(json_extract(
+      CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+      '$.txnId'
+    ) AS TEXT)) AS raw_txn_id,
+    CAST(json_extract(
+      CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+      '$.amount'
+    ) AS REAL) AS raw_amount,
+    CAST(json_extract(
+      CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+      '$.occurredAt'
+    ) AS TEXT) AS raw_occurred_at,
+    replace(replace(replace(replace(
+      trim(COALESCE(CAST(json_extract(
+        CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+        '$.memo'
+      ) AS TEXT), '')),
+      ' ', ''), char(9), ''), char(10), ''), char(13), '') AS raw_memo
+  FROM bank_transactions
+  WHERE connector_id = 'tdcc'
+), candidates AS (
+  SELECT
+    legacy.id AS legacy_id,
+    canonical.id AS canonical_id,
+    COUNT(*) OVER (PARTITION BY legacy.id) AS candidate_count
+  FROM normalized legacy
+  JOIN normalized canonical
+    ON canonical.account_id = legacy.account_id
+   AND canonical.id <> legacy.id
+   AND canonical.source_id = canonical.raw_txn_id
+   AND canonical.raw_txn_id <> ''
+   AND canonical.raw_occurred_at = legacy.raw_occurred_at
+   AND canonical.raw_amount = legacy.raw_amount
+   AND canonical.amount = legacy.amount
+   AND canonical.currency = legacy.currency
+   AND canonical.raw_memo = legacy.raw_memo
+  WHERE (legacy.source_id LIKE 'settlement:%' OR legacy.source_id = '')
+    AND COALESCE(legacy.raw_txn_id, '') = ''
+)
+SELECT legacy_id, canonical_id
+FROM candidates
+WHERE candidate_count = 1;
+
+-- A linked invoice may only point at one bank transaction. Keep every legacy
+-- row when remapping would overwrite or merge distinct user decisions.
+DELETE FROM migration_0032_tdcc_transaction_matches
+WHERE canonical_id IN (
+  SELECT matches.canonical_id
+  FROM migration_0032_tdcc_transaction_matches matches
+  JOIN invoice_transaction_preferences legacy_preference
+    ON legacy_preference.transaction_id = matches.legacy_id
+   AND legacy_preference.decision = 'linked'
+  GROUP BY matches.canonical_id
+  HAVING COUNT(*) > 1
+     OR EXISTS (
+       SELECT 1
+       FROM invoice_transaction_preferences canonical_preference
+       WHERE canonical_preference.transaction_id = matches.canonical_id
+         AND canonical_preference.decision = 'linked'
+     )
+);
+
+-- Conflicting manual classifications cannot be merged without choosing one
+-- on the user's behalf, so leave those transaction rows untouched.
+DELETE FROM migration_0032_tdcc_transaction_matches
+WHERE canonical_id IN (
+  SELECT decisions.canonical_id
+  FROM (
+    SELECT matches.canonical_id, override.category_id
+    FROM migration_0032_tdcc_transaction_matches matches
+    JOIN classification_overrides override
+      ON override.target_type = 'bank_transaction'
+     AND override.target_id = matches.legacy_id
+    UNION ALL
+    SELECT matches.canonical_id, override.category_id
+    FROM (
+      SELECT DISTINCT canonical_id
+      FROM migration_0032_tdcc_transaction_matches
+    ) matches
+    JOIN classification_overrides override
+      ON override.target_type = 'bank_transaction'
+     AND override.target_id = matches.canonical_id
+  ) decisions
+  GROUP BY decisions.canonical_id
+  HAVING COUNT(DISTINCT decisions.category_id) > 1
+);
+
+INSERT INTO bank_transaction_preferences
+  (transaction_id, excluded_from_calculation, created_at, updated_at)
+SELECT
+  matches.canonical_id,
+  MAX(preference.excluded_from_calculation),
+  MIN(preference.created_at),
+  MAX(preference.updated_at)
+FROM migration_0032_tdcc_transaction_matches matches
+JOIN bank_transaction_preferences preference
+  ON preference.transaction_id = matches.legacy_id
+GROUP BY matches.canonical_id
+HAVING COUNT(*) > 0
+ON CONFLICT(transaction_id) DO UPDATE SET
+  excluded_from_calculation = MAX(
+    bank_transaction_preferences.excluded_from_calculation,
+    excluded.excluded_from_calculation
+  ),
+  created_at = MIN(bank_transaction_preferences.created_at, excluded.created_at),
+  updated_at = MAX(bank_transaction_preferences.updated_at, excluded.updated_at);
+
+INSERT OR IGNORE INTO classification_overrides
+  (id, target_type, target_id, category_id, created_at, updated_at)
+SELECT
+  'override:bank_transaction:' || matches.canonical_id,
+  'bank_transaction',
+  matches.canonical_id,
+  MIN(override.category_id),
+  MIN(override.created_at),
+  MAX(override.updated_at)
+FROM migration_0032_tdcc_transaction_matches matches
+JOIN classification_overrides override
+  ON override.target_type = 'bank_transaction'
+ AND override.target_id = matches.legacy_id
+GROUP BY matches.canonical_id;
+
+UPDATE invoice_transaction_preferences
+SET transaction_id = (
+  SELECT matches.canonical_id
+  FROM migration_0032_tdcc_transaction_matches matches
+  WHERE matches.legacy_id = invoice_transaction_preferences.transaction_id
+)
+WHERE transaction_id IN (
+  SELECT legacy_id FROM migration_0032_tdcc_transaction_matches
+);
+
+DELETE FROM bank_transaction_preferences
+WHERE transaction_id IN (
+  SELECT legacy_id FROM migration_0032_tdcc_transaction_matches
+);
+
+DELETE FROM classification_overrides
+WHERE target_type = 'bank_transaction'
+  AND target_id IN (
+    SELECT legacy_id FROM migration_0032_tdcc_transaction_matches
+  );
+
+DELETE FROM bank_transactions
+WHERE id IN (
+  SELECT legacy_id FROM migration_0032_tdcc_transaction_matches
+);
+
+DROP TABLE migration_0032_tdcc_transaction_matches;
+
+-- Durable TDCC sync previously persisted an empty source_id when STAN was an
+-- empty string. Re-key those rows in place so the fixed normalizer will upsert
+-- them on the next sync. The transaction id stays unchanged, preserving all
+-- user references. Rows with a conflicting destination key remain untouched.
+UPDATE bank_transactions AS legacy
+SET source_id =
+  'missing:' ||
+  CAST(json_extract(
+    CASE WHEN json_valid(legacy.raw_payload) THEN legacy.raw_payload ELSE '{}' END,
+    '$.occurredAt'
+  ) AS TEXT) || ':' ||
+  CAST(json_extract(
+    CASE WHEN json_valid(legacy.raw_payload) THEN legacy.raw_payload ELSE '{}' END,
+    '$.amount'
+  ) AS TEXT) || ':' ||
+  COALESCE(NULLIF(replace(replace(replace(replace(
+    trim(COALESCE(CAST(json_extract(
+      CASE WHEN json_valid(legacy.raw_payload) THEN legacy.raw_payload ELSE '{}' END,
+      '$.memo'
+    ) AS TEXT), '')),
+    ' ', ''), char(9), ''), char(10), ''), char(13), ''), ''), '-')
+WHERE legacy.connector_id = 'tdcc'
+  AND legacy.source_id = ''
+  AND COALESCE(trim(CAST(json_extract(
+    CASE WHEN json_valid(legacy.raw_payload) THEN legacy.raw_payload ELSE '{}' END,
+    '$.txnId'
+  ) AS TEXT)), '') = ''
+  AND COALESCE(CAST(json_extract(
+    CASE WHEN json_valid(legacy.raw_payload) THEN legacy.raw_payload ELSE '{}' END,
+    '$.occurredAt'
+  ) AS TEXT), '') <> ''
+  AND json_type(
+    CASE WHEN json_valid(legacy.raw_payload) THEN legacy.raw_payload ELSE '{}' END,
+    '$.amount'
+  ) IN ('integer', 'real', 'text')
+  AND NOT EXISTS (
+    SELECT 1
+    FROM bank_transactions existing
+    WHERE existing.connector_id = legacy.connector_id
+      AND existing.account_id = legacy.account_id
+      AND existing.id <> legacy.id
+      AND existing.source_id =
+        'missing:' ||
+        CAST(json_extract(
+          CASE WHEN json_valid(legacy.raw_payload) THEN legacy.raw_payload ELSE '{}' END,
+          '$.occurredAt'
+        ) AS TEXT) || ':' ||
+        CAST(json_extract(
+          CASE WHEN json_valid(legacy.raw_payload) THEN legacy.raw_payload ELSE '{}' END,
+          '$.amount'
+        ) AS TEXT) || ':' ||
+        COALESCE(NULLIF(replace(replace(replace(replace(
+          trim(COALESCE(CAST(json_extract(
+            CASE WHEN json_valid(legacy.raw_payload) THEN legacy.raw_payload ELSE '{}' END,
+            '$.memo'
+          ) AS TEXT), '')),
+          ' ', ''), char(9), ''), char(10), ''), char(13), ''), ''), '-')
+  );

--- a/packages/db/migrations/0033_tdcc_stale_identity_cleanup.sql
+++ b/packages/db/migrations/0033_tdcc_stale_identity_cleanup.sql
@@ -1,0 +1,169 @@
+CREATE TABLE migration_0033_tdcc_transaction_matches (
+  legacy_id TEXT PRIMARY KEY,
+  canonical_id TEXT NOT NULL
+);
+
+INSERT INTO migration_0033_tdcc_transaction_matches (legacy_id, canonical_id)
+WITH normalized AS (
+  SELECT
+    id,
+    connector_id,
+    account_id,
+    source_id,
+    amount,
+    currency,
+    created_at,
+    trim(CAST(json_extract(
+      CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+      '$.txnId'
+    ) AS TEXT)) AS raw_txn_id,
+    CAST(json_extract(
+      CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+      '$.amount'
+    ) AS REAL) AS raw_amount,
+    CAST(json_extract(
+      CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+      '$.occurredAt'
+    ) AS TEXT) AS raw_occurred_at,
+    replace(replace(replace(replace(
+      trim(COALESCE(CAST(json_extract(
+        CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+        '$.memo'
+      ) AS TEXT), '')),
+      ' ', ''), char(9), ''), char(10), ''), char(13), '') AS raw_memo
+  FROM bank_transactions
+  WHERE connector_id = 'tdcc'
+), candidates AS (
+  SELECT
+    legacy.id AS legacy_id,
+    canonical.id AS canonical_id,
+    COUNT(*) OVER (PARTITION BY legacy.id) AS legacy_candidate_count,
+    COUNT(*) OVER (PARTITION BY canonical.id) AS canonical_candidate_count
+  FROM normalized legacy
+  JOIN normalized canonical
+    ON canonical.account_id = legacy.account_id
+   AND canonical.id <> legacy.id
+   AND canonical.source_id = canonical.raw_txn_id
+   AND canonical.raw_txn_id <> ''
+   AND instr(canonical.source_id, canonical.raw_occurred_at) > 0
+   AND canonical.raw_occurred_at <> ''
+   AND canonical.raw_occurred_at = legacy.raw_occurred_at
+   AND canonical.raw_amount = legacy.raw_amount
+   AND canonical.amount = legacy.amount
+   AND canonical.currency = legacy.currency
+   AND canonical.raw_memo = legacy.raw_memo
+   AND canonical.created_at > legacy.created_at
+  WHERE legacy.raw_txn_id <> ''
+    AND legacy.source_id = legacy.raw_txn_id
+    AND legacy.raw_occurred_at <> ''
+    AND instr(legacy.source_id, legacy.raw_occurred_at) = 0
+)
+SELECT legacy_id, canonical_id
+FROM candidates
+WHERE legacy_candidate_count = 1
+  AND canonical_candidate_count = 1;
+
+-- Never merge two linked invoice decisions into one transaction.
+DELETE FROM migration_0033_tdcc_transaction_matches
+WHERE canonical_id IN (
+  SELECT matches.canonical_id
+  FROM migration_0033_tdcc_transaction_matches matches
+  JOIN invoice_transaction_preferences legacy_preference
+    ON legacy_preference.transaction_id = matches.legacy_id
+   AND legacy_preference.decision = 'linked'
+  GROUP BY matches.canonical_id
+  HAVING COUNT(*) > 1
+     OR EXISTS (
+       SELECT 1
+       FROM invoice_transaction_preferences canonical_preference
+       WHERE canonical_preference.transaction_id = matches.canonical_id
+         AND canonical_preference.decision = 'linked'
+     )
+);
+
+-- Conflicting manual classifications are left for explicit user resolution.
+DELETE FROM migration_0033_tdcc_transaction_matches
+WHERE canonical_id IN (
+  SELECT decisions.canonical_id
+  FROM (
+    SELECT matches.canonical_id, override.category_id
+    FROM migration_0033_tdcc_transaction_matches matches
+    JOIN classification_overrides override
+      ON override.target_type = 'bank_transaction'
+     AND override.target_id = matches.legacy_id
+    UNION ALL
+    SELECT matches.canonical_id, override.category_id
+    FROM (
+      SELECT DISTINCT canonical_id
+      FROM migration_0033_tdcc_transaction_matches
+    ) matches
+    JOIN classification_overrides override
+      ON override.target_type = 'bank_transaction'
+     AND override.target_id = matches.canonical_id
+  ) decisions
+  GROUP BY decisions.canonical_id
+  HAVING COUNT(DISTINCT decisions.category_id) > 1
+);
+
+INSERT INTO bank_transaction_preferences
+  (transaction_id, excluded_from_calculation, created_at, updated_at)
+SELECT
+  matches.canonical_id,
+  MAX(preference.excluded_from_calculation),
+  MIN(preference.created_at),
+  MAX(preference.updated_at)
+FROM migration_0033_tdcc_transaction_matches matches
+JOIN bank_transaction_preferences preference
+  ON preference.transaction_id = matches.legacy_id
+GROUP BY matches.canonical_id
+HAVING COUNT(*) > 0
+ON CONFLICT(transaction_id) DO UPDATE SET
+  excluded_from_calculation = MAX(
+    bank_transaction_preferences.excluded_from_calculation,
+    excluded.excluded_from_calculation
+  ),
+  created_at = MIN(bank_transaction_preferences.created_at, excluded.created_at),
+  updated_at = MAX(bank_transaction_preferences.updated_at, excluded.updated_at);
+
+INSERT OR IGNORE INTO classification_overrides
+  (id, target_type, target_id, category_id, created_at, updated_at)
+SELECT
+  'override:bank_transaction:' || matches.canonical_id,
+  'bank_transaction',
+  matches.canonical_id,
+  MIN(override.category_id),
+  MIN(override.created_at),
+  MAX(override.updated_at)
+FROM migration_0033_tdcc_transaction_matches matches
+JOIN classification_overrides override
+  ON override.target_type = 'bank_transaction'
+ AND override.target_id = matches.legacy_id
+GROUP BY matches.canonical_id;
+
+UPDATE invoice_transaction_preferences
+SET transaction_id = (
+  SELECT matches.canonical_id
+  FROM migration_0033_tdcc_transaction_matches matches
+  WHERE matches.legacy_id = invoice_transaction_preferences.transaction_id
+)
+WHERE transaction_id IN (
+  SELECT legacy_id FROM migration_0033_tdcc_transaction_matches
+);
+
+DELETE FROM bank_transaction_preferences
+WHERE transaction_id IN (
+  SELECT legacy_id FROM migration_0033_tdcc_transaction_matches
+);
+
+DELETE FROM classification_overrides
+WHERE target_type = 'bank_transaction'
+  AND target_id IN (
+    SELECT legacy_id FROM migration_0033_tdcc_transaction_matches
+  );
+
+DELETE FROM bank_transactions
+WHERE id IN (
+  SELECT legacy_id FROM migration_0033_tdcc_transaction_matches
+);
+
+DROP TABLE migration_0033_tdcc_transaction_matches;


### PR DESCRIPTION
## 問題

TDCC 銀行交易的 STAN 可能是空字串或被銀行重複使用。舊 fallback 又把描述文字直接納入 source ID，描述中的空白差異會讓同一筆交易產生不同 ID；durable 路徑對空字串 STAN 也會直接寫入空 source ID。

這使同一筆交易同時保留 legacy row 與 canonical row，活動頁因此顯示重複。

## 修正

- 將 STAN 先 trim，空 STAN 以日期、淨額與去空白 memo 產生穩定非空 ID
- 缺失或格式錯誤日期使用固定 fallback，不再把目前時間放進交易 ID
- 保持既有重複非空 STAN compound ID 格式相容
- 新增 0032 migration，只合併同帳戶、精確時間、金額、幣別、去空白 memo 且唯一對應的 legacy row
- 新增 0033 migration，處理舊版 opaque provider ID 與新版 compound identity 的版本漂移；不寫死帳戶、日期或金額，並以同帳戶、完整交易欄位及雙向唯一候選限制合併
- 合併前保留銀行排除偏好、分類覆寫與發票連結；遇到衝突或模糊候選則不刪除
- 將 durable 路徑既有空 source ID 原地改成穩定 ID，保留 transaction id 與偏好關聯

## 驗證

- `npm run test:selfcheck -w @taiwan-fin-hub/connectors`
- `npx vitest run apps/worker/tests/features/sync/tdcc-transaction-identity-migration.test.ts apps/worker/tests/features/sync/persistence.test.ts`（17 tests passed）
- `npm run typecheck -w @taiwan-fin-hub/connectors`
- `npm run typecheck -w @taiwan-fin-hub/worker`
- Wrangler 本機套用 0032、0033 成功
- `git diff --check`

## 正式環境資料修復

- 0032 套用前唯讀預檢確認 2 筆 legacy row 唯一對到 1 筆 canonical row，另有 5 筆空 source ID 可安全原地重編；套用後目標交易由 3 筆剩 1 筆、空 source ID 由 5 筆降為 0。
- 0033 套用前唯讀預檢確認 1 筆 opaque legacy row 唯一對到 1 筆新版 compound row，且沒有交易偏好、分類覆寫或發票連結；套用後舊 identity row 為 0、canonical row 保留 1 筆。
