### PR TITLE
fix(連接器): 修正第一銀行 010103 交易明細擷取

### DIFF
--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -34,10 +34,6 @@ const LOGIN_RESULT_ATTEMPTS = 30;
 const LOGIN_RESULT_POLL_MS = 500;
 const FRAME_TIMEOUT_MS = 15_000;
 const FRAME_READ_RETRY_MS = 250;
-// After #searchBtn, a missing 010103 iframe will never appear. Poll briefly
-// then POST the live 0101 form; do not stack another 10s ACTION_TIMEOUT.
-const RESULT_FRAME_WAIT_MS = 2_000;
-const FRAME_PROBE_TIMEOUT_MS = 1_000;
 const CARD_RESPONSE_TIMEOUT_MS = 10_000;
 const SESSION_RELEASE_TIMEOUT_MS = 2_000;
 const SESSION_RELEASE_POLL_MS = 100;
@@ -801,11 +797,8 @@ async function collectFirstbankPayloads(
 
     await navigateFrame(frame, TRANSACTION_URL);
     const queryFrame = await waitForLiveTransactionQueryFrame(page, frame);
-    const transactionHistoryHtml = await submitTransactionQuery(
-      page,
-      queryFrame,
-    );
-    const cardFrame = pickLiveFrame(page, frame) ?? queryFrame;
+    const transactionHistoryHtml = await submitTransactionQuery(queryFrame);
+    const cardFrame = pickLiveFrame(page, queryFrame) ?? queryFrame;
 
     await collectCardPayload(cardFrame, "F1632", 1, "cardBill", captured);
     await collectCardPayload(cardFrame, "F1633", 2, "recentPayments", captured);
@@ -955,40 +948,19 @@ function cardResponseKey(url: string): CardPayloadKey | undefined {
   return undefined;
 }
 
-async function submitTransactionQuery(page: Page, frame: Frame) {
+async function submitTransactionQuery(frame: Frame) {
   await dismissBankNotice(frame);
   await fillTransactionDateRange(frame);
   await waitForQueryAccountOptions(frame);
   await selectQueryAccount(frame);
   const queryPost = await captureTransactionQueryPost(frame);
-  await clickTransactionSearch(frame);
-
-  // Cloudflare Browser Rendering often invalidates the iframe handle when
-  // #searchBtn navigates 0101.html → 010103.html. Drop the old Frame and
-  // re-resolve a live document that actually has the result header.
-  let resultFrame = await waitForLiveTransactionResultFrame(page);
-  if (!resultFrame) {
-    const retryFrame = await findLiveTransactionQueryFrame(page);
-    if (retryFrame && (await pageAsksForQueryAccount(retryFrame))) {
-      await selectQueryAccount(retryFrame);
-      await clickTransactionSearch(retryFrame);
-      resultFrame = await waitForLiveTransactionResultFrame(page);
-    }
+  if (!queryPost) {
+    throw new FirstbankConnectionError("第一銀行交易明細查詢表單格式已變更。");
   }
-  if (resultFrame) {
-    try {
-      return await serializeFirstbankTables(resultFrame);
-    } catch (error) {
-      if (!isTransactionHistoryReadError(error)) throw error;
-    }
-  }
-
-  // Result iframe is gone or empty. POST the live 0101 form from a still-live
-  // frame (same pattern as deposit overview) instead of waiting out another
-  // iframe timeout.
-  const posted = await postTransactionQuery(page, frame, queryPost);
-  if (posted) return posted;
-  throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
+  // Same pattern as deposit overview: keep the live 0101 document and POST
+  // its form via fetch. Clicking #searchBtn navigates 0101 → 010103 and
+  // Cloudflare Browser Rendering drops the iframe.
+  return postTransactionQuery(frame, queryPost);
 }
 
 async function waitForDepositOverview(frame: Frame) {
@@ -1052,36 +1024,6 @@ async function hasTransactionSearchControl(frame: Frame) {
   } catch {
     return false;
   }
-}
-
-async function waitForLiveTransactionResultFrame(page: Page) {
-  const deadline = Date.now() + RESULT_FRAME_WAIT_MS;
-  while (Date.now() < deadline) {
-    const result = await findLiveTransactionResultFrame(page);
-    if (result) return result;
-    if (await anyLiveFrameAsksForQueryAccount(page)) return undefined;
-    await delay(FRAME_READ_RETRY_MS);
-  }
-  return findLiveTransactionResultFrame(page);
-}
-
-async function findLiveTransactionResultFrame(page: Page) {
-  for (const frame of liveFrames(page)) {
-    await dismissBankNotice(frame, FRAME_PROBE_TIMEOUT_MS);
-    if (await hasTransactionResultHeader(frame, FRAME_PROBE_TIMEOUT_MS)) {
-      return frame;
-    }
-  }
-  return undefined;
-}
-
-async function anyLiveFrameAsksForQueryAccount(page: Page) {
-  for (const frame of liveFrames(page)) {
-    if (await pageAsksForQueryAccount(frame, FRAME_PROBE_TIMEOUT_MS)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 async function fillTransactionDateRange(frame: Frame) {
@@ -1170,52 +1112,7 @@ async function selectQueryAccount(frame: Frame, dryRun = false) {
   }
 }
 
-async function pageAsksForQueryAccount(
-  frame: Frame,
-  timeoutMs = ACTION_TIMEOUT_MS,
-) {
-  try {
-    return Boolean(
-      await withActionTimeout(
-        frame.evaluate(() =>
-          /請選擇查詢帳號|請選擇.*帳號/.test(document.body?.innerText ?? ""),
-        ),
-        timeoutMs,
-      ),
-    );
-  } catch {
-    return false;
-  }
-}
-
-async function clickTransactionSearch(frame: Frame) {
-  let submitted = false;
-  try {
-    submitted = Boolean(
-      await withActionTimeout(
-        frame.evaluate(() => {
-          const searchBtn = document.querySelector<HTMLElement>(
-            "#searchBtn, input[name=showList]",
-          );
-          if (searchBtn) {
-            searchBtn.click();
-            return true;
-          }
-          return false;
-        }),
-      ),
-    );
-  } catch (error) {
-    if (!isRecoverableFrameError(error)) throw error;
-    // The click itself can destroy the iframe execution context.
-    submitted = true;
-  }
-  if (!submitted) {
-    throw new FirstbankConnectionError("第一銀行交易明細查詢按鈕格式已變更。");
-  }
-}
-
-async function dismissBankNotice(frame: Frame, timeoutMs = ACTION_TIMEOUT_MS) {
+async function dismissBankNotice(frame: Frame) {
   try {
     await withActionTimeout(
       frame.evaluate(() => {
@@ -1235,34 +1132,9 @@ async function dismissBankNotice(frame: Frame, timeoutMs = ACTION_TIMEOUT_MS) {
         match?.click();
         return Boolean(match);
       }),
-      timeoutMs,
     );
   } catch {
     // Notice may already be gone after navigation.
-  }
-}
-
-async function hasTransactionResultHeader(
-  frame: Frame,
-  timeoutMs = ACTION_TIMEOUT_MS,
-) {
-  try {
-    return Boolean(
-      await withActionTimeout(
-        frame.evaluate(() => {
-          const rows = Array.from(document.querySelectorAll("tr"));
-          return rows.some((row) => {
-            const text = (row.innerText || "").replace(/\s+/g, " ");
-            return (
-              /交易日期|交易日/.test(text) && /支出|存入|交易金額/.test(text)
-            );
-          });
-        }),
-        timeoutMs,
-      ),
-    );
-  } catch {
-    return false;
   }
 }
 
@@ -1363,19 +1235,12 @@ async function captureTransactionQueryPost(
 }
 
 async function postTransactionQuery(
-  page: Page,
-  queryFrame: Frame,
-  snapshot: TransactionQueryPost | undefined,
+  frame: Frame,
+  payload: TransactionQueryPost,
 ) {
-  const liveQuery = await findLiveTransactionQueryFrame(page);
-  const request =
-    (liveQuery ? await captureTransactionQueryPost(liveQuery) : undefined) ??
-    snapshot;
-  const postFrame = liveQuery ?? pickLiveFrame(page, queryFrame);
-  if (!request || !postFrame) return undefined;
   try {
     const value = await withActionTimeout(
-      postFrame.evaluate(async (payload: TransactionQueryPost) => {
+      frame.evaluate(async (payload: TransactionQueryPost) => {
         try {
           const method =
             payload.method.toUpperCase() === "GET" ? "GET" : "POST";
@@ -1402,7 +1267,7 @@ async function postTransactionQuery(
         } catch {
           return { ok: false, status: 0, text: "" };
         }
-      }, request),
+      }, payload),
     );
     if (
       isRecord(value) &&
@@ -1414,66 +1279,7 @@ async function postTransactionQuery(
   } catch (error) {
     if (!isRecoverableFrameError(error)) throw error;
   }
-  return undefined;
-}
-
-async function serializeFirstbankTables(frame: Frame): Promise<string> {
-  const serialized = await withActionTimeout(
-    frame.evaluate(() => {
-      const escape = (value: string) =>
-        value
-          .replace(/&/g, "&amp;")
-          .replace(/</g, "&lt;")
-          .replace(/>/g, "&gt;");
-      return Array.from(document.querySelectorAll("table"))
-        .map((table) => {
-          const rows = Array.from(table.rows);
-          if (rows.length === 0) return "";
-          const rowHtml = rows
-            .map((row) => {
-              const className = row.getAttribute("class");
-              const rowAttributes = className
-                ? ` class="${escape(className)}"`
-                : "";
-              const cells = Array.from(row.cells)
-                .map((cell) => {
-                  const text = (cell.innerText || cell.textContent || "")
-                    .replace(/\s+/g, " ")
-                    .trim();
-                  return `<td>${escape(text)}</td>`;
-                })
-                .join("");
-              return `<tr${rowAttributes}>${cells}</tr>`;
-            })
-            .join("");
-          return `<table>${rowHtml}</table>`;
-        })
-        .filter(Boolean)
-        .join("\n");
-    }),
-  ).catch(() => "");
-
-  if (typeof serialized === "string" && serialized.trim()) {
-    return assertSerializedTransactionTables(serialized);
-  }
-
-  // Some browser mocks and older Puppeteer frames do not expose table rows
-  // through evaluate after a navigation. Keep the fallback table-only.
-  try {
-    const html = await withActionTimeout(frame.content());
-    if (typeof html !== "string") {
-      throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
-    }
-    return transactionHistoryFromHtml(html);
-  } catch (error) {
-    if (error instanceof FirstbankConnectionError) throw error;
-    throw new FirstbankConnectionError(
-      "第一銀行交易明細讀取失敗。",
-      undefined,
-      undefined,
-      error,
-    );
-  }
+  throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
 }
 
 async function waitForAuthenticatedFrame(
@@ -1837,13 +1643,6 @@ function isFirstbankAction(url: string) {
   } catch {
     return false;
   }
-}
-
-function isTransactionHistoryReadError(error: unknown) {
-  return (
-    error instanceof FirstbankConnectionError &&
-    error.message === "第一銀行交易明細讀取失敗。"
-  );
 }
 
 function transactionHistoryFromHtml(html: string) {

--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -34,6 +34,10 @@ const LOGIN_RESULT_ATTEMPTS = 30;
 const LOGIN_RESULT_POLL_MS = 500;
 const FRAME_TIMEOUT_MS = 15_000;
 const FRAME_READ_RETRY_MS = 250;
+// 010103 may replace and detach its iframe in Browser Rendering. Probe only
+// briefly before using the response body already captured from the same click.
+const RESULT_FRAME_WAIT_MS = 2_000;
+const FRAME_PROBE_TIMEOUT_MS = 1_000;
 const CARD_RESPONSE_TIMEOUT_MS = 10_000;
 const SESSION_RELEASE_TIMEOUT_MS = 2_000;
 const SESSION_RELEASE_POLL_MS = 100;
@@ -58,13 +62,13 @@ type CaptchaImage = {
 
 type CardPayloadKey = "cardBill" | "recentPayments" | "cardUnbilled";
 
-type TransactionQueryPost = {
-  action: string;
-  method: string;
-  body: string;
-};
-
 type CapturedCardResponses = Partial<Record<CardPayloadKey, unknown>>;
+
+type TransactionResponseCapture = {
+  armed: boolean;
+  html?: string;
+  pending: Set<Promise<void>>;
+};
 
 type BrowserResponse = {
   url(): string;
@@ -781,7 +785,23 @@ async function collectFirstbankPayloads(
   const frame = await waitForAuthenticatedFrame(page);
   const captured: CapturedCardResponses = {};
   const responseTasks: Promise<void>[] = [];
+  const transactionResponse: TransactionResponseCapture = {
+    armed: false,
+    pending: new Set(),
+  };
   const onResponse = (response: BrowserResponse) => {
+    if (
+      transactionResponse.armed &&
+      isTransactionResultResponse(response.url())
+    ) {
+      let task: Promise<void>;
+      task = captureTransactionResponse(response, transactionResponse).finally(
+        () => transactionResponse.pending.delete(task),
+      );
+      transactionResponse.pending.add(task);
+      void task.catch(() => undefined);
+      return;
+    }
     const key = cardResponseKey(response.url());
     if (!key) return;
     const task = captureCardResponse(response, key, captured);
@@ -797,8 +817,12 @@ async function collectFirstbankPayloads(
 
     await navigateFrame(frame, TRANSACTION_URL);
     const queryFrame = await waitForLiveTransactionQueryFrame(page, frame);
-    const transactionHistoryHtml = await submitTransactionQuery(queryFrame);
-    const cardFrame = pickLiveFrame(page, queryFrame) ?? queryFrame;
+    const transactionHistoryHtml = await submitTransactionQuery(
+      page,
+      queryFrame,
+      transactionResponse,
+    );
+    const cardFrame = pickLiveFrame(page, frame) ?? queryFrame;
 
     await collectCardPayload(cardFrame, "F1632", 1, "cardBill", captured);
     await collectCardPayload(cardFrame, "F1633", 2, "recentPayments", captured);
@@ -948,19 +972,51 @@ function cardResponseKey(url: string): CardPayloadKey | undefined {
   return undefined;
 }
 
-async function submitTransactionQuery(frame: Frame) {
+async function captureTransactionResponse(
+  response: BrowserResponse,
+  capture: TransactionResponseCapture,
+) {
+  try {
+    const html = transactionHistoryFromHtml(await response.text());
+    capture.html ??= html;
+  } catch {
+    // Invalid 010103 bodies do not mask a later live frame or valid response.
+  }
+}
+
+async function submitTransactionQuery(
+  page: Page,
+  frame: Frame,
+  transactionResponse: TransactionResponseCapture,
+) {
   await dismissBankNotice(frame);
   await fillTransactionDateRange(frame);
   await waitForQueryAccountOptions(frame);
   await selectQueryAccount(frame);
-  const queryPost = await captureTransactionQueryPost(frame);
-  if (!queryPost) {
-    throw new FirstbankConnectionError("第一銀行交易明細查詢表單格式已變更。");
+  transactionResponse.armed = true;
+  await clickTransactionSearch(frame);
+
+  const resultFrame = await waitForLiveTransactionResultFrame(
+    page,
+    transactionResponse,
+  );
+  if (resultFrame) {
+    try {
+      return await serializeFirstbankTables(resultFrame);
+    } catch (error) {
+      if (!isTransactionHistoryReadError(error)) throw error;
+    }
   }
-  // Same pattern as deposit overview: keep the live 0101 document and POST
-  // its form via fetch. Clicking #searchBtn navigates 0101 → 010103 and
-  // Cloudflare Browser Rendering drops the iframe.
-  return postTransactionQuery(frame, queryPost);
+
+  if (transactionResponse.html) return transactionResponse.html;
+  if (transactionResponse.pending.size > 0) {
+    await withActionTimeout(
+      Promise.allSettled(transactionResponse.pending),
+      FRAME_PROBE_TIMEOUT_MS,
+    ).catch(() => undefined);
+    if (transactionResponse.html) return transactionResponse.html;
+  }
+  throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
 }
 
 async function waitForDepositOverview(frame: Frame) {
@@ -1024,6 +1080,31 @@ async function hasTransactionSearchControl(frame: Frame) {
   } catch {
     return false;
   }
+}
+
+async function waitForLiveTransactionResultFrame(
+  page: Page,
+  transactionResponse: TransactionResponseCapture,
+) {
+  const deadline = Date.now() + RESULT_FRAME_WAIT_MS;
+  while (Date.now() < deadline) {
+    const result = await findLiveTransactionResultFrame(page);
+    if (result) return result;
+    if (transactionResponse.html) return undefined;
+    await delay(FRAME_READ_RETRY_MS);
+  }
+  return findLiveTransactionResultFrame(page);
+}
+
+async function findLiveTransactionResultFrame(page: Page) {
+  for (const frame of liveFrames(page)) {
+    if (!isTransactionResultResponse(frame.url())) continue;
+    await dismissBankNotice(frame, FRAME_PROBE_TIMEOUT_MS);
+    if (await hasTransactionResultHeader(frame, FRAME_PROBE_TIMEOUT_MS)) {
+      return frame;
+    }
+  }
+  return undefined;
 }
 
 async function fillTransactionDateRange(frame: Frame) {
@@ -1112,7 +1193,32 @@ async function selectQueryAccount(frame: Frame, dryRun = false) {
   }
 }
 
-async function dismissBankNotice(frame: Frame) {
+async function clickTransactionSearch(frame: Frame) {
+  let submitted = false;
+  try {
+    submitted = Boolean(
+      await withActionTimeout(
+        frame.evaluate(() => {
+          const searchBtn = document.querySelector<HTMLElement>(
+            "#searchBtn, input[name=showList]",
+          );
+          if (!searchBtn) return false;
+          searchBtn.click();
+          return true;
+        }),
+      ),
+    );
+  } catch (error) {
+    if (!isRecoverableFrameError(error)) throw error;
+    // The native click can destroy the iframe execution context immediately.
+    submitted = true;
+  }
+  if (!submitted) {
+    throw new FirstbankConnectionError("第一銀行交易明細查詢按鈕格式已變更。");
+  }
+}
+
+async function dismissBankNotice(frame: Frame, timeoutMs = ACTION_TIMEOUT_MS) {
   try {
     await withActionTimeout(
       frame.evaluate(() => {
@@ -1132,9 +1238,34 @@ async function dismissBankNotice(frame: Frame) {
         match?.click();
         return Boolean(match);
       }),
+      timeoutMs,
     );
   } catch {
     // Notice may already be gone after navigation.
+  }
+}
+
+async function hasTransactionResultHeader(
+  frame: Frame,
+  timeoutMs = ACTION_TIMEOUT_MS,
+) {
+  try {
+    return Boolean(
+      await withActionTimeout(
+        frame.evaluate(() => {
+          const rows = Array.from(document.querySelectorAll("tr"));
+          return rows.some((row) => {
+            const text = (row.innerText || "").replace(/\s+/g, " ");
+            return (
+              /交易日期|交易日/.test(text) && /支出|存入|交易金額/.test(text)
+            );
+          });
+        }),
+        timeoutMs,
+      ),
+    );
+  } catch {
+    return false;
   }
 }
 
@@ -1184,100 +1315,44 @@ async function fetchFrameResource(frame: Frame, path: string): Promise<string> {
   throw new FirstbankConnectionError("第一銀行存款總覽讀取失敗。");
 }
 
-async function captureTransactionQueryPost(
-  frame: Frame,
-): Promise<TransactionQueryPost | undefined> {
-  try {
-    const value = await withActionTimeout(
-      frame.evaluate(() => {
-        const form = document.querySelector("form");
-        if (!form) return null;
-        const action = new URL(
-          form.getAttribute("action") || form.action || "",
-          window.location.href,
-        ).href;
-        const method = (
-          form.getAttribute("method") ||
-          form.method ||
-          "POST"
-        ).toUpperCase();
-        const params = new URLSearchParams();
-        const formData = new FormData(form);
-        for (const [name, fieldValue] of formData.entries()) {
-          params.append(name, String(fieldValue));
-        }
-        const searchBtn = document.querySelector<HTMLInputElement>(
-          "#searchBtn, input[name=showList]",
-        );
-        if (searchBtn?.name && !params.has(searchBtn.name)) {
-          params.append(searchBtn.name, searchBtn.value ?? "");
-        }
-        return { action, method, body: params.toString() };
-      }),
-    );
-    if (
-      isRecord(value) &&
-      typeof value.action === "string" &&
-      isFirstbankAction(value.action) &&
-      typeof value.method === "string" &&
-      typeof value.body === "string"
-    ) {
-      return {
-        action: value.action,
-        method: value.method,
-        body: value.body,
-      };
-    }
-  } catch (error) {
-    if (!isRecoverableFrameError(error)) throw error;
-  }
-  return undefined;
-}
+async function serializeFirstbankTables(frame: Frame): Promise<string> {
+  const serialized = await withActionTimeout(
+    frame.evaluate(() => {
+      const escape = (value: string) =>
+        value
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+      return Array.from(document.querySelectorAll("table"))
+        .map((table) => {
+          const rows = Array.from(table.rows);
+          if (rows.length === 0) return "";
+          const rowHtml = rows
+            .map((row) => {
+              const className = row.getAttribute("class");
+              const rowAttributes = className
+                ? ` class="${escape(className)}"`
+                : "";
+              const cells = Array.from(row.cells)
+                .map((cell) => {
+                  const text = (cell.innerText || cell.textContent || "")
+                    .replace(/\s+/g, " ")
+                    .trim();
+                  return `<td>${escape(text)}</td>`;
+                })
+                .join("");
+              return `<tr${rowAttributes}>${cells}</tr>`;
+            })
+            .join("");
+          return `<table>${rowHtml}</table>`;
+        })
+        .filter(Boolean)
+        .join("\n");
+    }),
+  ).catch(() => "");
 
-async function postTransactionQuery(
-  frame: Frame,
-  payload: TransactionQueryPost,
-) {
-  try {
-    const value = await withActionTimeout(
-      frame.evaluate(async (payload: TransactionQueryPost) => {
-        try {
-          const method =
-            payload.method.toUpperCase() === "GET" ? "GET" : "POST";
-          const action =
-            method === "GET" && payload.body
-              ? `${payload.action}${payload.action.includes("?") ? "&" : "?"}${payload.body}`
-              : payload.action;
-          const response = await fetch(action, {
-            method,
-            credentials: "same-origin",
-            headers: {
-              Accept: "text/html, application/json",
-              ...(method === "GET"
-                ? {}
-                : { "Content-Type": "application/x-www-form-urlencoded" }),
-            },
-            body: method === "GET" ? undefined : payload.body,
-          });
-          return {
-            ok: response.ok,
-            status: response.status,
-            text: await response.text(),
-          };
-        } catch {
-          return { ok: false, status: 0, text: "" };
-        }
-      }, payload),
-    );
-    if (
-      isRecord(value) &&
-      value.ok === true &&
-      typeof value.text === "string"
-    ) {
-      return transactionHistoryFromHtml(value.text);
-    }
-  } catch (error) {
-    if (!isRecoverableFrameError(error)) throw error;
+  if (typeof serialized === "string" && serialized.trim()) {
+    return assertSerializedTransactionTables(serialized);
   }
   throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
 }
@@ -1637,12 +1712,23 @@ function pickLiveFrame(page: Page, preferred?: Frame) {
   return liveFrames(page)[0];
 }
 
-function isFirstbankAction(url: string) {
+function isTransactionResultResponse(url: string) {
   try {
-    return new URL(url).origin === ORIGIN;
+    const parsed = new URL(url);
+    return (
+      parsed.origin === ORIGIN &&
+      parsed.pathname.toLowerCase() === "/netbank/2/010103.html"
+    );
   } catch {
     return false;
   }
+}
+
+function isTransactionHistoryReadError(error: unknown) {
+  return (
+    error instanceof FirstbankConnectionError &&
+    error.message === "第一銀行交易明細讀取失敗。"
+  );
 }
 
 function transactionHistoryFromHtml(html: string) {

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -44,12 +44,13 @@ const transactionTables = `
 
 const TRANSACTION_RESULT_URL =
   "https://ibank.firstbank.com.tw/NetBank/2/010103.html";
-const TRANSACTION_QUERY_URL =
-  "https://ibank.firstbank.com.tw/NetBank/2/0101.html";
 
 type Listener = (...args: unknown[]) => void;
 
-function makeFrame(options?: { authenticated?: boolean }) {
+function makeFrame(options?: {
+  authenticated?: boolean;
+  transactionPostHtml?: string;
+}) {
   let currentUrl = options?.authenticated ? FRAME_URL : LOGIN_URL;
   return {
     detached: false,
@@ -71,6 +72,13 @@ function makeFrame(options?: { authenticated?: boolean }) {
           body: "txnStart=2026/07/29&txnEnd=2026/08/29&showList=Y",
         };
       }
+      if (source.includes("payload.action") && source.includes("fetch(")) {
+        return {
+          ok: true,
+          status: 200,
+          text: options?.transactionPostHtml ?? transactionTables,
+        };
+      }
       if (source.includes('querySelectorAll("table")')) {
         return currentUrl.includes("0101") ? transactionTables : depositTables;
       }
@@ -89,6 +97,7 @@ function makeFrame(options?: { authenticated?: boolean }) {
 function makePage(options?: {
   authenticated?: boolean;
   afterLogin?: "frame" | "interstitial";
+  transactionPostHtml?: string;
 }) {
   const afterLogin = options?.afterLogin ?? "frame";
   let currentUrl = options?.authenticated ? FRAME_URL : LOGIN_URL;
@@ -189,56 +198,6 @@ function makeBrowser(page: ReturnType<typeof makePage>) {
   };
 }
 
-function makeTransactionResultFrame() {
-  const frame = makeFrame({ authenticated: true });
-  frame.url.mockReturnValue(TRANSACTION_RESULT_URL);
-  frame.evaluate.mockImplementation(async (fn: unknown) => {
-    const source = String(fn);
-    if (source.includes("#btnOpen") || source.includes("#tFunc")) return true;
-    if (source.includes("交易日期")) return true;
-    if (source.includes('querySelectorAll("table")')) return transactionTables;
-    if (source.includes("searchBtn")) return false;
-    if (source.includes("請選擇查詢帳號")) return false;
-    return undefined;
-  });
-  frame.content.mockResolvedValue(transactionTables);
-  return frame;
-}
-
-function makeEmptyLiveFrame() {
-  const frame = makeFrame({ authenticated: true });
-  frame.url.mockReturnValue(TRANSACTION_QUERY_URL);
-  frame.evaluate.mockImplementation(async (fn: unknown) => {
-    const source = String(fn);
-    if (source.includes("#btnOpen") || source.includes("#tFunc")) return true;
-    if (source.includes("交易日期")) return false;
-    if (source.includes('querySelectorAll("table")')) return "";
-    if (source.includes("searchBtn")) return false;
-    if (source.includes("請選擇查詢帳號")) return false;
-    return undefined;
-  });
-  frame.content.mockResolvedValue("<html><body></body></html>");
-  return frame;
-}
-
-function makePostFallbackFrame() {
-  const frame = makeEmptyLiveFrame();
-  const previousEvaluate = frame.evaluate;
-  frame.evaluate = vi
-    .fn()
-    .mockImplementation(async (fn: unknown, arg?: unknown) => {
-      const source = String(fn);
-      if (
-        source.includes("fetch(action") ||
-        source.includes("payload.action")
-      ) {
-        return { ok: true, status: 200, text: transactionTables };
-      }
-      return previousEvaluate(fn, arg);
-    });
-  return frame;
-}
-
 function postedTransactionQuery(frame: ReturnType<typeof makeFrame>) {
   return frame.evaluate.mock.calls.some(
     ([fn]) =>
@@ -246,34 +205,11 @@ function postedTransactionQuery(frame: ReturnType<typeof makeFrame>) {
   );
 }
 
-function detachQueryFrameAfterSearch(
-  page: ReturnType<typeof makePage>,
-  nextFrames: Array<ReturnType<typeof makeFrame>>,
-) {
-  const queryFrame = page.frame;
-  const previousEvaluate = queryFrame.evaluate;
-  queryFrame.evaluate = vi
-    .fn()
-    .mockImplementation(async (fn: unknown, arg?: unknown) => {
-      const source = String(fn);
-      if (queryFrame.detached) {
-        throw new Error(
-          "Execution context was destroyed, most likely because of a navigation.",
-        );
-      }
-      if (source.includes("searchBtn") && source.includes(".click()")) {
-        queryFrame.detached = true;
-        page.frames.mockImplementation(() => nextFrames);
-        return true;
-      }
-      return previousEvaluate(fn, arg);
-    });
-  queryFrame.content.mockImplementation(async () => {
-    if (queryFrame.detached) {
-      throw new Error("Attempted to use detached Frame");
-    }
-    return "<html><body><form>查詢帳號</form></body></html>";
-  });
+function clickedTransactionSearch(frame: ReturnType<typeof makeFrame>) {
+  return frame.evaluate.mock.calls.some(
+    ([fn]) =>
+      String(fn).includes("searchBtn") && String(fn).includes(".click()"),
+  );
 }
 
 beforeEach(() => {
@@ -490,11 +426,9 @@ describe("第一銀行 browser session lifecycle", () => {
   });
 });
 
-describe("第一銀行交易明細 frame 重綁", () => {
-  it("query 導覽摧毀舊 frame 後，改從含交易日期表頭的新 frame 讀取明細", async () => {
+describe("第一銀行交易明細 in-frame POST", () => {
+  it("填完 0101 表單後直接 POST，不點擊 searchBtn，並從回應 HTML 解析明細", async () => {
     const page = makePage({ authenticated: true });
-    const resultFrame = makeTransactionResultFrame();
-    detachQueryFrameAfterSearch(page, [resultFrame]);
     const browser = makeBrowser(page);
     puppeteerMock.launch.mockResolvedValue(browser);
 
@@ -517,42 +451,9 @@ describe("第一銀行交易明細 frame 重綁", () => {
         }),
       ]),
     );
-    expect(resultFrame.evaluate).toHaveBeenCalled();
-    expect(page.frame.evaluate).toHaveBeenCalled();
-    expect(postedTransactionQuery(resultFrame)).toBe(false);
-  });
-
-  it("結果 iframe 未出現時，改從仍活著的 frame POST 0101 表單取得明細", async () => {
-    vi.useFakeTimers();
-    const page = makePage({ authenticated: true });
-    const liveFrame = makePostFallbackFrame();
-    detachQueryFrameAfterSearch(page, [liveFrame]);
-    const browser = makeBrowser(page);
-    puppeteerMock.launch.mockResolvedValue(browser);
-
-    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
-      ...credentials,
-      sessionCookies: JSON.stringify([
-        {
-          name: "SESSION",
-          value: "encrypted-at-rest",
-          domain: "ibank.firstbank.com.tw",
-        },
-      ]),
-    });
-    await vi.advanceTimersByTimeAsync(5_000);
-    const result = await pending;
-
-    expect(result.bankTransactions).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          amount: -100,
-          description: "測試交易",
-        }),
-      ]),
-    );
-    expect(postedTransactionQuery(liveFrame)).toBe(true);
-    const postCall = liveFrame.evaluate.mock.calls.find(
+    expect(postedTransactionQuery(page.frame)).toBe(true);
+    expect(clickedTransactionSearch(page.frame)).toBe(false);
+    const postCall = page.frame.evaluate.mock.calls.find(
       ([fn]) =>
         String(fn).includes("payload.action") && String(fn).includes("fetch("),
     );
@@ -562,14 +463,15 @@ describe("第一銀行交易明細 frame 重綁", () => {
         method: "POST",
       }),
     );
-    expect(liveFrame.content).not.toHaveBeenCalled();
+    expect(page.frame.content).not.toHaveBeenCalled();
+    expect(page.frame.waitForNavigation).not.toHaveBeenCalled();
   });
 
-  it("沒有任何 live frame 含交易明細表格時仍回報讀取失敗", async () => {
-    vi.useFakeTimers();
-    const page = makePage({ authenticated: true });
-    const emptyFrame = makeEmptyLiveFrame();
-    detachQueryFrameAfterSearch(page, [emptyFrame]);
+  it("POST HTML 沒有交易表格時仍回報讀取失敗", async () => {
+    const page = makePage({
+      authenticated: true,
+      transactionPostHtml: "<html><body><frameset></frameset></body></html>",
+    });
     const browser = makeBrowser(page);
     puppeteerMock.launch.mockResolvedValue(browser);
 
@@ -583,12 +485,11 @@ describe("第一銀行交易明細 frame 重綁", () => {
         },
       ]),
     });
-    const expectation =
-      expect(pending).rejects.toThrow("第一銀行交易明細讀取失敗。");
-    await vi.advanceTimersByTimeAsync(5_000);
-    await expectation;
+    await expect(pending).rejects.toThrow("第一銀行交易明細讀取失敗。");
     await expect(pending).rejects.toBeInstanceOf(FirstbankConnectionError);
-    expect(emptyFrame.content).not.toHaveBeenCalled();
-    expect(postedTransactionQuery(emptyFrame)).toBe(true);
+    expect(postedTransactionQuery(page.frame)).toBe(true);
+    expect(clickedTransactionSearch(page.frame)).toBe(false);
+    expect(page.frame.content).not.toHaveBeenCalled();
+    expect(page.frame.waitForNavigation).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -44,16 +44,18 @@ const transactionTables = `
 
 const TRANSACTION_RESULT_URL =
   "https://ibank.firstbank.com.tw/NetBank/2/010103.html";
+const TRANSACTION_QUERY_URL =
+  "https://ibank.firstbank.com.tw/NetBank/2/0101.html";
 
 type Listener = (...args: unknown[]) => void;
 
-function makeFrame(options?: {
-  authenticated?: boolean;
-  transactionPostHtml?: string;
-}) {
+function makeFrame(options?: { authenticated?: boolean }) {
   let currentUrl = options?.authenticated ? FRAME_URL : LOGIN_URL;
   return {
     detached: false,
+    setUrl(url: string) {
+      currentUrl = url;
+    },
     name: vi.fn().mockReturnValue("main"),
     url: vi.fn().mockImplementation(() => currentUrl),
     goto: vi.fn().mockImplementation(async (url: string) => {
@@ -65,22 +67,14 @@ function makeFrame(options?: {
       if (source.includes("fetch(resourcePath")) {
         return { ok: true, status: 200, text: depositTables };
       }
-      if (source.includes("new FormData(form)")) {
-        return {
-          action: TRANSACTION_RESULT_URL,
-          method: "POST",
-          body: "txnStart=2026/07/29&txnEnd=2026/08/29&showList=Y",
-        };
-      }
-      if (source.includes("payload.action") && source.includes("fetch(")) {
-        return {
-          ok: true,
-          status: 200,
-          text: options?.transactionPostHtml ?? transactionTables,
-        };
+      if (source.includes("searchBtn") && source.includes(".click()")) {
+        currentUrl = TRANSACTION_RESULT_URL;
+        return true;
       }
       if (source.includes('querySelectorAll("table")')) {
-        return currentUrl.includes("0101") ? transactionTables : depositTables;
+        return currentUrl.includes("010103")
+          ? transactionTables
+          : depositTables;
       }
       if (source.includes('querySelectorAll("select")')) return true;
       if (source.includes("searchBtn")) return true;
@@ -97,7 +91,6 @@ function makeFrame(options?: {
 function makePage(options?: {
   authenticated?: boolean;
   afterLogin?: "frame" | "interstitial";
-  transactionPostHtml?: string;
 }) {
   const afterLogin = options?.afterLogin ?? "frame";
   let currentUrl = options?.authenticated ? FRAME_URL : LOGIN_URL;
@@ -148,7 +141,7 @@ function makePage(options?: {
       if (options?.authenticated) {
         authenticated = true;
         currentUrl = FRAME_URL;
-        frame.url.mockReturnValue(FRAME_URL);
+        frame.setUrl(FRAME_URL);
       }
     }),
     off: vi.fn().mockImplementation((event: string, listener: Listener) => {
@@ -167,7 +160,7 @@ function makePage(options?: {
       click: vi.fn().mockImplementation(async () => {
         authenticated = true;
         currentUrl = FRAME_URL;
-        frame.url.mockReturnValue(FRAME_URL);
+        frame.setUrl(FRAME_URL);
       }),
     },
     type: vi.fn().mockResolvedValue(undefined),
@@ -179,10 +172,15 @@ function makePage(options?: {
       const response = {
         url: () => url,
         json: vi.fn().mockResolvedValue(payload),
-        text: vi.fn().mockResolvedValue(JSON.stringify(payload)),
+        text: vi
+          .fn()
+          .mockResolvedValue(
+            typeof payload === "string" ? payload : JSON.stringify(payload),
+          ),
       };
       for (const listener of listeners.get("response") ?? [])
         listener(response);
+      return response;
     },
   };
   return page;
@@ -210,6 +208,66 @@ function clickedTransactionSearch(frame: ReturnType<typeof makeFrame>) {
     ([fn]) =>
       String(fn).includes("searchBtn") && String(fn).includes(".click()"),
   );
+}
+
+function makeTransactionResultFrame() {
+  const frame = makeFrame({ authenticated: true });
+  frame.url.mockReturnValue(TRANSACTION_RESULT_URL);
+  frame.evaluate.mockImplementation(async (fn: unknown) => {
+    const source = String(fn);
+    if (source.includes("#btnOpen") || source.includes("#tFunc")) return true;
+    if (source.includes("交易日期")) return true;
+    if (source.includes('querySelectorAll("table")')) return transactionTables;
+    if (source.includes("searchBtn")) return false;
+    return undefined;
+  });
+  return frame;
+}
+
+function makeEmptyLiveFrame() {
+  const frame = makeFrame({ authenticated: true });
+  frame.url.mockReturnValue(TRANSACTION_QUERY_URL);
+  frame.evaluate.mockImplementation(async (fn: unknown) => {
+    const source = String(fn);
+    if (source.includes("#btnOpen") || source.includes("#tFunc")) return true;
+    if (source.includes("交易日期")) return false;
+    if (source.includes('querySelectorAll("table")')) return "";
+    if (source.includes("searchBtn")) return false;
+    return undefined;
+  });
+  return frame;
+}
+
+function detachQueryFrameAfterSearch(
+  page: ReturnType<typeof makePage>,
+  nextFrames: Array<ReturnType<typeof makeFrame>>,
+  responseHtml?: string,
+) {
+  let resultResponse:
+    ReturnType<ReturnType<typeof makePage>["emitResponse"]> | undefined;
+  const queryFrame = page.frame;
+  const previousEvaluate = queryFrame.evaluate;
+  queryFrame.evaluate = vi
+    .fn()
+    .mockImplementation(async (fn: unknown, arg?: unknown) => {
+      const source = String(fn);
+      if (queryFrame.detached) {
+        throw new Error("Execution context was destroyed during navigation");
+      }
+      if (source.includes("searchBtn") && source.includes(".click()")) {
+        queryFrame.detached = true;
+        page.frames.mockImplementation(() => nextFrames);
+        if (responseHtml !== undefined) {
+          resultResponse = page.emitResponse(
+            TRANSACTION_RESULT_URL,
+            responseHtml,
+          );
+        }
+        return true;
+      }
+      return previousEvaluate(fn, arg);
+    });
+  return () => resultResponse;
 }
 
 beforeEach(() => {
@@ -426,9 +484,11 @@ describe("第一銀行 browser session lifecycle", () => {
   });
 });
 
-describe("第一銀行交易明細 in-frame POST", () => {
-  it("填完 0101 表單後直接 POST，不點擊 searchBtn，並從回應 HTML 解析明細", async () => {
+describe("第一銀行交易明細 010103 擷取", () => {
+  it("點擊 searchBtn 後序列化仍存活的 010103 frame", async () => {
     const page = makePage({ authenticated: true });
+    const resultFrame = makeTransactionResultFrame();
+    detachQueryFrameAfterSearch(page, [resultFrame]);
     const browser = makeBrowser(page);
     puppeteerMock.launch.mockResolvedValue(browser);
 
@@ -451,27 +511,48 @@ describe("第一銀行交易明細 in-frame POST", () => {
         }),
       ]),
     );
-    expect(postedTransactionQuery(page.frame)).toBe(true);
-    expect(clickedTransactionSearch(page.frame)).toBe(false);
-    const postCall = page.frame.evaluate.mock.calls.find(
-      ([fn]) =>
-        String(fn).includes("payload.action") && String(fn).includes("fetch("),
-    );
-    expect(postCall?.[1]).toEqual(
-      expect.objectContaining({
-        action: TRANSACTION_RESULT_URL,
-        method: "POST",
-      }),
-    );
-    expect(page.frame.content).not.toHaveBeenCalled();
+    expect(clickedTransactionSearch(page.frame)).toBe(true);
+    expect(postedTransactionQuery(page.frame)).toBe(false);
+    expect(resultFrame.evaluate).toHaveBeenCalled();
     expect(page.frame.waitForNavigation).not.toHaveBeenCalled();
   });
 
-  it("POST HTML 沒有交易表格時仍回報讀取失敗", async () => {
-    const page = makePage({
-      authenticated: true,
-      transactionPostHtml: "<html><body><frameset></frameset></body></html>",
+  it("010103 iframe 消失時改從 page response 讀取明細", async () => {
+    const page = makePage({ authenticated: true });
+    const liveFrame = makeEmptyLiveFrame();
+    const resultResponse = detachQueryFrameAfterSearch(
+      page,
+      [liveFrame],
+      transactionTables,
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const result = await createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
     });
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+    expect(clickedTransactionSearch(page.frame)).toBe(true);
+    expect(postedTransactionQuery(page.frame)).toBe(false);
+    expect(resultResponse()?.text).toHaveBeenCalledOnce();
+    expect(page.frame.waitForNavigation).not.toHaveBeenCalled();
+  });
+
+  it("沒有 010103 frame 或 HTTP 回應時快速回報讀取失敗", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(page, []);
     const browser = makeBrowser(page);
     puppeteerMock.launch.mockResolvedValue(browser);
 
@@ -485,11 +566,12 @@ describe("第一銀行交易明細 in-frame POST", () => {
         },
       ]),
     });
-    await expect(pending).rejects.toThrow("第一銀行交易明細讀取失敗。");
+    const expectation =
+      expect(pending).rejects.toThrow("第一銀行交易明細讀取失敗。");
+    await vi.advanceTimersByTimeAsync(3_000);
+    await expectation;
     await expect(pending).rejects.toBeInstanceOf(FirstbankConnectionError);
-    expect(postedTransactionQuery(page.frame)).toBe(true);
-    expect(clickedTransactionSearch(page.frame)).toBe(false);
-    expect(page.frame.content).not.toHaveBeenCalled();
-    expect(page.frame.waitForNavigation).not.toHaveBeenCalled();
+    expect(clickedTransactionSearch(page.frame)).toBe(true);
+    expect(postedTransactionQuery(page.frame)).toBe(false);
   });
 });


### PR DESCRIPTION
## 問題

2026-08-29 11:07（台北）本機 Wrangler 手動同步在約 23 秒後回報「交易明細讀取失敗」。PR 原本把 0101 form 改成 in-frame POST，但銀行表單 POST 本身不回傳交易表格，因此無法解析明細。

## 修正

- 恢復點擊 `#searchBtn`，由銀行頁面原生流程送出 010103 查詢。
- 點擊後以短期限重新取得仍存活的 010103 frame，直接序列化其中的交易表格。
- click 前才啟用 page `response` 擷取；若 Cloudflare Browser Rendering 在導覽時丟棄 iframe，改讀取同一次 `/NetBank/2/010103.html` HTTP response body。
- 只接受第一銀行 origin 與精確 010103 path；無合法 live frame 或 HTTP 表格時快速回報「第一銀行交易明細讀取失敗。」。
- 移除不會回傳表格的 form POST 重播路徑。

## 驗證

- `npm run format:check`
- `npm run typecheck`
- `npx vitest run apps/worker/tests/connectors/firstbank-session.test.ts`（11 passed）
- `npx tsx tests/selfcheck/firstbank.selfcheck.ts`（從 `packages/connectors` 執行）

本次未重新觸發含銀行登入資料的 live Wrangler 同步；上述結果為本機程式與測試驗證。