### PR TITLE
fix(連接器): 以 Fetch 攔截補上第一銀行 010103 擷取

### DIFF
--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -36,8 +36,9 @@ const LOGIN_RESULT_POLL_MS = 500;
 const FRAME_TIMEOUT_MS = 15_000;
 const FRAME_READ_RETRY_MS = 250;
 // 010103 may replace and detach its iframe in Browser Rendering. Arm a
-// document-body waiter before submit and keep CDP listeners attached for
-// this window so a delayed responseReceived/loadingFinished can still settle.
+// document-body waiter before submit, intercept 010103 at Fetch response
+// stage, and keep listeners attached so a delayed or non-Document body
+// can still settle.
 const RESULT_CAPTURE_WAIT_MS = 10_000;
 const FRAME_PROBE_TIMEOUT_MS = 1_000;
 const CARD_RESPONSE_TIMEOUT_MS = 10_000;
@@ -84,12 +85,24 @@ type TransactionResponseCapture = {
 
 type TransactionDocumentResponseEvent = {
   requestId: string;
-  type: string;
+  type?: string;
   response: { url: string; status?: number };
 };
 
 type TransactionLoadingEvent = {
   requestId: string;
+};
+
+type NetworkRequestWillBeSentEvent = {
+  type?: string;
+  request: { url: string };
+};
+
+type FetchRequestPausedEvent = {
+  requestId: string;
+  resourceType?: string;
+  request: { url: string };
+  responseStatusCode?: number;
 };
 
 type BrowserResponse = {
@@ -819,17 +832,57 @@ async function collectFirstbankPayloads(
     await cdp.detach().catch(() => undefined);
     throw error;
   }
+  let fetchEnabled = false;
+  try {
+    await cdp.send("Fetch.enable", {
+      patterns: [
+        {
+          urlPattern: `*://${new URL(ORIGIN).host}/NetBank/2/010103*`,
+          requestStage: "Response",
+        },
+      ],
+    });
+    fetchEnabled = true;
+  } catch {
+    logFirstbankStage("010103-fetch-unavailable", {
+      path: "/NetBank/2/010103.html",
+    });
+  }
+  const onTransactionRequest = (event: NetworkRequestWillBeSentEvent) => {
+    const url = event.request?.url ?? "";
+    if (!isFirstbankUrl(url)) return;
+    const path = urlPathname(url);
+    if (!isNetBankTwoPath(path)) return;
+    logFirstbankStage("0101-cdp-request", {
+      path,
+      resourceType: event.type,
+    });
+  };
   const onTransactionDocumentResponse = (
     event: TransactionDocumentResponseEvent,
   ) => {
+    const url = event.response.url;
+    if (!isFirstbankUrl(url)) return;
+    const path = urlPathname(url);
+    const status = event.response.status;
+    const resourceType = event.type;
+    if (isNetBankTwoPath(path) && isCapturableResourceType(resourceType)) {
+      logFirstbankStage("0101-cdp-response", {
+        path,
+        status,
+        resourceType,
+      });
+    }
     if (
       transactionResponse.armed &&
-      event.type === "Document" &&
-      isTransactionResultResponse(event.response.url)
+      isTransactionResultResponse(url) &&
+      isCapturableResourceType(resourceType)
     ) {
-      const path = urlPathname(event.response.url);
-      const status = event.response.status;
-      logFirstbankStage("010103-cdp-response", { path, status });
+      logFirstbankStage("010103-cdp-response", {
+        path,
+        status,
+        resourceType,
+      });
       transactionResponse.requestIds.add(event.requestId);
       transactionResponse.documentMeta.set(event.requestId, { path, status });
     }
@@ -855,9 +908,19 @@ async function collectFirstbankPayloads(
     transactionResponse.requestIds.delete(event.requestId);
     transactionResponse.documentMeta.delete(event.requestId);
   };
+  const onFetchPaused = (event: FetchRequestPausedEvent) => {
+    let task: Promise<void>;
+    task = captureFetchPausedDocument(cdp, event, transactionResponse).finally(
+      () => transactionResponse.pending.delete(task),
+    );
+    transactionResponse.pending.add(task);
+    void task.catch(() => undefined);
+  };
+  cdp.on("Network.requestWillBeSent", onTransactionRequest);
   cdp.on("Network.responseReceived", onTransactionDocumentResponse);
   cdp.on("Network.loadingFinished", onTransactionDocumentLoaded);
   cdp.on("Network.loadingFailed", onTransactionDocumentFailed);
+  if (fetchEnabled) cdp.on("Fetch.requestPaused", onFetchPaused);
   const onResponse = (response: BrowserResponse) => {
     if (
       transactionResponse.armed &&
@@ -911,9 +974,14 @@ async function collectFirstbankPayloads(
     } as unknown as FirstbankPayloads;
   } finally {
     page.off("response", onResponse);
+    cdp.off("Network.requestWillBeSent", onTransactionRequest);
     cdp.off("Network.responseReceived", onTransactionDocumentResponse);
     cdp.off("Network.loadingFinished", onTransactionDocumentLoaded);
     cdp.off("Network.loadingFailed", onTransactionDocumentFailed);
+    if (fetchEnabled) {
+      cdp.off("Fetch.requestPaused", onFetchPaused);
+      await cdp.send("Fetch.disable").catch(() => undefined);
+    }
     await cdp.detach().catch(() => undefined);
   }
 }
@@ -1079,6 +1147,9 @@ async function captureTransactionDocument(
     const body = response.base64Encoded
       ? decodeBase64Text(response.body)
       : response.body;
+    if (typeof body !== "string") {
+      throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
+    }
     logFirstbankStage("010103-cdp-body", {
       path: meta?.path,
       status: meta?.status,
@@ -1110,6 +1181,48 @@ async function captureTransactionResponse(
     capture.settleDocumentBody(html);
   } catch {
     // Invalid 010103 bodies do not mask a later CDP capture or live frame.
+  }
+}
+
+async function captureFetchPausedDocument(
+  cdp: CDPSession,
+  event: FetchRequestPausedEvent,
+  capture: TransactionResponseCapture,
+) {
+  const url = event.request?.url ?? "";
+  const path = urlPathname(url);
+  const status = event.responseStatusCode;
+  try {
+    if (capture.armed && isTransactionResultResponse(url)) {
+      logFirstbankStage("010103-fetch-response", {
+        path,
+        status,
+        resourceType: event.resourceType,
+      });
+      const response = await cdp.send("Fetch.getResponseBody", {
+        requestId: event.requestId,
+      });
+      const body = response.base64Encoded
+        ? decodeBase64Text(response.body)
+        : response.body;
+      if (typeof body !== "string") {
+        throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
+      }
+      logFirstbankStage("010103-fetch-body", {
+        path,
+        status,
+        bodyLength: body.length,
+        hasTxnDateHeader: hasTransactionDateHeader(body),
+      });
+      const html = transactionHistoryFromHtml(body);
+      capture.settleDocumentBody(html);
+    }
+  } catch {
+    // Invalid or unavailable Fetch bodies do not mask a later live frame.
+  } finally {
+    await cdp
+      .send("Fetch.continueRequest", { requestId: event.requestId })
+      .catch(() => undefined);
   }
 }
 
@@ -1171,6 +1284,11 @@ async function waitForTransactionHistory(
   logFirstbankStage("010103-timeout", {
     path: "/NetBank/2/010103.html",
   });
+  for (const frame of liveFrames(page)) {
+    logFirstbankStage("010103-timeout-frame", {
+      path: framePathname(frame),
+    });
+  }
   throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
 }
 
@@ -1239,8 +1357,15 @@ async function hasTransactionSearchControl(frame: Frame) {
 
 async function findLiveTransactionResultFrame(page: Page) {
   for (const frame of liveFrames(page)) {
-    if (!isTransactionResultResponse(frame.url())) continue;
-    await dismissBankNotice(frame, FRAME_PROBE_TIMEOUT_MS);
+    let isResultUrl = false;
+    try {
+      isResultUrl = isTransactionResultResponse(frame.url());
+    } catch {
+      isResultUrl = false;
+    }
+    if (isResultUrl) {
+      await dismissBankNotice(frame, FRAME_PROBE_TIMEOUT_MS);
+    }
     if (await hasTransactionResultHeader(frame, FRAME_PROBE_TIMEOUT_MS)) {
       return frame;
     }
@@ -1856,12 +1981,36 @@ function pickLiveFrame(page: Page, preferred?: Frame) {
 function isTransactionResultResponse(url: string) {
   try {
     const parsed = new URL(url);
-    return (
-      parsed.origin === ORIGIN &&
-      parsed.pathname.toLowerCase() === "/netbank/2/010103.html"
-    );
+    if (parsed.origin !== ORIGIN) return false;
+    const path = parsed.pathname.toLowerCase().split(";")[0];
+    return /\/netbank\/2\/010103(?:\.html?)?$/.test(path);
   } catch {
     return false;
+  }
+}
+
+function isFirstbankUrl(url: string) {
+  try {
+    return new URL(url).origin === ORIGIN;
+  } catch {
+    return false;
+  }
+}
+
+function isNetBankTwoPath(path: string) {
+  return /\/netbank\/2\//i.test(path);
+}
+
+function isCapturableResourceType(type: string | undefined) {
+  if (!type) return true;
+  return /^(document|xhr|fetch|other)$/i.test(type);
+}
+
+function framePathname(frame: Frame) {
+  try {
+    return urlPathname(frame.url());
+  } catch {
+    return "(unavailable)";
   }
 }
 
@@ -1892,6 +2041,7 @@ function logFirstbankStage(
     status?: number;
     bodyLength?: number;
     hasTxnDateHeader?: boolean;
+    resourceType?: string;
   } = {},
 ) {
   const parts = [`[firstbank] ${stage}`];
@@ -1902,6 +2052,9 @@ function logFirstbankStage(
   }
   if (fields.hasTxnDateHeader !== undefined) {
     parts.push(`hasTxnDateHeader=${fields.hasTxnDateHeader}`);
+  }
+  if (fields.resourceType !== undefined) {
+    parts.push(`resourceType=${fields.resourceType}`);
   }
   console.log(parts.join(" "));
 }

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -120,7 +120,11 @@ function makePage(options?: {
       .fn()
       .mockImplementation(
         async (method: string, params?: { requestId?: string }) => {
-          if (method === "Network.getResponseBody" && params?.requestId) {
+          if (
+            (method === "Network.getResponseBody" ||
+              method === "Fetch.getResponseBody") &&
+            params?.requestId
+          ) {
             const body = cdpBodies.get(params.requestId);
             if (!body)
               throw new Error("No resource with given identifier found");
@@ -222,19 +226,36 @@ function makePage(options?: {
       body: string,
       base64Encoded = false,
       status = 200,
+      resourceType = "Document",
     ) {
       const requestId = "transaction-document";
       cdpBodies.set(requestId, { body, base64Encoded });
       for (const listener of cdpListeners.get("Network.responseReceived") ?? [])
         listener({
           requestId,
-          type: "Document",
+          type: resourceType,
           response: { url, status },
         });
     },
     emitTransactionDocumentLoaded() {
       for (const listener of cdpListeners.get("Network.loadingFinished") ?? [])
         listener({ requestId: "transaction-document" });
+    },
+    emitFetchPaused(
+      url: string,
+      body: string,
+      base64Encoded = false,
+      status = 200,
+    ) {
+      const requestId = "fetch-transaction-document";
+      cdpBodies.set(requestId, { body, base64Encoded });
+      for (const listener of cdpListeners.get("Fetch.requestPaused") ?? [])
+        listener({
+          requestId,
+          resourceType: "Document",
+          request: { url },
+          responseStatusCode: status,
+        });
     },
     emitTransactionDocument(url: string, body: string, base64Encoded = false) {
       const requestId = "transaction-document";
@@ -311,7 +332,12 @@ function detachQueryFrameAfterSearch(
   responseHtml?: string,
   responseUrl = TRANSACTION_RESULT_URL,
   base64Encoded = false,
-  timing?: { delayMs?: number; loadingFinishedDelayMs?: number },
+  timing?: {
+    delayMs?: number;
+    loadingFinishedDelayMs?: number;
+    fetchDelayMs?: number;
+    resourceType?: string;
+  },
 ) {
   const queryFrame = page.frame;
   const previousEvaluate = queryFrame.evaluate;
@@ -326,26 +352,37 @@ function detachQueryFrameAfterSearch(
         queryFrame.detached = true;
         page.frames.mockImplementation(() => nextFrames);
         if (responseHtml !== undefined) {
-          const delayMs = timing?.delayMs ?? 0;
-          const loadingFinishedDelayMs =
-            timing?.loadingFinishedDelayMs ?? delayMs;
-          if (delayMs <= 0 && loadingFinishedDelayMs <= 0) {
-            page.emitTransactionDocument(
-              responseUrl,
-              responseHtml,
-              base64Encoded,
-            );
-          } else {
+          const fetchDelayMs = timing?.fetchDelayMs;
+          if (fetchDelayMs !== undefined) {
+            setTimeout(() => {
+              page.emitFetchPaused(responseUrl, responseHtml, base64Encoded);
+            }, fetchDelayMs);
+          }
+          if (
+            timing?.delayMs !== undefined ||
+            timing?.loadingFinishedDelayMs !== undefined
+          ) {
+            const delayMs = timing?.delayMs ?? 0;
+            const loadingFinishedDelayMs =
+              timing?.loadingFinishedDelayMs ?? delayMs;
             setTimeout(() => {
               page.emitTransactionDocumentReceived(
                 responseUrl,
                 responseHtml,
                 base64Encoded,
+                200,
+                timing?.resourceType ?? "Document",
               );
             }, delayMs);
             setTimeout(() => {
               page.emitTransactionDocumentLoaded();
             }, loadingFinishedDelayMs);
+          } else if (fetchDelayMs === undefined) {
+            page.emitTransactionDocument(
+              responseUrl,
+              responseHtml,
+              base64Encoded,
+            );
           }
         }
         return true;
@@ -835,5 +872,119 @@ describe("第一銀行交易明細 010103 擷取", () => {
         requestId: "transaction-document",
       },
     );
+  });
+
+  it("結果 frame 帶 jsessionid 時仍序列化交易表", async () => {
+    const page = makePage({ authenticated: true });
+    const resultFrame = makeTransactionResultFrame();
+    resultFrame.url.mockReturnValue(
+      `${TRANSACTION_RESULT_URL};jsessionid=synthetic`,
+    );
+    detachQueryFrameAfterSearch(page, [resultFrame]);
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const result = await createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+  });
+
+  it("CDP 資源類型為 Other 時仍擷取延遲的 010103", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      { delayMs: 3_000, resourceType: "Other" },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    await vi.advanceTimersByTimeAsync(4_000);
+    const result = await pending;
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+  });
+
+  it("Network 事件缺失時改從 CDP Fetch.requestPaused 擷取 010103", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      { fetchDelayMs: 3_000 },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    let settled = false;
+    void pending.finally(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await pending;
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+    expect(page.cdpSession.send).toHaveBeenCalledWith("Fetch.enable", {
+      patterns: [
+        {
+          urlPattern: "*://ibank.firstbank.com.tw/NetBank/2/010103*",
+          requestStage: "Response",
+        },
+      ],
+    });
+    expect(page.cdpSession.send).toHaveBeenCalledWith("Fetch.getResponseBody", {
+      requestId: "fetch-transaction-document",
+    });
+    expect(page.cdpSession.send).toHaveBeenCalledWith("Fetch.continueRequest", {
+      requestId: "fetch-transaction-document",
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 問題

PR #113 已部署到 production。手動同步仍回「交易明細讀取失敗」（HTTP 502）。Worker log 顯示新程式有跑到：

- `[firstbank] 0101-query-submit path=/NetBank/2/0101.html`
- `[firstbank] 010103-timeout path=/NetBank/2/010103.html`

這 10 秒內**沒有** `010103-cdp-response`、`010103-http-response` 或 `010103-live-frame`。因此失敗原因不是「CDP 晚 2 秒才到」，而是 production Browser Rendering 根本沒有送出符合 `type=Document` 且 path 精確等於 `/NetBank/2/010103.html` 的事件，live iframe 也沒出現。

## 修正

- 在 CDP `Fetch.enable`（`requestStage: Response`）攔截 `010103`，用 `Fetch.getResponseBody` 讀 body，並務必 `Fetch.continueRequest`。
- `Network.responseReceived` 不再只接受 `Document`；`Other` / `XHR` / `Fetch` / 缺 type 也可擷取。
- 010103 URL 比對忽略 `jsessionid` 與 `.htm`。
- live frame 只要有「交易日期」表頭就序列化，不要求 URL 必須是精確 010103。
- 階段 log 增加 `resourceType`、`0101-cdp-request`／`0101-cdp-response`，逾時時記錄仍存活 frame 的 path。仍不記錄帳號、金額、cookie 或 HTML body。

## 測試

- 延遲 CDP、`resourceType=Other`、jsessionid frame、僅有 `Fetch.requestPaused` 的路徑。
- `npm run format:check`
- `npm run typecheck`
- First Bank session tests：18 passed

請等此 PR 部署後再同步。本次未重試 production 第一銀行同步。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb99c87c-25ae-4477-bb72-f0d1f65cffc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb99c87c-25ae-4477-bb72-f0d1f65cffc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

