### PR TITLE
fix(連接器): 修正第一銀行 010103 CDP 等待競態

### DIFF
--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -35,9 +35,10 @@ const LOGIN_RESULT_ATTEMPTS = 30;
 const LOGIN_RESULT_POLL_MS = 500;
 const FRAME_TIMEOUT_MS = 15_000;
 const FRAME_READ_RETRY_MS = 250;
-// 010103 may replace and detach its iframe in Browser Rendering. Probe only
-// briefly before using the response body already captured from the same click.
-const RESULT_FRAME_WAIT_MS = 2_000;
+// 010103 may replace and detach its iframe in Browser Rendering. Arm a
+// document-body waiter before submit and keep CDP listeners attached for
+// this window so a delayed responseReceived/loadingFinished can still settle.
+const RESULT_CAPTURE_WAIT_MS = 10_000;
 const FRAME_PROBE_TIMEOUT_MS = 1_000;
 const CARD_RESPONSE_TIMEOUT_MS = 10_000;
 const SESSION_RELEASE_TIMEOUT_MS = 2_000;
@@ -66,17 +67,25 @@ type CardPayloadKey = "cardBill" | "recentPayments" | "cardUnbilled";
 
 type CapturedCardResponses = Partial<Record<CardPayloadKey, unknown>>;
 
+type TransactionDocumentMeta = {
+  path: string;
+  status?: number;
+};
+
 type TransactionResponseCapture = {
   armed: boolean;
   html?: string;
   requestIds: Set<string>;
+  documentMeta: Map<string, TransactionDocumentMeta>;
   pending: Set<Promise<void>>;
+  documentBody: Promise<string>;
+  settleDocumentBody: (html: string) => void;
 };
 
 type TransactionDocumentResponseEvent = {
   requestId: string;
   type: string;
-  response: { url: string };
+  response: { url: string; status?: number };
 };
 
 type TransactionLoadingEvent = {
@@ -85,6 +94,7 @@ type TransactionLoadingEvent = {
 
 type BrowserResponse = {
   url(): string;
+  status(): number;
   json(): Promise<unknown>;
   text(): Promise<string>;
 };
@@ -798,11 +808,7 @@ async function collectFirstbankPayloads(
   const frame = await waitForAuthenticatedFrame(page);
   const captured: CapturedCardResponses = {};
   const responseTasks: Promise<void>[] = [];
-  const transactionResponse: TransactionResponseCapture = {
-    armed: false,
-    requestIds: new Set(),
-    pending: new Set(),
-  };
+  const transactionResponse = createTransactionResponseCapture();
   const cdp = await page.createCDPSession();
   try {
     await cdp.send("Network.enable", {
@@ -821,18 +827,25 @@ async function collectFirstbankPayloads(
       event.type === "Document" &&
       isTransactionResultResponse(event.response.url)
     ) {
+      const path = urlPathname(event.response.url);
+      const status = event.response.status;
+      logFirstbankStage("010103-cdp-response", { path, status });
       transactionResponse.requestIds.add(event.requestId);
+      transactionResponse.documentMeta.set(event.requestId, { path, status });
     }
   };
   const onTransactionDocumentLoaded = (event: TransactionLoadingEvent) => {
     if (!transactionResponse.requestIds.has(event.requestId)) return;
+    const meta = transactionResponse.documentMeta.get(event.requestId);
     let task: Promise<void>;
     task = captureTransactionDocument(
       cdp,
       event.requestId,
       transactionResponse,
+      meta,
     ).finally(() => {
       transactionResponse.requestIds.delete(event.requestId);
+      transactionResponse.documentMeta.delete(event.requestId);
       transactionResponse.pending.delete(task);
     });
     transactionResponse.pending.add(task);
@@ -840,6 +853,7 @@ async function collectFirstbankPayloads(
   };
   const onTransactionDocumentFailed = (event: TransactionLoadingEvent) => {
     transactionResponse.requestIds.delete(event.requestId);
+    transactionResponse.documentMeta.delete(event.requestId);
   };
   cdp.on("Network.responseReceived", onTransactionDocumentResponse);
   cdp.on("Network.loadingFinished", onTransactionDocumentLoaded);
@@ -849,6 +863,10 @@ async function collectFirstbankPayloads(
       transactionResponse.armed &&
       isTransactionResultResponse(response.url())
     ) {
+      logFirstbankStage("010103-http-response", {
+        path: urlPathname(response.url()),
+        status: httpStatus(response),
+      });
       let task: Promise<void>;
       task = captureTransactionResponse(response, transactionResponse).finally(
         () => transactionResponse.pending.delete(task),
@@ -1031,18 +1049,44 @@ function cardResponseKey(url: string): CardPayloadKey | undefined {
   return undefined;
 }
 
+function createTransactionResponseCapture(): TransactionResponseCapture {
+  let resolveDocumentBody = (_html: string) => {};
+  const documentBody = new Promise<string>((resolve) => {
+    resolveDocumentBody = resolve;
+  });
+  const capture: TransactionResponseCapture = {
+    armed: false,
+    requestIds: new Set(),
+    documentMeta: new Map(),
+    pending: new Set(),
+    documentBody,
+    settleDocumentBody(html: string) {
+      capture.html ??= html;
+      resolveDocumentBody(html);
+    },
+  };
+  return capture;
+}
+
 async function captureTransactionDocument(
   cdp: CDPSession,
   requestId: string,
   capture: TransactionResponseCapture,
+  meta?: TransactionDocumentMeta,
 ) {
   try {
     const response = await cdp.send("Network.getResponseBody", { requestId });
     const body = response.base64Encoded
       ? decodeBase64Text(response.body)
       : response.body;
+    logFirstbankStage("010103-cdp-body", {
+      path: meta?.path,
+      status: meta?.status,
+      bodyLength: body.length,
+      hasTxnDateHeader: hasTransactionDateHeader(body),
+    });
     const html = transactionHistoryFromHtml(body);
-    capture.html ??= html;
+    capture.settleDocumentBody(html);
   } catch {
     // Invalid or unavailable 010103 bodies do not mask a later live frame.
   }
@@ -1052,9 +1096,18 @@ async function captureTransactionResponse(
   response: BrowserResponse,
   capture: TransactionResponseCapture,
 ) {
+  const path = urlPathname(response.url());
+  const status = httpStatus(response);
   try {
-    const html = transactionHistoryFromHtml(await response.text());
-    capture.html ??= html;
+    const body = await response.text();
+    logFirstbankStage("010103-http-body", {
+      path,
+      status,
+      bodyLength: body.length,
+      hasTxnDateHeader: hasTransactionDateHeader(body),
+    });
+    const html = transactionHistoryFromHtml(body);
+    capture.settleDocumentBody(html);
   } catch {
     // Invalid 010103 bodies do not mask a later CDP capture or live frame.
   }
@@ -1070,36 +1123,54 @@ async function submitTransactionQuery(
   await waitForQueryAccountOptions(frame);
   await selectQueryAccount(frame);
   transactionResponse.armed = true;
+  logFirstbankStage("0101-query-submit", {
+    path: urlPathname(TRANSACTION_URL),
+  });
   await clickTransactionSearch(frame);
+  return waitForTransactionHistory(page, transactionResponse);
+}
 
-  const resultFrame = await waitForLiveTransactionResultFrame(
-    page,
-    transactionResponse,
-  );
-  if (resultFrame) {
-    try {
-      return await serializeFirstbankTables(resultFrame);
-    } catch (error) {
-      if (!isTransactionHistoryReadError(error)) throw error;
+async function waitForTransactionHistory(
+  page: Page,
+  capture: TransactionResponseCapture,
+) {
+  const deadline = Date.now() + RESULT_CAPTURE_WAIT_MS;
+  while (Date.now() < deadline) {
+    if (capture.html) return capture.html;
+    const resultFrame = await findLiveTransactionResultFrame(page);
+    if (resultFrame) {
+      try {
+        const html = await serializeFirstbankTables(resultFrame);
+        logFirstbankStage("010103-live-frame", {
+          path: urlPathname(resultFrame.url()),
+          bodyLength: html.length,
+          hasTxnDateHeader: hasTransactionDateHeader(html),
+        });
+        return html;
+      } catch (error) {
+        if (!isTransactionHistoryReadError(error)) throw error;
+      }
     }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    const arrived = await Promise.race([
+      capture.documentBody.then(() => true),
+      delay(Math.min(FRAME_READ_RETRY_MS, remaining)).then(() => false),
+    ]);
+    if (arrived && capture.html) return capture.html;
   }
 
-  if (transactionResponse.html) return transactionResponse.html;
-  if (transactionResponse.pending.size > 0) {
-    const tasks = Array.from(transactionResponse.pending);
+  if (capture.pending.size > 0) {
     await withActionTimeout(
-      Promise.allSettled(tasks),
+      Promise.allSettled(Array.from(capture.pending)),
       FRAME_PROBE_TIMEOUT_MS,
     ).catch(() => undefined);
-    if (transactionResponse.html) return transactionResponse.html;
   }
-  if (transactionResponse.requestIds.size > 0) {
-    const deadline = Date.now() + FRAME_PROBE_TIMEOUT_MS;
-    while (transactionResponse.requestIds.size > 0 && Date.now() < deadline) {
-      await delay(FRAME_READ_RETRY_MS);
-      if (transactionResponse.html) return transactionResponse.html;
-    }
-  }
+  if (capture.html) return capture.html;
+
+  logFirstbankStage("010103-timeout", {
+    path: "/NetBank/2/010103.html",
+  });
   throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
 }
 
@@ -1164,20 +1235,6 @@ async function hasTransactionSearchControl(frame: Frame) {
   } catch {
     return false;
   }
-}
-
-async function waitForLiveTransactionResultFrame(
-  page: Page,
-  transactionResponse: TransactionResponseCapture,
-) {
-  const deadline = Date.now() + RESULT_FRAME_WAIT_MS;
-  while (Date.now() < deadline) {
-    const result = await findLiveTransactionResultFrame(page);
-    if (result) return result;
-    if (transactionResponse.html) return undefined;
-    await delay(FRAME_READ_RETRY_MS);
-  }
-  return findLiveTransactionResultFrame(page);
 }
 
 async function findLiveTransactionResultFrame(page: Page) {
@@ -1806,6 +1863,47 @@ function isTransactionResultResponse(url: string) {
   } catch {
     return false;
   }
+}
+
+function urlPathname(url: string) {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return "(invalid)";
+  }
+}
+
+function httpStatus(response: BrowserResponse) {
+  try {
+    return response.status();
+  } catch {
+    return undefined;
+  }
+}
+
+function hasTransactionDateHeader(html: string) {
+  return /交易日期|交易日/.test(html);
+}
+
+function logFirstbankStage(
+  stage: string,
+  fields: {
+    path?: string;
+    status?: number;
+    bodyLength?: number;
+    hasTxnDateHeader?: boolean;
+  } = {},
+) {
+  const parts = [`[firstbank] ${stage}`];
+  if (fields.path !== undefined) parts.push(`path=${fields.path}`);
+  if (fields.status !== undefined) parts.push(`status=${fields.status}`);
+  if (fields.bodyLength !== undefined) {
+    parts.push(`bodyLength=${fields.bodyLength}`);
+  }
+  if (fields.hasTxnDateHeader !== undefined) {
+    parts.push(`hasTxnDateHeader=${fields.hasTxnDateHeader}`);
+  }
+  console.log(parts.join(" "));
 }
 
 function isTransactionHistoryReadError(error: unknown) {

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -205,6 +205,7 @@ function makePage(options?: {
     emitResponse(url: string, payload: unknown) {
       const response = {
         url: () => url,
+        status: () => 200,
         json: vi.fn().mockResolvedValue(payload),
         text: vi
           .fn()
@@ -216,11 +217,34 @@ function makePage(options?: {
         listener(response);
       return response;
     },
+    emitTransactionDocumentReceived(
+      url: string,
+      body: string,
+      base64Encoded = false,
+      status = 200,
+    ) {
+      const requestId = "transaction-document";
+      cdpBodies.set(requestId, { body, base64Encoded });
+      for (const listener of cdpListeners.get("Network.responseReceived") ?? [])
+        listener({
+          requestId,
+          type: "Document",
+          response: { url, status },
+        });
+    },
+    emitTransactionDocumentLoaded() {
+      for (const listener of cdpListeners.get("Network.loadingFinished") ?? [])
+        listener({ requestId: "transaction-document" });
+    },
     emitTransactionDocument(url: string, body: string, base64Encoded = false) {
       const requestId = "transaction-document";
       cdpBodies.set(requestId, { body, base64Encoded });
       for (const listener of cdpListeners.get("Network.responseReceived") ?? [])
-        listener({ requestId, type: "Document", response: { url } });
+        listener({
+          requestId,
+          type: "Document",
+          response: { url, status: 200 },
+        });
       for (const listener of cdpListeners.get("Network.loadingFinished") ?? [])
         listener({ requestId });
     },
@@ -287,6 +311,7 @@ function detachQueryFrameAfterSearch(
   responseHtml?: string,
   responseUrl = TRANSACTION_RESULT_URL,
   base64Encoded = false,
+  timing?: { delayMs?: number; loadingFinishedDelayMs?: number },
 ) {
   const queryFrame = page.frame;
   const previousEvaluate = queryFrame.evaluate;
@@ -301,11 +326,27 @@ function detachQueryFrameAfterSearch(
         queryFrame.detached = true;
         page.frames.mockImplementation(() => nextFrames);
         if (responseHtml !== undefined) {
-          page.emitTransactionDocument(
-            responseUrl,
-            responseHtml,
-            base64Encoded,
-          );
+          const delayMs = timing?.delayMs ?? 0;
+          const loadingFinishedDelayMs =
+            timing?.loadingFinishedDelayMs ?? delayMs;
+          if (delayMs <= 0 && loadingFinishedDelayMs <= 0) {
+            page.emitTransactionDocument(
+              responseUrl,
+              responseHtml,
+              base64Encoded,
+            );
+          } else {
+            setTimeout(() => {
+              page.emitTransactionDocumentReceived(
+                responseUrl,
+                responseHtml,
+                base64Encoded,
+              );
+            }, delayMs);
+            setTimeout(() => {
+              page.emitTransactionDocumentLoaded();
+            }, loadingFinishedDelayMs);
+          }
         }
         return true;
       }
@@ -653,7 +694,7 @@ describe("第一銀行交易明細 010103 擷取", () => {
     });
     const expectation =
       expect(pending).rejects.toThrow("第一銀行交易明細讀取失敗。");
-    await vi.advanceTimersByTimeAsync(3_000);
+    await vi.advanceTimersByTimeAsync(11_000);
     await expectation;
     expect(page.cdpSession.send).not.toHaveBeenCalledWith(
       "Network.getResponseBody",
@@ -661,7 +702,7 @@ describe("第一銀行交易明細 010103 擷取", () => {
     );
   });
 
-  it("沒有 010103 frame 或 HTTP 回應時快速回報讀取失敗", async () => {
+  it("沒有 010103 frame 或 HTTP 回應時逾時回報讀取失敗", async () => {
     vi.useFakeTimers();
     const page = makePage({ authenticated: true });
     detachQueryFrameAfterSearch(page, []);
@@ -680,7 +721,7 @@ describe("第一銀行交易明細 010103 擷取", () => {
     });
     const expectation =
       expect(pending).rejects.toThrow("第一銀行交易明細讀取失敗。");
-    await vi.advanceTimersByTimeAsync(3_000);
+    await vi.advanceTimersByTimeAsync(11_000);
     await expectation;
     await expect(pending).rejects.toBeInstanceOf(FirstbankConnectionError);
     expect(clickedTransactionSearch(page.frame)).toBe(true);
@@ -688,6 +729,111 @@ describe("第一銀行交易明細 010103 擷取", () => {
     expect(page.cdpSession.send).not.toHaveBeenCalledWith(
       "Network.getResponseBody",
       expect.anything(),
+    );
+  });
+
+  it("延遲到達的 CDP 010103 document 仍可擷取明細", async () => {
+    vi.useFakeTimers();
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((message) => {
+      logs.push(String(message));
+    });
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      { delayMs: 3_000 },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    try {
+      const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+        ...credentials,
+        sessionCookies: JSON.stringify([
+          {
+            name: "SESSION",
+            value: "encrypted-at-rest",
+            domain: "ibank.firstbank.com.tw",
+          },
+        ]),
+      });
+      let settled = false;
+      void pending.finally(() => {
+        settled = true;
+      });
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(2_000);
+      const result = await pending;
+      expect(result.bankTransactions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ amount: -100, description: "測試交易" }),
+        ]),
+      );
+      expect(page.cdpSession.send).toHaveBeenCalledWith(
+        "Network.getResponseBody",
+        { requestId: "transaction-document" },
+      );
+      expect(page.cdpSession.detach).toHaveBeenCalledOnce();
+      const joined = logs.join("\n");
+      expect(joined).toContain("path=/NetBank/2/010103.html");
+      expect(joined).toContain("status=200");
+      expect(joined).toMatch(/bodyLength=\d+/);
+      expect(joined).toContain("hasTxnDateHeader=true");
+      expect(joined).not.toContain("測試交易");
+      expect(joined).not.toContain("123456789012");
+      expect(joined).not.toContain("encrypted-at-rest");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("requestIds 仍為空時仍等待延後的 CDP loadingFinished", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      { delayMs: 3_000, loadingFinishedDelayMs: 4_000 },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    let settled = false;
+    void pending.finally(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(2_500);
+    const result = await pending;
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+    expect(page.cdpSession.send).toHaveBeenCalledWith(
+      "Network.getResponseBody",
+      {
+        requestId: "transaction-document",
+      },
     );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 問題

PR #112 合併後，本機 wrangler 可成功擷取 010103，但 production Browser Rendering 仍可能在 capture/verify 階段回 502。送出 0101 查詢後只等 2 秒找 live iframe；只有 CDP `requestIds` 已經在 Set 裡才再多等 1 秒。若 Cloudflare Browser Run 的 `responseReceived` / `loadingFinished` 在 2 秒後才到達，程式會丟出「交易明細讀取失敗」並拆除 CDP session／listeners。既有測試在 click 當下同步發出 CDP 事件，無法覆蓋延遲回應。

## 修正

- 在送出查詢前先掛上 010103 document-body Promise，等待過程不依賴 `requestIds` Set 當下是否已有值。
- 送出後統一等待約 10 秒，期間可接受 live result frame 序列化或已擷取的 CDP／HTTP HTML；等完才拆除 listeners。
- 階段 log 只記錄 URL path、HTTP status、body length、是否含「交易日期」表頭；不記錄帳號、金額、cookie 或 HTML body。

## 測試

- 新增 CDP `responseReceived`／`loadingFinished` 延遲到達的測試（含 `requestIds` 仍為空時仍等待 `loadingFinished`）。
- 從 repo root 執行：`npm run format:check`、`npm run typecheck`、First Bank session tests（15 passed）。

本次未執行 production 或任何包含銀行登入資料的同步。請勿合併前再對第一銀行做 production 重試。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb99c87c-25ae-4477-bb72-f0d1f65cffc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb99c87c-25ae-4477-bb72-f0d1f65cffc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

