### PR TITLE
修正：支援中國信託 App 5.2.26 同步

### DIFF
--- a/apps/worker/tests/connectors/ctbc.test.ts
+++ b/apps/worker/tests/connectors/ctbc.test.ts
@@ -33,7 +33,7 @@ describe("CTBC mobile API connector", () => {
     }
   });
 
-  it("generates the App 5.2.25 AES and RSA login format", () => {
+  it("generates the App 5.2.26 AES and RSA login format", () => {
     const encrypted = encryptCtbcPin("test-password", (length) =>
       new Uint8Array(length).fill(7),
     );
@@ -229,6 +229,7 @@ describe("CTBC mobile API connector", () => {
     expect(headerValue(calls[3]?.init.headers, "checksum")).toMatch(
       /^[0-9a-f]{64}$/,
     );
+    expect((calls[3]?.body as { appVer?: string }).appVer).toBe("5.2.26");
     expect(JSON.stringify(calls)).not.toContain("bank-password");
     expect(JSON.stringify(calls)).not.toContain("bank-user");
     expect(
@@ -262,6 +263,64 @@ describe("CTBC mobile API connector", () => {
       name: "CtbcVerificationRequiredError",
       message: expect.not.stringContaining("sensitive-upstream-text"),
     });
+  });
+
+  it("logs only safe account diagnostics when deposit initialization fails", async () => {
+    const accountId = "123456789012";
+    const responses = [
+      jsonResponse({ access_token: "oauth-token" }),
+      jsonResponse({ statusCode: "0000" }),
+      jsonResponse({ success: true, rsData: { seed: "seed" }, token: "token" }),
+      jsonResponse({ code: "0000", rsData: {}, token: "login-token" }),
+      jsonResponse({
+        code: "0000",
+        rsData: {
+          twdAcctSummaryResponse: {
+            demDepBalSummaryResponse: {
+              infoList: [
+                { accountNickName: "無帳號項目" },
+                { accountId, accountNickName: "薪轉帳戶" },
+              ],
+            },
+          },
+        },
+      }),
+      jsonResponse({ sys: "SVC", code: "0131", rsData: {} }),
+      jsonResponse({ code: "0000", rsData: {} }),
+    ];
+    const fetcher = vi.fn(async () => responses.shift()!) as CtbcFetch;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(
+      createCtbcConnector(fetcher).sync({
+        userId: "A123456789",
+        account: "bank-user",
+        password: "bank-password",
+      }),
+    ).rejects.toMatchObject({
+      name: "CtbcConnectionError",
+      message: "中國信託資料同步暫時無法完成。",
+    });
+
+    const initFailure = warn.mock.calls
+      .map(
+        ([message]) => JSON.parse(String(message)) as Record<string, unknown>,
+      )
+      .find((entry) => entry.event === "ctbc_deposit_init_failed");
+    expect(initFailure).toEqual({
+      event: "ctbc_deposit_init_failed",
+      accountIndex: 1,
+      accountCount: 1,
+      overviewFields: ["accountId", "accountNickName"],
+      requestedLast4: "9012",
+      requestedLength: 12,
+      requestedMasked: false,
+    });
+    expect(JSON.stringify(initFailure)).not.toContain(accountId);
+    expect(JSON.stringify(warn.mock.calls)).not.toContain("薪轉帳戶");
+    expect(responses).toHaveLength(0);
+
+    warn.mockRestore();
   });
 });
 

--- a/packages/connectors/src/ctbc-mobile-api.ts
+++ b/packages/connectors/src/ctbc-mobile-api.ts
@@ -6,7 +6,7 @@ import { BANK_SYNC_MONTHS } from "./sync-window";
 const CTBC_IMP_ORIGIN = "https://eb.ctbcbank.com/IMP";
 const CTBC_APPLICATION = "EBMW_Adapter";
 const CTBC_RESOURCE_ENDPOINT = `${CTBC_IMP_ORIGIN}/api/adapters/${CTBC_APPLICATION}/resource/ebmwResource`;
-const CTBC_APP_VERSION = "5.2.25";
+const CTBC_APP_VERSION = "5.2.26";
 const CTBC_WEB_VERSION = "20260722182433427";
 // MobileFirst client-credential value shipped in the public Android package.
 const CTBC_PUBLIC_CLIENT_TOKEN = "2ae74c0ad7a14739a2aab7340616d70e";
@@ -73,7 +73,7 @@ export function requireCtbcCredentials(
 }
 
 /**
- * Reproduces the App 5.2.25 `makeEncryptPINClear` format. Plaintext exists only
+ * Reproduces the App 5.2.26 `makeEncryptPINClear` format. Plaintext exists only
  * for the duration of this call and is never returned or included in errors.
  */
 export function encryptCtbcPin(
@@ -478,11 +478,28 @@ async function fetchDepositTransactions(
   depositOverview: JsonRecord,
 ) {
   const transactions: unknown[] = [];
-  const accountIds = extractDepositAccountIds(depositOverview);
-  for (const accountId of accountIds) {
-    const initial = await session.resource(DEPOSIT_TRANSACTIONS_INIT_RESOURCE, {
-      accountId,
-    });
+  const accounts = extractDepositAccounts(depositOverview);
+  for (const account of accounts) {
+    const { accountId } = account;
+    let initial: JsonRecord;
+    try {
+      initial = await session.resource(DEPOSIT_TRANSACTIONS_INIT_RESOURCE, {
+        accountId,
+      });
+    } catch (error) {
+      console.warn(
+        JSON.stringify({
+          event: "ctbc_deposit_init_failed",
+          accountIndex: account.overviewIndex,
+          accountCount: accounts.length,
+          overviewFields: account.fields,
+          requestedLast4: last4(accountId),
+          requestedLength: accountId.length,
+          requestedMasked: /[*Ｘx#•]/.test(accountId),
+        }),
+      );
+      throw error;
+    }
     const queryAccountId = selectTransactionAccountId(initial, accountId);
     for (const range of monthlyRanges(BANK_SYNC_MONTHS)) {
       let response: JsonRecord;
@@ -595,14 +612,16 @@ async function fetchPagedCardItems(
   return { rsData: { ...data, allItems } };
 }
 
-function extractDepositAccountIds(payload: JsonRecord) {
+function extractDepositAccounts(payload: JsonRecord) {
   const rsData = responseData(payload);
   const twd = recordValue(rsData.twdAcctSummaryResponse);
   const demand = recordValue(twd.demDepBalSummaryResponse);
-  return arrayValue(demand.infoList).flatMap((value) => {
+  return arrayValue(demand.infoList).flatMap((value, overviewIndex) => {
     if (!isRecord(value)) return [];
     const accountId = stringValue(value.accountId).trim();
-    return accountId ? [accountId] : [];
+    return accountId
+      ? [{ accountId, fields: Object.keys(value).sort(), overviewIndex }]
+      : [];
   });
 }
 


### PR DESCRIPTION
## 摘要

- 將中國信託行動銀行協定版本更新為 5.2.26，修復存款交易初始化回傳 SVC/0131 的同步失敗
- 在 q002/010 初始化失敗時加入安全診斷事件，只記錄帳戶位置、欄位名稱、末四碼、長度與遮罩狀態
- 補強 App 版本與初始化失敗的回歸測試，確保不記錄完整帳號、暱稱或上游原始回應

## 驗證

- CTBC connector tests：7 tests passed
- Worker tests：47 files / 383 tests passed
- Connector TypeScript typecheck passed
- Prettier 與 git diff --check passed
- Local 實際同步成功（使用者確認）

## 備註

- 保留既有 webVer、帳戶選擇與錯誤處理行為，未將 SVC/0131 視為空資料
- 未包含個人 VS Code／Wrangler debug 設定