### PR TITLE
fix(連接器): 第一銀行交易明細在結果 iframe 消失時改以表單 POST 讀取

### DIFF
--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -34,6 +34,10 @@ const LOGIN_RESULT_ATTEMPTS = 30;
 const LOGIN_RESULT_POLL_MS = 500;
 const FRAME_TIMEOUT_MS = 15_000;
 const FRAME_READ_RETRY_MS = 250;
+// After #searchBtn, a missing 010103 iframe will never appear. Poll briefly
+// then POST the live 0101 form; do not stack another 10s ACTION_TIMEOUT.
+const RESULT_FRAME_WAIT_MS = 2_000;
+const FRAME_PROBE_TIMEOUT_MS = 1_000;
 const CARD_RESPONSE_TIMEOUT_MS = 10_000;
 const SESSION_RELEASE_TIMEOUT_MS = 2_000;
 const SESSION_RELEASE_POLL_MS = 100;
@@ -57,6 +61,12 @@ type CaptchaImage = {
 };
 
 type CardPayloadKey = "cardBill" | "recentPayments" | "cardUnbilled";
+
+type TransactionQueryPost = {
+  action: string;
+  method: string;
+  body: string;
+};
 
 type CapturedCardResponses = Partial<Record<CardPayloadKey, unknown>>;
 
@@ -791,18 +801,15 @@ async function collectFirstbankPayloads(
 
     await navigateFrame(frame, TRANSACTION_URL);
     const queryFrame = await waitForLiveTransactionQueryFrame(page, frame);
-    const resultFrame = await submitTransactionQuery(page, queryFrame);
-    const transactionHistoryHtml = await serializeFirstbankTables(resultFrame);
-
-    await collectCardPayload(resultFrame, "F1632", 1, "cardBill", captured);
-    await collectCardPayload(
-      resultFrame,
-      "F1633",
-      2,
-      "recentPayments",
-      captured,
+    const transactionHistoryHtml = await submitTransactionQuery(
+      page,
+      queryFrame,
     );
-    await collectCardPayload(resultFrame, "F1634", 3, "cardUnbilled", captured);
+    const cardFrame = pickLiveFrame(page, frame) ?? queryFrame;
+
+    await collectCardPayload(cardFrame, "F1632", 1, "cardBill", captured);
+    await collectCardPayload(cardFrame, "F1633", 2, "recentPayments", captured);
+    await collectCardPayload(cardFrame, "F1634", 3, "cardUnbilled", captured);
     await Promise.allSettled(responseTasks);
 
     return {
@@ -953,6 +960,7 @@ async function submitTransactionQuery(page: Page, frame: Frame) {
   await fillTransactionDateRange(frame);
   await waitForQueryAccountOptions(frame);
   await selectQueryAccount(frame);
+  const queryPost = await captureTransactionQueryPost(frame);
   await clickTransactionSearch(frame);
 
   // Cloudflare Browser Rendering often invalidates the iframe handle when
@@ -967,10 +975,20 @@ async function submitTransactionQuery(page: Page, frame: Frame) {
       resultFrame = await waitForLiveTransactionResultFrame(page);
     }
   }
-  if (!resultFrame) {
-    throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
+  if (resultFrame) {
+    try {
+      return await serializeFirstbankTables(resultFrame);
+    } catch (error) {
+      if (!isTransactionHistoryReadError(error)) throw error;
+    }
   }
-  return resultFrame;
+
+  // Result iframe is gone or empty. POST the live 0101 form from a still-live
+  // frame (same pattern as deposit overview) instead of waiting out another
+  // iframe timeout.
+  const posted = await postTransactionQuery(page, frame, queryPost);
+  if (posted) return posted;
+  throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
 }
 
 async function waitForDepositOverview(frame: Frame) {
@@ -1037,7 +1055,7 @@ async function hasTransactionSearchControl(frame: Frame) {
 }
 
 async function waitForLiveTransactionResultFrame(page: Page) {
-  const deadline = Date.now() + ACTION_TIMEOUT_MS;
+  const deadline = Date.now() + RESULT_FRAME_WAIT_MS;
   while (Date.now() < deadline) {
     const result = await findLiveTransactionResultFrame(page);
     if (result) return result;
@@ -1049,15 +1067,19 @@ async function waitForLiveTransactionResultFrame(page: Page) {
 
 async function findLiveTransactionResultFrame(page: Page) {
   for (const frame of liveFrames(page)) {
-    await dismissBankNotice(frame);
-    if (await hasTransactionResultHeader(frame)) return frame;
+    await dismissBankNotice(frame, FRAME_PROBE_TIMEOUT_MS);
+    if (await hasTransactionResultHeader(frame, FRAME_PROBE_TIMEOUT_MS)) {
+      return frame;
+    }
   }
   return undefined;
 }
 
 async function anyLiveFrameAsksForQueryAccount(page: Page) {
   for (const frame of liveFrames(page)) {
-    if (await pageAsksForQueryAccount(frame)) return true;
+    if (await pageAsksForQueryAccount(frame, FRAME_PROBE_TIMEOUT_MS)) {
+      return true;
+    }
   }
   return false;
 }
@@ -1148,13 +1170,17 @@ async function selectQueryAccount(frame: Frame, dryRun = false) {
   }
 }
 
-async function pageAsksForQueryAccount(frame: Frame) {
+async function pageAsksForQueryAccount(
+  frame: Frame,
+  timeoutMs = ACTION_TIMEOUT_MS,
+) {
   try {
     return Boolean(
       await withActionTimeout(
         frame.evaluate(() =>
           /請選擇查詢帳號|請選擇.*帳號/.test(document.body?.innerText ?? ""),
         ),
+        timeoutMs,
       ),
     );
   } catch {
@@ -1163,12 +1189,6 @@ async function pageAsksForQueryAccount(frame: Frame) {
 }
 
 async function clickTransactionSearch(frame: Frame) {
-  const navigation = frame
-    .waitForNavigation({
-      waitUntil: "domcontentloaded",
-      timeout: NAVIGATION_TIMEOUT_MS,
-    })
-    .catch(() => undefined);
   let submitted = false;
   try {
     submitted = Boolean(
@@ -1193,10 +1213,9 @@ async function clickTransactionSearch(frame: Frame) {
   if (!submitted) {
     throw new FirstbankConnectionError("第一銀行交易明細查詢按鈕格式已變更。");
   }
-  await waitForNavigation(navigation, NAVIGATION_TIMEOUT_MS);
 }
 
-async function dismissBankNotice(frame: Frame) {
+async function dismissBankNotice(frame: Frame, timeoutMs = ACTION_TIMEOUT_MS) {
   try {
     await withActionTimeout(
       frame.evaluate(() => {
@@ -1216,13 +1235,17 @@ async function dismissBankNotice(frame: Frame) {
         match?.click();
         return Boolean(match);
       }),
+      timeoutMs,
     );
   } catch {
     // Notice may already be gone after navigation.
   }
 }
 
-async function hasTransactionResultHeader(frame: Frame) {
+async function hasTransactionResultHeader(
+  frame: Frame,
+  timeoutMs = ACTION_TIMEOUT_MS,
+) {
   try {
     return Boolean(
       await withActionTimeout(
@@ -1235,6 +1258,7 @@ async function hasTransactionResultHeader(frame: Frame) {
             );
           });
         }),
+        timeoutMs,
       ),
     );
   } catch {
@@ -1288,6 +1312,111 @@ async function fetchFrameResource(frame: Frame, path: string): Promise<string> {
   throw new FirstbankConnectionError("第一銀行存款總覽讀取失敗。");
 }
 
+async function captureTransactionQueryPost(
+  frame: Frame,
+): Promise<TransactionQueryPost | undefined> {
+  try {
+    const value = await withActionTimeout(
+      frame.evaluate(() => {
+        const form = document.querySelector("form");
+        if (!form) return null;
+        const action = new URL(
+          form.getAttribute("action") || form.action || "",
+          window.location.href,
+        ).href;
+        const method = (
+          form.getAttribute("method") ||
+          form.method ||
+          "POST"
+        ).toUpperCase();
+        const params = new URLSearchParams();
+        const formData = new FormData(form);
+        for (const [name, fieldValue] of formData.entries()) {
+          params.append(name, String(fieldValue));
+        }
+        const searchBtn = document.querySelector<HTMLInputElement>(
+          "#searchBtn, input[name=showList]",
+        );
+        if (searchBtn?.name && !params.has(searchBtn.name)) {
+          params.append(searchBtn.name, searchBtn.value ?? "");
+        }
+        return { action, method, body: params.toString() };
+      }),
+    );
+    if (
+      isRecord(value) &&
+      typeof value.action === "string" &&
+      isFirstbankAction(value.action) &&
+      typeof value.method === "string" &&
+      typeof value.body === "string"
+    ) {
+      return {
+        action: value.action,
+        method: value.method,
+        body: value.body,
+      };
+    }
+  } catch (error) {
+    if (!isRecoverableFrameError(error)) throw error;
+  }
+  return undefined;
+}
+
+async function postTransactionQuery(
+  page: Page,
+  queryFrame: Frame,
+  snapshot: TransactionQueryPost | undefined,
+) {
+  const liveQuery = await findLiveTransactionQueryFrame(page);
+  const request =
+    (liveQuery ? await captureTransactionQueryPost(liveQuery) : undefined) ??
+    snapshot;
+  const postFrame = liveQuery ?? pickLiveFrame(page, queryFrame);
+  if (!request || !postFrame) return undefined;
+  try {
+    const value = await withActionTimeout(
+      postFrame.evaluate(async (payload: TransactionQueryPost) => {
+        try {
+          const method =
+            payload.method.toUpperCase() === "GET" ? "GET" : "POST";
+          const action =
+            method === "GET" && payload.body
+              ? `${payload.action}${payload.action.includes("?") ? "&" : "?"}${payload.body}`
+              : payload.action;
+          const response = await fetch(action, {
+            method,
+            credentials: "same-origin",
+            headers: {
+              Accept: "text/html, application/json",
+              ...(method === "GET"
+                ? {}
+                : { "Content-Type": "application/x-www-form-urlencoded" }),
+            },
+            body: method === "GET" ? undefined : payload.body,
+          });
+          return {
+            ok: response.ok,
+            status: response.status,
+            text: await response.text(),
+          };
+        } catch {
+          return { ok: false, status: 0, text: "" };
+        }
+      }, request),
+    );
+    if (
+      isRecord(value) &&
+      value.ok === true &&
+      typeof value.text === "string"
+    ) {
+      return transactionHistoryFromHtml(value.text);
+    }
+  } catch (error) {
+    if (!isRecoverableFrameError(error)) throw error;
+  }
+  return undefined;
+}
+
 async function serializeFirstbankTables(frame: Frame): Promise<string> {
   const serialized = await withActionTimeout(
     frame.evaluate(() => {
@@ -1335,13 +1464,7 @@ async function serializeFirstbankTables(frame: Frame): Promise<string> {
     if (typeof html !== "string") {
       throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
     }
-    const tables = Array.from(html.matchAll(/<table\b[\s\S]*?<\/table>/gi))
-      .map((match) => match[0])
-      .join("\n");
-    if (!tables.trim()) {
-      throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
-    }
-    return assertSerializedTransactionTables(tables);
+    return transactionHistoryFromHtml(html);
   } catch (error) {
     if (error instanceof FirstbankConnectionError) throw error;
     throw new FirstbankConnectionError(
@@ -1697,6 +1820,46 @@ function liveFrames(page: Page) {
   return page.frames().filter((frame) => !isDetachedFrame(frame));
 }
 
+function pickLiveFrame(page: Page, preferred?: Frame) {
+  if (
+    preferred &&
+    !isDetachedFrame(preferred) &&
+    liveFrames(page).includes(preferred)
+  ) {
+    return preferred;
+  }
+  return liveFrames(page)[0];
+}
+
+function isFirstbankAction(url: string) {
+  try {
+    return new URL(url).origin === ORIGIN;
+  } catch {
+    return false;
+  }
+}
+
+function isTransactionHistoryReadError(error: unknown) {
+  return (
+    error instanceof FirstbankConnectionError &&
+    error.message === "第一銀行交易明細讀取失敗。"
+  );
+}
+
+function transactionHistoryFromHtml(html: string) {
+  const trimmed = html.trim();
+  if (!trimmed) {
+    throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
+  }
+  const tables = Array.from(trimmed.matchAll(/<table\b[\s\S]*?<\/table>/gi))
+    .map((match) => match[0])
+    .join("\n");
+  if (!tables.trim()) {
+    throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
+  }
+  return assertSerializedTransactionTables(tables);
+}
+
 function assertSerializedTransactionTables(html: string) {
   if (html.length > MAX_SERIALIZED_TABLE_BYTES) {
     throw new FirstbankConnectionError(
@@ -1709,7 +1872,10 @@ function assertSerializedTransactionTables(html: string) {
   return html;
 }
 
-async function withActionTimeout<T>(action: Promise<T>) {
+async function withActionTimeout<T>(
+  action: Promise<T>,
+  timeoutMs = ACTION_TIMEOUT_MS,
+) {
   action.catch(() => undefined);
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
@@ -1718,7 +1884,7 @@ async function withActionTimeout<T>(action: Promise<T>) {
       new Promise<never>((_resolve, reject) => {
         timer = setTimeout(
           () => reject(new FirstbankActionTimeoutError()),
-          ACTION_TIMEOUT_MS,
+          timeoutMs,
         );
       }),
     ]);
@@ -1755,21 +1921,4 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function delay(milliseconds: number) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
-}
-
-async function waitForNavigation(
-  navigation: Promise<unknown>,
-  timeoutMs: number,
-) {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    await Promise.race([
-      navigation,
-      new Promise<void>((resolve) => {
-        timer = setTimeout(resolve, timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
 }

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -64,6 +64,13 @@ function makeFrame(options?: { authenticated?: boolean }) {
       if (source.includes("fetch(resourcePath")) {
         return { ok: true, status: 200, text: depositTables };
       }
+      if (source.includes("new FormData(form)")) {
+        return {
+          action: TRANSACTION_RESULT_URL,
+          method: "POST",
+          body: "txnStart=2026/07/29&txnEnd=2026/08/29&showList=Y",
+        };
+      }
       if (source.includes('querySelectorAll("table")')) {
         return currentUrl.includes("0101") ? transactionTables : depositTables;
       }
@@ -212,6 +219,31 @@ function makeEmptyLiveFrame() {
   });
   frame.content.mockResolvedValue("<html><body></body></html>");
   return frame;
+}
+
+function makePostFallbackFrame() {
+  const frame = makeEmptyLiveFrame();
+  const previousEvaluate = frame.evaluate;
+  frame.evaluate = vi
+    .fn()
+    .mockImplementation(async (fn: unknown, arg?: unknown) => {
+      const source = String(fn);
+      if (
+        source.includes("fetch(action") ||
+        source.includes("payload.action")
+      ) {
+        return { ok: true, status: 200, text: transactionTables };
+      }
+      return previousEvaluate(fn, arg);
+    });
+  return frame;
+}
+
+function postedTransactionQuery(frame: ReturnType<typeof makeFrame>) {
+  return frame.evaluate.mock.calls.some(
+    ([fn]) =>
+      String(fn).includes("payload.action") && String(fn).includes("fetch("),
+  );
 }
 
 function detachQueryFrameAfterSearch(
@@ -487,6 +519,50 @@ describe("第一銀行交易明細 frame 重綁", () => {
     );
     expect(resultFrame.evaluate).toHaveBeenCalled();
     expect(page.frame.evaluate).toHaveBeenCalled();
+    expect(postedTransactionQuery(resultFrame)).toBe(false);
+  });
+
+  it("結果 iframe 未出現時，改從仍活著的 frame POST 0101 表單取得明細", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    const liveFrame = makePostFallbackFrame();
+    detachQueryFrameAfterSearch(page, [liveFrame]);
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await pending;
+
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          amount: -100,
+          description: "測試交易",
+        }),
+      ]),
+    );
+    expect(postedTransactionQuery(liveFrame)).toBe(true);
+    const postCall = liveFrame.evaluate.mock.calls.find(
+      ([fn]) =>
+        String(fn).includes("payload.action") && String(fn).includes("fetch("),
+    );
+    expect(postCall?.[1]).toEqual(
+      expect.objectContaining({
+        action: TRANSACTION_RESULT_URL,
+        method: "POST",
+      }),
+    );
+    expect(liveFrame.content).not.toHaveBeenCalled();
   });
 
   it("沒有任何 live frame 含交易明細表格時仍回報讀取失敗", async () => {
@@ -509,9 +585,10 @@ describe("第一銀行交易明細 frame 重綁", () => {
     });
     const expectation =
       expect(pending).rejects.toThrow("第一銀行交易明細讀取失敗。");
-    await vi.advanceTimersByTimeAsync(20_000);
+    await vi.advanceTimersByTimeAsync(5_000);
     await expectation;
     await expect(pending).rejects.toBeInstanceOf(FirstbankConnectionError);
     expect(emptyFrame.content).not.toHaveBeenCalled();
+    expect(postedTransactionQuery(emptyFrame)).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修復第一銀行正式環境交易明細同步：登入與存款總覽已可開始，但 `#searchBtn` 之後 Cloudflare Browser Rendering 不再露出含「交易日期」＋「支出／存入」的 `010103` iframe，最後以「第一銀行交易明細讀取失敗。」結束。先前 PR #109 的 live frame 重綁在結果 iframe 真的存在時仍有效；這次補上 **in-frame POST 後援**，並讓失效 iframe 路徑快速失敗，避免吃光 Workers Free 每日 10 分鐘 Browser Run。

## 原因

- 存款總覽走 in-frame `fetch`（`/NetBank/ajax/acntReview1.html`），不依賴查詢後的新 iframe。
- 交易明細按 `#searchBtn` 會把內容頁從 `0101.html` 導向 `010103.html`。正式環境在點擊後 `page.frames()` 重綁找不到結果文件。
- 失敗同步約 128 秒才 502。查詢後堆疊 `waitForNavigation` 20 秒與兩次 10 秒結果 frame 輪詢，對「永遠不會出現的 iframe」沒有幫助，卻會耗盡 Browser Rendering 工作階段與每日額度。

## 修正

- **重綁仍優先**：若短時間內出現含交易表頭的 live frame，仍從該 frame 序列化表格。
- **iframe 消失時的後援**：點擊前從仍活著的 `0101` 文件讀取 **form `action` 與欄位**（含 `#txnStart` / `#txnEnd`、帳號 select、`#searchBtn` / `showList`），再從仍活著的 frame 做 same-origin POST，取回 HTML。不發明銀行 URL，也不在 page HTTP 層攔截 `010103`。
- **快速失敗**：結果 frame 只短輪詢（2 秒），探測用 1 秒 timeout；不再等待 20 秒 navigation。讀取失敗應在數十秒內結束，而不是再等一輪 10 秒 timeout。
- 登入與存款總覽路徑不改。

## 測試與 CI

- `apps/worker/tests/connectors/firstbank-session.test.ts`
  - query 導覽摧毀舊 frame 後，仍從含交易日期表頭的新 frame 讀取（不走 POST）
  - 結果 iframe 未出現時，改從仍活著的 frame POST 0101 表單取得明細
  - 後援也拿不到表格時仍回報讀取失敗，且不再空等 20 秒
- 已從 **repo root** 跑 `npm run format:check`、`npm run typecheck`，以及 firstbank session tests（11 passed）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a741ec14-0556-4afa-8344-f6116a9b776e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a741ec14-0556-4afa-8344-f6116a9b776e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

