### PR TITLE
fix(連接器): 以 CDP 擷取第一銀行 010103 明細

### DIFF
--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -1,5 +1,6 @@
 import puppeteer, {
   type Browser,
+  type CDPSession,
   type CookieParam,
   type Dialog,
   type Frame,
@@ -42,6 +43,7 @@ const CARD_RESPONSE_TIMEOUT_MS = 10_000;
 const SESSION_RELEASE_TIMEOUT_MS = 2_000;
 const SESSION_RELEASE_POLL_MS = 100;
 const MAX_SERIALIZED_TABLE_BYTES = 512 * 1024;
+const TRANSACTION_DOCUMENT_BUFFER_BYTES = MAX_SERIALIZED_TABLE_BYTES * 2;
 const USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
   "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
@@ -67,7 +69,18 @@ type CapturedCardResponses = Partial<Record<CardPayloadKey, unknown>>;
 type TransactionResponseCapture = {
   armed: boolean;
   html?: string;
+  requestIds: Set<string>;
   pending: Set<Promise<void>>;
+};
+
+type TransactionDocumentResponseEvent = {
+  requestId: string;
+  type: string;
+  response: { url: string };
+};
+
+type TransactionLoadingEvent = {
+  requestId: string;
 };
 
 type BrowserResponse = {
@@ -787,8 +800,50 @@ async function collectFirstbankPayloads(
   const responseTasks: Promise<void>[] = [];
   const transactionResponse: TransactionResponseCapture = {
     armed: false,
+    requestIds: new Set(),
     pending: new Set(),
   };
+  const cdp = await page.createCDPSession();
+  try {
+    await cdp.send("Network.enable", {
+      maxTotalBufferSize: TRANSACTION_DOCUMENT_BUFFER_BYTES,
+      maxResourceBufferSize: TRANSACTION_DOCUMENT_BUFFER_BYTES,
+    });
+  } catch (error) {
+    await cdp.detach().catch(() => undefined);
+    throw error;
+  }
+  const onTransactionDocumentResponse = (
+    event: TransactionDocumentResponseEvent,
+  ) => {
+    if (
+      transactionResponse.armed &&
+      event.type === "Document" &&
+      isTransactionResultResponse(event.response.url)
+    ) {
+      transactionResponse.requestIds.add(event.requestId);
+    }
+  };
+  const onTransactionDocumentLoaded = (event: TransactionLoadingEvent) => {
+    if (!transactionResponse.requestIds.has(event.requestId)) return;
+    let task: Promise<void>;
+    task = captureTransactionDocument(
+      cdp,
+      event.requestId,
+      transactionResponse,
+    ).finally(() => {
+      transactionResponse.requestIds.delete(event.requestId);
+      transactionResponse.pending.delete(task);
+    });
+    transactionResponse.pending.add(task);
+    void task.catch(() => undefined);
+  };
+  const onTransactionDocumentFailed = (event: TransactionLoadingEvent) => {
+    transactionResponse.requestIds.delete(event.requestId);
+  };
+  cdp.on("Network.responseReceived", onTransactionDocumentResponse);
+  cdp.on("Network.loadingFinished", onTransactionDocumentLoaded);
+  cdp.on("Network.loadingFailed", onTransactionDocumentFailed);
   const onResponse = (response: BrowserResponse) => {
     if (
       transactionResponse.armed &&
@@ -838,6 +893,10 @@ async function collectFirstbankPayloads(
     } as unknown as FirstbankPayloads;
   } finally {
     page.off("response", onResponse);
+    cdp.off("Network.responseReceived", onTransactionDocumentResponse);
+    cdp.off("Network.loadingFinished", onTransactionDocumentLoaded);
+    cdp.off("Network.loadingFailed", onTransactionDocumentFailed);
+    await cdp.detach().catch(() => undefined);
   }
 }
 
@@ -972,6 +1031,23 @@ function cardResponseKey(url: string): CardPayloadKey | undefined {
   return undefined;
 }
 
+async function captureTransactionDocument(
+  cdp: CDPSession,
+  requestId: string,
+  capture: TransactionResponseCapture,
+) {
+  try {
+    const response = await cdp.send("Network.getResponseBody", { requestId });
+    const body = response.base64Encoded
+      ? decodeBase64Text(response.body)
+      : response.body;
+    const html = transactionHistoryFromHtml(body);
+    capture.html ??= html;
+  } catch {
+    // Invalid or unavailable 010103 bodies do not mask a later live frame.
+  }
+}
+
 async function captureTransactionResponse(
   response: BrowserResponse,
   capture: TransactionResponseCapture,
@@ -980,7 +1056,7 @@ async function captureTransactionResponse(
     const html = transactionHistoryFromHtml(await response.text());
     capture.html ??= html;
   } catch {
-    // Invalid 010103 bodies do not mask a later live frame or valid response.
+    // Invalid 010103 bodies do not mask a later CDP capture or live frame.
   }
 }
 
@@ -1010,11 +1086,19 @@ async function submitTransactionQuery(
 
   if (transactionResponse.html) return transactionResponse.html;
   if (transactionResponse.pending.size > 0) {
+    const tasks = Array.from(transactionResponse.pending);
     await withActionTimeout(
-      Promise.allSettled(transactionResponse.pending),
+      Promise.allSettled(tasks),
       FRAME_PROBE_TIMEOUT_MS,
     ).catch(() => undefined);
     if (transactionResponse.html) return transactionResponse.html;
+  }
+  if (transactionResponse.requestIds.size > 0) {
+    const deadline = Date.now() + FRAME_PROBE_TIMEOUT_MS;
+    while (transactionResponse.requestIds.size > 0 && Date.now() < deadline) {
+      await delay(FRAME_READ_RETRY_MS);
+      if (transactionResponse.html) return transactionResponse.html;
+    }
   }
   throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
 }
@@ -1783,6 +1867,15 @@ function bytesToBase64(bytes: Uint8Array | string) {
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);
   return btoa(binary);
+}
+
+function decodeBase64Text(value: string) {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new TextDecoder().decode(bytes);
 }
 
 function toArrayBuffer(bytes: Uint8Array | string) {

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -47,6 +47,13 @@ const TRANSACTION_RESULT_URL =
 const TRANSACTION_QUERY_URL =
   "https://ibank.firstbank.com.tw/NetBank/2/0101.html";
 
+function base64Text(value: string) {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
 type Listener = (...args: unknown[]) => void;
 
 function makeFrame(options?: { authenticated?: boolean }) {
@@ -97,6 +104,32 @@ function makePage(options?: {
   let authenticated = Boolean(options?.authenticated);
   let interstitialVisible = false;
   const listeners = new Map<string, Set<Listener>>();
+  const cdpListeners = new Map<string, Set<Listener>>();
+  const cdpBodies = new Map<string, { body: string; base64Encoded: boolean }>();
+  const cdpSession = {
+    detach: vi.fn().mockResolvedValue(undefined),
+    off: vi.fn().mockImplementation((event: string, listener: Listener) => {
+      cdpListeners.get(event)?.delete(listener);
+    }),
+    on: vi.fn().mockImplementation((event: string, listener: Listener) => {
+      const eventListeners = cdpListeners.get(event) ?? new Set<Listener>();
+      eventListeners.add(listener);
+      cdpListeners.set(event, eventListeners);
+    }),
+    send: vi
+      .fn()
+      .mockImplementation(
+        async (method: string, params?: { requestId?: string }) => {
+          if (method === "Network.getResponseBody" && params?.requestId) {
+            const body = cdpBodies.get(params.requestId);
+            if (!body)
+              throw new Error("No resource with given identifier found");
+            return body;
+          }
+          return {};
+        },
+      ),
+  };
   const frame = makeFrame(options);
   const originalFrameEvaluate = frame.evaluate;
   frame.evaluate = vi
@@ -128,6 +161,7 @@ function makePage(options?: {
         domain: "ibank.firstbank.com.tw",
       },
     ]),
+    createCDPSession: vi.fn().mockResolvedValue(cdpSession),
     evaluate: vi.fn().mockImplementation(async (fn: unknown) => {
       const source = String(fn);
       if (source.includes("image.naturalWidth")) return { x: 140, y: 360 };
@@ -182,6 +216,15 @@ function makePage(options?: {
         listener(response);
       return response;
     },
+    emitTransactionDocument(url: string, body: string, base64Encoded = false) {
+      const requestId = "transaction-document";
+      cdpBodies.set(requestId, { body, base64Encoded });
+      for (const listener of cdpListeners.get("Network.responseReceived") ?? [])
+        listener({ requestId, type: "Document", response: { url } });
+      for (const listener of cdpListeners.get("Network.loadingFinished") ?? [])
+        listener({ requestId });
+    },
+    cdpSession,
   };
   return page;
 }
@@ -242,9 +285,9 @@ function detachQueryFrameAfterSearch(
   page: ReturnType<typeof makePage>,
   nextFrames: Array<ReturnType<typeof makeFrame>>,
   responseHtml?: string,
+  responseUrl = TRANSACTION_RESULT_URL,
+  base64Encoded = false,
 ) {
-  let resultResponse:
-    ReturnType<ReturnType<typeof makePage>["emitResponse"]> | undefined;
   const queryFrame = page.frame;
   const previousEvaluate = queryFrame.evaluate;
   queryFrame.evaluate = vi
@@ -258,16 +301,16 @@ function detachQueryFrameAfterSearch(
         queryFrame.detached = true;
         page.frames.mockImplementation(() => nextFrames);
         if (responseHtml !== undefined) {
-          resultResponse = page.emitResponse(
-            TRANSACTION_RESULT_URL,
+          page.emitTransactionDocument(
+            responseUrl,
             responseHtml,
+            base64Encoded,
           );
         }
         return true;
       }
       return previousEvaluate(fn, arg);
     });
-  return () => resultResponse;
 }
 
 beforeEach(() => {
@@ -517,14 +560,10 @@ describe("第一銀行交易明細 010103 擷取", () => {
     expect(page.frame.waitForNavigation).not.toHaveBeenCalled();
   });
 
-  it("010103 iframe 消失時改從 page response 讀取明細", async () => {
+  it("010103 iframe 消失時改從 CDP document response 讀取明細", async () => {
     const page = makePage({ authenticated: true });
     const liveFrame = makeEmptyLiveFrame();
-    const resultResponse = detachQueryFrameAfterSearch(
-      page,
-      [liveFrame],
-      transactionTables,
-    );
+    detachQueryFrameAfterSearch(page, [liveFrame], transactionTables);
     const browser = makeBrowser(page);
     puppeteerMock.launch.mockResolvedValue(browser);
 
@@ -545,8 +584,81 @@ describe("第一銀行交易明細 010103 擷取", () => {
     );
     expect(clickedTransactionSearch(page.frame)).toBe(true);
     expect(postedTransactionQuery(page.frame)).toBe(false);
-    expect(resultResponse()?.text).toHaveBeenCalledOnce();
+    expect(page.cdpSession.send).toHaveBeenCalledWith(
+      "Network.enable",
+      expect.objectContaining({
+        maxTotalBufferSize: expect.any(Number),
+        maxResourceBufferSize: expect.any(Number),
+      }),
+    );
+    expect(page.cdpSession.send).toHaveBeenCalledWith(
+      "Network.getResponseBody",
+      { requestId: "transaction-document" },
+    );
+    expect(page.cdpSession.detach).toHaveBeenCalledOnce();
     expect(page.frame.waitForNavigation).not.toHaveBeenCalled();
+  });
+
+  it("解碼 CDP 的 base64 010103 document body", async () => {
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      base64Text(transactionTables),
+      TRANSACTION_RESULT_URL,
+      true,
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const result = await createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+  });
+
+  it("忽略非 010103 document 的 CDP response", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [],
+      transactionTables,
+      TRANSACTION_QUERY_URL,
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    const expectation =
+      expect(pending).rejects.toThrow("第一銀行交易明細讀取失敗。");
+    await vi.advanceTimersByTimeAsync(3_000);
+    await expectation;
+    expect(page.cdpSession.send).not.toHaveBeenCalledWith(
+      "Network.getResponseBody",
+      expect.anything(),
+    );
   });
 
   it("沒有 010103 frame 或 HTTP 回應時快速回報讀取失敗", async () => {
@@ -573,5 +685,9 @@ describe("第一銀行交易明細 010103 擷取", () => {
     await expect(pending).rejects.toBeInstanceOf(FirstbankConnectionError);
     expect(clickedTransactionSearch(page.frame)).toBe(true);
     expect(postedTransactionQuery(page.frame)).toBe(false);
+    expect(page.cdpSession.send).not.toHaveBeenCalledWith(
+      "Network.getResponseBody",
+      expect.anything(),
+    );
   });
 });


### PR DESCRIPTION
## 問題

PR #111 在本機可成功擷取第一銀行交易明細，但 production Browser Rendering 仍回傳 502。原因是 010103 導覽會替換／分離結果 iframe，而 page `response` 事件沒有收到該 iframe 的 document HTTP 回應。

## 修正

- 保留銀行頁面原生 `#searchBtn` 點擊流程，不重播表單 POST。
- 查詢前透過 page-level CDP session 啟用 `Network`，為 response body 設定有限的 1 MiB buffer。
- 只追蹤第一銀行同源、精確 `/NetBank/2/010103.html` 且資源類型為 `Document` 的回應。
- 等待 `Network.loadingFinished` 後，以 request ID 呼叫 `Network.getResponseBody`，並支援一般文字與 base64 body。
- 保留既有 live frame 與 page response 路徑；沒有合法 frame 或 document body 時維持短期限快速失敗。
- 完整移除 CDP listeners 並 detach session；不記錄 URL、HTML、帳戶或任何敏感資料。

## 測試

- `npm run format:check`
- `npm run typecheck`
- `npm run test:backend`
- First Bank session tests：13 passed
- Worker tests：406 passed
- DB tests：4 passed
- deploy/sync script tests：16 passed

本次未執行 production 或任何包含銀行登入資料的同步；驗證範圍為程式碼、合成測試與專案檢查。