### PR TITLE
修正：穩定集保交易識別碼並清理舊資料

### DIFF
--- a/apps/worker/tests/features/sync/tdcc-transaction-identity-migration.test.ts
+++ b/apps/worker/tests/features/sync/tdcc-transaction-identity-migration.test.ts
@@ -8,6 +8,7 @@ const migrationsDirectory = fileURLToPath(
 );
 const migrationFile = "0032_tdcc_bank_transaction_identity_cleanup.sql";
 const staleIdentityMigrationFile = "0033_tdcc_stale_identity_cleanup.sql";
+const lateIdentityMigrationFile = "0035_tdcc_late_identity_reconciliation.sql";
 const databases: DatabaseSync[] = [];
 
 afterEach(() => {
@@ -422,5 +423,297 @@ describe("TDCC bank transaction identity migration", () => {
         )
         .get(),
     ).toEqual({ transaction_id: "compound-canonical" });
+  });
+
+  it("re-keys old TDCC identities from semantic fields without changing row ids", () => {
+    const database = createDatabase(lateIdentityMigrationFile);
+    insertTransaction(database, {
+      id: "settlement-old",
+      sourceId: "settlement:bank-a:account-a:TWD:legacy",
+      txnId: "",
+    });
+    insertTransaction(database, {
+      id: "plain-old",
+      sourceId: "batch",
+      txnId: "batch",
+      occurredAt: "2026-04-16T08:30:45",
+      memo: "Plain payment",
+    });
+    const compoundSourceId = "batch:2026-04-17T08:30:45:375.0:0.0";
+    insertTransaction(database, {
+      id: "compound-old",
+      sourceId: compoundSourceId,
+      txnId: compoundSourceId,
+      occurredAt: "2026-04-17T08:30:45",
+      memo: "Compound payment",
+    });
+    database.exec(`
+      UPDATE bank_transactions
+      SET posted_date = '2026-04-15T08:30:45.000Z'
+      WHERE id = 'settlement-old';
+      INSERT INTO bank_transaction_preferences
+        (transaction_id, excluded_from_calculation, created_at, updated_at)
+      VALUES ('settlement-old', 1, '2026-04-01', '2026-04-15');
+      INSERT INTO classification_overrides
+        (id, target_type, target_id, category_id, created_at, updated_at)
+      VALUES ('settlement-old-override', 'bank_transaction',
+              'settlement-old', 'other', '2026-04-01', '2026-04-15');
+      INSERT INTO invoice_transaction_preferences
+        (invoice_id, transaction_id, decision, created_at, updated_at)
+      VALUES ('settlement-old-invoice', 'settlement-old', 'linked',
+              '2026-04-01', '2026-04-15');
+    `);
+
+    applyMigration(database, lateIdentityMigrationFile);
+    applyMigration(database, lateIdentityMigrationFile);
+    database.exec(`
+      INSERT INTO bank_transactions
+        (id, connector_id, account_id, source_id, posted_date, amount, currency,
+         description, raw_payload, created_at, updated_at)
+      VALUES
+        ('new-sync-id', 'tdcc', 'account-a',
+         'missing:2026-04-15T08:30:45:375:Provideradjustment',
+         '2026-04-15T08:30:45.000Z', 375, 'TWD', 'Provider adjustment',
+         '{}', '2026-04-20', '2026-04-20')
+      ON CONFLICT(connector_id, account_id, source_id) DO UPDATE SET
+        updated_at = excluded.updated_at;
+    `);
+
+    expect(
+      database
+        .prepare("SELECT id, source_id FROM bank_transactions ORDER BY id")
+        .all(),
+    ).toEqual([
+      {
+        id: "compound-old",
+        source_id: "missing:2026-04-17T08:30:45:375:Compoundpayment",
+      },
+      {
+        id: "plain-old",
+        source_id: "missing:2026-04-16T08:30:45:375:Plainpayment",
+      },
+      {
+        id: "settlement-old",
+        source_id: "missing:2026-04-15T08:30:45:375:Provideradjustment",
+      },
+    ]);
+    expect(
+      database
+        .prepare("SELECT transaction_id FROM bank_transaction_preferences")
+        .get(),
+    ).toEqual({ transaction_id: "settlement-old" });
+    expect(
+      database.prepare("SELECT target_id FROM classification_overrides").get(),
+    ).toEqual({ target_id: "settlement-old" });
+    expect(
+      database
+        .prepare(
+          "SELECT transaction_id FROM invoice_transaction_preferences WHERE invoice_id = 'settlement-old-invoice'",
+        )
+        .get(),
+    ).toEqual({ transaction_id: "settlement-old" });
+  });
+
+  it("merges semantic TDCC duplicates and transfers user references", () => {
+    const database = createDatabase(lateIdentityMigrationFile);
+    const canonicalSourceId =
+      "missing:2026-04-15T08:30:45:375:Provideradjustment";
+    insertTransaction(database, {
+      id: "settlement-legacy",
+      sourceId: "settlement:bank-a:account-a:TWD:legacy",
+      txnId: "",
+      memo: "Provider  adjustment",
+    });
+    insertTransaction(database, {
+      id: "missing-canonical",
+      sourceId: canonicalSourceId,
+      txnId: canonicalSourceId,
+    });
+
+    const batchOccurredAt = "2026-04-18T08:30:45";
+    const compoundSourceId = `batch:${batchOccurredAt}:375.0:0.0`;
+    insertTransaction(database, {
+      id: "compound-legacy",
+      sourceId: compoundSourceId,
+      txnId: compoundSourceId,
+      occurredAt: batchOccurredAt,
+      memo: "Batch payment",
+    });
+    insertTransaction(database, {
+      id: "plain-newer",
+      sourceId: "batch",
+      txnId: "batch",
+      occurredAt: batchOccurredAt,
+      memo: "Batch payment",
+    });
+    database.exec(`
+      UPDATE bank_transactions
+      SET created_at = CASE id
+        WHEN 'settlement-legacy' THEN '2026-04-01T00:00:00.000Z'
+        WHEN 'missing-canonical' THEN '2026-04-16T00:00:00.000Z'
+        WHEN 'compound-legacy' THEN '2026-04-01T00:00:00.000Z'
+        WHEN 'plain-newer' THEN '2026-04-16T00:00:00.000Z'
+      END
+      WHERE id IN (
+        'settlement-legacy',
+        'missing-canonical',
+        'compound-legacy',
+        'plain-newer'
+      );
+      INSERT INTO bank_transaction_preferences
+        (transaction_id, excluded_from_calculation, created_at, updated_at)
+      VALUES ('settlement-legacy', 1, '2026-04-01', '2026-04-15');
+      INSERT INTO classification_overrides
+        (id, target_type, target_id, category_id, created_at, updated_at)
+      VALUES ('settlement-legacy-override', 'bank_transaction',
+              'settlement-legacy', 'other', '2026-04-01', '2026-04-15');
+      INSERT INTO invoice_transaction_preferences
+        (invoice_id, transaction_id, decision, created_at, updated_at)
+      VALUES ('settlement-invoice', 'settlement-legacy', 'linked',
+              '2026-04-01', '2026-04-15');
+    `);
+
+    applyMigration(database, lateIdentityMigrationFile);
+
+    expect(
+      database
+        .prepare("SELECT id, source_id FROM bank_transactions ORDER BY id")
+        .all(),
+    ).toEqual([
+      {
+        id: "missing-canonical",
+        source_id: canonicalSourceId,
+      },
+      {
+        id: "plain-newer",
+        source_id: `missing:${batchOccurredAt}:375:Batchpayment`,
+      },
+    ]);
+    expect(
+      database
+        .prepare(
+          "SELECT transaction_id, excluded_from_calculation FROM bank_transaction_preferences",
+        )
+        .get(),
+    ).toEqual({
+      transaction_id: "missing-canonical",
+      excluded_from_calculation: 1,
+    });
+    expect(
+      database
+        .prepare("SELECT target_id, category_id FROM classification_overrides")
+        .get(),
+    ).toEqual({ target_id: "missing-canonical", category_id: "other" });
+    expect(
+      database
+        .prepare(
+          "SELECT transaction_id FROM invoice_transaction_preferences WHERE invoice_id = 'settlement-invoice'",
+        )
+        .get(),
+    ).toEqual({ transaction_id: "missing-canonical" });
+  });
+
+  it("keeps semantic duplicates with conflicting user decisions untouched", () => {
+    const database = createDatabase(lateIdentityMigrationFile);
+    const canonicalSourceId =
+      "missing:2026-04-15T08:30:45:375:Provideradjustment";
+    insertTransaction(database, {
+      id: "conflict-legacy",
+      sourceId: "batch",
+      txnId: "batch",
+    });
+    insertTransaction(database, {
+      id: "conflict-canonical",
+      sourceId: canonicalSourceId,
+      txnId: canonicalSourceId,
+    });
+    database.exec(`
+      INSERT INTO classification_overrides
+        (id, target_type, target_id, category_id, created_at, updated_at)
+      VALUES
+        ('conflict-legacy-override', 'bank_transaction',
+         'conflict-legacy', 'tax', '2026-04-01', '2026-04-01'),
+        ('conflict-canonical-override', 'bank_transaction',
+         'conflict-canonical', 'insurance', '2026-04-01', '2026-04-01');
+      INSERT INTO invoice_transaction_preferences
+        (invoice_id, transaction_id, decision, created_at, updated_at)
+      VALUES
+        ('conflict-legacy-invoice', 'conflict-legacy', 'linked',
+         '2026-04-01', '2026-04-01'),
+        ('conflict-canonical-invoice', 'conflict-canonical', 'linked',
+         '2026-04-01', '2026-04-01');
+    `);
+
+    applyMigration(database, lateIdentityMigrationFile);
+
+    expect(
+      database
+        .prepare("SELECT id, source_id FROM bank_transactions ORDER BY id")
+        .all(),
+    ).toEqual([
+      { id: "conflict-canonical", source_id: canonicalSourceId },
+      { id: "conflict-legacy", source_id: "batch" },
+    ]);
+    expect(
+      database
+        .prepare(
+          "SELECT target_id, category_id FROM classification_overrides ORDER BY target_id",
+        )
+        .all(),
+    ).toEqual([
+      { target_id: "conflict-canonical", category_id: "insurance" },
+      { target_id: "conflict-legacy", category_id: "tax" },
+    ]);
+    expect(
+      database
+        .prepare(
+          "SELECT invoice_id, transaction_id FROM invoice_transaction_preferences ORDER BY invoice_id",
+        )
+        .all(),
+    ).toEqual([
+      {
+        invoice_id: "conflict-canonical-invoice",
+        transaction_id: "conflict-canonical",
+      },
+      {
+        invoice_id: "conflict-legacy-invoice",
+        transaction_id: "conflict-legacy",
+      },
+    ]);
+  });
+
+  it("leaves an invalid target occupant and colliding row untouched", () => {
+    const database = createDatabase(lateIdentityMigrationFile);
+    const occupiedSourceId = "missing:2026-04-15T08:30:45:0:Provideradjustment";
+    insertTransaction(database, {
+      id: "invalid-amount",
+      sourceId: occupiedSourceId,
+      txnId: occupiedSourceId,
+      amount: 0,
+    });
+    insertTransaction(database, {
+      id: "valid-candidate",
+      sourceId: "legacy-zero",
+      txnId: "legacy-zero",
+      amount: 0,
+    });
+    database.exec(`
+      UPDATE bank_transactions
+      SET raw_payload = json_set(raw_payload, '$.amount', 'bad')
+      WHERE id = 'invalid-amount';
+    `);
+
+    applyMigration(database, lateIdentityMigrationFile);
+
+    expect(
+      database
+        .prepare(
+          "SELECT id, source_id FROM bank_transactions WHERE id IN ('invalid-amount', 'valid-candidate') ORDER BY id",
+        )
+        .all(),
+    ).toEqual([
+      { id: "invalid-amount", source_id: occupiedSourceId },
+      { id: "valid-candidate", source_id: "legacy-zero" },
+    ]);
   });
 });

--- a/packages/connectors/src/tdcc-epassbook-client.ts
+++ b/packages/connectors/src/tdcc-epassbook-client.ts
@@ -32,9 +32,8 @@ export type BankTransaction = {
  * page uses an empty string); `nextPageToken` is omitted when the API reports
  * that there are no more pages.
  *
- * `details` is intentionally kept alongside the normalized transactions. A
- * durable Queue consumer can persist the raw page and re-run normalization at
- * finalization, which preserves duplicate-STAN handling across page boundaries.
+ * `details` is intentionally kept alongside the normalized transactions so a
+ * durable Queue consumer can persist the provider rows across page boundaries.
  */
 export type BankTransactionPage = {
   pageToken: string;
@@ -532,25 +531,11 @@ export class EPassbookClient {
   }
 }
 
-/**
- * Normalize raw TSP007 rows. Keeping this outside the client makes it usable
- * by durable consumers when staged pages are finalized together (duplicate
- * STAN values are only detectable after all pages have been collected).
- */
+/** Normalize raw TSP007 rows into identities that depend on one row only. */
 export function normalizeBankTransactionDetails(
   details: BankTransactionDetail[],
 ): BankTransaction[] {
-  // ponytail: some banks reuse the same stan for recurring/batch entries (e.g.
-  // interest). Count occurrences so duplicates get a compound key that
-  // includes date+amounts.
-  const stanCount = new Map<string, number>();
-  for (const detail of details) {
-    const stan = detail.stan?.trim();
-    if (stan) stanCount.set(stan, (stanCount.get(stan) ?? 0) + 1);
-  }
-
   return details.map((detail) => {
-    const stan = detail.stan?.trim();
     const dt = detail.txnDateTime?.trim() ?? "";
     const hasValidDateTime = /^\d{14}$/.test(dt);
     const occurredAt = hasValidDateTime
@@ -560,13 +545,14 @@ export function normalizeBankTransactionDetails(
     const transferOutAmount = detail.transferOutAmount?.trim() || "0";
     const memo = detail.memo?.trim() || detail.summary?.trim();
     const amount = String(Number(transferInAmount) - Number(transferOutAmount));
-    const isDupStan = stan && (stanCount.get(stan) ?? 0) > 1;
-    const txnId = isDupStan
-      ? `${stan}:${occurredAt}:${transferInAmount}:${transferOutAmount}`
-      : stan ||
-        ["missing", occurredAt, amount, memo?.replace(/\s+/g, "") || "-"].join(
-          ":",
-        );
+    // Keep the established prefix, but do not include STAN because TDCC may
+    // add it after the transaction first appears.
+    const txnId = [
+      "missing",
+      occurredAt,
+      amount,
+      memo?.replace(/[\u0009-\u000d\u0020\u00a0\u3000]+/g, "") || "-",
+    ].join(":");
     return {
       txnId,
       occurredAt,

--- a/packages/connectors/tests/selfcheck/tdcc.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/tdcc.selfcheck.ts
@@ -293,13 +293,17 @@ async function main() {
     "blank STAN ids must remain stable across syncs",
   );
 
-  const duplicateStan = normalizeBankTransactionDetails([
-    {
-      stan: "00000",
-      txnDateTime: "20260821000000",
-      transferInAmount: "102.0",
-      transferOutAmount: "0.0",
-    },
+  const semanticTransactionDetail = {
+    txnDateTime: "20260821000000",
+    transferInAmount: "102.0",
+    transferOutAmount: "0.0",
+    memo: "Interest payment",
+  };
+  const transactionWithoutStan = normalizeBankTransactionDetails([
+    semanticTransactionDetail,
+  ])[0];
+  const transactionWithStan = normalizeBankTransactionDetails([
+    { ...semanticTransactionDetail, stan: "00000" },
     {
       stan: "00000",
       txnDateTime: "20260620000000",
@@ -308,9 +312,13 @@ async function main() {
     },
   ]);
   assert.equal(
-    duplicateStan[0]?.txnId,
-    "00000:2026-08-21T00:00:00:102.0:0.0",
-    "existing compound ids for duplicate non-empty STAN values must stay compatible",
+    transactionWithoutStan?.txnId,
+    "missing:2026-08-21T00:00:00:102:Interestpayment",
+  );
+  assert.equal(
+    transactionWithStan[0]?.txnId,
+    transactionWithoutStan?.txnId,
+    "a STAN appearing later must not change the transaction id",
   );
 
   const malformedDate = normalizeBankTransactionDetails([
@@ -389,9 +397,15 @@ async function main() {
   assert.equal(result.bankBalanceSnapshots?.length, 1);
   assert.equal(result.bankBalanceSnapshots?.[0]?.balance, 45678);
   assert.equal(result.bankTransactions?.length, 2);
-  assert.equal(result.bankTransactions?.[0]?.sourceId, "live-cash-move-1");
+  assert.equal(
+    result.bankTransactions?.[0]?.sourceId,
+    "missing:2024-06-14T12:00:00:1000:Settlementcredit",
+  );
   assert.equal(result.bankTransactions?.[0]?.amount, 1000);
-  assert.equal(result.bankTransactions?.[1]?.sourceId, "live-cash-move-2");
+  assert.equal(
+    result.bankTransactions?.[1]?.sourceId,
+    "missing:2024-06-15T13:00:00:-250:Settlementdebit",
+  );
   assert.equal(result.bankTransactions?.[1]?.amount, -250);
   assert.deepEqual(
     tspPageTokens.slice(0, 2),
@@ -419,7 +433,10 @@ async function main() {
   assert.equal(firstPage.pageRecordCount, 1);
   assert.equal(firstPage.totalCount, 2);
   assert.equal(firstPage.nextPageToken, "NEXT-1");
-  assert.equal(firstPage.transactions[0]?.txnId, "live-cash-move-1");
+  assert.equal(
+    firstPage.transactions[0]?.txnId,
+    "missing:2024-06-14T12:00:00:1000:Settlementcredit",
+  );
   const secondPage = await pageClient.getBankTransactionsPage(
     "004",
     "1234567890",

--- a/packages/db/migrations/0035_tdcc_late_identity_reconciliation.sql
+++ b/packages/db/migrations/0035_tdcc_late_identity_reconciliation.sql
@@ -1,0 +1,292 @@
+-- TDCC may add or change STAN after a transaction first appears. Use the
+-- account-scoped semantic fields that remain stable across syncs instead.
+CREATE TABLE migration_0035_tdcc_identity_targets (
+  transaction_id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL,
+  currency TEXT NOT NULL,
+  target_source_id TEXT NOT NULL
+);
+
+INSERT INTO migration_0035_tdcc_identity_targets (
+  transaction_id,
+  account_id,
+  currency,
+  target_source_id
+)
+WITH normalized AS (
+  SELECT
+    id,
+    account_id,
+    amount,
+    currency,
+    json_type(
+      CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+      '$.amount'
+    ) AS raw_amount_type,
+    json_type(
+      CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+      '$.occurredAt'
+    ) AS raw_occurred_at_type,
+    json_type(
+      CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+      '$.memo'
+    ) AS raw_memo_type,
+    trim(COALESCE(CAST(json_extract(
+      CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+      '$.amount'
+    ) AS TEXT), '')) AS raw_amount_text,
+    CAST(json_extract(
+      CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+      '$.amount'
+    ) AS REAL) AS raw_amount,
+    trim(COALESCE(CAST(json_extract(
+      CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+      '$.occurredAt'
+    ) AS TEXT), '')) AS raw_occurred_at,
+    replace(replace(replace(replace(replace(replace(replace(replace(
+      trim(COALESCE(CAST(json_extract(
+        CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+        '$.memo'
+      ) AS TEXT), '')),
+      ' ', ''),
+      char(9), ''),
+      char(10), ''),
+      char(11), ''),
+      char(12), ''),
+      char(13), ''),
+      char(160), ''),
+      char(12288), '') AS raw_memo
+  FROM bank_transactions
+  WHERE connector_id = 'tdcc'
+), targets AS (
+  SELECT
+    id AS transaction_id,
+    account_id,
+    currency,
+    'missing:' || raw_occurred_at || ':' || raw_amount_text || ':' ||
+      COALESCE(NULLIF(raw_memo, ''), '-') AS target_source_id
+  FROM normalized
+  WHERE raw_amount_type IN ('integer', 'real', 'text')
+    AND raw_occurred_at_type = 'text'
+    AND COALESCE(raw_memo_type, 'null') IN ('text', 'null')
+    AND raw_occurred_at <> ''
+    AND raw_amount_text <> ''
+    AND raw_amount_text GLOB '*[0-9]*'
+    AND raw_amount_text NOT GLOB '*[^0-9.-]*'
+    AND length(raw_amount_text) - length(replace(raw_amount_text, '.', '')) <= 1
+    AND length(raw_amount_text) - length(replace(raw_amount_text, '-', '')) <= 1
+    AND instr(substr(raw_amount_text, 2), '-') = 0
+    AND raw_amount = amount
+)
+SELECT transaction_id, account_id, currency, target_source_id
+FROM targets;
+
+CREATE TABLE migration_0035_tdcc_identity_groups (
+  account_id TEXT NOT NULL,
+  target_source_id TEXT NOT NULL,
+  survivor_id TEXT NOT NULL,
+  PRIMARY KEY (account_id, target_source_id)
+);
+
+INSERT INTO migration_0035_tdcc_identity_groups (
+  account_id,
+  target_source_id,
+  survivor_id
+)
+WITH ranked AS (
+  SELECT
+    target.account_id,
+    target.target_source_id,
+    target.transaction_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY target.account_id, target.target_source_id
+      ORDER BY
+        CASE
+          WHEN row_data.source_id = target.target_source_id THEN 0
+          ELSE 1
+        END,
+        row_data.created_at DESC,
+        row_data.id
+    ) AS survivor_rank
+  FROM migration_0035_tdcc_identity_targets target
+  JOIN bank_transactions row_data
+    ON row_data.id = target.transaction_id
+)
+SELECT account_id, target_source_id, transaction_id
+FROM ranked
+WHERE survivor_rank = 1;
+
+-- Leave a semantic group untouched when its key is occupied by a row other
+-- than the selected survivor, currencies disagree, or merging would overwrite
+-- user decisions.
+DELETE FROM migration_0035_tdcc_identity_groups
+WHERE EXISTS (
+  SELECT 1
+  FROM bank_transactions destination
+  WHERE destination.connector_id = 'tdcc'
+    AND destination.account_id =
+      migration_0035_tdcc_identity_groups.account_id
+    AND destination.source_id =
+      migration_0035_tdcc_identity_groups.target_source_id
+    AND destination.id <>
+      migration_0035_tdcc_identity_groups.survivor_id
+);
+
+DELETE FROM migration_0035_tdcc_identity_groups
+WHERE (
+  SELECT COUNT(DISTINCT target.currency)
+  FROM migration_0035_tdcc_identity_targets target
+  WHERE target.account_id = migration_0035_tdcc_identity_groups.account_id
+    AND target.target_source_id =
+      migration_0035_tdcc_identity_groups.target_source_id
+) > 1;
+
+DELETE FROM migration_0035_tdcc_identity_groups
+WHERE (
+  SELECT COUNT(*)
+  FROM invoice_transaction_preferences preference
+  JOIN migration_0035_tdcc_identity_targets target
+    ON target.transaction_id = preference.transaction_id
+  WHERE target.account_id = migration_0035_tdcc_identity_groups.account_id
+    AND target.target_source_id =
+      migration_0035_tdcc_identity_groups.target_source_id
+    AND preference.decision = 'linked'
+) > 1;
+
+DELETE FROM migration_0035_tdcc_identity_groups
+WHERE (
+  SELECT COUNT(DISTINCT override.category_id)
+  FROM classification_overrides override
+  JOIN migration_0035_tdcc_identity_targets target
+    ON target.transaction_id = override.target_id
+  WHERE override.target_type = 'bank_transaction'
+    AND target.account_id = migration_0035_tdcc_identity_groups.account_id
+    AND target.target_source_id =
+      migration_0035_tdcc_identity_groups.target_source_id
+) > 1;
+
+DELETE FROM migration_0035_tdcc_identity_groups
+WHERE EXISTS (
+  SELECT 1
+  FROM classification_overrides override
+  WHERE override.id =
+      'override:bank_transaction:' ||
+      migration_0035_tdcc_identity_groups.survivor_id
+    AND (
+      override.target_type <> 'bank_transaction'
+      OR override.target_id <>
+        migration_0035_tdcc_identity_groups.survivor_id
+    )
+);
+
+INSERT INTO bank_transaction_preferences (
+  transaction_id,
+  excluded_from_calculation,
+  created_at,
+  updated_at
+)
+SELECT
+  group_row.survivor_id,
+  MAX(preference.excluded_from_calculation),
+  MIN(preference.created_at),
+  MAX(preference.updated_at)
+FROM migration_0035_tdcc_identity_groups group_row
+JOIN migration_0035_tdcc_identity_targets target
+  ON target.account_id = group_row.account_id
+ AND target.target_source_id = group_row.target_source_id
+JOIN bank_transaction_preferences preference
+  ON preference.transaction_id = target.transaction_id
+GROUP BY group_row.survivor_id
+ON CONFLICT(transaction_id) DO UPDATE SET
+  excluded_from_calculation = MAX(
+    bank_transaction_preferences.excluded_from_calculation,
+    excluded.excluded_from_calculation
+  ),
+  created_at = MIN(bank_transaction_preferences.created_at, excluded.created_at),
+  updated_at = MAX(bank_transaction_preferences.updated_at, excluded.updated_at);
+
+INSERT OR IGNORE INTO classification_overrides (
+  id,
+  target_type,
+  target_id,
+  category_id,
+  created_at,
+  updated_at
+)
+SELECT
+  'override:bank_transaction:' || group_row.survivor_id,
+  'bank_transaction',
+  group_row.survivor_id,
+  MIN(override.category_id),
+  MIN(override.created_at),
+  MAX(override.updated_at)
+FROM migration_0035_tdcc_identity_groups group_row
+JOIN migration_0035_tdcc_identity_targets target
+  ON target.account_id = group_row.account_id
+ AND target.target_source_id = group_row.target_source_id
+JOIN classification_overrides override
+  ON override.target_type = 'bank_transaction'
+ AND override.target_id = target.transaction_id
+GROUP BY group_row.survivor_id;
+
+UPDATE invoice_transaction_preferences
+SET transaction_id = (
+  SELECT group_row.survivor_id
+  FROM migration_0035_tdcc_identity_targets target
+  JOIN migration_0035_tdcc_identity_groups group_row
+    ON group_row.account_id = target.account_id
+   AND group_row.target_source_id = target.target_source_id
+  WHERE target.transaction_id =
+    invoice_transaction_preferences.transaction_id
+)
+WHERE transaction_id IN (
+  SELECT target.transaction_id
+  FROM migration_0035_tdcc_identity_targets target
+  JOIN migration_0035_tdcc_identity_groups group_row
+    ON group_row.account_id = target.account_id
+   AND group_row.target_source_id = target.target_source_id
+);
+
+DELETE FROM bank_transaction_preferences
+WHERE transaction_id IN (
+  SELECT target.transaction_id
+  FROM migration_0035_tdcc_identity_targets target
+  JOIN migration_0035_tdcc_identity_groups group_row
+    ON group_row.account_id = target.account_id
+   AND group_row.target_source_id = target.target_source_id
+  WHERE target.transaction_id <> group_row.survivor_id
+);
+
+DELETE FROM classification_overrides
+WHERE target_type = 'bank_transaction'
+  AND target_id IN (
+    SELECT target.transaction_id
+    FROM migration_0035_tdcc_identity_targets target
+    JOIN migration_0035_tdcc_identity_groups group_row
+      ON group_row.account_id = target.account_id
+     AND group_row.target_source_id = target.target_source_id
+    WHERE target.transaction_id <> group_row.survivor_id
+  );
+
+DELETE FROM bank_transactions
+WHERE id IN (
+  SELECT target.transaction_id
+  FROM migration_0035_tdcc_identity_targets target
+  JOIN migration_0035_tdcc_identity_groups group_row
+    ON group_row.account_id = target.account_id
+   AND group_row.target_source_id = target.target_source_id
+  WHERE target.transaction_id <> group_row.survivor_id
+);
+
+UPDATE bank_transactions
+SET source_id = (
+  SELECT group_row.target_source_id
+  FROM migration_0035_tdcc_identity_groups group_row
+  WHERE group_row.survivor_id = bank_transactions.id
+)
+WHERE id IN (
+  SELECT survivor_id FROM migration_0035_tdcc_identity_groups
+);
+
+DROP TABLE migration_0035_tdcc_identity_groups;
+DROP TABLE migration_0035_tdcc_identity_targets;


### PR DESCRIPTION
## 變更內容

- TDCC 交易識別碼固定使用「時間＋標準化金額＋去空白摘要」，不再受 STAN 後續出現或批次內容影響。
- 新增一次性 D1 migration，將舊有 settlement、plain／compound identity 轉成穩定 key，合併安全的重複列並保留排除設定、分類與發票連結。
- 對帳務關聯衝突、不同幣別、無效 raw payload 與既有 key 佔用採保守保留，避免誤合併。

## 驗證

- TDCC identity migration：9/9 通過
- Worker：382 項測試通過
- DB、connector selfcheck、型別與格式檢查通過

## 部署注意

正式套用 migration 前，需先確認沒有執行中的 TDCC sync、staging 或舊 Queue 訊息，避免舊 key 在清理後重新寫入。
