### PR TITLE
修正第一銀行 Browser Run 存款、交易與信用卡同步

### DIFF
--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -75,6 +75,7 @@ type CapturedCardResponses = Partial<Record<CardPayloadKey, unknown>>;
 type DepositResponseCapture = {
   html?: string;
   observed: boolean;
+  status?: number;
   pending: Set<Promise<void>>;
   responseBody: Promise<string>;
   settleResponseBody: (html: string) => void;
@@ -1033,10 +1034,16 @@ async function collectFirstbankPayloads(
   };
   page.on("dialog", onDialog);
   const onPageError = (error: unknown) => {
-    logFirstbankStage("0101-page-error", {
-      detail: safeDiagnosticText(
-        error instanceof Error ? error.message : String(error),
-      ),
+    const message = error instanceof Error ? error.message : String(error);
+    if (isFramesetParentNoise(message)) {
+      logFirstbankStage("frameset-noise", {
+        detail: "resizeFrame",
+        elapsedMs: elapsedSinceArmed(transactionResponse),
+      });
+      return;
+    }
+    logFirstbankStage("page-error", {
+      detail: safeDiagnosticText(message),
       elapsedMs: elapsedSinceArmed(transactionResponse),
     });
   };
@@ -1302,6 +1309,7 @@ async function captureDepositResponse(
     status,
     bodyLength: body.length,
   });
+  capture.status = status;
   if (
     typeof status === "number" &&
     status >= 200 &&
@@ -1860,8 +1868,16 @@ async function navigateToReadyFrame(
   url: string,
   path: string,
 ) {
-  if (framePathname(frame) !== path) await navigateFrame(frame, url);
-  return waitForReadyFrameByPath(page, path, frame);
+  const target = nestedContentFrame(page, frame);
+  if (framePathname(target) !== path) await navigateFrame(target, url);
+  return waitForReadyFrameByPath(page, path, target);
+}
+
+function nestedContentFrame(page: Page, preferred: Frame) {
+  const main = (page as Page & { mainFrame?: () => Frame }).mainFrame?.();
+  if (!main || preferred !== main) return preferred;
+  const nested = liveFrames(page).find((candidate) => candidate !== main);
+  return nested ?? preferred;
 }
 
 async function waitForReadyFrameByPath(
@@ -1924,13 +1940,77 @@ async function collectDepositOverview(
     ).catch(() => undefined);
   }
   if (capture.html) return capture.html;
+  if (capture.observed) {
+    logFirstbankStage("deposit-ajax-failed", {
+      path: DEPOSIT_AJAX_PATH,
+      status: capture.status,
+      detail: "empty-or-error-response",
+    });
+    // The native handler already issued the bank POST. Never click or POST
+    // again after a captured non-2xx / empty body.
+    throw new FirstbankConnectionError("第一銀行存款總覽讀取失敗。");
+  }
+  logFirstbankStage("deposit-ajax-fallback", {
+    path: DEPOSIT_AJAX_PATH,
+    detail: "missing-listener",
+  });
+  // Click did not surface a capturable page response. Do not click again;
+  // read the same-origin ajax endpoint from inside the live overview frame.
+  const liveFrame = liveDepositOverviewFrame(page, frame);
+  return fetchDepositOverview(liveFrame);
+}
+
+function liveDepositOverviewFrame(page: Page, preferred: Frame) {
+  const path = urlPathname(ACCOUNT_OVERVIEW_URL);
+  const nested = nestedContentFrame(page, preferred);
+  const frames = liveFrames(page);
+  const ready =
+    frames.find((candidate) => framePathname(candidate) === path) ??
+    (frames.includes(nested) ? nested : undefined) ??
+    (frames.includes(preferred) ? preferred : undefined) ??
+    frames[0];
+  if (!ready) {
+    throw new FirstbankConnectionError("第一銀行存款總覽讀取失敗。");
+  }
+  return ready;
+}
+
+async function fetchDepositOverview(frame: Frame): Promise<string> {
+  try {
+    const value = await withActionTimeout(
+      frame.evaluate(async (resourcePath) => {
+        try {
+          const response = await fetch(resourcePath, {
+            method: "POST",
+            credentials: "same-origin",
+            headers: { Accept: "text/html, application/json" },
+          });
+          return {
+            ok: response.ok,
+            status: response.status,
+            text: await response.text(),
+          };
+        } catch {
+          return { ok: false, status: 0, text: "" };
+        }
+      }, DEPOSIT_AJAX_PATH),
+    );
+    if (isRecord(value) && typeof value.status === "number") {
+      const body = typeof value.text === "string" ? value.text : "";
+      logFirstbankStage("deposit-ajax", {
+        path: DEPOSIT_AJAX_PATH,
+        status: value.status,
+        bodyLength: body.length,
+      });
+      if (value.ok === true && body.trim()) return body;
+    }
+  } catch (error) {
+    if (!isRecoverableFrameError(error)) throw error;
+  }
   logFirstbankStage("deposit-ajax-failed", {
     path: DEPOSIT_AJAX_PATH,
-    detail: "missing-response",
+    detail: "fallback-fetch",
   });
-  // The click already dispatched the bank-owned POST. Never click again on a
-  // timeout: Puppeteer cannot cancel the in-page AJAX and a retry could issue
-  // a duplicate financial request.
   throw new FirstbankConnectionError("第一銀行存款總覽讀取失敗。");
 }
 
@@ -2475,6 +2555,10 @@ function httpStatus(response: BrowserResponse) {
   } catch {
     return undefined;
   }
+}
+
+function isFramesetParentNoise(message: string) {
+  return /resizeFrame is not a function/i.test(message);
 }
 
 function hasTransactionDateHeader(html: string) {

--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -76,6 +76,10 @@ type TransactionDocumentMeta = {
 type TransactionResponseCapture = {
   armed: boolean;
   html?: string;
+  verificationRequested: boolean;
+  verificationResponded: boolean;
+  verificationFailed: boolean;
+  verificationRequestIds: Set<string>;
   requestIds: Set<string>;
   documentMeta: Map<string, TransactionDocumentMeta>;
   pending: Set<Promise<void>>;
@@ -94,6 +98,7 @@ type TransactionLoadingEvent = {
 };
 
 type NetworkRequestWillBeSentEvent = {
+  requestId: string;
   type?: string;
   request: { url: string };
 };
@@ -857,6 +862,10 @@ async function collectFirstbankPayloads(
       path,
       resourceType: event.type,
     });
+    if (transactionResponse.armed && isTransactionVerificationResponse(url)) {
+      transactionResponse.verificationRequested = true;
+      transactionResponse.verificationRequestIds.add(event.requestId);
+    }
   };
   const onTransactionDocumentResponse = (
     event: TransactionDocumentResponseEvent,
@@ -868,6 +877,21 @@ async function collectFirstbankPayloads(
     const resourceType = event.type;
     if (isNetBankTwoPath(path) && isCapturableResourceType(resourceType)) {
       logFirstbankStage("0101-cdp-response", {
+        path,
+        status,
+        resourceType,
+      });
+    }
+    if (
+      transactionResponse.armed &&
+      isTransactionVerificationResponse(url) &&
+      transactionResponse.verificationRequestIds.delete(event.requestId)
+    ) {
+      transactionResponse.verificationResponded = true;
+      if (typeof status === "number" && (status < 200 || status >= 400)) {
+        transactionResponse.verificationFailed = true;
+      }
+      logFirstbankStage("0101-verification-response", {
         path,
         status,
         resourceType,
@@ -905,6 +929,12 @@ async function collectFirstbankPayloads(
     void task.catch(() => undefined);
   };
   const onTransactionDocumentFailed = (event: TransactionLoadingEvent) => {
+    if (transactionResponse.verificationRequestIds.delete(event.requestId)) {
+      transactionResponse.verificationFailed = true;
+      logFirstbankStage("0101-verification-failed", {
+        path: "/NetBank/2/verifyDV.html",
+      });
+    }
     transactionResponse.requestIds.delete(event.requestId);
     transactionResponse.documentMeta.delete(event.requestId);
   };
@@ -1124,6 +1154,10 @@ function createTransactionResponseCapture(): TransactionResponseCapture {
   });
   const capture: TransactionResponseCapture = {
     armed: false,
+    verificationRequested: false,
+    verificationResponded: false,
+    verificationFailed: false,
+    verificationRequestIds: new Set(),
     requestIds: new Set(),
     documentMeta: new Map(),
     pending: new Set(),
@@ -1288,6 +1322,14 @@ async function waitForTransactionHistory(
     logFirstbankStage("010103-timeout-frame", {
       path: framePathname(frame),
     });
+  }
+  if (
+    capture.verificationRequested &&
+    (!capture.verificationResponded ||
+      capture.verificationFailed ||
+      capture.verificationRequestIds.size > 0)
+  ) {
+    throw new FirstbankConnectionError("第一銀行交易明細前置驗證沒有完成。");
   }
   throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
 }
@@ -1469,14 +1511,18 @@ async function clickTransactionSearch(frame: Frame) {
             "#searchBtn, input[name=showList]",
           );
           if (!searchBtn) return false;
-          searchBtn.click();
+          // First Bank's click handler performs a synchronous verifyDV XHR.
+          // Let Runtime.evaluate return before that handler starts so Browser
+          // Run can continue delivering the response and navigation events.
+          setTimeout(() => searchBtn.click(), 0);
           return true;
         }),
       ),
     );
   } catch (error) {
     if (!isRecoverableFrameError(error)) throw error;
-    // The native click can destroy the iframe execution context immediately.
+    // The queued click can navigate or replace the iframe immediately after
+    // Runtime.evaluate returns. Network listeners remain armed above.
     submitted = true;
   }
   if (!submitted) {
@@ -1989,6 +2035,18 @@ function isTransactionResultResponse(url: string) {
   }
 }
 
+function isTransactionVerificationResponse(url: string) {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.origin === ORIGIN &&
+      parsed.pathname.toLowerCase().split(";")[0] === "/netbank/2/verifydv.html"
+    );
+  } catch {
+    return false;
+  }
+}
+
 function isFirstbankUrl(url: string) {
   try {
     return new URL(url).origin === ORIGIN;
@@ -2016,7 +2074,7 @@ function framePathname(frame: Frame) {
 
 function urlPathname(url: string) {
   try {
-    return new URL(url).pathname;
+    return new URL(url).pathname.split(";")[0];
   } catch {
     return "(invalid)";
   }

--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -38,8 +38,9 @@ const FRAME_READ_RETRY_MS = 250;
 // 010103 may replace and detach its iframe in Browser Rendering. Arm a
 // document-body waiter before submit, intercept 010103 at Fetch response
 // stage, and keep listeners attached so a delayed or non-Document body
-// can still settle. The bank's search handler first runs a blocking verifyDV
-// XHR, so the result budget restarts once that verification settles.
+// can still settle. If the bank's search handler emits verifyDV, the result
+// budget restarts once that verification settles; missing verifyDV CDP
+// events must not block a new live result frame or already-captured HTML.
 const RESULT_CAPTURE_WAIT_MS = 10_000;
 const RESULT_CAPTURE_MAX_WAIT_MS = 30_000;
 const DEPOSIT_CAPTURE_WAIT_MS = 15_000;
@@ -1473,33 +1474,29 @@ async function waitForTransactionHistory(
     const remaining =
       transactionCaptureDeadline(capture, startedAt) - Date.now();
     if (remaining <= 0) break;
-    // Settle the search handler's own requests before touching the page: the
-    // result cannot exist in the same tick as the submit, and the first probe
-    // must not run before verifyDV is registered.
-    const arrived = await Promise.race([
+    // Give the queued search click a tick to emit CDP events before probing.
+    await Promise.race([
       capture.documentBody.then(() => true),
       delay(Math.min(FRAME_READ_RETRY_MS, remaining)).then(() => false),
     ]);
     const arrivedHistory = readyTransactionHistory(capture);
-    if (arrived && arrivedHistory) return arrivedHistory;
-    // The search handler blocks the query frame's renderer on verifyDV, so
-    // Runtime.evaluate probes cannot run and only queue behind it. Rely on the
-    // CDP and HTTP listeners until that verification settles.
-    if (
-      !capture.verificationRequested ||
-      !capture.verificationResponded ||
-      capture.verificationFailed ||
-      capture.verificationRequestIds.size > 0
-    ) {
-      continue;
-    }
+    if (arrivedHistory) return arrivedHistory;
+    // verifyDV, when observed and still in flight, blocks the query frame's
+    // renderer; Runtime.evaluate only queues behind it. Skip probes until it
+    // settles. If verifyDV was never observed, still serialize a newly
+    // appeared live result frame — local Chromium often never surfaces that
+    // CDP event.
+    if (isVerificationInFlight(capture)) continue;
     const resultFrame = await findLiveTransactionResultFrame(
       page,
       capture.existingResultFrames,
     );
     if (!resultFrame) continue;
     try {
-      const html = await serializeFirstbankTables(resultFrame);
+      const html = await serializeFirstbankTables(
+        resultFrame,
+        FRAME_PROBE_TIMEOUT_MS,
+      );
       logFirstbankStage("010103-live-frame", {
         path: urlPathname(resultFrame.url()),
         bodyLength: html.length,
@@ -1548,16 +1545,16 @@ async function waitForTransactionHistory(
 }
 
 function readyTransactionHistory(capture: TransactionResponseCapture) {
-  if (!capture.html) return undefined;
-  if (!capture.verificationRequested) return capture.html;
-  if (
-    capture.verificationResponded &&
-    !capture.verificationFailed &&
-    capture.verificationRequestIds.size === 0
-  ) {
-    return capture.html;
-  }
-  return undefined;
+  // Already-captured 010103 HTML is the fallback path. Do not wait for a
+  // verifyDV CDP event that local Chromium may never emit.
+  return capture.html;
+}
+
+function isVerificationInFlight(capture: TransactionResponseCapture) {
+  return (
+    capture.verificationRequested &&
+    (!capture.verificationResponded || capture.verificationRequestIds.size > 0)
+  );
 }
 
 function transactionCaptureDeadline(
@@ -2002,7 +1999,10 @@ async function findDepositTrigger(frame: Frame) {
   }
 }
 
-async function serializeFirstbankTables(frame: Frame): Promise<string> {
+async function serializeFirstbankTables(
+  frame: Frame,
+  timeoutMs = ACTION_TIMEOUT_MS,
+): Promise<string> {
   const serialized = await withActionTimeout(
     frame.evaluate(() => {
       const escape = (value: string) =>
@@ -2036,6 +2036,7 @@ async function serializeFirstbankTables(frame: Frame): Promise<string> {
         .filter(Boolean)
         .join("\n");
     }),
+    timeoutMs,
   ).catch(() => "");
 
   if (typeof serialized === "string" && serialized.trim()) {

--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -38,8 +38,11 @@ const FRAME_READ_RETRY_MS = 250;
 // 010103 may replace and detach its iframe in Browser Rendering. Arm a
 // document-body waiter before submit, intercept 010103 at Fetch response
 // stage, and keep listeners attached so a delayed or non-Document body
-// can still settle.
+// can still settle. The bank's search handler first runs a blocking verifyDV
+// XHR, so the result budget restarts once that verification settles.
 const RESULT_CAPTURE_WAIT_MS = 10_000;
+const RESULT_CAPTURE_MAX_WAIT_MS = 30_000;
+const DEPOSIT_CAPTURE_WAIT_MS = 15_000;
 const FRAME_PROBE_TIMEOUT_MS = 1_000;
 const CARD_RESPONSE_TIMEOUT_MS = 10_000;
 const SESSION_RELEASE_TIMEOUT_MS = 2_000;
@@ -68,6 +71,14 @@ type CardPayloadKey = "cardBill" | "recentPayments" | "cardUnbilled";
 
 type CapturedCardResponses = Partial<Record<CardPayloadKey, unknown>>;
 
+type DepositResponseCapture = {
+  html?: string;
+  observed: boolean;
+  pending: Set<Promise<void>>;
+  responseBody: Promise<string>;
+  settleResponseBody: (html: string) => void;
+};
+
 type TransactionDocumentMeta = {
   path: string;
   status?: number;
@@ -75,13 +86,17 @@ type TransactionDocumentMeta = {
 
 type TransactionResponseCapture = {
   armed: boolean;
+  armedAt?: number;
+  existingResultFrames: Set<Frame>;
   html?: string;
   verificationRequested: boolean;
   verificationResponded: boolean;
   verificationFailed: boolean;
+  verificationSettledAt?: number;
   verificationRequestIds: Set<string>;
   requestIds: Set<string>;
   documentMeta: Map<string, TransactionDocumentMeta>;
+  inFlight: Map<string, { path: string; startedAt: number }>;
   pending: Set<Promise<void>>;
   documentBody: Promise<string>;
   settleDocumentBody: (html: string) => void;
@@ -826,6 +841,7 @@ async function collectFirstbankPayloads(
   const frame = await waitForAuthenticatedFrame(page);
   const captured: CapturedCardResponses = {};
   const responseTasks: Promise<void>[] = [];
+  const depositResponse = createDepositResponseCapture();
   const transactionResponse = createTransactionResponseCapture();
   const cdp = await page.createCDPSession();
   try {
@@ -857,6 +873,12 @@ async function collectFirstbankPayloads(
     const url = event.request?.url ?? "";
     if (!isFirstbankUrl(url)) return;
     const path = urlPathname(url);
+    if (isCapturableResourceType(event.type)) {
+      transactionResponse.inFlight.set(event.requestId, {
+        path,
+        startedAt: Date.now(),
+      });
+    }
     if (!isNetBankTwoPath(path)) return;
     logFirstbankStage("0101-cdp-request", {
       path,
@@ -872,6 +894,7 @@ async function collectFirstbankPayloads(
   ) => {
     const url = event.response.url;
     if (!isFirstbankUrl(url)) return;
+    transactionResponse.inFlight.delete(event.requestId);
     const path = urlPathname(url);
     const status = event.response.status;
     const resourceType = event.type;
@@ -888,6 +911,7 @@ async function collectFirstbankPayloads(
       transactionResponse.verificationRequestIds.delete(event.requestId)
     ) {
       transactionResponse.verificationResponded = true;
+      transactionResponse.verificationSettledAt = Date.now();
       if (typeof status === "number" && (status < 200 || status >= 400)) {
         transactionResponse.verificationFailed = true;
       }
@@ -895,6 +919,7 @@ async function collectFirstbankPayloads(
         path,
         status,
         resourceType,
+        elapsedMs: elapsedSinceArmed(transactionResponse),
       });
     }
     if (
@@ -906,12 +931,14 @@ async function collectFirstbankPayloads(
         path,
         status,
         resourceType,
+        elapsedMs: elapsedSinceArmed(transactionResponse),
       });
       transactionResponse.requestIds.add(event.requestId);
       transactionResponse.documentMeta.set(event.requestId, { path, status });
     }
   };
   const onTransactionDocumentLoaded = (event: TransactionLoadingEvent) => {
+    transactionResponse.inFlight.delete(event.requestId);
     if (!transactionResponse.requestIds.has(event.requestId)) return;
     const meta = transactionResponse.documentMeta.get(event.requestId);
     let task: Promise<void>;
@@ -929,10 +956,13 @@ async function collectFirstbankPayloads(
     void task.catch(() => undefined);
   };
   const onTransactionDocumentFailed = (event: TransactionLoadingEvent) => {
+    transactionResponse.inFlight.delete(event.requestId);
     if (transactionResponse.verificationRequestIds.delete(event.requestId)) {
       transactionResponse.verificationFailed = true;
+      transactionResponse.verificationSettledAt = Date.now();
       logFirstbankStage("0101-verification-failed", {
         path: "/NetBank/2/verifyDV.html",
+        elapsedMs: elapsedSinceArmed(transactionResponse),
       });
     }
     transactionResponse.requestIds.delete(event.requestId);
@@ -952,6 +982,16 @@ async function collectFirstbankPayloads(
   cdp.on("Network.loadingFailed", onTransactionDocumentFailed);
   if (fetchEnabled) cdp.on("Fetch.requestPaused", onFetchPaused);
   const onResponse = (response: BrowserResponse) => {
+    if (isDepositOverviewResponse(response.url())) {
+      depositResponse.observed = true;
+      let task: Promise<void>;
+      task = captureDepositResponse(response, depositResponse).finally(() =>
+        depositResponse.pending.delete(task),
+      );
+      depositResponse.pending.add(task);
+      void task.catch(() => undefined);
+      return;
+    }
     if (
       transactionResponse.armed &&
       isTransactionResultResponse(response.url())
@@ -959,6 +999,7 @@ async function collectFirstbankPayloads(
       logFirstbankStage("010103-http-response", {
         path: urlPathname(response.url()),
         status: httpStatus(response),
+        elapsedMs: elapsedSinceArmed(transactionResponse),
       });
       let task: Promise<void>;
       task = captureTransactionResponse(response, transactionResponse).finally(
@@ -975,20 +1016,65 @@ async function collectFirstbankPayloads(
     void task.catch(() => undefined);
   };
   page.on("response", onResponse);
+  // A native confirm/alert raised by the bank's own handlers freezes the
+  // renderer until it is answered, which stalls every in-flight request and
+  // every CDP event for that frame. Keep one accepting listener attached for
+  // the whole collection so the query can never wedge behind a dialog.
+  const onDialog = (dialog: Dialog) => {
+    logFirstbankStage("0101-dialog", {
+      detail: describeDialog(dialog),
+      elapsedMs: elapsedSinceArmed(transactionResponse),
+    });
+    void dialog
+      .accept()
+      .catch(() => dialog.dismiss().catch(() => undefined))
+      .catch(() => undefined);
+  };
+  page.on("dialog", onDialog);
+  const onPageError = (error: unknown) => {
+    logFirstbankStage("0101-page-error", {
+      detail: safeDiagnosticText(
+        error instanceof Error ? error.message : String(error),
+      ),
+      elapsedMs: elapsedSinceArmed(transactionResponse),
+    });
+  };
+  page.on("pageerror", onPageError);
 
   try {
-    await navigateFrame(frame, ACCOUNT_OVERVIEW_URL);
-    const depositAjax = await fetchFrameResource(frame, DEPOSIT_AJAX_PATH);
-    await waitForDepositOverview(frame);
+    logFirstbankStage("collect-start", { path: framePathname(frame) });
+    const overviewPath = urlPathname(ACCOUNT_OVERVIEW_URL);
+    const overviewFrame = await navigateToReadyFrame(
+      page,
+      frame,
+      ACCOUNT_OVERVIEW_URL,
+      overviewPath,
+    );
+    logFirstbankStage("overview-frame", {
+      path: framePathname(overviewFrame),
+    });
+    const depositOverviewHtml = await collectDepositOverview(
+      page,
+      overviewFrame,
+      depositResponse,
+    );
+    const depositFrame = await waitForReadyFrameByPath(
+      page,
+      overviewPath,
+      overviewFrame,
+    );
 
-    await navigateFrame(frame, TRANSACTION_URL);
-    const queryFrame = await waitForLiveTransactionQueryFrame(page, frame);
+    await navigateFrame(depositFrame, TRANSACTION_URL);
+    const queryFrame = await waitForLiveTransactionQueryFrame(
+      page,
+      depositFrame,
+    );
     const transactionHistoryHtml = await submitTransactionQuery(
       page,
       queryFrame,
       transactionResponse,
     );
-    const cardFrame = pickLiveFrame(page, frame) ?? queryFrame;
+    const cardFrame = pickLiveFrame(page, depositFrame) ?? queryFrame;
 
     await collectCardPayload(cardFrame, "F1632", 1, "cardBill", captured);
     await collectCardPayload(cardFrame, "F1633", 2, "recentPayments", captured);
@@ -996,14 +1082,22 @@ async function collectFirstbankPayloads(
     await Promise.allSettled(responseTasks);
 
     return {
-      depositOverviewHtml: depositAjax,
+      depositOverviewHtml,
       transactionHistoryHtml,
       cardBill: captured.cardBill,
       cardUnbilled: captured.cardUnbilled,
       recentPayments: captured.recentPayments,
     } as unknown as FirstbankPayloads;
   } finally {
+    if (transactionResponse.pending.size > 0) {
+      await withActionTimeout(
+        Promise.allSettled(Array.from(transactionResponse.pending)),
+        RESULT_CAPTURE_WAIT_MS,
+      ).catch(() => undefined);
+    }
     page.off("response", onResponse);
+    page.off("dialog", onDialog);
+    page.off("pageerror", onPageError);
     cdp.off("Network.requestWillBeSent", onTransactionRequest);
     cdp.off("Network.responseReceived", onTransactionDocumentResponse);
     cdp.off("Network.loadingFinished", onTransactionDocumentLoaded);
@@ -1154,12 +1248,14 @@ function createTransactionResponseCapture(): TransactionResponseCapture {
   });
   const capture: TransactionResponseCapture = {
     armed: false,
+    existingResultFrames: new Set(),
     verificationRequested: false,
     verificationResponded: false,
     verificationFailed: false,
     verificationRequestIds: new Set(),
     requestIds: new Set(),
     documentMeta: new Map(),
+    inFlight: new Map(),
     pending: new Set(),
     documentBody,
     settleDocumentBody(html: string) {
@@ -1168,6 +1264,53 @@ function createTransactionResponseCapture(): TransactionResponseCapture {
     },
   };
   return capture;
+}
+
+function createDepositResponseCapture(): DepositResponseCapture {
+  let resolveResponseBody = (_html: string) => {};
+  const responseBody = new Promise<string>((resolve) => {
+    resolveResponseBody = resolve;
+  });
+  const capture: DepositResponseCapture = {
+    observed: false,
+    pending: new Set(),
+    responseBody,
+    settleResponseBody(html: string) {
+      capture.html = html;
+      resolveResponseBody(html);
+    },
+  };
+  return capture;
+}
+
+async function captureDepositResponse(
+  response: BrowserResponse,
+  capture: DepositResponseCapture,
+) {
+  const path = urlPathname(response.url());
+  const status = httpStatus(response);
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {
+    // The waiter is still settled so a failed body read cannot trigger the
+    // bank's request a second time.
+  }
+  logFirstbankStage("deposit-ajax", {
+    path,
+    status,
+    bodyLength: body.length,
+  });
+  if (
+    typeof status === "number" &&
+    status >= 200 &&
+    status < 400 &&
+    body.trim()
+  ) {
+    capture.settleResponseBody(body);
+    return;
+  }
+  capture.settleResponseBody("");
 }
 
 async function captureTransactionDocument(
@@ -1226,6 +1369,7 @@ async function captureFetchPausedDocument(
   const url = event.request?.url ?? "";
   const path = urlPathname(url);
   const status = event.responseStatusCode;
+  let capturedHtml: string | undefined;
   try {
     if (capture.armed && isTransactionResultResponse(url)) {
       logFirstbankStage("010103-fetch-response", {
@@ -1248,8 +1392,7 @@ async function captureFetchPausedDocument(
         bodyLength: body.length,
         hasTxnDateHeader: hasTransactionDateHeader(body),
       });
-      const html = transactionHistoryFromHtml(body);
-      capture.settleDocumentBody(html);
+      capturedHtml = transactionHistoryFromHtml(body);
     }
   } catch {
     // Invalid or unavailable Fetch bodies do not mask a later live frame.
@@ -1258,6 +1401,7 @@ async function captureFetchPausedDocument(
       .send("Fetch.continueRequest", { requestId: event.requestId })
       .catch(() => undefined);
   }
+  if (capturedHtml !== undefined) capture.settleDocumentBody(capturedHtml);
 }
 
 async function submitTransactionQuery(
@@ -1265,15 +1409,53 @@ async function submitTransactionQuery(
   frame: Frame,
   transactionResponse: TransactionResponseCapture,
 ) {
-  await dismissBankNotice(frame);
-  await fillTransactionDateRange(frame);
-  await waitForQueryAccountOptions(frame);
-  await selectQueryAccount(frame);
+  const deadline = Date.now() + ACTION_TIMEOUT_MS;
+  let queryFrame = frame;
+  for (;;) {
+    queryFrame = await waitForLiveTransactionQueryFrame(
+      page,
+      queryFrame,
+      deadline,
+    );
+    await dismissBankNotice(queryFrame);
+    await fillTransactionDateRange(queryFrame);
+    const accountFrame = await waitForQueryAccountOptions(
+      page,
+      queryFrame,
+      deadline,
+    );
+    if (accountFrame !== queryFrame) {
+      queryFrame = accountFrame;
+      continue;
+    }
+    if (!(await selectQueryAccount(queryFrame))) {
+      const replacement = await findLiveTransactionQueryFrame(page, queryFrame);
+      if (replacement && replacement !== queryFrame) {
+        queryFrame = replacement;
+        continue;
+      }
+      throw new FirstbankConnectionError("第一銀行交易明細查詢帳號無法選取。");
+    }
+    const clickFrame = await waitForLiveTransactionQueryFrame(
+      page,
+      queryFrame,
+      deadline,
+    );
+    if (clickFrame !== queryFrame) {
+      queryFrame = clickFrame;
+      continue;
+    }
+    break;
+  }
+  transactionResponse.existingResultFrames = new Set(
+    liveFrames(page).filter((candidate) => isTransactionResultFrame(candidate)),
+  );
   transactionResponse.armed = true;
+  transactionResponse.armedAt = Date.now();
   logFirstbankStage("0101-query-submit", {
     path: urlPathname(TRANSACTION_URL),
   });
-  await clickTransactionSearch(frame);
+  await clickTransactionSearch(queryFrame);
   return waitForTransactionHistory(page, transactionResponse);
 }
 
@@ -1281,46 +1463,77 @@ async function waitForTransactionHistory(
   page: Page,
   capture: TransactionResponseCapture,
 ) {
-  const deadline = Date.now() + RESULT_CAPTURE_WAIT_MS;
-  while (Date.now() < deadline) {
-    if (capture.html) return capture.html;
-    const resultFrame = await findLiveTransactionResultFrame(page);
-    if (resultFrame) {
-      try {
-        const html = await serializeFirstbankTables(resultFrame);
-        logFirstbankStage("010103-live-frame", {
-          path: urlPathname(resultFrame.url()),
-          bodyLength: html.length,
-          hasTxnDateHeader: hasTransactionDateHeader(html),
-        });
-        return html;
-      } catch (error) {
-        if (!isTransactionHistoryReadError(error)) throw error;
-      }
+  const startedAt = Date.now();
+  for (;;) {
+    const captured = readyTransactionHistory(capture);
+    if (captured) return captured;
+    if (capture.verificationFailed) {
+      throw new FirstbankConnectionError("第一銀行交易明細前置驗證沒有完成。");
     }
-    const remaining = deadline - Date.now();
+    const remaining =
+      transactionCaptureDeadline(capture, startedAt) - Date.now();
     if (remaining <= 0) break;
+    // Settle the search handler's own requests before touching the page: the
+    // result cannot exist in the same tick as the submit, and the first probe
+    // must not run before verifyDV is registered.
     const arrived = await Promise.race([
       capture.documentBody.then(() => true),
       delay(Math.min(FRAME_READ_RETRY_MS, remaining)).then(() => false),
     ]);
-    if (arrived && capture.html) return capture.html;
+    const arrivedHistory = readyTransactionHistory(capture);
+    if (arrived && arrivedHistory) return arrivedHistory;
+    // The search handler blocks the query frame's renderer on verifyDV, so
+    // Runtime.evaluate probes cannot run and only queue behind it. Rely on the
+    // CDP and HTTP listeners until that verification settles.
+    if (
+      !capture.verificationRequested ||
+      !capture.verificationResponded ||
+      capture.verificationFailed ||
+      capture.verificationRequestIds.size > 0
+    ) {
+      continue;
+    }
+    const resultFrame = await findLiveTransactionResultFrame(
+      page,
+      capture.existingResultFrames,
+    );
+    if (!resultFrame) continue;
+    try {
+      const html = await serializeFirstbankTables(resultFrame);
+      logFirstbankStage("010103-live-frame", {
+        path: urlPathname(resultFrame.url()),
+        bodyLength: html.length,
+        hasTxnDateHeader: hasTransactionDateHeader(html),
+        elapsedMs: elapsedSinceArmed(capture),
+      });
+      return html;
+    } catch (error) {
+      if (!isTransactionHistoryReadError(error)) throw error;
+    }
   }
 
   if (capture.pending.size > 0) {
     await withActionTimeout(
       Promise.allSettled(Array.from(capture.pending)),
-      FRAME_PROBE_TIMEOUT_MS,
+      RESULT_CAPTURE_WAIT_MS,
     ).catch(() => undefined);
   }
-  if (capture.html) return capture.html;
+  const captured = readyTransactionHistory(capture);
+  if (captured) return captured;
 
   logFirstbankStage("010103-timeout", {
     path: "/NetBank/2/010103.html",
+    elapsedMs: elapsedSinceArmed(capture),
   });
   for (const frame of liveFrames(page)) {
     logFirstbankStage("010103-timeout-frame", {
       path: framePathname(frame),
+    });
+  }
+  for (const entry of capture.inFlight.values()) {
+    logFirstbankStage("010103-timeout-inflight", {
+      path: entry.path,
+      elapsedMs: Date.now() - entry.startedAt,
     });
   }
   if (
@@ -1334,50 +1547,60 @@ async function waitForTransactionHistory(
   throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
 }
 
-async function waitForDepositOverview(frame: Frame) {
-  const deadline = Date.now() + ACTION_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    if (await hasDepositOverview(frame)) return;
-    await delay(FRAME_READ_RETRY_MS);
+function readyTransactionHistory(capture: TransactionResponseCapture) {
+  if (!capture.html) return undefined;
+  if (!capture.verificationRequested) return capture.html;
+  if (
+    capture.verificationResponded &&
+    !capture.verificationFailed &&
+    capture.verificationRequestIds.size === 0
+  ) {
+    return capture.html;
   }
+  return undefined;
 }
 
-async function hasDepositOverview(frame: Frame) {
-  try {
-    return Boolean(
-      await withActionTimeout(
-        frame.evaluate(() => {
-          const text = (document.body?.innerText ?? "").replace(/\s+/g, " ");
-          return /帳號/.test(text) && /帳面餘額|可用餘額|存款餘額/.test(text);
-        }),
-      ),
-    );
-  } catch {
-    return false;
-  }
+function transactionCaptureDeadline(
+  capture: TransactionResponseCapture,
+  startedAt: number,
+) {
+  const hardDeadline = startedAt + RESULT_CAPTURE_MAX_WAIT_MS;
+  if (capture.verificationRequestIds.size > 0) return hardDeadline;
+  const settledAt = capture.verificationSettledAt ?? startedAt;
+  return Math.min(
+    Math.max(settledAt, startedAt) + RESULT_CAPTURE_WAIT_MS,
+    hardDeadline,
+  );
 }
 
-async function waitForLiveTransactionQueryFrame(page: Page, preferred?: Frame) {
-  const deadline = Date.now() + ACTION_TIMEOUT_MS;
+async function waitForLiveTransactionQueryFrame(
+  page: Page,
+  preferred?: Frame,
+  deadline = Date.now() + ACTION_TIMEOUT_MS,
+) {
   while (Date.now() < deadline) {
-    const found = await findLiveTransactionQueryFrame(page);
+    const found = await findLiveTransactionQueryFrame(page, preferred);
     if (found) return found;
     await delay(FRAME_READ_RETRY_MS);
   }
-  const found = await findLiveTransactionQueryFrame(page);
+  const found = await findLiveTransactionQueryFrame(page, preferred);
   if (found) return found;
-  if (
-    preferred &&
-    !isDetachedFrame(preferred) &&
-    liveFrames(page).includes(preferred)
-  ) {
-    return preferred;
-  }
-  return waitForAuthenticatedFrame(page);
+  throw new FirstbankConnectionError("第一銀行交易明細查詢頁面尚未載入完成。");
 }
 
-async function findLiveTransactionQueryFrame(page: Page) {
-  for (const frame of liveFrames(page)) {
+async function findLiveTransactionQueryFrame(page: Page, preferred?: Frame) {
+  const queryPath = urlPathname(TRANSACTION_URL);
+  const frames = liveFrames(page);
+  const preferredIsLive = preferred !== undefined && frames.includes(preferred);
+  const candidates = preferredIsLive
+    ? framePathname(preferred) === queryPath
+      ? [preferred]
+      : []
+    : frames.filter(
+        (frame) => frame !== preferred && framePathname(frame) === queryPath,
+      );
+  for (const frame of candidates) {
+    if (!(await isFrameDocumentReady(frame))) continue;
     if (await hasTransactionSearchControl(frame)) return frame;
   }
   return undefined;
@@ -1390,6 +1613,7 @@ async function hasTransactionSearchControl(frame: Frame) {
         frame.evaluate(() =>
           Boolean(document.querySelector("#searchBtn, input[name=showList]")),
         ),
+        FRAME_PROBE_TIMEOUT_MS,
       ),
     );
   } catch {
@@ -1397,8 +1621,12 @@ async function hasTransactionSearchControl(frame: Frame) {
   }
 }
 
-async function findLiveTransactionResultFrame(page: Page) {
+async function findLiveTransactionResultFrame(
+  page: Page,
+  excludedFrames: ReadonlySet<Frame>,
+) {
   for (const frame of liveFrames(page)) {
+    if (excludedFrames.has(frame)) continue;
     let isResultUrl = false;
     try {
       isResultUrl = isTransactionResultResponse(frame.url());
@@ -1413,6 +1641,14 @@ async function findLiveTransactionResultFrame(page: Page) {
     }
   }
   return undefined;
+}
+
+function isTransactionResultFrame(frame: Frame) {
+  try {
+    return isTransactionResultResponse(frame.url());
+  } catch {
+    return false;
+  }
 }
 
 async function fillTransactionDateRange(frame: Frame) {
@@ -1459,12 +1695,21 @@ function formatTaipeiDate(ms: number) {
   return `${value("year")}/${value("month")}/${value("day")}`;
 }
 
-async function waitForQueryAccountOptions(frame: Frame) {
-  const deadline = Date.now() + ACTION_TIMEOUT_MS;
+async function waitForQueryAccountOptions(
+  page: Page,
+  preferred: Frame,
+  deadline = Date.now() + ACTION_TIMEOUT_MS,
+) {
   while (Date.now() < deadline) {
-    if (await selectQueryAccount(frame, true)) return;
+    const frame = await findLiveTransactionQueryFrame(page, preferred);
+    if (!frame) {
+      await delay(FRAME_READ_RETRY_MS);
+      continue;
+    }
+    if (await selectQueryAccount(frame, true)) return frame;
     await delay(FRAME_READ_RETRY_MS);
   }
+  throw new FirstbankConnectionError("第一銀行交易明細查詢帳號無法選取。");
 }
 
 async function selectQueryAccount(frame: Frame, dryRun = false) {
@@ -1472,16 +1717,29 @@ async function selectQueryAccount(frame: Frame, dryRun = false) {
     return Boolean(
       await withActionTimeout(
         frame.evaluate((shouldSelect) => {
+          type QueryAccountSelect = {
+            options: ArrayLike<{
+              selected: boolean;
+              text: string;
+              value: string;
+            }>;
+            selectedIndex: number;
+            value: string;
+            dispatchEvent: (event: Event) => boolean;
+          };
           const isPlaceholder = (text: string, value: string) => {
             const normalized = text.replace(/\s+/g, "");
-            return !value.trim() || /請選擇|選擇帳號|^-+$/.test(normalized);
+            return (
+              !value.trim() ||
+              value.trim() === "0" ||
+              /請選擇|選擇帳號|pleaseselect|selectaccount|^-+$/i.test(
+                normalized,
+              )
+            );
           };
-          const select = Array.from(document.querySelectorAll("select")).find(
-            (candidate) =>
-              Array.from(candidate.options).some(
-                (option) => !isPlaceholder(option.text, option.value),
-              ),
-          );
+          const select = document.querySelector(
+            'select[name="acnt"]',
+          ) as QueryAccountSelect | null;
           if (!select) return false;
           const option = Array.from(select.options).find(
             (candidate) => !isPlaceholder(candidate.text, candidate.value),
@@ -1492,7 +1750,12 @@ async function selectQueryAccount(frame: Frame, dryRun = false) {
           option.selected = true;
           select.dispatchEvent(new Event("input", { bubbles: true }));
           select.dispatchEvent(new Event("change", { bubbles: true }));
-          return select.value === option.value;
+          const selected = select.options[select.selectedIndex];
+          return (
+            select.value === option.value &&
+            selected !== undefined &&
+            !isPlaceholder(selected.text, selected.value)
+          );
         }, !dryRun),
       ),
     );
@@ -1594,37 +1857,149 @@ async function navigateFrame(frame: Frame, url: string) {
   }
 }
 
-async function fetchFrameResource(frame: Frame, path: string): Promise<string> {
-  try {
-    const value = await withActionTimeout(
-      frame.evaluate(async (resourcePath) => {
-        try {
-          const response = await fetch(resourcePath, {
-            method: "POST",
-            credentials: "same-origin",
-            headers: { Accept: "text/html, application/json" },
-          });
-          return {
-            ok: response.ok,
-            status: response.status,
-            text: await response.text(),
-          };
-        } catch {
-          return { ok: false, status: 0, text: "" };
-        }
-      }, path),
+async function navigateToReadyFrame(
+  page: Page,
+  frame: Frame,
+  url: string,
+  path: string,
+) {
+  if (framePathname(frame) !== path) await navigateFrame(frame, url);
+  return waitForReadyFrameByPath(page, path, frame);
+}
+
+async function waitForReadyFrameByPath(
+  page: Page,
+  path: string,
+  _preferred?: Frame,
+) {
+  const deadline = Date.now() + ACTION_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const candidates = liveFrames(page).filter(
+      (candidate) => framePathname(candidate) === path,
     );
-    if (
-      isRecord(value) &&
-      value.ok === true &&
-      typeof value.text === "string"
-    ) {
-      return value.text;
+    for (const candidate of candidates) {
+      if (await isFrameDocumentReady(candidate)) return candidate;
     }
-  } catch (error) {
-    if (!isRecoverableFrameError(error)) throw error;
+    await delay(FRAME_READ_RETRY_MS);
   }
+  throw new FirstbankConnectionError("第一銀行存款總覽頁面尚未載入完成。");
+}
+
+async function isFrameDocumentReady(frame: Frame) {
+  try {
+    return Boolean(
+      await withActionTimeout(
+        frame.evaluate(() =>
+          Boolean(
+            document.body &&
+            (document.readyState === "interactive" ||
+              document.readyState === "complete"),
+          ),
+        ),
+        FRAME_PROBE_TIMEOUT_MS,
+      ),
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function collectDepositOverview(
+  page: Page,
+  frame: Frame,
+  capture: DepositResponseCapture,
+) {
+  if (!capture.observed) {
+    const triggered = await triggerDepositOverview(page, frame);
+    if (!triggered) {
+      throw new FirstbankConnectionError("第一銀行存款總覽按鈕格式已變更。");
+    }
+  }
+  const html = await withActionTimeout(
+    capture.responseBody,
+    DEPOSIT_CAPTURE_WAIT_MS,
+  ).catch(() => "");
+  if (html) return html;
+  if (capture.pending.size > 0) {
+    await withActionTimeout(
+      Promise.allSettled(Array.from(capture.pending)),
+      FRAME_PROBE_TIMEOUT_MS,
+    ).catch(() => undefined);
+  }
+  if (capture.html) return capture.html;
+  logFirstbankStage("deposit-ajax-failed", {
+    path: DEPOSIT_AJAX_PATH,
+    detail: "missing-response",
+  });
+  // The click already dispatched the bank-owned POST. Never click again on a
+  // timeout: Puppeteer cannot cancel the in-page AJAX and a retry could issue
+  // a duplicate financial request.
   throw new FirstbankConnectionError("第一銀行存款總覽讀取失敗。");
+}
+
+async function triggerDepositOverview(page: Page, preferred: Frame) {
+  const deadline = Date.now() + ACTION_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const frames = liveFrames(page);
+    const preferredIsLive = frames.includes(preferred);
+    const candidates = preferredIsLive
+      ? framePathname(preferred) === urlPathname(ACCOUNT_OVERVIEW_URL)
+        ? [preferred]
+        : []
+      : frames.filter(
+          (candidate) =>
+            candidate !== preferred &&
+            framePathname(candidate) === urlPathname(ACCOUNT_OVERVIEW_URL),
+        );
+    for (const frame of candidates) {
+      if (!(await isFrameDocumentReady(frame))) continue;
+      const selector = await findDepositTrigger(frame);
+      if (selector === undefined) continue;
+      try {
+        await withActionTimeout(frame.click(selector));
+        return true;
+      } catch (error) {
+        if (isRecoverableFrameError(error)) {
+          // The original click may already be executing in the page. Listeners
+          // are armed before it, so wait for that one response instead of
+          // re-clicking on either this frame or a replacement.
+          return true;
+        }
+        throw error;
+      }
+    }
+    await delay(FRAME_READ_RETRY_MS);
+  }
+  return false;
+}
+
+async function findDepositTrigger(frame: Frame) {
+  try {
+    const selector = await withActionTimeout(
+      frame.evaluate(() => {
+        const isVisible = (element: Element | null) => {
+          if (!(element instanceof HTMLElement)) return false;
+          const style = window.getComputedStyle(element);
+          return style.display !== "none" && style.visibility !== "hidden";
+        };
+        const depositTriggerSelector = "#btnOpen a";
+        if (isVisible(document.querySelector(depositTriggerSelector))) {
+          return depositTriggerSelector;
+        }
+        const typeSelector =
+          '#overview-account a[onclick*="chgAcntReviewType(\'1\')"], a[href="#tab1"]';
+        return isVisible(document.querySelector(typeSelector))
+          ? typeSelector
+          : undefined;
+      }),
+      FRAME_PROBE_TIMEOUT_MS,
+    );
+    return typeof selector === "string" ? selector : undefined;
+  } catch {
+    // A read-only selector probe can be retried on a replacement frame because
+    // no bank request has been dispatched yet.
+    return undefined;
+  }
 }
 
 async function serializeFirstbankTables(frame: Frame): Promise<string> {
@@ -1982,7 +2357,7 @@ function isRecoverableFrameError(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
   return (
     error instanceof FirstbankActionTimeoutError ||
-    /Execution context was destroyed|Cannot find context|detached Frame|Target closed|Navigation timeout of \d+ ms exceeded|timed out.*protocolTimeout|Runtime\.callFunctionOn timed out/i.test(
+    /Execution context was destroyed|Cannot find context|Navigating frame was detached|Waiting failed: Frame detached|frame got detached|detached frame|Target closed|Navigation timeout of \d+ ms exceeded|timed out.*protocolTimeout|Runtime\.callFunctionOn timed out/i.test(
       message,
     )
   );
@@ -2030,6 +2405,19 @@ function isTransactionResultResponse(url: string) {
     if (parsed.origin !== ORIGIN) return false;
     const path = parsed.pathname.toLowerCase().split(";")[0];
     return /\/netbank\/2\/010103(?:\.html?)?$/.test(path);
+  } catch {
+    return false;
+  }
+}
+
+function isDepositOverviewResponse(url: string) {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.origin === ORIGIN &&
+      parsed.pathname.toLowerCase().split(";")[0] ===
+        DEPOSIT_AJAX_PATH.toLowerCase()
+    );
   } catch {
     return false;
   }
@@ -2100,6 +2488,8 @@ function logFirstbankStage(
     bodyLength?: number;
     hasTxnDateHeader?: boolean;
     resourceType?: string;
+    elapsedMs?: number;
+    detail?: string;
   } = {},
 ) {
   const parts = [`[firstbank] ${stage}`];
@@ -2114,7 +2504,43 @@ function logFirstbankStage(
   if (fields.resourceType !== undefined) {
     parts.push(`resourceType=${fields.resourceType}`);
   }
+  if (fields.elapsedMs !== undefined) {
+    parts.push(`elapsedMs=${fields.elapsedMs}`);
+  }
+  if (fields.detail !== undefined) parts.push(`detail=${fields.detail}`);
   console.log(parts.join(" "));
+}
+
+function elapsedSinceArmed(capture: TransactionResponseCapture) {
+  if (capture.armedAt === undefined) return undefined;
+  return Date.now() - capture.armedAt;
+}
+
+function describeDialog(dialog: Dialog) {
+  let type = "unknown";
+  let message = "";
+  try {
+    type = dialog.type();
+  } catch {
+    type = "unknown";
+  }
+  try {
+    message = dialog.message();
+  } catch {
+    message = "";
+  }
+  return `${type}:${safeDiagnosticText(message)}`;
+}
+
+// Dialog and page error text can quote balances or account numbers, so every
+// digit is masked and token/URL-shaped content is redacted before the message
+// reaches the logs.
+function safeDiagnosticText(value: string) {
+  return safeErrorMessage(maskDigits(value)).slice(0, 120);
+}
+
+function maskDigits(value: string) {
+  return value.replace(/\d/g, "#").replace(/\s+/g, " ").trim().slice(0, 120);
 }
 
 function isTransactionHistoryReadError(error: unknown) {

--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -45,9 +45,19 @@ const FRAME_READ_RETRY_MS = 250;
 // events must not block a new live result frame or already-captured HTML.
 const RESULT_CAPTURE_WAIT_MS = 10_000;
 const RESULT_CAPTURE_MAX_WAIT_MS = 30_000;
-const DEPOSIT_CAPTURE_WAIT_MS = 15_000;
+// Once CDP confirms the native read-only POST was dispatched, allow a wider
+// response window without retaining the old 15-second idle penalty.
+const DEPOSIT_CAPTURE_WAIT_MS = 5_000;
+// Recorder HAR: acntReview1 completes in about 0.85s. If neither CDP sees the
+// native POST nor the page receives its response within this grace window,
+// stop idling and use the already-tested same-origin fallback fetch.
+const DEPOSIT_REQUEST_GRACE_MS = 2_000;
 const FRAME_PROBE_TIMEOUT_MS = 1_000;
-const CARD_RESPONSE_TIMEOUT_MS = 10_000;
+// The recorder's first billing query takes a little over 11 seconds from the
+// First Bank bridge page to CMSQRY0014. Browser Rendering is slower than the
+// local recorder, so keep enough headroom and fail closed if a dispatched card
+// query never produces its expected response.
+const CARD_RESPONSE_TIMEOUT_MS = 30_000;
 const SESSION_RELEASE_TIMEOUT_MS = 2_000;
 const SESSION_RELEASE_POLL_MS = 100;
 const MAX_SERIALIZED_TABLE_BYTES = 512 * 1024;
@@ -77,8 +87,11 @@ type CapturedCardResponses = Partial<Record<CardPayloadKey, unknown>>;
 type DepositResponseCapture = {
   html?: string;
   observed: boolean;
+  requested: boolean;
   status?: number;
   pending: Set<Promise<void>>;
+  requestObserved: Promise<void>;
+  settleRequestObserved: () => void;
   responseBody: Promise<string>;
   settleResponseBody: (html: string) => void;
 };
@@ -878,6 +891,13 @@ async function collectFirstbankPayloads(
   const onTransactionRequest = (event: NetworkRequestWillBeSentEvent) => {
     const url = event.request?.url ?? "";
     if (!isFirstbankUrl(url)) return;
+    if (isDepositOverviewResponse(url)) {
+      depositResponse.settleRequestObserved();
+      logFirstbankStage("deposit-cdp-request", {
+        path: DEPOSIT_AJAX_PATH,
+        resourceType: event.type,
+      });
+    }
     const path = urlPathname(url);
     if (isCapturableResourceType(event.type)) {
       transactionResponse.inFlight.set(event.requestId, {
@@ -1017,6 +1037,11 @@ async function collectFirstbankPayloads(
     }
     const key = cardResponseKey(response.url());
     if (!key) return;
+    logFirstbankStage("card-http-response", {
+      path: urlPathname(response.url()),
+      status: httpStatus(response),
+      detail: key,
+    });
     const task = captureCardResponse(response, key, captured);
     responseTasks.push(task);
     void task.catch(() => undefined);
@@ -1086,11 +1111,8 @@ async function collectFirstbankPayloads(
       queryFrame,
       transactionResponse,
     );
-    const cardFrame = pickLiveFrame(page, depositFrame) ?? queryFrame;
-
-    await collectCardPayload(cardFrame, "F1632", 1, "cardBill", captured);
-    await collectCardPayload(cardFrame, "F1633", 2, "recentPayments", captured);
-    await collectCardPayload(cardFrame, "F1634", 3, "cardUnbilled", captured);
+    const cardFrame = pickCardNavigationFrame(page, depositFrame) ?? queryFrame;
+    await collectCardPayloads(page, cardFrame, captured);
     await Promise.allSettled(responseTasks);
 
     return {
@@ -1122,39 +1144,97 @@ async function collectFirstbankPayloads(
   }
 }
 
+const CARD_QUERIES = [
+  { dataFunc: "F1632", func: 1, key: "cardBill" },
+  { dataFunc: "F1633", func: 2, key: "recentPayments" },
+  { dataFunc: "F1634", func: 3, key: "cardUnbilled" },
+] as const satisfies ReadonlyArray<{
+  dataFunc: string;
+  func: number;
+  key: CardPayloadKey;
+}>;
+
+async function collectCardPayloads(
+  page: Page,
+  preferred: Frame,
+  captured: CapturedCardResponses,
+) {
+  let frame = preferred;
+  for (const query of CARD_QUERIES) {
+    frame = await collectCardPayload(
+      page,
+      frame,
+      query.dataFunc,
+      query.func,
+      query.key,
+      captured,
+    );
+  }
+}
+
 async function collectCardPayload(
-  frame: Frame,
+  page: Page,
+  preferred: Frame,
   dataFunc: string,
   func: number,
   key: CardPayloadKey,
   captured: CapturedCardResponses,
 ) {
-  if (Object.prototype.hasOwnProperty.call(captured, key)) return;
-  await navigateFrame(frame, HOME_URL);
+  if (Object.prototype.hasOwnProperty.call(captured, key)) return preferred;
+  const startedAt = Date.now();
+  const frame = await waitForCardHomeFunctions(page, preferred);
+  logFirstbankStage("card-query-start", {
+    path: framePathname(frame),
+    detail: key,
+  });
   const opened = await openCardFunction(frame, dataFunc);
-  if (!opened) return;
-  await delay(FRAME_READ_RETRY_MS * 4);
-  if (await isServiceOverview(frame)) {
-    await navigateFrame(
-      frame,
-      `${ORIGIN}/NetBank/ajax/frameFirstCard.html?func=${func}`,
-    );
+  if (!opened) {
+    throw new FirstbankConnectionError("第一銀行信用卡功能入口讀取失敗。");
   }
-  if (await isServiceOverview(frame)) return;
+  logFirstbankStage("card-click", {
+    path: framePathname(frame),
+    detail: key,
+  });
+  if (!Object.prototype.hasOwnProperty.call(captured, key)) {
+    await delay(FRAME_READ_RETRY_MS * 4);
+    if (await isServiceOverview(frame)) {
+      logFirstbankStage("card-bridge-fallback", {
+        path: `/NetBank/ajax/frameFirstCard.html?func=${func}`,
+        detail: key,
+      });
+      await navigateFrame(
+        frame,
+        `${ORIGIN}/NetBank/ajax/frameFirstCard.html?func=${func}`,
+      );
+    }
+  }
   try {
     await waitForCardResponse(captured, key);
   } catch (error) {
     if (!(error instanceof FirstbankActionTimeoutError)) throw error;
+    logFirstbankStage("card-query-timeout", {
+      path: framePathname(frame),
+      elapsedMs: Date.now() - startedAt,
+      detail: key,
+    });
+    throw new FirstbankConnectionError("第一銀行信用卡資料讀取失敗。");
   }
+  logFirstbankStage("card-query-complete", {
+    path: framePathname(frame),
+    elapsedMs: Date.now() - startedAt,
+    detail: key,
+  });
+  return pickCardNavigationFrame(page, frame) ?? frame;
 }
 
 async function openCardFunction(frame: Frame, dataFunc: string) {
+  let prepared = false;
   try {
-    return Boolean(
+    prepared = Boolean(
       await withActionTimeout(
-        frame.evaluate((func) => {
+        frame.evaluate((cardDataFunc) => {
           const link = document.querySelector<HTMLAnchorElement>(
-            `a[data-func="${func}"]`,
+            `a[data-func="${cardDataFunc}"]`,
           );
           if (!link) return false;
           const collapse = link.closest("li.collapse");
@@ -1162,13 +1242,109 @@ async function openCardFunction(frame: Frame, dataFunc: string) {
           const panel = collapse?.querySelector<HTMLElement>(":scope > .panel");
           heading?.click();
           if (panel) panel.style.display = "block";
-          link.click();
           return true;
         }, dataFunc),
       ),
     );
   } catch {
     return false;
+  }
+  if (!prepared) return false;
+  try {
+    await withActionTimeout(frame.click(`a[data-func="${dataFunc}"]`));
+    return true;
+  } catch (error) {
+    if (
+      error instanceof FirstbankActionTimeoutError ||
+      isRecoverableFrameError(error)
+    ) {
+      // A native click may navigate or replace the card frame before the
+      // Runtime call settles. The response listener remains attached.
+      return true;
+    }
+    return false;
+  }
+}
+
+async function navigateToCardHome(page: Page, preferred: Frame) {
+  const homePath = urlPathname(HOME_URL);
+  const target = await waitForCardNavigationFrame(page, preferred);
+  logFirstbankStage("card-navigation-frame", {
+    path: framePathname(target),
+  });
+  if (framePathname(target) !== homePath) await navigateFrame(target, HOME_URL);
+  return waitForReadyFrameByPath(
+    page,
+    homePath,
+    target,
+    "第一銀行信用卡功能頁面尚未載入完成。",
+  );
+}
+
+async function waitForCardNavigationFrame(page: Page, preferred: Frame) {
+  const deadline = Date.now() + ACTION_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const frame = pickCardNavigationFrame(page, preferred);
+    if (frame) return frame;
+    await delay(FRAME_READ_RETRY_MS);
+  }
+  throw new FirstbankConnectionError("第一銀行信用卡功能頁面尚未載入完成。");
+}
+
+async function waitForCardHomeFunctions(page: Page, preferred: Frame) {
+  const homePath = urlPathname(HOME_URL);
+  let frame = await navigateToCardHome(page, preferred);
+  const deadline = Date.now() + ACTION_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const main = (page as Page & { mainFrame?: () => Frame }).mainFrame?.();
+    const candidates = liveFrames(page).filter(
+      (candidate) =>
+        candidate !== main && framePathname(candidate) === homePath,
+    );
+    for (const candidate of candidates) {
+      const availableFunctions = await findCardFunctions(candidate);
+      if (
+        CARD_QUERIES.every(({ dataFunc }) =>
+          availableFunctions.includes(dataFunc),
+        )
+      ) {
+        logFirstbankStage("card-home-ready", {
+          path: framePathname(candidate),
+          detail: "F1632,F1633,F1634",
+        });
+        return candidate;
+      }
+      frame = candidate;
+    }
+    await delay(FRAME_READ_RETRY_MS);
+  }
+  const availableFunctions = await findCardFunctions(frame);
+  const missingFunctions = CARD_QUERIES.filter(
+    ({ dataFunc }) => !availableFunctions.includes(dataFunc),
+  )
+    .map(({ dataFunc }) => dataFunc)
+    .join(",");
+  logFirstbankStage("card-function-timeout", {
+    path: framePathname(frame),
+    detail: missingFunctions || "unknown",
+  });
+  throw new FirstbankConnectionError("第一銀行信用卡功能入口讀取失敗。");
+}
+
+async function findCardFunctions(frame: Frame) {
+  try {
+    const functions = await withActionTimeout(
+      frame.evaluate(() =>
+        ["F1632", "F1633", "F1634"].filter((cardDataFunc) =>
+          Boolean(document.querySelector(`a[data-func="${cardDataFunc}"]`)),
+        ),
+      ),
+    );
+    return Array.isArray(functions)
+      ? functions.filter((value): value is string => typeof value === "string")
+      : [];
+  } catch {
+    return [];
   }
 }
 
@@ -1233,17 +1409,55 @@ async function captureCardResponse(
   captured: CapturedCardResponses,
 ) {
   try {
-    captured[key] = await response.json();
+    storeCardResponse(captured, key, await response.json());
     return;
   } catch {
     try {
       const text = await response.text();
-      captured[key] = JSON.parse(text) as unknown;
+      storeCardResponse(captured, key, JSON.parse(text) as unknown);
     } catch {
       // A matching non-JSON response is ignored; parser must not receive an
       // invented payload that could look like a successful empty sync.
     }
   }
+}
+
+function storeCardResponse(
+  captured: CapturedCardResponses,
+  key: CardPayloadKey,
+  payload: unknown,
+) {
+  const previous = captured[key];
+  captured[key] =
+    key === "recentPayments" && previous !== undefined
+      ? mergeRecentPaymentResponses(previous, payload)
+      : payload;
+}
+
+function mergeRecentPaymentResponses(previous: unknown, next: unknown) {
+  if (!isRecord(previous) || !isRecord(next)) return next;
+  const previousContent = isRecord(previous.CONTENT)
+    ? previous.CONTENT
+    : isRecord(previous.content)
+      ? previous.content
+      : undefined;
+  const nextContent = isRecord(next.CONTENT)
+    ? next.CONTENT
+    : isRecord(next.content)
+      ? next.content
+      : undefined;
+  const previousRecords = previousContent?.Records ?? previousContent?.records;
+  const nextRecords = nextContent?.Records ?? nextContent?.records;
+  if (!Array.isArray(previousRecords) || !Array.isArray(nextRecords)) {
+    return next;
+  }
+  return {
+    ...next,
+    CONTENT: {
+      ...nextContent,
+      Records: [...previousRecords, ...nextRecords],
+    },
+  };
 }
 
 function cardResponseKey(url: string): CardPayloadKey | undefined {
@@ -1280,12 +1494,22 @@ function createTransactionResponseCapture(): TransactionResponseCapture {
 
 function createDepositResponseCapture(): DepositResponseCapture {
   let resolveResponseBody = (_html: string) => {};
+  let resolveRequestObserved = () => {};
   const responseBody = new Promise<string>((resolve) => {
     resolveResponseBody = resolve;
   });
+  const requestObserved = new Promise<void>((resolve) => {
+    resolveRequestObserved = resolve;
+  });
   const capture: DepositResponseCapture = {
     observed: false,
+    requested: false,
     pending: new Set(),
+    requestObserved,
+    settleRequestObserved() {
+      capture.requested = true;
+      resolveRequestObserved();
+    },
     responseBody,
     settleResponseBody(html: string) {
       capture.html = html;
@@ -1892,19 +2116,24 @@ function nestedContentFrame(page: Page, preferred: Frame) {
 async function waitForReadyFrameByPath(
   page: Page,
   path: string,
-  _preferred?: Frame,
+  preferred?: Frame,
+  errorMessage = "第一銀行存款總覽頁面尚未載入完成。",
 ) {
   const deadline = Date.now() + ACTION_TIMEOUT_MS;
   while (Date.now() < deadline) {
-    const candidates = liveFrames(page).filter(
+    const matchingFrames = liveFrames(page).filter(
       (candidate) => framePathname(candidate) === path,
     );
+    const candidates =
+      preferred && matchingFrames.includes(preferred)
+        ? [preferred, ...matchingFrames.filter((frame) => frame !== preferred)]
+        : matchingFrames;
     for (const candidate of candidates) {
       if (await isFrameDocumentReady(candidate)) return candidate;
     }
     await delay(FRAME_READ_RETRY_MS);
   }
-  throw new FirstbankConnectionError("第一銀行存款總覽頁面尚未載入完成。");
+  throw new FirstbankConnectionError(errorMessage);
 }
 
 async function isFrameDocumentReady(frame: Frame) {
@@ -1937,10 +2166,20 @@ async function collectDepositOverview(
       throw new FirstbankConnectionError("第一銀行存款總覽按鈕格式已變更。");
     }
   }
-  const html = await withActionTimeout(
-    capture.responseBody,
-    DEPOSIT_CAPTURE_WAIT_MS,
-  ).catch(() => "");
+  const firstSignal = await Promise.race([
+    capture.responseBody.then((html) => ({ type: "response" as const, html })),
+    capture.requestObserved.then(() => ({ type: "request" as const })),
+    delay(DEPOSIT_REQUEST_GRACE_MS).then(() => ({ type: "timeout" as const })),
+  ]);
+  const html =
+    firstSignal.type === "response"
+      ? firstSignal.html
+      : firstSignal.type === "request"
+        ? await withActionTimeout(
+            capture.responseBody,
+            DEPOSIT_CAPTURE_WAIT_MS,
+          ).catch(() => "")
+        : "";
   if (html) return html;
   if (capture.pending.size > 0) {
     await withActionTimeout(
@@ -1961,7 +2200,7 @@ async function collectDepositOverview(
   }
   logFirstbankStage("deposit-ajax-fallback", {
     path: DEPOSIT_AJAX_PATH,
-    detail: "missing-listener",
+    detail: capture.requested ? "missing-response" : "missing-request",
   });
   // Click did not surface a capturable page response. Do not click again;
   // read the same-origin ajax endpoint from inside the live overview frame.
@@ -2603,6 +2842,34 @@ function pickLiveFrame(page: Page, preferred?: Frame) {
     return preferred;
   }
   return liveFrames(page)[0];
+}
+
+function pickCardNavigationFrame(page: Page, preferred?: Frame) {
+  const main = (page as Page & { mainFrame?: () => Frame }).mainFrame?.();
+  const directChildren = (
+    main as (Frame & { childFrames?: () => Frame[] }) | undefined
+  )?.childFrames?.();
+  const live = liveFrames(page).filter((frame) => frame !== main);
+  const frames =
+    directChildren && directChildren.length > 0
+      ? directChildren.filter((frame) => live.includes(frame))
+      : live;
+  const byPath = (pattern: RegExp) =>
+    frames.find((frame) => pattern.test(framePathname(frame)));
+  return (
+    byPath(/^\/NetBank\/1\/01\.jsp$/i) ??
+    byPath(/^\/NetBank\/2\/010103(?:\.html?)?$/i) ??
+    byPath(/^\/NetBank\/2\/0101(?:\.html?)?$/i) ??
+    (preferred &&
+    frames.includes(preferred) &&
+    !/^\/NetBank\/1\/acntReviewAll\.html$/i.test(framePathname(preferred))
+      ? preferred
+      : undefined) ??
+    frames.find((frame) =>
+      /^\/NetBank\/(?:1|2|ajax)\//i.test(framePathname(frame)),
+    ) ??
+    frames[0]
+  );
 }
 
 function isTransactionResultResponse(url: string) {

--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -36,8 +36,9 @@ const LOGIN_RESULT_POLL_MS = 500;
 const FRAME_TIMEOUT_MS = 15_000;
 const FRAME_READ_RETRY_MS = 250;
 // 010103 may replace and detach its iframe in Browser Rendering. Arm a
-// document-body waiter before submit and keep CDP listeners attached for
-// this window so a delayed responseReceived/loadingFinished can still settle.
+// document-body waiter before submit, intercept 010103 at Fetch response
+// stage, and keep listeners attached so a delayed or non-Document body
+// can still settle.
 const RESULT_CAPTURE_WAIT_MS = 10_000;
 const FRAME_PROBE_TIMEOUT_MS = 1_000;
 const CARD_RESPONSE_TIMEOUT_MS = 10_000;
@@ -84,12 +85,24 @@ type TransactionResponseCapture = {
 
 type TransactionDocumentResponseEvent = {
   requestId: string;
-  type: string;
+  type?: string;
   response: { url: string; status?: number };
 };
 
 type TransactionLoadingEvent = {
   requestId: string;
+};
+
+type NetworkRequestWillBeSentEvent = {
+  type?: string;
+  request: { url: string };
+};
+
+type FetchRequestPausedEvent = {
+  requestId: string;
+  resourceType?: string;
+  request: { url: string };
+  responseStatusCode?: number;
 };
 
 type BrowserResponse = {
@@ -819,17 +832,57 @@ async function collectFirstbankPayloads(
     await cdp.detach().catch(() => undefined);
     throw error;
   }
+  let fetchEnabled = false;
+  try {
+    await cdp.send("Fetch.enable", {
+      patterns: [
+        {
+          urlPattern: `*://${new URL(ORIGIN).host}/NetBank/2/010103*`,
+          requestStage: "Response",
+        },
+      ],
+    });
+    fetchEnabled = true;
+  } catch {
+    logFirstbankStage("010103-fetch-unavailable", {
+      path: "/NetBank/2/010103.html",
+    });
+  }
+  const onTransactionRequest = (event: NetworkRequestWillBeSentEvent) => {
+    const url = event.request?.url ?? "";
+    if (!isFirstbankUrl(url)) return;
+    const path = urlPathname(url);
+    if (!isNetBankTwoPath(path)) return;
+    logFirstbankStage("0101-cdp-request", {
+      path,
+      resourceType: event.type,
+    });
+  };
   const onTransactionDocumentResponse = (
     event: TransactionDocumentResponseEvent,
   ) => {
+    const url = event.response.url;
+    if (!isFirstbankUrl(url)) return;
+    const path = urlPathname(url);
+    const status = event.response.status;
+    const resourceType = event.type;
+    if (isNetBankTwoPath(path) && isCapturableResourceType(resourceType)) {
+      logFirstbankStage("0101-cdp-response", {
+        path,
+        status,
+        resourceType,
+      });
+    }
     if (
       transactionResponse.armed &&
-      event.type === "Document" &&
-      isTransactionResultResponse(event.response.url)
+      isTransactionResultResponse(url) &&
+      isCapturableResourceType(resourceType)
     ) {
-      const path = urlPathname(event.response.url);
-      const status = event.response.status;
-      logFirstbankStage("010103-cdp-response", { path, status });
+      logFirstbankStage("010103-cdp-response", {
+        path,
+        status,
+        resourceType,
+      });
       transactionResponse.requestIds.add(event.requestId);
       transactionResponse.documentMeta.set(event.requestId, { path, status });
     }
@@ -855,9 +908,19 @@ async function collectFirstbankPayloads(
     transactionResponse.requestIds.delete(event.requestId);
     transactionResponse.documentMeta.delete(event.requestId);
   };
+  const onFetchPaused = (event: FetchRequestPausedEvent) => {
+    let task: Promise<void>;
+    task = captureFetchPausedDocument(cdp, event, transactionResponse).finally(
+      () => transactionResponse.pending.delete(task),
+    );
+    transactionResponse.pending.add(task);
+    void task.catch(() => undefined);
+  };
+  cdp.on("Network.requestWillBeSent", onTransactionRequest);
   cdp.on("Network.responseReceived", onTransactionDocumentResponse);
   cdp.on("Network.loadingFinished", onTransactionDocumentLoaded);
   cdp.on("Network.loadingFailed", onTransactionDocumentFailed);
+  if (fetchEnabled) cdp.on("Fetch.requestPaused", onFetchPaused);
   const onResponse = (response: BrowserResponse) => {
     if (
       transactionResponse.armed &&
@@ -911,9 +974,14 @@ async function collectFirstbankPayloads(
     } as unknown as FirstbankPayloads;
   } finally {
     page.off("response", onResponse);
+    cdp.off("Network.requestWillBeSent", onTransactionRequest);
     cdp.off("Network.responseReceived", onTransactionDocumentResponse);
     cdp.off("Network.loadingFinished", onTransactionDocumentLoaded);
     cdp.off("Network.loadingFailed", onTransactionDocumentFailed);
+    if (fetchEnabled) {
+      cdp.off("Fetch.requestPaused", onFetchPaused);
+      await cdp.send("Fetch.disable").catch(() => undefined);
+    }
     await cdp.detach().catch(() => undefined);
   }
 }
@@ -1079,6 +1147,9 @@ async function captureTransactionDocument(
     const body = response.base64Encoded
       ? decodeBase64Text(response.body)
       : response.body;
+    if (typeof body !== "string") {
+      throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
+    }
     logFirstbankStage("010103-cdp-body", {
       path: meta?.path,
       status: meta?.status,
@@ -1110,6 +1181,48 @@ async function captureTransactionResponse(
     capture.settleDocumentBody(html);
   } catch {
     // Invalid 010103 bodies do not mask a later CDP capture or live frame.
+  }
+}
+
+async function captureFetchPausedDocument(
+  cdp: CDPSession,
+  event: FetchRequestPausedEvent,
+  capture: TransactionResponseCapture,
+) {
+  const url = event.request?.url ?? "";
+  const path = urlPathname(url);
+  const status = event.responseStatusCode;
+  try {
+    if (capture.armed && isTransactionResultResponse(url)) {
+      logFirstbankStage("010103-fetch-response", {
+        path,
+        status,
+        resourceType: event.resourceType,
+      });
+      const response = await cdp.send("Fetch.getResponseBody", {
+        requestId: event.requestId,
+      });
+      const body = response.base64Encoded
+        ? decodeBase64Text(response.body)
+        : response.body;
+      if (typeof body !== "string") {
+        throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
+      }
+      logFirstbankStage("010103-fetch-body", {
+        path,
+        status,
+        bodyLength: body.length,
+        hasTxnDateHeader: hasTransactionDateHeader(body),
+      });
+      const html = transactionHistoryFromHtml(body);
+      capture.settleDocumentBody(html);
+    }
+  } catch {
+    // Invalid or unavailable Fetch bodies do not mask a later live frame.
+  } finally {
+    await cdp
+      .send("Fetch.continueRequest", { requestId: event.requestId })
+      .catch(() => undefined);
   }
 }
 
@@ -1171,6 +1284,11 @@ async function waitForTransactionHistory(
   logFirstbankStage("010103-timeout", {
     path: "/NetBank/2/010103.html",
   });
+  for (const frame of liveFrames(page)) {
+    logFirstbankStage("010103-timeout-frame", {
+      path: framePathname(frame),
+    });
+  }
   throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
 }
 
@@ -1239,8 +1357,15 @@ async function hasTransactionSearchControl(frame: Frame) {
 
 async function findLiveTransactionResultFrame(page: Page) {
   for (const frame of liveFrames(page)) {
-    if (!isTransactionResultResponse(frame.url())) continue;
-    await dismissBankNotice(frame, FRAME_PROBE_TIMEOUT_MS);
+    let isResultUrl = false;
+    try {
+      isResultUrl = isTransactionResultResponse(frame.url());
+    } catch {
+      isResultUrl = false;
+    }
+    if (isResultUrl) {
+      await dismissBankNotice(frame, FRAME_PROBE_TIMEOUT_MS);
+    }
     if (await hasTransactionResultHeader(frame, FRAME_PROBE_TIMEOUT_MS)) {
       return frame;
     }
@@ -1856,12 +1981,36 @@ function pickLiveFrame(page: Page, preferred?: Frame) {
 function isTransactionResultResponse(url: string) {
   try {
     const parsed = new URL(url);
-    return (
-      parsed.origin === ORIGIN &&
-      parsed.pathname.toLowerCase() === "/netbank/2/010103.html"
-    );
+    if (parsed.origin !== ORIGIN) return false;
+    const path = parsed.pathname.toLowerCase().split(";")[0];
+    return /\/netbank\/2\/010103(?:\.html?)?$/.test(path);
   } catch {
     return false;
+  }
+}
+
+function isFirstbankUrl(url: string) {
+  try {
+    return new URL(url).origin === ORIGIN;
+  } catch {
+    return false;
+  }
+}
+
+function isNetBankTwoPath(path: string) {
+  return /\/netbank\/2\//i.test(path);
+}
+
+function isCapturableResourceType(type: string | undefined) {
+  if (!type) return true;
+  return /^(document|xhr|fetch|other)$/i.test(type);
+}
+
+function framePathname(frame: Frame) {
+  try {
+    return urlPathname(frame.url());
+  } catch {
+    return "(unavailable)";
   }
 }
 
@@ -1892,6 +2041,7 @@ function logFirstbankStage(
     status?: number;
     bodyLength?: number;
     hasTxnDateHeader?: boolean;
+    resourceType?: string;
   } = {},
 ) {
   const parts = [`[firstbank] ${stage}`];
@@ -1902,6 +2052,9 @@ function logFirstbankStage(
   }
   if (fields.hasTxnDateHeader !== undefined) {
     parts.push(`hasTxnDateHeader=${fields.hasTxnDateHeader}`);
+  }
+  if (fields.resourceType !== undefined) {
+    parts.push(`resourceType=${fields.resourceType}`);
   }
   console.log(parts.join(" "));
 }

--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -19,6 +19,8 @@ const ACCOUNT_OVERVIEW_URL = `${ORIGIN}/NetBank/1/acntReviewAll.html`;
 const HOME_URL = `${ORIGIN}/NetBank/1/01.jsp`;
 const DEPOSIT_AJAX_PATH = "/NetBank/ajax/acntReview1.html";
 const TRANSACTION_URL = `${ORIGIN}/NetBank/2/0101.html`;
+const CHANGE_LANGUAGE_PATH = "/NetBank/chgLanguage.html";
+const ACCEPT_LANGUAGE = "zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7";
 const CAPTCHA_SELECTOR = 'img[src*="code_verify1.jpg"]';
 const CAPTCHA_DIGIT_MIN = 4;
 const CAPTCHA_DIGIT_MAX = 8;
@@ -283,6 +285,7 @@ export function createFirstbankConnector(
         }
         authenticated = true;
 
+        await ensureTraditionalChineseUi(page);
         const payloads = await collectFirstbankPayloads(page);
         const data = parseFirstbankData(payloads);
         const dataWithOptionalRecords = data as typeof data & {
@@ -432,6 +435,7 @@ async function openLoginAndCaptureCaptcha(
   config: FirstbankBrowserConfig,
 ): Promise<CaptchaImage> {
   await gotoAllowingTimeout(page, LOGIN_URL);
+  await switchLoginPageToTraditionalChinese(page);
   await openLoginAndFill(page, config);
 
   try {
@@ -1835,10 +1839,15 @@ async function hasTransactionResultHeader(
         frame.evaluate(() => {
           const rows = Array.from(document.querySelectorAll("tr"));
           return rows.some((row) => {
-            const text = (row.innerText || "").replace(/\s+/g, " ");
-            return (
-              /交易日期|交易日/.test(text) && /支出|存入|交易金額/.test(text)
-            );
+            const text = (row.innerText || "").replace(/\s+/g, "");
+            const hasDate =
+              /交易日期|交易日/.test(text) ||
+              /transactiondate/i.test(text) ||
+              /date/i.test(text);
+            const hasAmount =
+              /支出|存入|交易金額/.test(text) ||
+              /withdrawal|deposit|debit|credit/i.test(text);
+            return Boolean(hasDate && hasAmount);
           });
         }),
         timeoutMs,
@@ -2299,7 +2308,123 @@ async function closeFirstbankBrowser(browser: Browser) {
 async function configurePage(page: Page) {
   await page.setViewport({ width: 1280, height: 800 });
   await page.setUserAgent(USER_AGENT);
+  await page.setExtraHTTPHeaders({
+    "Accept-Language": ACCEPT_LANGUAGE,
+  });
   page.setDefaultNavigationTimeout(NAVIGATION_TIMEOUT_MS);
+}
+
+function localeEvaluateTargets(page: Page): Array<Page | Frame> {
+  const frames = liveFrames(page);
+  return frames.length > 0 ? frames : [page];
+}
+
+/**
+ * 實際英文登入頁（index103.html）的語系控制為
+ * `<a href="#" onclick="ajaxSetLocale('zh_TW');">中文</a>`。
+ * `ajaxSetLocale` 定義於 `/NetBank/include/common_js.jsp`，會 POST
+ * `/NetBank/chgLanguage.html`（`setLocale=`），成功後 reload `index103.html`。
+ * 未登入的 frame.html / 01.jsp 沒有語系選單；銀行 FAQ 說明畫面語言依瀏覽器
+ * Accept-Language（zh-TW）。登入後若找不到該 onclick，不杜撰 selector。
+ */
+async function hasProvenChineseLocaleLink(target: Page | Frame) {
+  try {
+    return Boolean(
+      await withActionTimeout(
+        target.evaluate(() =>
+          Array.from(document.querySelectorAll("a[onclick]")).some((element) =>
+            (element.getAttribute("onclick") || "").includes(
+              "ajaxSetLocale('zh_TW')",
+            ),
+          ),
+        ),
+      ),
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function clickProvenChineseLocaleLink(target: Page | Frame) {
+  try {
+    return Boolean(
+      await withActionTimeout(
+        target.evaluate(() => {
+          const link = Array.from(
+            document.querySelectorAll<HTMLAnchorElement>("a[onclick]"),
+          ).find((element) =>
+            (element.getAttribute("onclick") || "").includes(
+              "ajaxSetLocale('zh_TW')",
+            ),
+          );
+          if (!link) return false;
+          link.click();
+          return true;
+        }),
+      ),
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function postChangeLanguageWithoutNavigation(target: Page | Frame) {
+  try {
+    const result = await withActionTimeout(
+      target.evaluate(async () => {
+        // firstbank-locale-chgLanguage: same path/body as ajaxSetLocale('zh_TW').
+        const response = await fetch("/NetBank/chgLanguage.html", {
+          method: "POST",
+          credentials: "same-origin",
+          redirect: "manual",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: "setLocale=zh_TW",
+        });
+        return { status: response.status };
+      }),
+    );
+    return isRecord(result) && typeof result.status === "number"
+      ? result.status
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function switchLoginPageToTraditionalChinese(page: Page) {
+  for (const target of localeEvaluateTargets(page)) {
+    if (!(await clickProvenChineseLocaleLink(target))) continue;
+    logFirstbankStage("locale-zh-link-clicked", {
+      path: urlPathname(LOGIN_URL),
+      detail: "ajaxSetLocale(zh_TW)",
+    });
+    await page
+      .waitForNavigation({
+        waitUntil: "domcontentloaded",
+        timeout: NAVIGATION_TIMEOUT_MS,
+      })
+      .catch(() => undefined);
+    return;
+  }
+}
+
+async function ensureTraditionalChineseUi(page: Page) {
+  for (const target of localeEvaluateTargets(page)) {
+    if (!(await hasProvenChineseLocaleLink(target))) continue;
+    const status = await postChangeLanguageWithoutNavigation(target);
+    logFirstbankStage("locale-chgLanguage", {
+      path: CHANGE_LANGUAGE_PATH,
+      status,
+      detail: "setLocale=zh_TW",
+    });
+    return;
+  }
+  logFirstbankStage("locale-control-absent", {
+    path: urlPathname(HOME_URL),
+    detail: "no ajaxSetLocale(zh_TW) on frameset/home",
+  });
 }
 
 async function fillInput(page: Page, selector: string, value: string) {
@@ -2561,8 +2686,32 @@ function isFramesetParentNoise(message: string) {
   return /resizeFrame is not a function/i.test(message);
 }
 
+function compactHtmlText(html: string) {
+  return html.replace(/<[^>]+>/g, "").replace(/\s+/g, "");
+}
+
+function hasTransactionDateSignal(text: string) {
+  return (
+    /交易日期|交易日/.test(text) ||
+    /transactiondate/i.test(text) ||
+    /date/i.test(text)
+  );
+}
+
+function hasTransactionAmountSignal(text: string) {
+  return (
+    /支出|存入|交易金額/.test(text) ||
+    /withdrawal|deposit|debit|credit/i.test(text)
+  );
+}
+
+function hasTransactionTableSignals(html: string) {
+  const text = compactHtmlText(html);
+  return hasTransactionDateSignal(text) && hasTransactionAmountSignal(text);
+}
+
 function hasTransactionDateHeader(html: string) {
-  return /交易日期|交易日/.test(html);
+  return hasTransactionDateSignal(compactHtmlText(html));
 }
 
 function logFirstbankStage(
@@ -2655,7 +2804,7 @@ function assertSerializedTransactionTables(html: string) {
       "第一銀行交易明細資料量超過單次同步上限。",
     );
   }
-  if (!/交易日期|交易日/.test(html) || !/支出|存入|交易金額/.test(html)) {
+  if (!hasTransactionTableSignals(html)) {
     throw new FirstbankConnectionError("第一銀行交易明細讀取失敗。");
   }
   return html;

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -120,7 +120,11 @@ function makePage(options?: {
       .fn()
       .mockImplementation(
         async (method: string, params?: { requestId?: string }) => {
-          if (method === "Network.getResponseBody" && params?.requestId) {
+          if (
+            (method === "Network.getResponseBody" ||
+              method === "Fetch.getResponseBody") &&
+            params?.requestId
+          ) {
             const body = cdpBodies.get(params.requestId);
             if (!body)
               throw new Error("No resource with given identifier found");
@@ -222,19 +226,36 @@ function makePage(options?: {
       body: string,
       base64Encoded = false,
       status = 200,
+      resourceType = "Document",
     ) {
       const requestId = "transaction-document";
       cdpBodies.set(requestId, { body, base64Encoded });
       for (const listener of cdpListeners.get("Network.responseReceived") ?? [])
         listener({
           requestId,
-          type: "Document",
+          type: resourceType,
           response: { url, status },
         });
     },
     emitTransactionDocumentLoaded() {
       for (const listener of cdpListeners.get("Network.loadingFinished") ?? [])
         listener({ requestId: "transaction-document" });
+    },
+    emitFetchPaused(
+      url: string,
+      body: string,
+      base64Encoded = false,
+      status = 200,
+    ) {
+      const requestId = "fetch-transaction-document";
+      cdpBodies.set(requestId, { body, base64Encoded });
+      for (const listener of cdpListeners.get("Fetch.requestPaused") ?? [])
+        listener({
+          requestId,
+          resourceType: "Document",
+          request: { url },
+          responseStatusCode: status,
+        });
     },
     emitTransactionDocument(url: string, body: string, base64Encoded = false) {
       const requestId = "transaction-document";
@@ -311,7 +332,12 @@ function detachQueryFrameAfterSearch(
   responseHtml?: string,
   responseUrl = TRANSACTION_RESULT_URL,
   base64Encoded = false,
-  timing?: { delayMs?: number; loadingFinishedDelayMs?: number },
+  timing?: {
+    delayMs?: number;
+    loadingFinishedDelayMs?: number;
+    fetchDelayMs?: number;
+    resourceType?: string;
+  },
 ) {
   const queryFrame = page.frame;
   const previousEvaluate = queryFrame.evaluate;
@@ -326,26 +352,37 @@ function detachQueryFrameAfterSearch(
         queryFrame.detached = true;
         page.frames.mockImplementation(() => nextFrames);
         if (responseHtml !== undefined) {
-          const delayMs = timing?.delayMs ?? 0;
-          const loadingFinishedDelayMs =
-            timing?.loadingFinishedDelayMs ?? delayMs;
-          if (delayMs <= 0 && loadingFinishedDelayMs <= 0) {
-            page.emitTransactionDocument(
-              responseUrl,
-              responseHtml,
-              base64Encoded,
-            );
-          } else {
+          const fetchDelayMs = timing?.fetchDelayMs;
+          if (fetchDelayMs !== undefined) {
+            setTimeout(() => {
+              page.emitFetchPaused(responseUrl, responseHtml, base64Encoded);
+            }, fetchDelayMs);
+          }
+          if (
+            timing?.delayMs !== undefined ||
+            timing?.loadingFinishedDelayMs !== undefined
+          ) {
+            const delayMs = timing?.delayMs ?? 0;
+            const loadingFinishedDelayMs =
+              timing?.loadingFinishedDelayMs ?? delayMs;
             setTimeout(() => {
               page.emitTransactionDocumentReceived(
                 responseUrl,
                 responseHtml,
                 base64Encoded,
+                200,
+                timing?.resourceType ?? "Document",
               );
             }, delayMs);
             setTimeout(() => {
               page.emitTransactionDocumentLoaded();
             }, loadingFinishedDelayMs);
+          } else if (fetchDelayMs === undefined) {
+            page.emitTransactionDocument(
+              responseUrl,
+              responseHtml,
+              base64Encoded,
+            );
           }
         }
         return true;
@@ -835,5 +872,119 @@ describe("第一銀行交易明細 010103 擷取", () => {
         requestId: "transaction-document",
       },
     );
+  });
+
+  it("結果 frame 帶 jsessionid 時仍序列化交易表", async () => {
+    const page = makePage({ authenticated: true });
+    const resultFrame = makeTransactionResultFrame();
+    resultFrame.url.mockReturnValue(
+      `${TRANSACTION_RESULT_URL};jsessionid=synthetic`,
+    );
+    detachQueryFrameAfterSearch(page, [resultFrame]);
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const result = await createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+  });
+
+  it("CDP 資源類型為 Other 時仍擷取延遲的 010103", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      { delayMs: 3_000, resourceType: "Other" },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    await vi.advanceTimersByTimeAsync(4_000);
+    const result = await pending;
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+  });
+
+  it("Network 事件缺失時改從 CDP Fetch.requestPaused 擷取 010103", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      { fetchDelayMs: 3_000 },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    let settled = false;
+    void pending.finally(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await pending;
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+    expect(page.cdpSession.send).toHaveBeenCalledWith("Fetch.enable", {
+      patterns: [
+        {
+          urlPattern: "*://ibank.firstbank.com.tw/NetBank/2/010103*",
+          requestStage: "Response",
+        },
+      ],
+    });
+    expect(page.cdpSession.send).toHaveBeenCalledWith("Fetch.getResponseBody", {
+      requestId: "fetch-transaction-document",
+    });
+    expect(page.cdpSession.send).toHaveBeenCalledWith("Fetch.continueRequest", {
+      requestId: "fetch-transaction-document",
+    });
   });
 });

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -21,6 +21,8 @@ import {
 const LOGIN_URL = "https://ibank.firstbank.com.tw/NetBank/index103.html";
 const LOGIN_LANDING_URL = "https://ibank.firstbank.com.tw/NetBank/login.html";
 const FRAME_URL = "https://ibank.firstbank.com.tw/NetBank/frame.html";
+const ACCOUNT_OVERVIEW_URL =
+  "https://ibank.firstbank.com.tw/NetBank/1/acntReviewAll.html";
 
 const credentials = {
   userId: "A123456789",
@@ -69,9 +71,12 @@ function makeFrame(options?: { authenticated?: boolean }) {
     goto: vi.fn().mockImplementation(async (url: string) => {
       currentUrl = url;
     }),
+    click: vi.fn().mockResolvedValue(undefined),
     waitForNavigation: vi.fn().mockResolvedValue(undefined),
     evaluate: vi.fn().mockImplementation(async (fn: unknown, arg?: unknown) => {
       const source = String(fn);
+      if (source.includes("document.readyState")) return true;
+      if (source.includes("depositTriggerSelector")) return "#btnOpen a";
       if (source.includes("fetch(resourcePath")) {
         return { ok: true, status: 200, text: depositTables };
       }
@@ -86,7 +91,11 @@ function makeFrame(options?: { authenticated?: boolean }) {
           ? transactionTables
           : depositTables;
       }
-      if (source.includes('querySelectorAll("select")')) return true;
+      if (
+        source.includes("acnt") ||
+        source.includes('querySelectorAll("select")')
+      )
+        return true;
       if (source.includes("searchBtn")) return true;
       if (source.includes("帳面餘額") || source.includes("可用餘額"))
         return true;
@@ -143,6 +152,9 @@ function makePage(options?: {
     .fn()
     .mockImplementation(async (fn: unknown, arg?: unknown) => {
       const source = String(fn);
+      if (source.includes("depositTriggerSelector")) {
+        return originalFrameEvaluate(fn, arg);
+      }
       if (source.includes("#btnOpen") || source.includes("#tFunc")) {
         return authenticated;
       }
@@ -242,6 +254,18 @@ function makePage(options?: {
           response: { url, status },
         });
     },
+    dialogs: [] as Array<{ accept: ReturnType<typeof vi.fn> }>,
+    emitDialog(message: string, type = "confirm") {
+      const dialog = {
+        type: () => type,
+        message: () => message,
+        accept: vi.fn().mockResolvedValue(undefined),
+        dismiss: vi.fn().mockResolvedValue(undefined),
+      };
+      page.dialogs.push(dialog);
+      for (const listener of listeners.get("dialog") ?? []) listener(dialog);
+      return dialog;
+    },
     emitCdpLoadingFailed(requestId: string) {
       for (const listener of cdpListeners.get("Network.loadingFailed") ?? [])
         listener({ requestId });
@@ -296,6 +320,14 @@ function makePage(options?: {
     },
     cdpSession,
   };
+  frame.click.mockImplementation(async (selector: string) => {
+    if (selector === "#btnOpen a") {
+      page.emitResponse(
+        "https://ibank.firstbank.com.tw/NetBank/ajax/acntReview1.html",
+        depositTables,
+      );
+    }
+  });
   return page;
 }
 
@@ -325,6 +357,12 @@ function clickedTransactionSearch(frame: ReturnType<typeof makeFrame>) {
       source.includes(".click()")
     );
   });
+}
+
+function probedTransactionHeader(frame: ReturnType<typeof makeFrame>) {
+  return frame.evaluate.mock.calls.some(([fn]) =>
+    String(fn).includes("交易日期"),
+  );
 }
 
 function directlySubmitsForm(frame: ReturnType<typeof makeFrame>) {
@@ -361,6 +399,59 @@ function makeEmptyLiveFrame() {
   return frame;
 }
 
+function mockQueryAccountSelect(
+  frame: ReturnType<typeof makeFrame>,
+  values: Array<{ text: string; value: string; selected?: boolean }>,
+) {
+  const options = values.map((value) => ({
+    ...value,
+    selected: Boolean(value.selected),
+  }));
+  let selectedValue =
+    options.find((option) => option.selected)?.value ?? options[0]?.value ?? "";
+  const dispatchEvent = vi.fn();
+  const select = {
+    options,
+    get selectedIndex() {
+      return options.findIndex((option) => option.selected);
+    },
+    get value() {
+      return selectedValue;
+    },
+    set value(value: string) {
+      selectedValue = value;
+      for (const option of options) option.selected = option.value === value;
+    },
+    dispatchEvent,
+  };
+  const previousEvaluate = frame.evaluate;
+  frame.evaluate = vi
+    .fn()
+    .mockImplementation(async (fn: unknown, arg?: unknown) => {
+      if (!String(fn).includes("acnt")) {
+        return previousEvaluate(fn, arg);
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(
+        globalThis,
+        "document",
+      );
+      Object.defineProperty(globalThis, "document", {
+        configurable: true,
+        value: { querySelector: () => select },
+      });
+      try {
+        return (fn as (shouldSelect: boolean) => unknown)(Boolean(arg));
+      } finally {
+        if (descriptor) {
+          Object.defineProperty(globalThis, "document", descriptor);
+        } else {
+          delete (globalThis as { document?: unknown }).document;
+        }
+      }
+    });
+  return { dispatchEvent, options, select };
+}
+
 function detachQueryFrameAfterSearch(
   page: ReturnType<typeof makePage>,
   nextFrames: Array<ReturnType<typeof makeFrame>>,
@@ -373,9 +464,12 @@ function detachQueryFrameAfterSearch(
     fetchDelayMs?: number;
     resourceType?: string;
     verification?: "response" | "pending" | "failed";
+    verificationDelayMs?: number;
+    dialogMessage?: string;
+    queryFrame?: ReturnType<typeof makeFrame>;
   },
 ) {
-  const queryFrame = page.frame;
+  const queryFrame = timing?.queryFrame ?? page.frame;
   const previousEvaluate = queryFrame.evaluate;
   queryFrame.evaluate = vi
     .fn()
@@ -390,15 +484,21 @@ function detachQueryFrameAfterSearch(
         setTimeout(() => {
           const verification = timing?.verification ?? "response";
           page.emitCdpRequest(VERIFY_DV_URL, "verify-dv");
-          if (verification === "pending") return;
-          if (verification === "failed") {
-            page.emitCdpLoadingFailed("verify-dv");
-            return;
+          if (timing?.dialogMessage !== undefined) {
+            page.emitDialog(timing.dialogMessage);
           }
-          page.emitCdpResponse(VERIFY_DV_URL, "verify-dv");
-          queryFrame.detached = true;
-          page.frames.mockImplementation(() => nextFrames);
-          if (responseHtml !== undefined) {
+          if (verification === "pending") return;
+          // The bank only submits the query once verifyDV settles, so every
+          // later emission is scheduled relative to that verification.
+          setTimeout(() => {
+            if (verification === "failed") {
+              page.emitCdpLoadingFailed("verify-dv");
+              return;
+            }
+            page.emitCdpResponse(VERIFY_DV_URL, "verify-dv");
+            queryFrame.detached = true;
+            page.frames.mockImplementation(() => nextFrames);
+            if (responseHtml === undefined) return;
             const fetchDelayMs = timing?.fetchDelayMs;
             if (fetchDelayMs !== undefined) {
               setTimeout(() => {
@@ -431,7 +531,7 @@ function detachQueryFrameAfterSearch(
                 base64Encoded,
               );
             }
-          }
+          }, timing?.verificationDelayMs ?? 0);
         }, 0);
         return true;
       }
@@ -527,6 +627,11 @@ describe("第一銀行 browser session lifecycle", () => {
 
   it("submits a four-to-eight character CAPTCHA and closes the browser after sync", async () => {
     const page = makePage();
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+    );
     const browser = makeBrowser(page);
     puppeteerMock.sessions.mockResolvedValue([
       { sessionId: "firstbank-session", startTime: Date.now() },
@@ -565,6 +670,11 @@ describe("第一銀行 browser session lifecycle", () => {
 
   it("restores valid cookies without invoking OCR", async () => {
     const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+    );
     const browser = makeBrowser(page);
     puppeteerMock.launch.mockResolvedValue(browser);
     const recognize = vi.fn();
@@ -654,6 +764,189 @@ describe("第一銀行 browser session lifecycle", () => {
 });
 
 describe("第一銀行交易明細 010103 擷取", () => {
+  it("存款總覽依 Recorder 點擊銀行原生 handler 且不注入 fetch", async () => {
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((message) => {
+      logs.push(String(message));
+    });
+    const page = makePage({ authenticated: true });
+    const staleFrame = page.frame;
+    staleFrame.setUrl(ACCOUNT_OVERVIEW_URL);
+    page.goto.mockImplementation(async () => {
+      staleFrame.setUrl(ACCOUNT_OVERVIEW_URL);
+    });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    try {
+      const result = await createFirstbankConnector(
+        {} as Fetcher,
+        vi.fn(),
+      ).sync({
+        ...credentials,
+        sessionCookies: JSON.stringify([
+          {
+            name: "SESSION",
+            value: "encrypted-at-rest",
+            domain: "ibank.firstbank.com.tw",
+          },
+        ]),
+      });
+
+      expect(result.bankTransactions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ amount: -100, description: "測試交易" }),
+        ]),
+      );
+      expect(
+        staleFrame.goto.mock.calls.some(
+          ([url]) => url === ACCOUNT_OVERVIEW_URL,
+        ),
+      ).toBe(false);
+      expect(staleFrame.click).toHaveBeenCalledTimes(1);
+      expect(staleFrame.click).toHaveBeenCalledWith("#btnOpen a");
+      expect(
+        staleFrame.evaluate.mock.calls.some(([fn]) =>
+          String(fn).includes("fetch(resourcePath"),
+        ),
+      ).toBe(false);
+      expect(logs.some((line) => line.includes("deposit-ajax-failed"))).toBe(
+        false,
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("存款總覽 frame replacement 後只在不同且 ready 的 frame 點擊一次", async () => {
+    const page = makePage({ authenticated: true });
+    const staleFrame = page.frame;
+    const replacementFrame = makeFrame({ authenticated: true });
+    let currentFrames = [staleFrame];
+    page.frames.mockImplementation(() => currentFrames);
+    const previousEvaluate = staleFrame.evaluate;
+    staleFrame.evaluate = vi
+      .fn()
+      .mockImplementation(async (fn: unknown, arg?: unknown) => {
+        if (
+          staleFrame.url() === ACCOUNT_OVERVIEW_URL &&
+          String(fn).includes("document.readyState")
+        ) {
+          staleFrame.detached = true;
+          replacementFrame.setUrl(ACCOUNT_OVERVIEW_URL);
+          currentFrames = [replacementFrame];
+          throw new Error("waitForFunction failed: frame got detached");
+        }
+        return previousEvaluate(fn, arg);
+      });
+    replacementFrame.click.mockImplementation(async (selector: string) => {
+      if (selector === "#btnOpen a") {
+        page.emitResponse(
+          "https://ibank.firstbank.com.tw/NetBank/ajax/acntReview1.html",
+          depositTables,
+        );
+      }
+    });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      { queryFrame: replacementFrame },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const result = await createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+
+    expect(result.bankAccounts).toHaveLength(1);
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+    expect(staleFrame.click).not.toHaveBeenCalled();
+    expect(replacementFrame.click).toHaveBeenCalledTimes(1);
+    expect(replacementFrame.click).toHaveBeenCalledWith("#btnOpen a");
+  });
+
+  it("英文 placeholder value 0 不會被選成查詢帳號", async () => {
+    const page = makePage({ authenticated: true });
+    const accountSelect = mockQueryAccountSelect(page.frame, [
+      { text: "--Please select--", value: "0", selected: true },
+      { text: "masked-account", value: "24657009679" },
+    ]);
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const result = await createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+    expect(accountSelect.select.value).toBe("24657009679");
+    expect(accountSelect.options[0]?.selected).toBe(false);
+    expect(accountSelect.options[1]?.selected).toBe(true);
+    expect(accountSelect.dispatchEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it("只有 placeholder 時不送出交易查詢", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    mockQueryAccountSelect(page.frame, [
+      { text: "--Please select--", value: "0", selected: true },
+    ]);
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    const expectation =
+      expect(pending).rejects.toThrow("第一銀行交易明細查詢帳號無法選取。");
+    await vi.advanceTimersByTimeAsync(11_000);
+    await expectation;
+    expect(clickedTransactionSearch(page.frame)).toBe(false);
+  });
+
   it("點擊 searchBtn 後序列化仍存活的 010103 frame", async () => {
     const page = makePage({ authenticated: true });
     const resultFrame = makeTransactionResultFrame();
@@ -844,13 +1137,323 @@ describe("第一銀行交易明細 010103 擷取", () => {
     });
     const expectation =
       expect(pending).rejects.toThrow("第一銀行交易明細前置驗證沒有完成。");
-    await vi.advanceTimersByTimeAsync(11_000);
+    await vi.advanceTimersByTimeAsync(31_000);
     await expectation;
     expect(clickedTransactionSearch(page.frame)).toBe(true);
     expect(page.cdpSession.send).not.toHaveBeenCalledWith(
       "Network.getResponseBody",
       expect.anything(),
     );
+  });
+
+  it("verifyDV 延遲回應時延長等待並擷取 010103", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      { verificationDelayMs: 15_000, delayMs: 1_000 },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    let settled = false;
+    void pending.finally(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(11_000);
+    expect(settled).toBe(false);
+    // A blocked query frame must not be probed with Runtime.evaluate while the
+    // bank's verifyDV request is still in flight.
+    expect(probedTransactionHeader(page.frame)).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(6_000);
+    const result = await pending;
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+    expect(page.cdpSession.send).toHaveBeenCalledWith(
+      "Network.getResponseBody",
+      { requestId: "transaction-document" },
+    );
+  });
+
+  it("查詢跳出原生對話框時自動接受並遮罩訊息數字", async () => {
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((message) => {
+      logs.push(String(message));
+    });
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      { dialogMessage: "查詢區間 20260101 至 20260131 帳號 123456789012" },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    try {
+      const result = await createFirstbankConnector(
+        {} as Fetcher,
+        vi.fn(),
+      ).sync({
+        ...credentials,
+        sessionCookies: JSON.stringify([
+          {
+            name: "SESSION",
+            value: "encrypted-at-rest",
+            domain: "ibank.firstbank.com.tw",
+          },
+        ]),
+      });
+
+      expect(result.bankTransactions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ amount: -100, description: "測試交易" }),
+        ]),
+      );
+      expect(page.dialogs).toHaveLength(1);
+      expect(page.dialogs[0]?.accept).toHaveBeenCalledOnce();
+      const dialogLine = logs.find((line) => line.includes("0101-dialog"));
+      expect(dialogLine).toContain(
+        "detail=confirm:查詢區間 ######## 至 ######## 帳號 ############",
+      );
+      expect(dialogLine).not.toContain("123456789012");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("存款總覽 AJAX 非 2xx 時記錄狀態並回報讀取失敗", async () => {
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((message) => {
+      logs.push(String(message));
+    });
+    const page = makePage({ authenticated: true });
+    page.frame.click.mockImplementation(async (selector: string) => {
+      if (selector === "#btnOpen a") {
+        const response = {
+          url: () =>
+            "https://ibank.firstbank.com.tw/NetBank/ajax/acntReview1.html",
+          status: () => 403,
+          json: vi.fn().mockRejectedValue(new Error("not json")),
+          text: vi.fn().mockResolvedValue(""),
+        };
+        const pageListeners = page.on.mock.calls.find(
+          ([event]) => event === "response",
+        )?.[1] as Listener | undefined;
+        pageListeners?.(response);
+      }
+    });
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    try {
+      await expect(
+        createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+          ...credentials,
+          sessionCookies: JSON.stringify([
+            {
+              name: "SESSION",
+              value: "encrypted-at-rest",
+              domain: "ibank.firstbank.com.tw",
+            },
+          ]),
+        }),
+      ).rejects.toThrow("第一銀行存款總覽讀取失敗。");
+
+      expect(
+        logs.find((line) => line.includes("deposit-ajax path=")),
+      ).toContain("status=403 bodyLength=0");
+      expect(page.frame.click).toHaveBeenCalledTimes(1);
+      expect(logs.some((line) => line.includes("collect-start"))).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("存款總覽回應逾時後不會再次點擊銀行 handler", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    page.frame.click.mockResolvedValue(undefined);
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    const expectation =
+      expect(pending).rejects.toThrow("第一銀行存款總覽讀取失敗。");
+    await vi.advanceTimersByTimeAsync(25_000);
+    await expectation;
+
+    expect(page.frame.click).toHaveBeenCalledTimes(1);
+    expect(page.frame.click).toHaveBeenCalledWith("#btnOpen a");
+  });
+
+  it("交易頁 frame 導覽 replacement 後只在 ready 的 0101 frame 送出一次", async () => {
+    const page = makePage({ authenticated: true });
+    const overviewFrame = page.frame;
+    overviewFrame.setUrl(ACCOUNT_OVERVIEW_URL);
+    const queryFrame = makeFrame({ authenticated: true });
+    queryFrame.setUrl(TRANSACTION_QUERY_URL);
+    const notReadyQueryFrame = makeFrame({ authenticated: true });
+    notReadyQueryFrame.setUrl(TRANSACTION_QUERY_URL);
+    notReadyQueryFrame.evaluate.mockImplementation(async (fn: unknown) => {
+      if (String(fn).includes("document.readyState")) return false;
+      return undefined;
+    });
+    const rootFrame = makeFrame({ authenticated: true });
+    rootFrame.setUrl(FRAME_URL);
+    overviewFrame.goto.mockImplementation(async (url: string) => {
+      overviewFrame.setUrl(url);
+      if (url === TRANSACTION_QUERY_URL) {
+        overviewFrame.detached = true;
+        page.frames.mockImplementation(() => [
+          rootFrame,
+          notReadyQueryFrame,
+          queryFrame,
+        ]);
+        throw new Error("Navigating frame was detached");
+      }
+    });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      { queryFrame },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const result = await createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+    expect(clickedTransactionSearch(overviewFrame)).toBe(false);
+    expect(clickedTransactionSearch(rootFrame)).toBe(false);
+    expect(clickedTransactionSearch(notReadyQueryFrame)).toBe(false);
+    expect(clickedTransactionSearch(queryFrame)).toBe(true);
+  });
+
+  it("找不到 ready 的 0101 replacement 時不會把 root frame 當查詢頁", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    const overviewFrame = page.frame;
+    overviewFrame.setUrl(ACCOUNT_OVERVIEW_URL);
+    const rootFrame = makeFrame({ authenticated: true });
+    rootFrame.setUrl(FRAME_URL);
+    const notReadyQueryFrame = makeFrame({ authenticated: true });
+    notReadyQueryFrame.setUrl(TRANSACTION_QUERY_URL);
+    notReadyQueryFrame.evaluate.mockImplementation(async (fn: unknown) => {
+      if (String(fn).includes("document.readyState")) return false;
+      return undefined;
+    });
+    overviewFrame.goto.mockImplementation(async (url: string) => {
+      overviewFrame.setUrl(url);
+      if (url === TRANSACTION_QUERY_URL) {
+        overviewFrame.detached = true;
+        page.frames.mockImplementation(() => [rootFrame, notReadyQueryFrame]);
+        throw new Error("Waiting failed: Frame detached");
+      }
+    });
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    const expectation = expect(pending).rejects.toThrow(
+      "第一銀行交易明細查詢頁面尚未載入完成。",
+    );
+    await vi.advanceTimersByTimeAsync(11_000);
+    await expectation;
+
+    expect(clickedTransactionSearch(overviewFrame)).toBe(false);
+    expect(clickedTransactionSearch(rootFrame)).toBe(false);
+    expect(clickedTransactionSearch(notReadyQueryFrame)).toBe(false);
+  });
+
+  it("本次 verifyDV 完成前不會採用既有的舊 010103 frame", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    const staleResultFrame = makeTransactionResultFrame();
+    const queryFrame = page.frame;
+    page.frames.mockImplementation(() => [queryFrame, staleResultFrame]);
+    detachQueryFrameAfterSearch(
+      page,
+      [staleResultFrame],
+      undefined,
+      TRANSACTION_RESULT_URL,
+      false,
+      { verification: "pending" },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    const expectation =
+      expect(pending).rejects.toThrow("第一銀行交易明細前置驗證沒有完成。");
+    await vi.advanceTimersByTimeAsync(31_000);
+    await expectation;
+
+    expect(probedTransactionHeader(staleResultFrame)).toBe(false);
   });
 
   it("verifyDV loadingFailed 時回報前置驗證未完成", async () => {

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -37,10 +37,29 @@ const depositTables = `
   </table>
 `;
 
+const englishDepositTables = `
+  <table>
+    <tr class="ResultHeader">
+      <td>Account and Nickname</td><td>Currency</td><td>Ledger Balance</td>
+      <td>Available Balance</td>
+    </tr>
+    <tr class="ResultContent">
+      <td>123456789012</td><td>NTD</td><td>100,000</td><td>90,000</td>
+    </tr>
+  </table>
+`;
+
 const transactionTables = `
   <table>
     <tr class="ResultHeader"><td>交易日期</td><td>支出</td><td>摘要</td></tr>
     <tr class="ResultContent"><td>2026/08/20</td><td>100</td><td>測試交易</td></tr>
+  </table>
+`;
+
+const englishTransactionTables = `
+  <table>
+    <tr class="ResultHeader"><td>Date</td><td>Withdrawal</td><td>Summary</td></tr>
+    <tr class="ResultContent"><td>2026/08/20</td><td>100</td><td>Test txn</td></tr>
   </table>
 `;
 
@@ -214,6 +233,7 @@ function makePage(options?: {
     }),
     setCookie: vi.fn().mockResolvedValue(undefined),
     setDefaultNavigationTimeout: vi.fn(),
+    setExtraHTTPHeaders: vi.fn().mockResolvedValue(undefined),
     setUserAgent: vi.fn().mockResolvedValue(undefined),
     setViewport: vi.fn().mockResolvedValue(undefined),
     mouse: {
@@ -751,9 +771,128 @@ describe("第一銀行 browser session lifecycle", () => {
     });
 
     expect(page.setCookie).toHaveBeenCalledOnce();
+    expect(page.setExtraHTTPHeaders).toHaveBeenCalledWith({
+      "Accept-Language": "zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7",
+    });
     expect(recognize).not.toHaveBeenCalled();
     expect(result.bankAccounts).toHaveLength(1);
     expect(browser.close).toHaveBeenCalledOnce();
+  });
+
+  it("登入後若頁面有 ajaxSetLocale(zh_TW) 則 POST chgLanguage 且不導回登入頁", async () => {
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((message) => {
+      logs.push(String(message));
+    });
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+    );
+    const previousEvaluate = page.frame.evaluate;
+    page.frame.evaluate = vi
+      .fn()
+      .mockImplementation(async (fn: unknown, arg?: unknown) => {
+        const source = String(fn);
+        if (
+          source.includes("ajaxSetLocale('zh_TW')") &&
+          !source.includes(".click()")
+        ) {
+          return true;
+        }
+        if (source.includes("firstbank-locale-chgLanguage")) {
+          return { status: 302 };
+        }
+        return previousEvaluate(fn, arg);
+      });
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    try {
+      await createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+        ...credentials,
+        sessionCookies: JSON.stringify([
+          {
+            name: "SESSION",
+            value: "encrypted-at-rest",
+            domain: "ibank.firstbank.com.tw",
+          },
+        ]),
+      });
+
+      expect(
+        page.frame.evaluate.mock.calls.some(([fn]) =>
+          String(fn).includes("firstbank-locale-chgLanguage"),
+        ),
+      ).toBe(true);
+      expect(
+        page.goto.mock.calls.some(
+          ([url]) =>
+            typeof url === "string" && url.includes("/NetBank/index103.html"),
+        ),
+      ).toBe(false);
+      expect(logs.some((line) => line.includes("locale-chgLanguage"))).toBe(
+        true,
+      );
+      expect(logs.some((line) => line.includes("locale-control-absent"))).toBe(
+        false,
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("英文存款總覽與 010103 表頭仍可解析", async () => {
+    const page = makePage({ authenticated: true });
+    page.frame.click.mockImplementation(async (selector: string) => {
+      if (selector === "#btnOpen a") {
+        page.emitResponse(
+          "https://ibank.firstbank.com.tw/NetBank/ajax/acntReview1.html",
+          englishDepositTables,
+        );
+      }
+    });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeTransactionResultFrame(englishTransactionTables)],
+      englishTransactionTables,
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const result = await createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+
+    expect(result.bankAccounts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceId: expect.stringMatching(/^bank:firstbank:/),
+        }),
+      ]),
+    );
+    expect(result.bankBalanceSnapshots).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          balance: 100000,
+          availableBalance: 90000,
+          currency: "TWD",
+        }),
+      ]),
+    );
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "Test txn" }),
+      ]),
+    );
   });
 
   it("limits automatic OCR to three attempts and rejects malformed answers", async () => {

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -75,6 +75,94 @@ const TRANSACTION_RESULT_URL =
 const TRANSACTION_QUERY_URL =
   "https://ibank.firstbank.com.tw/NetBank/2/0101.html";
 const VERIFY_DV_URL = "https://ibank.firstbank.com.tw/NetBank/2/verifyDV.html";
+const DEPOSIT_AJAX_URL =
+  "https://ibank.firstbank.com.tw/NetBank/ajax/acntReview1.html";
+const HOME_URL = "https://ibank.firstbank.com.tw/NetBank/1/01.jsp";
+const CARD_BRIDGE_URL =
+  "https://ibank.firstbank.com.tw/NetBank/ajax/frameFirstCard.html";
+const CARD_BILL_URL =
+  "https://ccard.firstbank.com.tw/cmsweb/Detail/sendCMSQRY0014";
+const CARD_PAYMENT_URL =
+  "https://ccard.firstbank.com.tw/cmsweb/Detail/sendCMSQRY0006";
+const CARD_UNBILLED_URL =
+  "https://ccard.firstbank.com.tw/cmsweb/Detail/sendCMSQRY0008";
+
+const emptyCardPayloads = {
+  F1632: {
+    url: CARD_BILL_URL,
+    payload: {
+      HEAD: { MSGID: "CMSQRY0014", RETURNCODE: "0000" },
+      CONTENT: { BillRecords: [] },
+    },
+  },
+  F1633: {
+    url: CARD_PAYMENT_URL,
+    payload: {
+      HEAD: { MSGID: "CMSQRY0006", RETURNCODE: "0000" },
+      CONTENT: { Records: [] },
+    },
+  },
+  F1634: {
+    url: CARD_UNBILLED_URL,
+    payload: {
+      HEAD: { MSGID: "CMSQRY0008", RETURNCODE: "0000" },
+      CONTENT: { Records: [] },
+    },
+  },
+} as const;
+
+const cardBillPayload = {
+  HEAD: { MSGID: "CMSQRY0014", RETURNCODE: "0000" },
+  CONTENT: {
+    BillRecords: [
+      {
+        BillDate: "2026/08/03",
+        PayEndDate: "2026/08/18",
+        TotalAmount: "1,234",
+        MinAmount: "500",
+        CreditAmount: "50,000",
+        Records: [
+          {
+            CardNo: "************1234",
+            TransDate: "2026/07/20",
+            AcctDate: "2026/07/22",
+            TransDetail: "測試信用卡消費",
+            AcctAmount: "1,234",
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const recentPaymentPayloads = [
+  {
+    HEAD: { MSGID: "CMSQRY0006", RETURNCODE: "0000" },
+    CONTENT: {
+      Records: [
+        {
+          PayDate: "20260818",
+          Amount: "500",
+          Currency: "TWD",
+          Memo: "測試最近一筆繳款",
+        },
+      ],
+    },
+  },
+  {
+    HEAD: { MSGID: "CMSQRY0006", RETURNCODE: "0000" },
+    CONTENT: {
+      Records: [
+        {
+          PayDate: "20260819",
+          Amount: "25",
+          Currency: "USD",
+          Memo: "測試未出帳繳款",
+        },
+      ],
+    },
+  },
+] as const;
 
 function base64Text(value: string) {
   const bytes = new TextEncoder().encode(value);
@@ -417,7 +505,7 @@ function directlySubmitsForm(frame: ReturnType<typeof makeFrame>) {
 
 function makeTransactionResultFrame(html = transactionTables) {
   const frame = makeFrame({ authenticated: true });
-  frame.url.mockReturnValue(TRANSACTION_RESULT_URL);
+  frame.setUrl(TRANSACTION_RESULT_URL);
   frame.evaluate.mockImplementation(async (fn: unknown) => {
     const source = String(fn);
     if (source.includes("document.readyState")) return true;
@@ -432,9 +520,10 @@ function makeTransactionResultFrame(html = transactionTables) {
 
 function makeEmptyLiveFrame() {
   const frame = makeFrame({ authenticated: true });
-  frame.url.mockReturnValue(TRANSACTION_QUERY_URL);
+  frame.setUrl(TRANSACTION_QUERY_URL);
   frame.evaluate.mockImplementation(async (fn: unknown) => {
     const source = String(fn);
+    if (source.includes("document.readyState")) return true;
     if (source.includes("#btnOpen") || source.includes("#tFunc")) return true;
     if (source.includes("交易日期")) return false;
     if (source.includes('querySelectorAll("table")')) return "";
@@ -515,8 +604,11 @@ function detachQueryFrameAfterSearch(
     emitResultRequest?: boolean;
     replaceDelayMs?: number;
     replaceWith?: Array<ReturnType<typeof makeFrame>>;
+    keepQueryFrameLive?: boolean;
+    staleQueryUrl?: string;
   },
 ) {
+  installCardFlow(page, [...nextFrames, ...(timing?.replaceWith ?? [])]);
   const queryFrame = timing?.queryFrame ?? page.frame;
   const previousEvaluate = queryFrame.evaluate;
   queryFrame.evaluate = vi
@@ -547,7 +639,10 @@ function detachQueryFrameAfterSearch(
             if (verification !== "none") {
               page.emitCdpResponse(VERIFY_DV_URL, "verify-dv");
             }
-            queryFrame.detached = true;
+            queryFrame.detached = !timing?.keepQueryFrameLive;
+            if (timing?.staleQueryUrl) {
+              queryFrame.setUrl(timing.staleQueryUrl);
+            }
             page.frames.mockImplementation(() => nextFrames);
             if (timing?.emitResultRequest) {
               page.emitCdpRequest(
@@ -614,6 +709,48 @@ function detachQueryFrameAfterSearch(
       }
       return previousEvaluate(fn, arg);
     });
+}
+
+function installCardFlow(
+  page: ReturnType<typeof makePage>,
+  frames: Array<ReturnType<typeof makeFrame>>,
+) {
+  for (const frame of new Set(frames)) {
+    const previousEvaluate = frame.evaluate;
+    frame.evaluate = vi
+      .fn()
+      .mockImplementation(async (fn: unknown, arg?: unknown) => {
+        const source = String(fn);
+        if (isCardFunctionProbe(source)) {
+          return ["F1632", "F1633", "F1634"];
+        }
+        if (
+          source.includes("cardDataFunc") &&
+          source.includes("link.closest")
+        ) {
+          return true;
+        }
+        return previousEvaluate(fn, arg);
+      });
+    const previousClick = frame.click;
+    frame.click = vi.fn().mockImplementation(async (selector: string) => {
+      const match = selector.match(/a\[data-func="(F163[234])"\]/);
+      if (!match) return previousClick(selector);
+      const dataFunc = match[1] as keyof typeof emptyCardPayloads;
+      const response = emptyCardPayloads[dataFunc];
+      frame.setUrl(`${CARD_BRIDGE_URL}?func=${dataFunc.slice(-1)}`);
+      page.emitResponse(response.url, response.payload);
+    });
+  }
+}
+
+function isCardFunctionProbe(source: string) {
+  return (
+    source.includes('"F1632"') &&
+    source.includes('"F1633"') &&
+    source.includes('"F1634"') &&
+    source.includes("querySelector")
+  );
 }
 
 beforeEach(() => {
@@ -959,6 +1096,210 @@ describe("第一銀行 browser session lifecycle", () => {
   });
 });
 
+describe("第一銀行信用卡 Browser Run 擷取", () => {
+  it("總覽頁找不到 Recorder 的三個信用卡入口時不再誤報同步成功", async () => {
+    vi.useFakeTimers();
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((message) => {
+      logs.push(String(message));
+    });
+    const page = makePage({ authenticated: true });
+    const cardFrame = makeEmptyLiveFrame();
+    detachQueryFrameAfterSearch(page, [cardFrame], transactionTables);
+    const previousEvaluate = cardFrame.evaluate;
+    cardFrame.evaluate = vi
+      .fn()
+      .mockImplementation(async (fn: unknown, arg?: unknown) => {
+        if (isCardFunctionProbe(String(fn))) return [];
+        return previousEvaluate(fn, arg);
+      });
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    try {
+      const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+        ...credentials,
+        sessionCookies: JSON.stringify([
+          {
+            name: "SESSION",
+            value: "encrypted-at-rest",
+            domain: "ibank.firstbank.com.tw",
+          },
+        ]),
+      });
+      const expectation =
+        expect(pending).rejects.toThrow("第一銀行信用卡功能入口讀取失敗。");
+      await vi.advanceTimersByTimeAsync(12_000);
+      await expectation;
+
+      expect(
+        cardFrame.click.mock.calls.some(([selector]) =>
+          String(selector).includes("data-func"),
+        ),
+      ).toBe(false);
+      expect(logs.join("\n")).toContain(
+        "card-function-timeout path=/NetBank/1/01.jsp detail=F1632,F1633,F1634",
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("排除主 frameset 並等待超過舊 10 秒門檻的帳單回應", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    const mainFrame = makeFrame({ authenticated: true });
+    mainFrame.setUrl(FRAME_URL);
+    const staleOverviewFrame = page.frame;
+    const cardFrame = makeTransactionResultFrame();
+    Object.assign(mainFrame, {
+      childFrames: vi.fn().mockReturnValue([staleOverviewFrame, cardFrame]),
+    });
+    Object.assign(page, { mainFrame: vi.fn().mockReturnValue(mainFrame) });
+    detachQueryFrameAfterSearch(
+      page,
+      [mainFrame, staleOverviewFrame, cardFrame],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      {
+        keepQueryFrameLive: true,
+        staleQueryUrl: ACCOUNT_OVERVIEW_URL,
+      },
+    );
+    const previousGoto = cardFrame.goto;
+    const navigatedFunctions: string[] = [];
+    let activeNavigationTimer: ReturnType<typeof setTimeout> | undefined;
+    let activeResponseTimer: ReturnType<typeof setTimeout> | undefined;
+    cardFrame.goto = vi.fn().mockImplementation(async (url: string) => {
+      if (url === HOME_URL && activeNavigationTimer !== undefined) {
+        clearTimeout(activeNavigationTimer);
+        activeNavigationTimer = undefined;
+      }
+      if (url === HOME_URL && activeResponseTimer !== undefined) {
+        clearTimeout(activeResponseTimer);
+        activeResponseTimer = undefined;
+      }
+      await previousGoto(url);
+    });
+    cardFrame.click = vi.fn().mockImplementation(async (selector: string) => {
+      const match = selector.match(/a\[data-func="(F163[234])"\]/);
+      if (!match) return;
+      const dataFunc = match[1] as keyof typeof emptyCardPayloads;
+      const response = emptyCardPayloads[dataFunc];
+      const payload = dataFunc === "F1632" ? cardBillPayload : response.payload;
+      activeNavigationTimer = setTimeout(() => {
+        activeNavigationTimer = undefined;
+        navigatedFunctions.push(dataFunc);
+        cardFrame.setUrl(`${CARD_BRIDGE_URL}?func=${dataFunc.slice(-1)}`);
+      }, 0);
+      activeResponseTimer = setTimeout(
+        () => {
+          activeResponseTimer = undefined;
+          if (dataFunc === "F1633") {
+            for (const recentPayment of recentPaymentPayloads) {
+              page.emitResponse(response.url, recentPayment);
+            }
+          } else {
+            page.emitResponse(response.url, payload);
+          }
+        },
+        dataFunc === "F1632" ? 12_000 : 250,
+      );
+    });
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    await vi.advanceTimersByTimeAsync(20_000);
+    const result = await pending;
+
+    expect(result.creditCardBills).toEqual([
+      expect.objectContaining({ statementAmount: 1234 }),
+    ]);
+    expect(result.bankAccounts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ accountType: "credit" }),
+      ]),
+    );
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ description: "測試最近一筆繳款" }),
+        expect.objectContaining({ description: "測試未出帳繳款" }),
+      ]),
+    );
+    expect(mainFrame.goto).not.toHaveBeenCalledWith(
+      HOME_URL,
+      expect.anything(),
+    );
+    expect(staleOverviewFrame.goto).not.toHaveBeenCalledWith(
+      HOME_URL,
+      expect.anything(),
+    );
+    expect(navigatedFunctions).toEqual(["F1632", "F1633", "F1634"]);
+    expect(cardFrame.click).toHaveBeenCalledWith('a[data-func="F1632"]');
+    expect(cardFrame.click).toHaveBeenCalledWith('a[data-func="F1633"]');
+    expect(cardFrame.click).toHaveBeenCalledWith('a[data-func="F1634"]');
+  });
+
+  it("信用卡入口已點擊但任一預期 API 未回應時同步失敗", async () => {
+    vi.useFakeTimers();
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((message) => {
+      logs.push(String(message));
+    });
+    const page = makePage({ authenticated: true });
+    const cardFrame = makeEmptyLiveFrame();
+    detachQueryFrameAfterSearch(page, [cardFrame], transactionTables);
+    cardFrame.click = vi.fn().mockImplementation(async (selector: string) => {
+      const match = selector.match(/a\[data-func="(F163[234])"\]/);
+      if (!match) return;
+      const dataFunc = match[1] as keyof typeof emptyCardPayloads;
+      cardFrame.setUrl(`${CARD_BRIDGE_URL}?func=${dataFunc.slice(-1)}`);
+      if (dataFunc === "F1632") {
+        page.emitResponse(CARD_BILL_URL, cardBillPayload);
+      }
+    });
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    try {
+      const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+        ...credentials,
+        sessionCookies: JSON.stringify([
+          {
+            name: "SESSION",
+            value: "encrypted-at-rest",
+            domain: "ibank.firstbank.com.tw",
+          },
+        ]),
+      });
+      const expectation =
+        expect(pending).rejects.toThrow("第一銀行信用卡資料讀取失敗。");
+      await vi.advanceTimersByTimeAsync(35_000);
+      await expectation;
+
+      expect(cardFrame.click).toHaveBeenCalledWith('a[data-func="F1632"]');
+      expect(cardFrame.click).toHaveBeenCalledWith('a[data-func="F1633"]');
+      expect(cardFrame.click).not.toHaveBeenCalledWith('a[data-func="F1634"]');
+      expect(logs.join("\n")).toContain(
+        "card-query-timeout path=/NetBank/ajax/frameFirstCard.html elapsedMs=31000 detail=recentPayments",
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});
+
 describe("第一銀行交易明細 010103 擷取", () => {
   it("存款總覽依 Recorder 點擊銀行原生 handler 且不注入 fetch", async () => {
     const logs: string[] = [];
@@ -1045,7 +1386,15 @@ describe("第一銀行交易明細 010103 擷取", () => {
           },
         ]),
       });
-      await vi.advanceTimersByTimeAsync(20_000);
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(page.frame.click).toHaveBeenCalledTimes(1);
+      expect(fetchedDepositAjax(page.frame)).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(page.frame.click).toHaveBeenCalledTimes(1);
+      expect(fetchedDepositAjax(page.frame)).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(5_000);
       const result = await pending;
 
       expect(result.bankAccounts).toHaveLength(1);
@@ -1066,6 +1415,86 @@ describe("第一銀行交易明細 010103 擷取", () => {
     } finally {
       logSpy.mockRestore();
     }
+  });
+
+  it("CDP 已觀測到存款 POST 時等待原回應而不發 fallback POST", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    page.frame.click.mockImplementation(async (selector: string) => {
+      if (selector !== "#btnOpen a") return;
+      page.emitCdpRequest(DEPOSIT_AJAX_URL, "deposit-request");
+      setTimeout(() => {
+        page.emitResponse(DEPOSIT_AJAX_URL, depositTables);
+      }, 3_000);
+    });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(page.frame.click).toHaveBeenCalledTimes(1);
+    expect(fetchedDepositAjax(page.frame)).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(3_500);
+    const result = await pending;
+    expect(result.bankAccounts).toHaveLength(1);
+    expect(page.frame.click).toHaveBeenCalledTimes(1);
+    expect(fetchedDepositAjax(page.frame)).toBe(false);
+  });
+
+  it("CDP 存款 POST 沒有回應時最多等待五秒才發 fallback POST", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    page.frame.click.mockImplementation(async (selector: string) => {
+      if (selector === "#btnOpen a") {
+        page.emitCdpRequest(DEPOSIT_AJAX_URL, "deposit-request");
+      }
+    });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(page.frame.click).toHaveBeenCalledTimes(1);
+    expect(fetchedDepositAjax(page.frame)).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(page.frame.click).toHaveBeenCalledTimes(1);
+    expect(fetchedDepositAjax(page.frame)).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await pending;
+    expect(result.bankAccounts).toHaveLength(1);
   });
 
   it("parent.resizeFrame 不是函式時不當成失敗也不當成 0101 錯誤", async () => {
@@ -1344,6 +1773,7 @@ describe("第一銀行交易明細 010103 擷取", () => {
       false,
       { verification: "none", emitResultRequest: true },
     );
+    installCardFlow(page, [liveFrame]);
     const browser = makeBrowser(page);
     puppeteerMock.launch.mockResolvedValue(browser);
 
@@ -2070,9 +2500,7 @@ describe("第一銀行交易明細 010103 擷取", () => {
   it("結果 frame 帶 jsessionid 時仍序列化交易表", async () => {
     const page = makePage({ authenticated: true });
     const resultFrame = makeTransactionResultFrame();
-    resultFrame.url.mockReturnValue(
-      `${TRANSACTION_RESULT_URL};jsessionid=synthetic`,
-    );
+    resultFrame.setUrl(`${TRANSACTION_RESULT_URL};jsessionid=synthetic`);
     detachQueryFrameAfterSearch(page, [resultFrame]);
     const browser = makeBrowser(page);
     puppeteerMock.launch.mockResolvedValue(browser);

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -44,6 +44,13 @@ const transactionTables = `
   </table>
 `;
 
+const replacementTransactionTables = `
+  <table>
+    <tr class="ResultHeader"><td>交易日期</td><td>支出</td><td>摘要</td></tr>
+    <tr class="ResultContent"><td>2026/08/21</td><td>250</td><td>替換後交易</td></tr>
+  </table>
+`;
+
 const TRANSACTION_RESULT_URL =
   "https://ibank.firstbank.com.tw/NetBank/2/010103.html";
 const TRANSACTION_QUERY_URL =
@@ -349,14 +356,18 @@ function postedTransactionQuery(frame: ReturnType<typeof makeFrame>) {
 }
 
 function clickedTransactionSearch(frame: ReturnType<typeof makeFrame>) {
-  return frame.evaluate.mock.calls.some(([fn]) => {
+  return transactionSearchClickCount(frame) > 0;
+}
+
+function transactionSearchClickCount(frame: ReturnType<typeof makeFrame>) {
+  return frame.evaluate.mock.calls.filter(([fn]) => {
     const source = String(fn);
     return (
       source.includes("searchBtn") &&
       source.includes("setTimeout") &&
       source.includes(".click()")
     );
-  });
+  }).length;
 }
 
 function probedTransactionHeader(frame: ReturnType<typeof makeFrame>) {
@@ -371,14 +382,15 @@ function directlySubmitsForm(frame: ReturnType<typeof makeFrame>) {
   );
 }
 
-function makeTransactionResultFrame() {
+function makeTransactionResultFrame(html = transactionTables) {
   const frame = makeFrame({ authenticated: true });
   frame.url.mockReturnValue(TRANSACTION_RESULT_URL);
   frame.evaluate.mockImplementation(async (fn: unknown) => {
     const source = String(fn);
+    if (source.includes("document.readyState")) return true;
     if (source.includes("#btnOpen") || source.includes("#tFunc")) return true;
     if (source.includes("交易日期")) return true;
-    if (source.includes('querySelectorAll("table")')) return transactionTables;
+    if (source.includes('querySelectorAll("table")')) return html;
     if (source.includes("searchBtn")) return false;
     return undefined;
   });
@@ -463,10 +475,13 @@ function detachQueryFrameAfterSearch(
     loadingFinishedDelayMs?: number;
     fetchDelayMs?: number;
     resourceType?: string;
-    verification?: "response" | "pending" | "failed";
+    verification?: "response" | "pending" | "failed" | "none";
     verificationDelayMs?: number;
     dialogMessage?: string;
     queryFrame?: ReturnType<typeof makeFrame>;
+    emitResultRequest?: boolean;
+    replaceDelayMs?: number;
+    replaceWith?: Array<ReturnType<typeof makeFrame>>;
   },
 ) {
   const queryFrame = timing?.queryFrame ?? page.frame;
@@ -483,21 +498,42 @@ function detachQueryFrameAfterSearch(
         // first, then the real button click emits the bank requests.
         setTimeout(() => {
           const verification = timing?.verification ?? "response";
-          page.emitCdpRequest(VERIFY_DV_URL, "verify-dv");
+          if (verification !== "none") {
+            page.emitCdpRequest(VERIFY_DV_URL, "verify-dv");
+          }
           if (timing?.dialogMessage !== undefined) {
             page.emitDialog(timing.dialogMessage);
           }
           if (verification === "pending") return;
-          // The bank only submits the query once verifyDV settles, so every
-          // later emission is scheduled relative to that verification.
-          setTimeout(() => {
+
+          const afterVerification = () => {
             if (verification === "failed") {
               page.emitCdpLoadingFailed("verify-dv");
               return;
             }
-            page.emitCdpResponse(VERIFY_DV_URL, "verify-dv");
+            if (verification !== "none") {
+              page.emitCdpResponse(VERIFY_DV_URL, "verify-dv");
+            }
             queryFrame.detached = true;
             page.frames.mockImplementation(() => nextFrames);
+            if (timing?.emitResultRequest) {
+              page.emitCdpRequest(
+                TRANSACTION_RESULT_URL,
+                "result-document",
+                "Document",
+              );
+            }
+            if (
+              timing?.replaceDelayMs !== undefined &&
+              timing.replaceWith !== undefined
+            ) {
+              setTimeout(() => {
+                for (const frame of nextFrames) {
+                  frame.detached = true;
+                }
+                page.frames.mockImplementation(() => timing.replaceWith ?? []);
+              }, timing.replaceDelayMs);
+            }
             if (responseHtml === undefined) return;
             const fetchDelayMs = timing?.fetchDelayMs;
             if (fetchDelayMs !== undefined) {
@@ -531,7 +567,15 @@ function detachQueryFrameAfterSearch(
                 base64Encoded,
               );
             }
-          }, timing?.verificationDelayMs ?? 0);
+          };
+
+          if (verification === "none") {
+            afterVerification();
+            return;
+          }
+          // The bank only submits the query once verifyDV settles, so every
+          // later emission is scheduled relative to that verification.
+          setTimeout(afterVerification, timing?.verificationDelayMs ?? 0);
         }, 0);
         return true;
       }
@@ -980,6 +1024,158 @@ describe("第一銀行交易明細 010103 擷取", () => {
     expect(page.frame.waitForNavigation).not.toHaveBeenCalled();
   });
 
+  it("未觀測到 verifyDV 時仍序列化新出現的 live 010103 frame", async () => {
+    const page = makePage({ authenticated: true });
+    const resultFrame = makeTransactionResultFrame();
+    detachQueryFrameAfterSearch(
+      page,
+      [resultFrame],
+      undefined,
+      TRANSACTION_RESULT_URL,
+      false,
+      { verification: "none" },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const result = await createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          amount: -100,
+          description: "測試交易",
+        }),
+      ]),
+    );
+    expect(clickedTransactionSearch(page.frame)).toBe(true);
+    expect(transactionSearchClickCount(page.frame)).toBe(1);
+    expect(postedTransactionQuery(page.frame)).toBe(false);
+    expect(page.cdpSession.send).not.toHaveBeenCalledWith(
+      "Network.getResponseBody",
+      expect.anything(),
+    );
+    expect(
+      resultFrame.evaluate.mock.calls.some(([fn]) =>
+        String(fn).includes('querySelectorAll("table")'),
+      ),
+    ).toBe(true);
+  });
+
+  it("等待中結果 frame 被置換且 execution context 銷毀後改序列化新 frame", async () => {
+    const page = makePage({ authenticated: true });
+    const staleResultFrame = makeTransactionResultFrame();
+    const dyingFrame = makeFrame({ authenticated: true });
+    const liveFrame = makeTransactionResultFrame(replacementTransactionTables);
+    const queryFrame = page.frame;
+    page.frames.mockImplementation(() => [queryFrame, staleResultFrame]);
+    dyingFrame.setUrl(TRANSACTION_RESULT_URL);
+    dyingFrame.evaluate.mockImplementation(async (fn: unknown) => {
+      const source = String(fn);
+      if (source.includes("document.readyState")) return true;
+      if (source.includes("#btnOpen") || source.includes("#tFunc")) return true;
+      if (source.includes("交易日期")) return true;
+      if (source.includes('querySelectorAll("table")')) {
+        dyingFrame.detached = true;
+        page.frames.mockImplementation(() => [liveFrame]);
+        throw new Error("Execution context was destroyed during navigation");
+      }
+      if (source.includes("searchBtn")) return false;
+      return undefined;
+    });
+    detachQueryFrameAfterSearch(
+      page,
+      [dyingFrame],
+      undefined,
+      TRANSACTION_RESULT_URL,
+      false,
+      { verification: "none", emitResultRequest: true },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const result = await createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          amount: -250,
+          description: "替換後交易",
+        }),
+      ]),
+    );
+    expect(result.bankTransactions).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ description: "測試交易" }),
+      ]),
+    );
+    expect(probedTransactionHeader(staleResultFrame)).toBe(false);
+    expect(transactionSearchClickCount(queryFrame)).toBe(1);
+    expect(page.cdpSession.send).not.toHaveBeenCalledWith(
+      "Network.getResponseBody",
+      expect.anything(),
+    );
+    expect(
+      liveFrame.evaluate.mock.calls.some(([fn]) =>
+        String(fn).includes('querySelectorAll("table")'),
+      ),
+    ).toBe(true);
+  });
+
+  it("未觀測到 verifyDV 時仍接受已擷取的 010103 HTML", async () => {
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      { verification: "none" },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const result = await createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+
+    expect(result.bankTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ amount: -100, description: "測試交易" }),
+      ]),
+    );
+    expect(page.cdpSession.send).toHaveBeenCalledWith(
+      "Network.getResponseBody",
+      { requestId: "transaction-document" },
+    );
+    expect(transactionSearchClickCount(page.frame)).toBe(1);
+  });
+
   it("010103 iframe 消失時改從 CDP document response 讀取明細", async () => {
     const page = makePage({ authenticated: true });
     const liveFrame = makeEmptyLiveFrame();
@@ -1104,6 +1300,7 @@ describe("第一銀行交易明細 010103 擷取", () => {
     await expectation;
     await expect(pending).rejects.toBeInstanceOf(FirstbankConnectionError);
     expect(clickedTransactionSearch(page.frame)).toBe(true);
+    expect(transactionSearchClickCount(page.frame)).toBe(1);
     expect(postedTransactionQuery(page.frame)).toBe(false);
     expect(page.cdpSession.send).not.toHaveBeenCalledWith(
       "Network.getResponseBody",

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -46,6 +46,7 @@ const TRANSACTION_RESULT_URL =
   "https://ibank.firstbank.com.tw/NetBank/2/010103.html";
 const TRANSACTION_QUERY_URL =
   "https://ibank.firstbank.com.tw/NetBank/2/0101.html";
+const VERIFY_DV_URL = "https://ibank.firstbank.com.tw/NetBank/2/verifyDV.html";
 
 function base64Text(value: string) {
   const bytes = new TextEncoder().encode(value);
@@ -74,8 +75,10 @@ function makeFrame(options?: { authenticated?: boolean }) {
       if (source.includes("fetch(resourcePath")) {
         return { ok: true, status: 200, text: depositTables };
       }
-      if (source.includes("searchBtn") && source.includes(".click()")) {
-        currentUrl = TRANSACTION_RESULT_URL;
+      if (source.includes("searchBtn") && source.includes("setTimeout")) {
+        setTimeout(() => {
+          currentUrl = TRANSACTION_RESULT_URL;
+        }, 0);
         return true;
       }
       if (source.includes('querySelectorAll("table")')) {
@@ -87,7 +90,7 @@ function makeFrame(options?: { authenticated?: boolean }) {
       if (source.includes("searchBtn")) return true;
       if (source.includes("帳面餘額") || source.includes("可用餘額"))
         return true;
-      if (source.includes("交易日期")) return true;
+      if (source.includes("交易日期")) return currentUrl.includes("010103");
       if (source.includes("targetLabel")) return false;
       return undefined;
     }),
@@ -221,6 +224,28 @@ function makePage(options?: {
         listener(response);
       return response;
     },
+    emitCdpRequest(url: string, requestId: string, resourceType = "XHR") {
+      for (const listener of cdpListeners.get("Network.requestWillBeSent") ??
+        [])
+        listener({ requestId, type: resourceType, request: { url } });
+    },
+    emitCdpResponse(
+      url: string,
+      requestId: string,
+      status = 200,
+      resourceType = "XHR",
+    ) {
+      for (const listener of cdpListeners.get("Network.responseReceived") ?? [])
+        listener({
+          requestId,
+          type: resourceType,
+          response: { url, status },
+        });
+    },
+    emitCdpLoadingFailed(requestId: string) {
+      for (const listener of cdpListeners.get("Network.loadingFailed") ?? [])
+        listener({ requestId });
+    },
     emitTransactionDocumentReceived(
       url: string,
       body: string,
@@ -292,9 +317,19 @@ function postedTransactionQuery(frame: ReturnType<typeof makeFrame>) {
 }
 
 function clickedTransactionSearch(frame: ReturnType<typeof makeFrame>) {
-  return frame.evaluate.mock.calls.some(
-    ([fn]) =>
-      String(fn).includes("searchBtn") && String(fn).includes(".click()"),
+  return frame.evaluate.mock.calls.some(([fn]) => {
+    const source = String(fn);
+    return (
+      source.includes("searchBtn") &&
+      source.includes("setTimeout") &&
+      source.includes(".click()")
+    );
+  });
+}
+
+function directlySubmitsForm(frame: ReturnType<typeof makeFrame>) {
+  return frame.evaluate.mock.calls.some(([fn]) =>
+    String(fn).includes("form.submit"),
   );
 }
 
@@ -337,6 +372,7 @@ function detachQueryFrameAfterSearch(
     loadingFinishedDelayMs?: number;
     fetchDelayMs?: number;
     resourceType?: string;
+    verification?: "response" | "pending" | "failed";
   },
 ) {
   const queryFrame = page.frame;
@@ -348,43 +384,55 @@ function detachQueryFrameAfterSearch(
       if (queryFrame.detached) {
         throw new Error("Execution context was destroyed during navigation");
       }
-      if (source.includes("searchBtn") && source.includes(".click()")) {
-        queryFrame.detached = true;
-        page.frames.mockImplementation(() => nextFrames);
-        if (responseHtml !== undefined) {
-          const fetchDelayMs = timing?.fetchDelayMs;
-          if (fetchDelayMs !== undefined) {
-            setTimeout(() => {
-              page.emitFetchPaused(responseUrl, responseHtml, base64Encoded);
-            }, fetchDelayMs);
+      if (source.includes("searchBtn") && source.includes("setTimeout")) {
+        // Match the connector's browser-side timer: Runtime.evaluate returns
+        // first, then the real button click emits the bank requests.
+        setTimeout(() => {
+          const verification = timing?.verification ?? "response";
+          page.emitCdpRequest(VERIFY_DV_URL, "verify-dv");
+          if (verification === "pending") return;
+          if (verification === "failed") {
+            page.emitCdpLoadingFailed("verify-dv");
+            return;
           }
-          if (
-            timing?.delayMs !== undefined ||
-            timing?.loadingFinishedDelayMs !== undefined
-          ) {
-            const delayMs = timing?.delayMs ?? 0;
-            const loadingFinishedDelayMs =
-              timing?.loadingFinishedDelayMs ?? delayMs;
-            setTimeout(() => {
-              page.emitTransactionDocumentReceived(
+          page.emitCdpResponse(VERIFY_DV_URL, "verify-dv");
+          queryFrame.detached = true;
+          page.frames.mockImplementation(() => nextFrames);
+          if (responseHtml !== undefined) {
+            const fetchDelayMs = timing?.fetchDelayMs;
+            if (fetchDelayMs !== undefined) {
+              setTimeout(() => {
+                page.emitFetchPaused(responseUrl, responseHtml, base64Encoded);
+              }, fetchDelayMs);
+            }
+            if (
+              timing?.delayMs !== undefined ||
+              timing?.loadingFinishedDelayMs !== undefined
+            ) {
+              const delayMs = timing?.delayMs ?? 0;
+              const loadingFinishedDelayMs =
+                timing?.loadingFinishedDelayMs ?? delayMs;
+              setTimeout(() => {
+                page.emitTransactionDocumentReceived(
+                  responseUrl,
+                  responseHtml,
+                  base64Encoded,
+                  200,
+                  timing?.resourceType ?? "Document",
+                );
+              }, delayMs);
+              setTimeout(() => {
+                page.emitTransactionDocumentLoaded();
+              }, loadingFinishedDelayMs);
+            } else if (fetchDelayMs === undefined) {
+              page.emitTransactionDocument(
                 responseUrl,
                 responseHtml,
                 base64Encoded,
-                200,
-                timing?.resourceType ?? "Document",
               );
-            }, delayMs);
-            setTimeout(() => {
-              page.emitTransactionDocumentLoaded();
-            }, loadingFinishedDelayMs);
-          } else if (fetchDelayMs === undefined) {
-            page.emitTransactionDocument(
-              responseUrl,
-              responseHtml,
-              base64Encoded,
-            );
+            }
           }
-        }
+        }, 0);
         return true;
       }
       return previousEvaluate(fn, arg);
@@ -634,6 +682,7 @@ describe("第一銀行交易明細 010103 擷取", () => {
     );
     expect(clickedTransactionSearch(page.frame)).toBe(true);
     expect(postedTransactionQuery(page.frame)).toBe(false);
+    expect(directlySubmitsForm(page.frame)).toBe(false);
     expect(resultFrame.evaluate).toHaveBeenCalled();
     expect(page.frame.waitForNavigation).not.toHaveBeenCalled();
   });
@@ -769,6 +818,76 @@ describe("第一銀行交易明細 010103 擷取", () => {
     );
   });
 
+  it("verifyDV 只有 request 沒有 response 時回報前置驗證未完成", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      { verification: "pending" },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    const expectation =
+      expect(pending).rejects.toThrow("第一銀行交易明細前置驗證沒有完成。");
+    await vi.advanceTimersByTimeAsync(11_000);
+    await expectation;
+    expect(clickedTransactionSearch(page.frame)).toBe(true);
+    expect(page.cdpSession.send).not.toHaveBeenCalledWith(
+      "Network.getResponseBody",
+      expect.anything(),
+    );
+  });
+
+  it("verifyDV loadingFailed 時回報前置驗證未完成", async () => {
+    vi.useFakeTimers();
+    const page = makePage({ authenticated: true });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+      TRANSACTION_RESULT_URL,
+      false,
+      { verification: "failed" },
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+      ...credentials,
+      sessionCookies: JSON.stringify([
+        {
+          name: "SESSION",
+          value: "encrypted-at-rest",
+          domain: "ibank.firstbank.com.tw",
+        },
+      ]),
+    });
+    const expectation =
+      expect(pending).rejects.toThrow("第一銀行交易明細前置驗證沒有完成。");
+    await vi.advanceTimersByTimeAsync(11_000);
+    await expectation;
+    expect(clickedTransactionSearch(page.frame)).toBe(true);
+    expect(page.cdpSession.send).not.toHaveBeenCalledWith(
+      "Network.getResponseBody",
+      expect.anything(),
+    );
+  });
+
   it("延遲到達的 CDP 010103 document 仍可擷取明細", async () => {
     vi.useFakeTimers();
     const logs: string[] = [];
@@ -780,7 +899,7 @@ describe("第一銀行交易明細 010103 擷取", () => {
       page,
       [makeEmptyLiveFrame()],
       transactionTables,
-      TRANSACTION_RESULT_URL,
+      `${TRANSACTION_RESULT_URL};jsessionid=synthetic-secret`,
       false,
       { delayMs: 3_000 },
     );
@@ -821,6 +940,25 @@ describe("第一銀行交易明細 010103 擷取", () => {
       expect(joined).toContain("status=200");
       expect(joined).toMatch(/bodyLength=\d+/);
       expect(joined).toContain("hasTxnDateHeader=true");
+      const verificationRequestIndex = logs.findIndex((line) =>
+        line.includes("0101-cdp-request path=/NetBank/2/verifyDV.html"),
+      );
+      const verificationResponseIndex = logs.findIndex((line) =>
+        line.includes(
+          "0101-verification-response path=/NetBank/2/verifyDV.html",
+        ),
+      );
+      const transactionResponseIndex = logs.findIndex((line) =>
+        line.includes("010103-cdp-response path=/NetBank/2/010103.html"),
+      );
+      expect(verificationRequestIndex).toBeGreaterThanOrEqual(0);
+      expect(verificationResponseIndex).toBeGreaterThan(
+        verificationRequestIndex,
+      );
+      expect(transactionResponseIndex).toBeGreaterThan(
+        verificationResponseIndex,
+      );
+      expect(joined).not.toContain("synthetic-secret");
       expect(joined).not.toContain("測試交易");
       expect(joined).not.toContain("123456789012");
       expect(joined).not.toContain("encrypted-at-rest");

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -826,12 +826,12 @@ describe("第一銀行 browser session lifecycle", () => {
           String(fn).includes("firstbank-locale-chgLanguage"),
         ),
       ).toBe(true);
+      expect(page.waitForNavigation).not.toHaveBeenCalled();
       expect(
-        page.goto.mock.calls.some(
-          ([url]) =>
-            typeof url === "string" && url.includes("/NetBank/index103.html"),
+        page.goto.mock.calls.filter(([url]) =>
+          String(url).includes("/NetBank/index103.html"),
         ),
-      ).toBe(false);
+      ).toHaveLength(1);
       expect(logs.some((line) => line.includes("locale-chgLanguage"))).toBe(
         true,
       );

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -273,6 +273,11 @@ function makePage(options?: {
       for (const listener of listeners.get("dialog") ?? []) listener(dialog);
       return dialog;
     },
+    emitPageError(message: string) {
+      const error = new Error(message);
+      for (const listener of listeners.get("pageerror") ?? []) listener(error);
+      return error;
+    },
     emitCdpLoadingFailed(requestId: string) {
       for (const listener of cdpListeners.get("Network.loadingFailed") ?? [])
         listener({ requestId });
@@ -346,6 +351,14 @@ function makeBrowser(page: ReturnType<typeof makePage>) {
     newPage: vi.fn().mockResolvedValue(page),
     sessionId: vi.fn().mockReturnValue("firstbank-session"),
   };
+}
+
+function fetchedDepositAjax(frame: ReturnType<typeof makeFrame>) {
+  return frame.evaluate.mock.calls.some(
+    ([fn, arg]) =>
+      String(fn).includes("fetch(resourcePath") &&
+      arg === "/NetBank/ajax/acntReview1.html",
+  );
 }
 
 function postedTransactionQuery(frame: ReturnType<typeof makeFrame>) {
@@ -854,14 +867,106 @@ describe("第一銀行交易明細 010103 擷取", () => {
       ).toBe(false);
       expect(staleFrame.click).toHaveBeenCalledTimes(1);
       expect(staleFrame.click).toHaveBeenCalledWith("#btnOpen a");
-      expect(
-        staleFrame.evaluate.mock.calls.some(([fn]) =>
-          String(fn).includes("fetch(resourcePath"),
-        ),
-      ).toBe(false);
+      expect(fetchedDepositAjax(staleFrame)).toBe(false);
+      expect(logs.some((line) => line.includes("deposit-ajax-fallback"))).toBe(
+        false,
+      );
       expect(logs.some((line) => line.includes("deposit-ajax-failed"))).toBe(
         false,
       );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("存款總覽點擊沒有捕捉到 ajax 時改以 in-frame fetch POST 讀取", async () => {
+    vi.useFakeTimers();
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((message) => {
+      logs.push(String(message));
+    });
+    const page = makePage({ authenticated: true });
+    page.frame.click.mockResolvedValue(undefined);
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    try {
+      const pending = createFirstbankConnector({} as Fetcher, vi.fn()).sync({
+        ...credentials,
+        sessionCookies: JSON.stringify([
+          {
+            name: "SESSION",
+            value: "encrypted-at-rest",
+            domain: "ibank.firstbank.com.tw",
+          },
+        ]),
+      });
+      await vi.advanceTimersByTimeAsync(20_000);
+      const result = await pending;
+
+      expect(result.bankAccounts).toHaveLength(1);
+      expect(result.bankTransactions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ amount: -100, description: "測試交易" }),
+        ]),
+      );
+      expect(page.frame.click).toHaveBeenCalledTimes(1);
+      expect(page.frame.click).toHaveBeenCalledWith("#btnOpen a");
+      expect(fetchedDepositAjax(page.frame)).toBe(true);
+      expect(logs.some((line) => line.includes("deposit-ajax-fallback"))).toBe(
+        true,
+      );
+      expect(logs.some((line) => line.includes("deposit-ajax-failed"))).toBe(
+        false,
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("parent.resizeFrame 不是函式時不當成失敗也不當成 0101 錯誤", async () => {
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((message) => {
+      logs.push(String(message));
+    });
+    const page = makePage({ authenticated: true });
+    const originalClick = page.frame.click.getMockImplementation();
+    page.frame.click.mockImplementation(async (selector: string) => {
+      page.emitPageError("parent.resizeFrame is not a function");
+      if (originalClick) return originalClick(selector);
+    });
+    detachQueryFrameAfterSearch(
+      page,
+      [makeEmptyLiveFrame()],
+      transactionTables,
+    );
+    const browser = makeBrowser(page);
+    puppeteerMock.launch.mockResolvedValue(browser);
+
+    try {
+      const result = await createFirstbankConnector(
+        {} as Fetcher,
+        vi.fn(),
+      ).sync({
+        ...credentials,
+        sessionCookies: JSON.stringify([
+          {
+            name: "SESSION",
+            value: "encrypted-at-rest",
+            domain: "ibank.firstbank.com.tw",
+          },
+        ]),
+      });
+
+      expect(result.bankAccounts).toHaveLength(1);
+      expect(logs.some((line) => line.includes("frameset-noise"))).toBe(true);
+      expect(logs.some((line) => line.includes("0101-page-error"))).toBe(false);
+      expect(page.frame.click).toHaveBeenCalledTimes(1);
     } finally {
       logSpy.mockRestore();
     }
@@ -1482,6 +1587,7 @@ describe("第一銀行交易明細 010103 擷取", () => {
         logs.find((line) => line.includes("deposit-ajax path=")),
       ).toContain("status=403 bodyLength=0");
       expect(page.frame.click).toHaveBeenCalledTimes(1);
+      expect(fetchedDepositAjax(page.frame)).toBe(false);
       expect(logs.some((line) => line.includes("collect-start"))).toBe(true);
     } finally {
       logSpy.mockRestore();
@@ -1492,6 +1598,15 @@ describe("第一銀行交易明細 010103 擷取", () => {
     vi.useFakeTimers();
     const page = makePage({ authenticated: true });
     page.frame.click.mockResolvedValue(undefined);
+    const previousEvaluate = page.frame.evaluate;
+    page.frame.evaluate = vi
+      .fn()
+      .mockImplementation(async (fn: unknown, arg?: unknown) => {
+        if (String(fn).includes("fetch(resourcePath")) {
+          return { ok: false, status: 0, text: "" };
+        }
+        return previousEvaluate(fn, arg);
+      });
     const browser = makeBrowser(page);
     puppeteerMock.launch.mockResolvedValue(browser);
 
@@ -1512,6 +1627,7 @@ describe("第一銀行交易明細 010103 擷取", () => {
 
     expect(page.frame.click).toHaveBeenCalledTimes(1);
     expect(page.frame.click).toHaveBeenCalledWith("#btnOpen a");
+    expect(fetchedDepositAjax(page.frame)).toBe(true);
   });
 
   it("交易頁 frame 導覽 replacement 後只在 ready 的 0101 frame 送出一次", async () => {

--- a/packages/connectors/src/firstbank.ts
+++ b/packages/connectors/src/firstbank.ts
@@ -273,10 +273,31 @@ function parseDepositOverviewHtml(
 
 function parseDepositHeader(cells: string[]): DepositHeader | undefined {
   const labels = cells.map(normalizeLabel);
-  const account = findHeaderIndex(labels, [/帳號.*暱稱/, /帳號/, /帳戶號碼/]);
-  const currency = findHeaderIndex(labels, [/幣別/]);
-  const balance = findHeaderIndex(labels, [/帳面餘額/, /存款餘額/, /^餘額$/]);
-  const availableBalance = findHeaderIndex(labels, [/可用餘額/, /可動用/]);
+  // 英文 iBank 存款表頭：Account / nickname、Currency、Ledger/Book balance、
+  // Available。不可只用 /account/，否則會誤把 Account Type 當帳號欄。
+  const account = findHeaderIndex(labels, [
+    /帳號.*暱稱/,
+    /帳號/,
+    /帳戶號碼/,
+    /account(?:and)?nickname/,
+    /account(?:no|number|num)(?:and)?nickname/,
+    /^account(?:no|number|num)?$/,
+  ]);
+  const currency = findHeaderIndex(labels, [/幣別/, /^currency$/, /^ccy$/]);
+  const balance = findHeaderIndex(labels, [
+    /帳面餘額/,
+    /存款餘額/,
+    /^餘額$/,
+    /ledger(?:book)?balance/,
+    /bookbalance/,
+    /depositbalance/,
+    /^balance$/,
+  ]);
+  const availableBalance = findHeaderIndex(labels, [
+    /可用餘額/,
+    /可動用/,
+    /^available(?:balance)?$/,
+  ]);
   if (
     account === undefined ||
     currency === undefined ||
@@ -285,7 +306,13 @@ function parseDepositHeader(cells: string[]): DepositHeader | undefined {
     return undefined;
   }
   return {
-    accountType: findHeaderIndex(labels, [/帳戶類別/, /帳戶類型/, /帳別/]),
+    accountType: findHeaderIndex(labels, [
+      /帳戶類別/,
+      /帳戶類型/,
+      /帳別/,
+      /^accounttype$/,
+      /accountcategory/,
+    ]),
     account,
     currency,
     balance,
@@ -443,11 +470,37 @@ function parseTransactionHeader(
   cells: string[],
 ): TransactionHeader | undefined {
   const labels = cells.map(normalizeLabel);
-  const date = findHeaderIndex(labels, [/交易日期/, /交易日/, /^日期$/]);
+  const date = findHeaderIndex(labels, [
+    /交易日期/,
+    /交易日/,
+    /^日期$/,
+    /transactiondate/,
+    /txndate/,
+    /^date$/,
+  ]);
   if (date === undefined) return undefined;
-  const debit = findHeaderIndex(labels, [/支出金額/, /^支出$/, /提款/, /扣款/]);
-  const credit = findHeaderIndex(labels, [/存入金額/, /^存入$/, /存款/]);
-  const amount = findHeaderIndex(labels, [/交易金額/, /^金額$/]);
+  const debit = findHeaderIndex(labels, [
+    /支出金額/,
+    /^支出$/,
+    /提款/,
+    /扣款/,
+    /^withdrawal(?:amount)?$/,
+    /^debit(?:amount)?$/,
+    /^withdraw(?:amount)?$/,
+  ]);
+  const credit = findHeaderIndex(labels, [
+    /存入金額/,
+    /^存入$/,
+    /存款/,
+    /^deposit(?:amount)?$/,
+    /^credit(?:amount)?$/,
+  ]);
+  const amount = findHeaderIndex(labels, [
+    /交易金額/,
+    /^金額$/,
+    /transactionamount/,
+    /^amount$/,
+  ]);
   if (debit === undefined && credit === undefined && amount === undefined) {
     return undefined;
   }
@@ -456,12 +509,34 @@ function parseTransactionHeader(
     debit,
     credit,
     amount,
-    balance: findHeaderIndex(labels, [/餘額/, /結餘/]),
-    currency: findHeaderIndex(labels, [/幣別/]),
-    type: findHeaderIndex(labels, [/交易類別/, /^類別$/, /交易種類/]),
-    status: findHeaderIndex(labels, [/交易狀態/, /^狀態$/]),
-    memo: findHeaderIndex(labels, [/備註/, /說明/]),
-    summary: findHeaderIndex(labels, [/摘要/, /明細/]),
+    balance: findHeaderIndex(labels, [
+      /餘額/,
+      /結餘/,
+      /^balance$/,
+      /endingbalance/,
+    ]),
+    currency: findHeaderIndex(labels, [/幣別/, /^currency$/, /^ccy$/]),
+    type: findHeaderIndex(labels, [
+      /交易類別/,
+      /^類別$/,
+      /交易種類/,
+      /transactiontype/,
+      /txtype/,
+    ]),
+    status: findHeaderIndex(labels, [/交易狀態/, /^狀態$/, /^status$/]),
+    memo: findHeaderIndex(labels, [
+      /備註/,
+      /說明/,
+      /^memo$/,
+      /^remarks?$/,
+      /^description$/,
+    ]),
+    summary: findHeaderIndex(labels, [
+      /摘要/,
+      /明細/,
+      /^summary$/,
+      /^particulars?$/,
+    ]),
   };
 }
 
@@ -513,7 +588,7 @@ function parseTransactionRow(
     postedDate: date.date,
     authorizedAt: date.dateTime,
     description,
-    status: /待處理|處理中|未入帳|圈存|pending/i.test(statusText)
+    status: /待處理|處理中|未入帳|圈存|pending|processing/i.test(statusText)
       ? "pending"
       : "posted",
   };
@@ -1099,9 +1174,10 @@ function extractHtmlRows(html: string): HtmlRow[] {
 }
 
 function findPageAccountIdentity(text: string) {
-  const accountLabel = /(?:帳號|帳戶|賬號)\s*[：:]?\s*([^\s，,；;|<]+)/i.exec(
-    text,
-  );
+  const accountLabel =
+    /(?:帳號|帳戶|賬號|account(?:\s*(?:no\.?|number))?)\s*[：:]?\s*([^\s，,；;|<]+)/i.exec(
+      text,
+    );
   return accountLabel?.[1]
     ? extractAccountIdentity(accountLabel[1])?.token
     : undefined;
@@ -1120,7 +1196,10 @@ function extractAccountIdentity(value: unknown) {
   const nickname = text
     .replace(candidate, " ")
     .replace(/[()（）【】\[\]：:|]/g, " ")
-    .replace(/帳號與暱稱|帳號|暱稱/g, " ")
+    .replace(
+      /帳號與暱稱|帳號|暱稱|account\s*and\s*nickname|account\s*\/?\s*nickname|nickname|account(?:\s*(?:no\.?|number))?/gi,
+      " ",
+    )
     .replace(/\s+/g, " ")
     .trim();
   return {
@@ -1151,12 +1230,14 @@ function normalizeCurrency(value: unknown): string | undefined {
   if (typeof value !== "string" && typeof value !== "number") return undefined;
   const text = String(value).trim().toUpperCase();
   if (!text || isDash(text)) return undefined;
-  if (/新臺?幣|臺幣|台幣|NTD?|NT\$/.test(text)) return TWD;
-  if (/美金|美元/.test(text)) return "USD";
-  if (/日圓|日元/.test(text)) return "JPY";
-  if (/歐元/.test(text)) return "EUR";
-  if (/英鎊/.test(text)) return "GBP";
-  if (/港幣|港元/.test(text)) return "HKD";
+  if (/新臺?幣|臺幣|台幣|NTD?|NT\$|NEW\s*TAIWAN\s*DOLLAR/.test(text)) {
+    return TWD;
+  }
+  if (/美金|美元|US\s*DOLLAR/.test(text)) return "USD";
+  if (/日圓|日元|JAPANESE\s*YEN/.test(text)) return "JPY";
+  if (/歐元|EURO/.test(text)) return "EUR";
+  if (/英鎊|POUND\s*STERLING/.test(text)) return "GBP";
+  if (/港幣|港元|HONG\s*KONG\s*DOLLAR/.test(text)) return "HKD";
   const code = text.match(/\b[A-Z]{3}\b/)?.[0] ?? text;
   return SUPPORTED_CURRENCIES.has(code) ? code : undefined;
 }
@@ -1305,7 +1386,9 @@ function isCardSummary(value: string) {
 }
 
 function isNoDataText(value: string) {
-  return /查無(?:資料|符合)|無符合資料|沒有資料|no\s+data/i.test(value);
+  return /查無(?:資料|符合)|無符合資料|沒有資料|no\s+data|no\s+records?/i.test(
+    value,
+  );
 }
 
 function isDash(value: unknown) {

--- a/packages/connectors/tests/selfcheck/firstbank.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/firstbank.selfcheck.ts
@@ -198,6 +198,91 @@ assert.doesNotMatch(serialized, new RegExp(accountNumber));
 assert.doesNotMatch(serialized, /synthetic-password/);
 assert.match(serialized, /8765/);
 
+const englishDepositOverviewHtml = `
+  <table>
+    <tr class="ResultHeader">
+      <td>Branch</td><td>Account<br>Type</td><td>Account<br>and Nickname</td>
+      <td>Currency</td><td>Ledger<br>Balance</td><td>Available<br>Balance</td><td>Other</td>
+    </tr>
+    <tr class="ResultContent">
+      <td>Synthetic Branch</td><td>iLEO Account</td><td>${accountNumber}<br>Daily deposit</td>
+      <td>New Taiwan Dollar</td><td>12,345</td><td>11,000</td><td>-</td>
+    </tr>
+    <tr class="ResultContent">
+      <td>Synthetic Branch</td><td>VISA Debit Card</td><td>4321********8765</td>
+      <td>-</td><td>-</td><td>-</td><td>-</td>
+    </tr>
+  </table>
+`;
+
+const englishBookBalanceOverviewHtml = englishDepositOverviewHtml
+  .replace("Account<br>and Nickname", "Account / nickname")
+  .replace("Ledger<br>Balance", "Book<br>Balance")
+  .replace("Available<br>Balance", "Available")
+  .replace("New Taiwan Dollar", "NTD");
+
+const englishTransactionHistoryHtml = `
+  <div>Account No.: ${accountNumber}</div>
+  <table>
+    <tr class="ResultHeader">
+      <td>Date</td><td>Type</td><td>Withdrawal</td>
+      <td>Deposit</td><td>Balance</td><td>Status</td><td>Memo</td><td>Summary</td>
+    </tr>
+    <tr class="ResultContent">
+      <td>2026/08/20 09:10:11</td><td>Payment</td><td>345</td><td>0</td>
+      <td>12,000</td><td>Normal</td><td>Synthetic shop</td><td>Shopping</td>
+    </tr>
+    <tr class="ResultContent">
+      <td>2026/08/21 10:20:30</td><td>Incoming transfer</td><td>0</td><td>2,000</td>
+      <td>14,000</td><td>Processing</td><td>Synthetic credit</td><td>Payroll</td>
+    </tr>
+  </table>
+`;
+
+const englishParsed = parseFirstbankData(
+  {
+    depositOverviewHtml: englishDepositOverviewHtml,
+    transactionHistoryHtml: englishTransactionHistoryHtml,
+  },
+  now,
+);
+const englishBookParsed = parseFirstbankData(
+  { depositOverviewHtml: englishBookBalanceOverviewHtml },
+  now,
+);
+
+assert.equal(englishParsed.bankAccounts.length, 2);
+assert.equal(
+  englishParsed.bankAccounts.find(
+    (account) => account.accountType === "savings",
+  )?.accountName,
+  "Daily deposit",
+);
+assert.equal(englishParsed.bankBalanceSnapshots[0]?.balance, 12345);
+assert.equal(englishParsed.bankBalanceSnapshots[0]?.availableBalance, 11000);
+assert.equal(englishParsed.bankBalanceSnapshots[0]?.currency, "TWD");
+assert.equal(englishBookParsed.bankBalanceSnapshots[0]?.balance, 12345);
+assert.equal(
+  englishBookParsed.bankBalanceSnapshots[0]?.availableBalance,
+  11000,
+);
+assert.equal(englishParsed.bankTransactions.length, 2);
+assert.equal(
+  englishParsed.bankTransactions.find(
+    (transaction) => transaction.description === "Shopping",
+  )?.amount,
+  -345,
+);
+assert.equal(
+  englishParsed.bankTransactions.find(
+    (transaction) => transaction.description === "Payroll",
+  )?.amount,
+  2000,
+);
+const englishSerialized = JSON.stringify(englishParsed);
+assert.doesNotMatch(englishSerialized, new RegExp(accountNumber));
+assert.match(englishSerialized, /8765/);
+
 assert.deepEqual(
   parseFirstbankData({
     depositOverviewHtml: "<p>查無資料</p>",

--- a/packages/connectors/tests/selfcheck/firstbank.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/firstbank.selfcheck.ts
@@ -251,7 +251,7 @@ const englishBookParsed = parseFirstbankData(
   now,
 );
 
-assert.equal(englishParsed.bankAccounts.length, 2);
+assert.equal(englishParsed.bankAccounts.length, 1);
 assert.equal(
   englishParsed.bankAccounts.find(
     (account) => account.accountType === "savings",
@@ -281,7 +281,7 @@ assert.equal(
 );
 const englishSerialized = JSON.stringify(englishParsed);
 assert.doesNotMatch(englishSerialized, new RegExp(accountNumber));
-assert.match(englishSerialized, /8765/);
+assert.doesNotMatch(englishSerialized, /8765/);
 
 assert.deepEqual(
   parseFirstbankData({


### PR DESCRIPTION
## 問題\n\n第一銀行在 Cloudflare Browser Run 的 iframe 與 CDP 時序不同於本機，曾造成存款總覽、交易明細與信用卡資料擷取失敗；成功後存款總覽另有約 15 秒固定等待。\n\n## 修正\n\n- 保留銀行原生查詢操作，處理 frame replacement、execution context 與延遲 CDP 回應。\n- 補強存款總覽與交易明細的中英文解析及安全 fallback。\n- 完成信用卡帳單、近期繳款及未出帳明細擷取。\n- 存款原生請求未出現時，2 秒後使用 fallback；已出現但未取得回應時最多等待 5 秒。\n- 不因 timeout 重複點擊銀行查詢按鈕。\n\n## 驗證\n\n- Browser Run 已實際成功取得存款、交易與信用卡資料。\n- First Bank tests：43 passed。\n- Worker tests：48 files、436 tests passed。\n- D1 tests：4 passed。\n- Connector self-check、deploy tests、typecheck、format check 均通過。\n\n本 PR 已直接以 main 為 base，並完整包含原 PR #114 的修正。