### PR TITLE
fix(連接器): 第一銀行交易明細查詢後重抓 frame

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,14 @@
 - 後端測試：`npm run test:backend`
 - 全部 workspace 建置：`npm run build`
 
+## 提交與 PR 前必跑檢查
+
+每次 commit 或開／更新 PR 前，必須從 **repo root** 跑與 CI 相同的檢查，不得省略。
+
+- 先跑 `npm run format:check`，再跑 `npm run typecheck`，然後跑此次變更適用的 `npm run test:backend` 或前端 unit tests。
+- **禁止**用 `prettier --check <touched files>` 代替 `npm run format:check`。只對改動檔跑 Prettier 通過，不算完成。
+- CI（`.github/workflows/ci.yml`）順序為 `format:check` → `typecheck` → `test:backend` → `test:unit` → `build`。在本地通過前三項中適用的檢查之前，不得視為 commit 完成。
+
 ## 文件維護
 
 - 架構判斷以實際程式碼及各 workspace 的 `package.json` 為最終依據。

--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -790,12 +790,19 @@ async function collectFirstbankPayloads(
     await waitForDepositOverview(frame);
 
     await navigateFrame(frame, TRANSACTION_URL);
-    await submitTransactionQuery(frame);
-    const transactionHistoryHtml = await serializeFirstbankTables(frame);
+    const queryFrame = await waitForLiveTransactionQueryFrame(page, frame);
+    const resultFrame = await submitTransactionQuery(page, queryFrame);
+    const transactionHistoryHtml = await serializeFirstbankTables(resultFrame);
 
-    await collectCardPayload(frame, "F1632", 1, "cardBill", captured);
-    await collectCardPayload(frame, "F1633", 2, "recentPayments", captured);
-    await collectCardPayload(frame, "F1634", 3, "cardUnbilled", captured);
+    await collectCardPayload(resultFrame, "F1632", 1, "cardBill", captured);
+    await collectCardPayload(
+      resultFrame,
+      "F1633",
+      2,
+      "recentPayments",
+      captured,
+    );
+    await collectCardPayload(resultFrame, "F1634", 3, "cardUnbilled", captured);
     await Promise.allSettled(responseTasks);
 
     return {
@@ -941,21 +948,29 @@ function cardResponseKey(url: string): CardPayloadKey | undefined {
   return undefined;
 }
 
-async function submitTransactionQuery(frame: Frame) {
-  try {
-    await dismissBankNotice(frame);
-    await fillTransactionDateRange(frame);
-    await waitForQueryAccountOptions(frame);
-    await selectQueryAccount(frame);
-    await clickTransactionSearch(frame);
-    if (!(await waitForTransactionResult(frame))) {
-      await selectQueryAccount(frame);
-      await clickTransactionSearch(frame);
-      await waitForTransactionResult(frame);
+async function submitTransactionQuery(page: Page, frame: Frame) {
+  await dismissBankNotice(frame);
+  await fillTransactionDateRange(frame);
+  await waitForQueryAccountOptions(frame);
+  await selectQueryAccount(frame);
+  await clickTransactionSearch(frame);
+
+  // Cloudflare Browser Rendering often invalidates the iframe handle when
+  // #searchBtn navigates 0101.html → 010103.html. Drop the old Frame and
+  // re-resolve a live document that actually has the result header.
+  let resultFrame = await waitForLiveTransactionResultFrame(page);
+  if (!resultFrame) {
+    const retryFrame = await findLiveTransactionQueryFrame(page);
+    if (retryFrame && (await pageAsksForQueryAccount(retryFrame))) {
+      await selectQueryAccount(retryFrame);
+      await clickTransactionSearch(retryFrame);
+      resultFrame = await waitForLiveTransactionResultFrame(page);
     }
-  } catch (error) {
-    if (!isRecoverableFrameError(error)) throw error;
   }
+  if (!resultFrame) {
+    throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
+  }
+  return resultFrame;
 }
 
 async function waitForDepositOverview(frame: Frame) {
@@ -981,15 +996,70 @@ async function hasDepositOverview(frame: Frame) {
   }
 }
 
-async function waitForTransactionResult(frame: Frame) {
+async function waitForLiveTransactionQueryFrame(page: Page, preferred?: Frame) {
   const deadline = Date.now() + ACTION_TIMEOUT_MS;
   while (Date.now() < deadline) {
-    await dismissBankNotice(frame);
-    if (await hasTransactionResultHeader(frame)) return true;
-    if (await pageAsksForQueryAccount(frame)) return false;
+    const found = await findLiveTransactionQueryFrame(page);
+    if (found) return found;
     await delay(FRAME_READ_RETRY_MS);
   }
-  return hasTransactionResultHeader(frame);
+  const found = await findLiveTransactionQueryFrame(page);
+  if (found) return found;
+  if (
+    preferred &&
+    !isDetachedFrame(preferred) &&
+    liveFrames(page).includes(preferred)
+  ) {
+    return preferred;
+  }
+  return waitForAuthenticatedFrame(page);
+}
+
+async function findLiveTransactionQueryFrame(page: Page) {
+  for (const frame of liveFrames(page)) {
+    if (await hasTransactionSearchControl(frame)) return frame;
+  }
+  return undefined;
+}
+
+async function hasTransactionSearchControl(frame: Frame) {
+  try {
+    return Boolean(
+      await withActionTimeout(
+        frame.evaluate(() =>
+          Boolean(document.querySelector("#searchBtn, input[name=showList]")),
+        ),
+      ),
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function waitForLiveTransactionResultFrame(page: Page) {
+  const deadline = Date.now() + ACTION_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const result = await findLiveTransactionResultFrame(page);
+    if (result) return result;
+    if (await anyLiveFrameAsksForQueryAccount(page)) return undefined;
+    await delay(FRAME_READ_RETRY_MS);
+  }
+  return findLiveTransactionResultFrame(page);
+}
+
+async function findLiveTransactionResultFrame(page: Page) {
+  for (const frame of liveFrames(page)) {
+    await dismissBankNotice(frame);
+    if (await hasTransactionResultHeader(frame)) return frame;
+  }
+  return undefined;
+}
+
+async function anyLiveFrameAsksForQueryAccount(page: Page) {
+  for (const frame of liveFrames(page)) {
+    if (await pageAsksForQueryAccount(frame)) return true;
+  }
+  return false;
 }
 
 async function fillTransactionDateRange(frame: Frame) {
@@ -1099,18 +1169,27 @@ async function clickTransactionSearch(frame: Frame) {
       timeout: NAVIGATION_TIMEOUT_MS,
     })
     .catch(() => undefined);
-  const submitted = await withActionTimeout(
-    frame.evaluate(() => {
-      const searchBtn = document.querySelector<HTMLElement>(
-        "#searchBtn, input[name=showList]",
-      );
-      if (searchBtn) {
-        searchBtn.click();
-        return true;
-      }
-      return false;
-    }),
-  );
+  let submitted = false;
+  try {
+    submitted = Boolean(
+      await withActionTimeout(
+        frame.evaluate(() => {
+          const searchBtn = document.querySelector<HTMLElement>(
+            "#searchBtn, input[name=showList]",
+          );
+          if (searchBtn) {
+            searchBtn.click();
+            return true;
+          }
+          return false;
+        }),
+      ),
+    );
+  } catch (error) {
+    if (!isRecoverableFrameError(error)) throw error;
+    // The click itself can destroy the iframe execution context.
+    submitted = true;
+  }
   if (!submitted) {
     throw new FirstbankConnectionError("第一銀行交易明細查詢按鈕格式已變更。");
   }
@@ -1246,12 +1325,7 @@ async function serializeFirstbankTables(frame: Frame): Promise<string> {
   ).catch(() => "");
 
   if (typeof serialized === "string" && serialized.trim()) {
-    if (serialized.length > MAX_SERIALIZED_TABLE_BYTES) {
-      throw new FirstbankConnectionError(
-        "第一銀行交易明細資料量超過單次同步上限。",
-      );
-    }
-    return serialized;
+    return assertSerializedTransactionTables(serialized);
   }
 
   // Some browser mocks and older Puppeteer frames do not expose table rows
@@ -1267,12 +1341,7 @@ async function serializeFirstbankTables(frame: Frame): Promise<string> {
     if (!tables.trim()) {
       throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
     }
-    if (tables.length > MAX_SERIALIZED_TABLE_BYTES) {
-      throw new FirstbankConnectionError(
-        "第一銀行交易明細資料量超過單次同步上限。",
-      );
-    }
-    return tables;
+    return assertSerializedTransactionTables(tables);
   } catch (error) {
     if (error instanceof FirstbankConnectionError) throw error;
     throw new FirstbankConnectionError(
@@ -1622,6 +1691,22 @@ function errorMessage(error: unknown) {
 
 function isDetachedFrame(frame: Frame) {
   return Boolean((frame as Frame & { detached?: boolean }).detached);
+}
+
+function liveFrames(page: Page) {
+  return page.frames().filter((frame) => !isDetachedFrame(frame));
+}
+
+function assertSerializedTransactionTables(html: string) {
+  if (html.length > MAX_SERIALIZED_TABLE_BYTES) {
+    throw new FirstbankConnectionError(
+      "第一銀行交易明細資料量超過單次同步上限。",
+    );
+  }
+  if (!/交易日期|交易日/.test(html) || !/支出|存入|交易金額/.test(html)) {
+    throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
+  }
+  return html;
 }
 
 async function withActionTimeout<T>(action: Promise<T>) {

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const puppeteerMock = vi.hoisted(() => ({
   connect: vi.fn(),
@@ -42,11 +42,17 @@ const transactionTables = `
   </table>
 `;
 
+const TRANSACTION_RESULT_URL =
+  "https://ibank.firstbank.com.tw/NetBank/2/010103.html";
+const TRANSACTION_QUERY_URL =
+  "https://ibank.firstbank.com.tw/NetBank/2/0101.html";
+
 type Listener = (...args: unknown[]) => void;
 
 function makeFrame(options?: { authenticated?: boolean }) {
   let currentUrl = options?.authenticated ? FRAME_URL : LOGIN_URL;
   return {
+    detached: false,
     name: vi.fn().mockReturnValue("main"),
     url: vi.fn().mockImplementation(() => currentUrl),
     goto: vi.fn().mockImplementation(async (url: string) => {
@@ -176,6 +182,68 @@ function makeBrowser(page: ReturnType<typeof makePage>) {
   };
 }
 
+function makeTransactionResultFrame() {
+  const frame = makeFrame({ authenticated: true });
+  frame.url.mockReturnValue(TRANSACTION_RESULT_URL);
+  frame.evaluate.mockImplementation(async (fn: unknown) => {
+    const source = String(fn);
+    if (source.includes("#btnOpen") || source.includes("#tFunc")) return true;
+    if (source.includes("交易日期")) return true;
+    if (source.includes('querySelectorAll("table")')) return transactionTables;
+    if (source.includes("searchBtn")) return false;
+    if (source.includes("請選擇查詢帳號")) return false;
+    return undefined;
+  });
+  frame.content.mockResolvedValue(transactionTables);
+  return frame;
+}
+
+function makeEmptyLiveFrame() {
+  const frame = makeFrame({ authenticated: true });
+  frame.url.mockReturnValue(TRANSACTION_QUERY_URL);
+  frame.evaluate.mockImplementation(async (fn: unknown) => {
+    const source = String(fn);
+    if (source.includes("#btnOpen") || source.includes("#tFunc")) return true;
+    if (source.includes("交易日期")) return false;
+    if (source.includes('querySelectorAll("table")')) return "";
+    if (source.includes("searchBtn")) return false;
+    if (source.includes("請選擇查詢帳號")) return false;
+    return undefined;
+  });
+  frame.content.mockResolvedValue("<html><body></body></html>");
+  return frame;
+}
+
+function detachQueryFrameAfterSearch(
+  page: ReturnType<typeof makePage>,
+  nextFrames: Array<ReturnType<typeof makeFrame>>,
+) {
+  const queryFrame = page.frame;
+  const previousEvaluate = queryFrame.evaluate;
+  queryFrame.evaluate = vi
+    .fn()
+    .mockImplementation(async (fn: unknown, arg?: unknown) => {
+      const source = String(fn);
+      if (queryFrame.detached) {
+        throw new Error(
+          "Execution context was destroyed, most likely because of a navigation.",
+        );
+      }
+      if (source.includes("searchBtn") && source.includes(".click()")) {
+        queryFrame.detached = true;
+        page.frames.mockImplementation(() => nextFrames);
+        return true;
+      }
+      return previousEvaluate(fn, arg);
+    });
+  queryFrame.content.mockImplementation(async () => {
+    if (queryFrame.detached) {
+      throw new Error("Attempted to use detached Frame");
+    }
+    return "<html><body><form>查詢帳號</form></body></html>";
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   puppeteerMock.sessions.mockResolvedValue([]);
@@ -185,6 +253,10 @@ beforeEach(() => {
     allowedBrowserAcquisitions: 1,
     timeUntilNextAllowedBrowserAcquisition: 0,
   });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("第一銀行 browser session lifecycle", () => {
@@ -383,5 +455,64 @@ describe("第一銀行 browser session lifecycle", () => {
     );
     expect(page.mouse.click).not.toHaveBeenCalled();
     expect(browser.close).toHaveBeenCalledOnce();
+  });
+});
+
+describe("第一銀行交易明細 frame 重綁", () => {
+  it("query 導覽摧毀舊 frame 後，改從含交易日期表頭的新 frame 讀取明細", async () => {
+    const page = makePage({ authenticated: true });
+    const resultFrame = makeTransactionResultFrame();
+    detachQueryFrameAfterSearch(page, [resultFrame]);
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const result = await createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          amount: -100,
+          description: "測試交易",
+        }),
+      ]),
+    );
+    expect(resultFrame.evaluate).toHaveBeenCalled();
+    expect(page.frame.evaluate).toHaveBeenCalled();
+  });
+
+  it("沒有任何 live frame 含交易明細表格時仍回報讀取失敗", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    const emptyFrame = makeEmptyLiveFrame();
+    detachQueryFrameAfterSearch(page, [emptyFrame]);
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    const expectation = expect(pending).rejects.toThrow(
+      "第一銀行交易明細讀取失敗。",
+    );
+    await vi.advanceTimersByTimeAsync(20_000);
+    await expectation;
+    await expect(pending).rejects.toBeInstanceOf(FirstbankConnectionError);
+    expect(emptyFrame.content).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -507,9 +507,8 @@ describe("第一銀行交易明細 frame 重綁", () => {
         },
       ]),
     });
-    const expectation = expect(pending).rejects.toThrow(
-      "第一銀行交易明細讀取失敗。",
-    );
+    const expectation =
+      expect(pending).rejects.toThrow("第一銀行交易明細讀取失敗。");
     await vi.advanceTimersByTimeAsync(20_000);
     await expectation;
     await expect(pending).rejects.toBeInstanceOf(FirstbankConnectionError);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修復第一銀行 Browser Rendering 同步在登入成功後，因交易明細查詢導覽讓 iframe handle 失效，而回報「第一銀行交易明細讀取失敗」的問題。

PR #108 已合併，無法再往該 PR 追加 commit，因此以 `codex/firstbank-web` 為起點另開此後續 PR 對準 `main`。

## 原因

第一銀行網銀是 frameset。存款總覽走 in-frame `fetch`，frame handle 仍有效；交易明細按 `#searchBtn` 會把內容頁從 `0101.html` 導向 `010103.html`。本機 Chromium 通常保有同一個 Frame；Cloudflare `@cloudflare/puppeteer` 常會銷毀該 iframe 的 execution context。先前 `submitTransactionQuery` 吞掉 recoverable frame error 後，仍對 stale handle 做 `serializeFirstbankTables`。

## 修正

- 查詢送出後丟棄舊 Frame，從 `page.frames()` 重抓 live frame。
- 優先選文件含「交易日期」+「支出／存入」表頭的 frame，等表頭與表格出現後才序列化該 frame。
- 不再序列化 `0101` 查詢表單；沒有任何 live frame 含明細表格時，仍回報「第一銀行交易明細讀取失敗」。
- 查詢 click 若因 navigation 摧毀 execution context，視為已送出並改綁新 frame，而不是繼續讀死掉的 handle。

未改為攔截 `010103` HTTP 或 in-frame form POST。

## 測試與 CI 約定

- 延伸 `apps/worker/tests/connectors/firstbank-session.test.ts`：
  - query 導覽摧毀舊 frame 後，改從含交易日期表頭的新 frame 讀取明細
  - 沒有任何 live frame 含表格時仍回報讀取失敗
- 已從 **repo root** 跑 `npm run format:check`、`npm run typecheck`，以及 firstbank session tests（10 passed）。禁止只對改動檔跑 Prettier 代替 `format:check`。
- `AGENTS.md` 新增「提交與 PR 前必跑檢查」，規定每次 commit／PR 必須跑與 CI 相同的 root 檢查。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b8f7b3c-8caa-49d3-8565-7ce44f7e1b3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b8f7b3c-8caa-49d3-8565-7ce44f7e1b3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

