### PR TITLE
修正台新人工驗證工作階段與中信登入錯誤分類

### DIFF
--- a/apps/worker/src/connectors/taishin.ts
+++ b/apps/worker/src/connectors/taishin.ts
@@ -2,6 +2,8 @@ import puppeteer, {
   type Browser,
   type Frame,
   type Page,
+  type HTTPRequest,
+  type HTTPResponse,
 } from "@cloudflare/puppeteer";
 import {
   BANK_SYNC_MONTHS,
@@ -33,6 +35,17 @@ const USER_AGENT =
 
 type JsonRecord = Record<string, unknown>;
 type BrowserPage = Page | Frame;
+type SessionCheckDiagnostic = {
+  result?: string;
+  httpStatus?: number;
+  isJson?: boolean;
+  timedOut?: boolean;
+  validJson?: boolean;
+  hasApiError?: boolean;
+  expired?: boolean;
+  hasSessionId?: boolean;
+  checkFailed?: boolean;
+};
 export type TaishinSyncStage =
   | "acquire_browser"
   | "initialize_browser_page"
@@ -174,7 +187,11 @@ export function createTaishinConnector(
         const pages = await browserInstance.pages();
         page = pages[0] ?? (await browserInstance.newPage());
         stage = "configure_browser_page";
-        await configurePage(page);
+        // Reconnecting creates a new Puppeteer emulation manager. Setting
+        // isMobile again reloads the preserved page and loses the CAPTCHA form.
+        if (!(config.browserSessionId && config.captcha)) {
+          await configurePage(page);
+        }
         let loggedIn = false;
 
         let pageContext: BrowserPage = page;
@@ -190,7 +207,7 @@ export function createTaishinConnector(
           }
           assertCaptcha(config.captcha, config.captchaDigitCount ?? 6);
           pageContext = await findLoginFrame(page);
-          await submitLogin(pageContext, config.captcha);
+          await submitLogin(pageContext, config.captcha, "manual", page);
           loggedIn = true;
         } else if (config.sessionCookies) {
           stage = "restore_session";
@@ -344,7 +361,7 @@ async function loginWithOcr(
         captcha.digitCount,
       );
       assertCaptcha(answer, captcha.digitCount);
-      await submitLogin(frame, answer);
+      await submitLogin(frame, answer, "automatic", page);
       return frame;
     } catch (error) {
       if (error instanceof TaishinCredentialRejectedError) throw error;
@@ -461,16 +478,34 @@ function hasBillPayload(payload: unknown) {
   );
 }
 
-async function hasValidSession(page: BrowserPage) {
+async function hasValidSession(
+  page: BrowserPage,
+  diagnostic?: SessionCheckDiagnostic,
+) {
   try {
-    const payload = await postJson(page, SESSION_CHECK_PATH, {});
-    return (
-      isRecord(payload) &&
-      payload.RESULT !== "EXPIRED" &&
-      typeof payload.DBSESSIONID === "string" &&
-      payload.DBSESSIONID.length > 0
+    const payload = await postJson(
+      page,
+      SESSION_CHECK_PATH,
+      {},
+      REQUIRED_API_TIMEOUT_MS,
+      diagnostic,
     );
+    const expired = isRecord(payload) && payload.RESULT === "EXPIRED";
+    const hasSessionId =
+      isRecord(payload) &&
+      typeof payload.DBSESSIONID === "string" &&
+      payload.DBSESSIONID.length > 0;
+    if (diagnostic) {
+      const result = isRecord(payload) ? payload.RESULT : undefined;
+      Object.assign(diagnostic, {
+        expired,
+        hasSessionId,
+        result: safeLoginCode(result),
+      });
+    }
+    return !expired && hasSessionId;
   } catch {
+    if (diagnostic) diagnostic.checkFailed = true;
     return false;
   }
 }
@@ -480,6 +515,7 @@ async function postJson(
   path: string,
   body?: JsonRecord | string,
   timeoutMs = REQUIRED_API_TIMEOUT_MS,
+  diagnostic?: SessionCheckDiagnostic,
 ) {
   const response = await page.evaluate(
     async (input: {
@@ -537,6 +573,13 @@ async function postJson(
     { path, body, timeoutMs },
   );
   const endpoint = path.split("/").at(-1) ?? path;
+  if (diagnostic) {
+    Object.assign(diagnostic, {
+      httpStatus: response.status,
+      isJson: response.contentType.includes("application/json"),
+      timedOut: response.timedOut === true,
+    });
+  }
   if (response.timedOut) {
     throw new TaishinTransientConnectionError(
       `台新信用卡 API ${endpoint} 請求逾時。`,
@@ -570,6 +613,10 @@ async function postJson(
   }
   try {
     const payload = JSON.parse(response.text) as unknown;
+    if (diagnostic) {
+      diagnostic.validJson = true;
+      diagnostic.hasApiError = isRecord(payload) && Boolean(payload.error);
+    }
     if (isRecord(payload) && Boolean(payload.error)) {
       const endpoint = path.split("/").at(-1) ?? path;
       const detail = summarizeApiError(payload.error);
@@ -580,6 +627,7 @@ async function postJson(
     return payload;
   } catch (error) {
     if (error instanceof TaishinConnectionError) throw error;
+    if (diagnostic) diagnostic.validJson = false;
     throw new TaishinConnectionError("台新信用卡 API 回應格式無效。");
   }
 }
@@ -817,77 +865,159 @@ async function captureCaptcha(page: BrowserPage) {
   return { bytes, digitCount: target.digitCount };
 }
 
-async function submitLogin(page: BrowserPage, captcha: string) {
-  const captchaInput =
-    'input[data-taishin-field="captcha"], input[placeholder*="驗證碼"]';
-  await typeInput(page, captchaInput, captcha);
-  const loginButton = await page.evaluate(() => {
-    const normalize = (value: string | null | undefined) =>
-      value?.replace(/\s+/g, "").trim() ?? "";
-    const candidates = Array.from(
-      document.querySelectorAll<HTMLElement>("body *"),
-    ).filter((element) => {
-      const rect = element.getBoundingClientRect();
-      const label =
-        element.tagName === "INPUT"
-          ? (element as HTMLInputElement).value
-          : element.innerText;
-      return (
-        !element.hidden &&
-        !("disabled" in element && Boolean(element.disabled)) &&
-        element.getAttribute("aria-disabled") !== "true" &&
-        rect.width > 0 &&
-        rect.height > 0 &&
-        [label, element.getAttribute("aria-label"), element.title].some(
-          (value) => normalize(value) === "登入網銀",
-        )
-      );
+async function submitLogin(
+  page: BrowserPage,
+  captcha: string,
+  mode: "manual" | "automatic" = "automatic",
+  networkPage?: Page,
+) {
+  const startedAt = Date.now();
+  const sessionChecks: SessionCheckDiagnostic[] = [];
+  let loginRequestCount = 0;
+  let loginResponseCount = 0;
+  const pendingResponses: Promise<void>[] = [];
+  const isLoginUrl = (url: string) =>
+    url.split("?")[0] ===
+    "https://my.taishinbank.com.tw/TIBNetBank/svc/web/login/login";
+  const onRequest = (request: HTTPRequest) => {
+    if (isLoginUrl(request.url())) loginRequestCount += 1;
+  };
+  const onResponse = (response: HTTPResponse) => {
+    if (!isLoginUrl(response.url())) return;
+    loginResponseCount += 1;
+    pendingResponses.push(logLoginResponse(response, mode));
+  };
+  networkPage?.on("request", onRequest);
+  networkPage?.on("response", onResponse);
+  try {
+    const captchaInput =
+      'input[data-taishin-field="captcha"], input[placeholder*="驗證碼"]';
+    await typeInput(page, captchaInput, captcha);
+    const loginButton = await page.evaluate(() => {
+      const normalize = (value: string | null | undefined) =>
+        value?.replace(/\s+/g, "").trim() ?? "";
+      const candidates = Array.from(
+        document.querySelectorAll<HTMLElement>("body *"),
+      ).filter((element) => {
+        const rect = element.getBoundingClientRect();
+        const label =
+          element.tagName === "INPUT"
+            ? (element as HTMLInputElement).value
+            : element.innerText;
+        return (
+          !element.hidden &&
+          !("disabled" in element && Boolean(element.disabled)) &&
+          element.getAttribute("aria-disabled") !== "true" &&
+          rect.width > 0 &&
+          rect.height > 0 &&
+          [label, element.getAttribute("aria-label"), element.title].some(
+            (value) => normalize(value) === "登入網銀",
+          )
+        );
+      });
+      const target =
+        candidates.find((element) =>
+          element.matches(
+            'button, a, input[type="button"], input[type="submit"], [role="button"], [class*="btn"], [class*="button"]',
+          ),
+        ) ?? candidates.at(-1);
+      if (!target) return false;
+      target.dataset.taishinLogin = "submit";
+      target.click();
+      return true;
     });
-    const target =
-      candidates.find((element) =>
-        element.matches(
-          'button, a, input[type="button"], input[type="submit"], [role="button"], [class*="btn"], [class*="button"]',
-        ),
-      ) ?? candidates.at(-1);
-    if (!target) return false;
-    target.dataset.taishinLogin = "submit";
-    target.click();
-    return true;
-  });
-  if (!loginButton) {
-    throw new TaishinConnectionError("台新登入按鈕結構已變更。");
-  }
+    if (!loginButton) {
+      throw new TaishinConnectionError("台新登入按鈕結構已變更。");
+    }
 
-  for (let attempt = 0; attempt < LOGIN_RESULT_ATTEMPTS; attempt += 1) {
-    const detail = await readLoginDetail(page);
-    if (isCaptchaRejected(detail)) {
-      throw new TaishinCaptchaRejectedError("台新圖形驗證碼錯誤。");
+    for (let attempt = 0; attempt < LOGIN_RESULT_ATTEMPTS; attempt += 1) {
+      const detail = await readLoginDetail(page);
+      if (isCaptchaRejected(detail)) {
+        throw new TaishinCaptchaRejectedError("台新圖形驗證碼錯誤。");
+      }
+      if (isCredentialRejected(detail)) {
+        throw new TaishinCredentialRejectedError(
+          "台新登入資料遭銀行拒絕，請確認設定。",
+        );
+      }
+      if (/USER\s*正在線上.*無法登入/i.test(detail)) {
+        throw new TaishinVerificationRequiredError(
+          "台新網銀已有使用中連線，請先登出後再試。",
+        );
+      }
+      const diagnostic: SessionCheckDiagnostic = {};
+      sessionChecks.push(diagnostic);
+      if (await hasValidSession(page, diagnostic)) return;
+      if (attempt < LOGIN_RESULT_ATTEMPTS - 1) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, LOGIN_RESULT_POLL_MS),
+        );
+      }
     }
-    if (isCredentialRejected(detail)) {
-      throw new TaishinCredentialRejectedError(
-        "台新登入資料遭銀行拒絕，請確認設定。",
-      );
-    }
-    if (/USER\s*正在線上.*無法登入/i.test(detail)) {
-      throw new TaishinVerificationRequiredError(
-        "台新網銀已有使用中連線，請先登出後再試。",
-      );
-    }
-    if (await hasValidSession(page)) return;
-    if (attempt < LOGIN_RESULT_ATTEMPTS - 1) {
-      await new Promise((resolve) => setTimeout(resolve, LOGIN_RESULT_POLL_MS));
-    }
-  }
 
-  throw new TaishinLoginOutcomeUnknownError(
-    "台新銀行登入失敗，請改用人工驗證。",
+    console.warn(
+      JSON.stringify({
+        event: "taishin_login_outcome_unknown",
+        mode,
+        attempts: sessionChecks.length,
+        elapsedMs: Date.now() - startedAt,
+        sessionChecks,
+        loginRequestCount,
+        loginResponseCount,
+      }),
+    );
+    throw new TaishinLoginOutcomeUnknownError(
+      mode === "manual"
+        ? "台新人工驗證已送出，但尚未確認登入成功，請稍後重新取得驗證碼再試。"
+        : "台新自動驗證已送出，但尚未確認登入成功。",
+    );
+  } finally {
+    networkPage?.off("request", onRequest);
+    networkPage?.off("response", onResponse);
+    await Promise.all(pendingResponses);
+  }
+}
+
+function safeLoginCode(value: unknown) {
+  if (typeof value !== "string") return "missing";
+  if (!value) return "empty";
+  return /^[A-Z][A-Z0-9_]{0,23}$/.test(value) || /^[0-9]{1,3}$/.test(value)
+    ? value
+    : "unrecognized";
+}
+
+async function logLoginResponse(
+  response: HTTPResponse,
+  mode: "manual" | "automatic",
+) {
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    // Do not log response bodies or upstream exception messages.
+  }
+  console.warn(
+    JSON.stringify({
+      event: "taishin_login_response",
+      mode,
+      httpStatus: response.status(),
+      validJson: payload !== undefined,
+      result: safeLoginCode(isRecord(payload) ? payload.RESULT : undefined),
+      status: safeLoginCode(isRecord(payload) ? payload.STATUS : undefined),
+      hasErrorMessage: isRecord(payload) && Boolean(payload.ERRORMSG),
+    }),
   );
 }
 
 async function readLoginDetail(page: BrowserPage) {
   return page
     .evaluate(() =>
-      (document.body?.innerText ?? "")
+      (
+        document.querySelector<HTMLElement>(".js-popup.active ._popup_text")
+          ?.innerText ||
+        document.body?.innerText ||
+        ""
+      )
         .replace(/\s+/g, " ")
         .trim()
         .slice(0, 1_000),

--- a/apps/worker/tests/connectors/ctbc.test.ts
+++ b/apps/worker/tests/connectors/ctbc.test.ts
@@ -265,6 +265,69 @@ describe("CTBC mobile API connector", () => {
     });
   });
 
+  it.each([
+    { label: "without a description", response: { sys: "SVC", code: "X999" } },
+    {
+      label: "with a maintenance description",
+      response: {
+        sys: "SVC",
+        code: "X999",
+        desc: "系統維護中，暫停登入服務",
+      },
+    },
+  ])(
+    "treats SVC/X999 login failures as connection errors $label",
+    async ({ response }) => {
+      const responses = [
+        jsonResponse({ access_token: "oauth-token" }),
+        jsonResponse({ statusCode: "0000" }),
+        jsonResponse({
+          success: true,
+          rsData: { seed: "seed" },
+          token: "token",
+        }),
+        jsonResponse(response),
+      ];
+      const fetcher = vi.fn(async () => responses.shift()!) as CtbcFetch;
+
+      await expect(
+        createCtbcConnector(fetcher).sync({
+          userId: "A123456789",
+          account: "bank-user",
+          password: "bank-password",
+        }),
+      ).rejects.toMatchObject({
+        name: "CtbcConnectionError",
+        message: "中國信託資料同步暫時無法完成。",
+      });
+    },
+  );
+
+  it("turns an explicit needOTP flag in a failed response into a user-action error", async () => {
+    const responses = [
+      jsonResponse({ access_token: "oauth-token" }),
+      jsonResponse({ statusCode: "0000" }),
+      jsonResponse({ success: true, rsData: { seed: "seed" }, token: "token" }),
+      jsonResponse({
+        sys: "SVC",
+        code: "X999",
+        rsData: { needOTP: true },
+      }),
+    ];
+    const fetcher = vi.fn(async () => responses.shift()!) as CtbcFetch;
+
+    await expect(
+      createCtbcConnector(fetcher).sync({
+        userId: "A123456789",
+        account: "bank-user",
+        password: "bank-password",
+      }),
+    ).rejects.toMatchObject({
+      name: "CtbcVerificationRequiredError",
+      message: "中國信託登入需要重新驗證，請先至官方 App 完成驗證。",
+    });
+  });
+
   it("logs only safe account diagnostics when deposit initialization fails", async () => {
     const accountId = "123456789012";
     const responses = [

--- a/apps/worker/tests/connectors/taishin-session.test.ts
+++ b/apps/worker/tests/connectors/taishin-session.test.ts
@@ -13,6 +13,7 @@ import {
   createTaishinConnector,
   prepareTaishinCaptcha,
   TaishinBrowserCapacityError,
+  TaishinCaptchaRejectedError,
   TaishinConnectionError,
   TaishinCredentialRejectedError,
   TaishinSyncStageError,
@@ -36,6 +37,55 @@ const captchaTarget = {
   digitCount: 6,
 };
 
+const SECRET_PAGE_TEXT = "raw-secret-login-page";
+const SECRET_SESSION_BODY = "raw-secret-session-body";
+const SECRET_ERROR_MESSAGE = "raw-secret-error-message";
+
+const manualUnknownCases = [
+  {
+    name: "HTTP 200 JSON without a session id",
+    response: () => ({
+      ok: true,
+      status: 200,
+      contentType: "application/json",
+      text: JSON.stringify({
+        RESULT: "SUCCESS",
+        diagnostic: SECRET_SESSION_BODY,
+      }),
+      timedOut: false,
+      errorName: "",
+      errorMessage: SECRET_ERROR_MESSAGE,
+    }),
+    sessionCheck: {
+      httpStatus: 200,
+      isJson: true,
+      timedOut: false,
+      validJson: true,
+      hasApiError: false,
+      expired: false,
+      hasSessionId: false,
+    },
+  },
+  {
+    name: "HTTP 503 session check",
+    response: () => ({
+      ok: false,
+      status: 503,
+      contentType: "application/json",
+      text: JSON.stringify({ error: SECRET_SESSION_BODY }),
+      timedOut: false,
+      errorName: "",
+      errorMessage: SECRET_ERROR_MESSAGE,
+    }),
+    sessionCheck: {
+      httpStatus: 503,
+      isJson: true,
+      timedOut: false,
+      checkFailed: true,
+    },
+  },
+] as const;
+
 function page() {
   return {
     $: vi.fn().mockResolvedValue({
@@ -43,6 +93,8 @@ function page() {
     }),
     click: vi.fn().mockResolvedValue(undefined),
     evaluate: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
     goto: vi.fn().mockResolvedValue(undefined),
     cookies: vi
       .fn()
@@ -622,7 +674,7 @@ describe("Taishin browser session lifecycle", () => {
     expect(browserInstance.disconnect).toHaveBeenCalledOnce();
   });
 
-  it("closes the manual browser when CAPTCHA verification fails", async () => {
+  it("preserves the CAPTCHA page on reconnect and closes it after rejection", async () => {
     const browserPage = page();
     browserPage.evaluate
       .mockResolvedValueOnce(true)
@@ -643,6 +695,10 @@ describe("Taishin browser session lifecycle", () => {
       }),
     ).rejects.toThrow("圖形驗證碼錯誤");
 
+    // Reapplying mobile emulation on a reconnected Page triggers a reload.
+    expect(browserPage.setViewport).not.toHaveBeenCalled();
+    expect(browserPage.setUserAgent).not.toHaveBeenCalled();
+    expect(browserPage.goto).not.toHaveBeenCalled();
     expect(browserInstance.close).toHaveBeenCalledOnce();
     expect(browserInstance.disconnect).not.toHaveBeenCalled();
   });
@@ -694,6 +750,240 @@ describe("Taishin browser session lifecycle", () => {
     expect(loginButton.click).toHaveBeenCalledOnce();
     expect(browserPage.click).not.toHaveBeenCalled();
   });
+
+  it("prioritizes an active popup when rejecting a CAPTCHA", async () => {
+    const browserPage = page();
+    const popup = { innerText: "驗證碼輸入錯誤" };
+    const querySelector = vi.fn().mockReturnValue(popup);
+    const noisyBodyText = `${"x".repeat(2_000)}-footer`;
+    browserPage.evaluate
+      .mockResolvedValueOnce(true)
+      .mockImplementationOnce(async (callback: () => unknown) => {
+        vi.stubGlobal("document", {
+          querySelector,
+          body: { innerText: noisyBodyText },
+        });
+        try {
+          return callback();
+        } finally {
+          vi.unstubAllGlobals();
+        }
+      });
+    const browserInstance = browser(browserPage);
+    puppeteerMock.sessions.mockResolvedValue([
+      { sessionId: "taishin-session", startTime: Date.now() },
+    ]);
+    puppeteerMock.connect.mockResolvedValue(browserInstance);
+
+    await expect(
+      createTaishinConnector({} as Fetcher).sync({
+        ...credentials,
+        browserSessionId: "taishin-session",
+        browserSessionExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+        captchaDigitCount: 6,
+        captcha: "123456",
+      }),
+    ).rejects.toBeInstanceOf(TaishinCaptchaRejectedError);
+
+    expect(querySelector).toHaveBeenCalledWith(".js-popup.active ._popup_text");
+    expect(browserPage.evaluate).toHaveBeenCalledTimes(2);
+    expect(browserInstance.close).toHaveBeenCalledOnce();
+  });
+
+  it("records a safe manual login response diagnostic", async () => {
+    const browserPage = page();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    type EventHandler = (payload: unknown) => void | Promise<void>;
+    const handlers = new Map<string, Set<EventHandler>>();
+    browserPage.on.mockImplementation(
+      (event: string, handler: EventHandler) => {
+        const eventHandlers = handlers.get(event) ?? new Set<EventHandler>();
+        eventHandlers.add(handler);
+        handlers.set(event, eventHandlers);
+        return browserPage;
+      },
+    );
+    browserPage.off.mockImplementation(
+      (event: string, handler: EventHandler) => {
+        handlers.get(event)?.delete(handler);
+        return browserPage;
+      },
+    );
+    const emit = async (event: string, payload: unknown) => {
+      await Promise.all(
+        [...(handlers.get(event) ?? [])].map((handler) =>
+          Promise.resolve(handler(payload)),
+        ),
+      );
+    };
+    const loginUrl =
+      "https://my.taishinbank.com.tw/TIBNetBank/svc/web/login/login";
+    const loginRequest = { url: vi.fn().mockReturnValue(loginUrl) };
+    const loginResponse = {
+      url: vi.fn().mockReturnValue(loginUrl),
+      status: vi.fn().mockReturnValue(200),
+      json: vi.fn().mockResolvedValue({
+        RESULT: "FAIL",
+        STATUS: "A",
+        ERRORMSG: "private-body",
+        TOKEN: "secret-token",
+      }),
+    };
+    let clickEvents: Promise<void> | undefined;
+    const loginButton = {
+      tagName: "BUTTON",
+      innerText: "登入網銀",
+      hidden: false,
+      title: "",
+      dataset: {} as Record<string, string>,
+      getAttribute: vi.fn().mockReturnValue(null),
+      getBoundingClientRect: vi
+        .fn()
+        .mockReturnValue({ width: 300, height: 50 }),
+      matches: vi.fn().mockReturnValue(true),
+      click: vi.fn(() => {
+        clickEvents = Promise.all([
+          emit("request", loginRequest),
+          emit("response", loginResponse),
+        ]).then(() => undefined);
+      }),
+    };
+    browserPage.evaluate
+      .mockImplementationOnce(async (callback: () => unknown) => {
+        vi.stubGlobal("document", {
+          querySelectorAll: vi.fn().mockReturnValue([loginButton]),
+        });
+        try {
+          const result = callback();
+          if (clickEvents) await clickEvents;
+          return result;
+        } finally {
+          vi.unstubAllGlobals();
+        }
+      })
+      .mockResolvedValueOnce("驗證碼輸入錯誤");
+    const browserInstance = browser(browserPage);
+    puppeteerMock.sessions.mockResolvedValue([
+      { sessionId: "taishin-session", startTime: Date.now() },
+    ]);
+    puppeteerMock.connect.mockResolvedValue(browserInstance);
+
+    try {
+      await expect(
+        createTaishinConnector({} as Fetcher).sync({
+          ...credentials,
+          browserSessionId: "taishin-session",
+          browserSessionExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+          captchaDigitCount: 6,
+          captcha: "123456",
+        }),
+      ).rejects.toBeInstanceOf(TaishinCaptchaRejectedError);
+
+      expect(browserPage.on).toHaveBeenCalledWith(
+        "request",
+        expect.any(Function),
+      );
+      expect(browserPage.on).toHaveBeenCalledWith(
+        "response",
+        expect.any(Function),
+      );
+      expect(browserPage.off).toHaveBeenCalledWith(
+        "request",
+        expect.any(Function),
+      );
+      expect(browserPage.off).toHaveBeenCalledWith(
+        "response",
+        expect.any(Function),
+      );
+      expect(loginRequest.url).toHaveBeenCalledOnce();
+      expect(loginResponse.url).toHaveBeenCalledOnce();
+      expect(loginResponse.status).toHaveBeenCalledOnce();
+      expect(loginResponse.json).toHaveBeenCalledOnce();
+
+      const diagnostic = warn.mock.calls
+        .map(([value]) => JSON.parse(String(value)) as Record<string, unknown>)
+        .find((value) => value.event === "taishin_login_response");
+      expect(diagnostic).toMatchObject({
+        event: "taishin_login_response",
+        mode: "manual",
+        httpStatus: 200,
+        validJson: true,
+        result: "FAIL",
+        status: "A",
+        hasErrorMessage: true,
+      });
+      const serialized = JSON.stringify(warn.mock.calls);
+      for (const secret of [
+        "private-body",
+        "secret-token",
+        credentials.userId,
+        credentials.account,
+        credentials.password,
+        "123456",
+      ]) {
+        expect(serialized).not.toContain(secret);
+      }
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it.each(manualUnknownCases)(
+    "reports a safe manual unknown outcome after ten session checks ($name)",
+    async ({ response, sessionCheck }) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-09-06T12:00:00.000Z"));
+      const warn = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+      try {
+        const browserPage = page();
+        browserPage.evaluate
+          .mockResolvedValueOnce(true)
+          .mockImplementation((_callback, input?: { path?: string }) =>
+            Promise.resolve(input?.path ? response() : SECRET_PAGE_TEXT),
+          );
+        const browserInstance = browser(browserPage);
+        puppeteerMock.sessions.mockResolvedValue([
+          { sessionId: "taishin-session", startTime: Date.now() },
+        ]);
+        puppeteerMock.connect.mockResolvedValue(browserInstance);
+
+        const pending = createTaishinConnector({} as Fetcher).sync({
+          ...credentials,
+          browserSessionId: "taishin-session",
+          browserSessionExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+          captchaDigitCount: 6,
+          captcha: "123456",
+        });
+        const rejected = expect(pending).rejects.toMatchObject({
+          name: "TaishinLoginOutcomeUnknownError",
+          message:
+            "台新人工驗證已送出，但尚未確認登入成功，請稍後重新取得驗證碼再試。",
+        });
+        await vi.runAllTimersAsync();
+        await rejected;
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        const diagnostic = JSON.parse(String(warn.mock.calls[0]?.[0]));
+        expect(diagnostic).toMatchObject({
+          event: "taishin_login_outcome_unknown",
+          mode: "manual",
+          attempts: 10,
+          elapsedMs: expect.any(Number),
+          sessionChecks: Array.from({ length: 10 }, () => sessionCheck),
+        });
+        const serialized = String(warn.mock.calls[0]?.[0]);
+        expect(serialized).not.toContain(SECRET_PAGE_TEXT);
+        expect(serialized).not.toContain(SECRET_SESSION_BODY);
+        expect(serialized).not.toContain(SECRET_ERROR_MESSAGE);
+        expect(browserInstance.close).toHaveBeenCalledOnce();
+      } finally {
+        warn.mockRestore();
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("accepts a valid bank session without relying on account overview text", async () => {
     const browserPage = page();

--- a/packages/connectors/src/ctbc-mobile-api.ts
+++ b/packages/connectors/src/ctbc-mobile-api.ts
@@ -464,7 +464,7 @@ class CtbcMobileSession {
         statusCode,
       }),
     );
-    if (isLogin || isVerificationResponse(response)) {
+    if (isVerificationResponse(response)) {
       throw new CtbcVerificationRequiredError(
         "中國信託登入需要重新驗證，請先至官方 App 完成驗證。",
       );
@@ -764,12 +764,9 @@ function isVerificationResponse(response: JsonRecord) {
   if (["0526", "2802", "2911", "4002", "4050", "9015", "9030"].includes(code)) {
     return true;
   }
-  const description = stringValue(
-    response.desc || response.message || response.statusMessage,
-  );
-  return /otp|verification|device|login|password|驗證|裝置|登入|密碼/i.test(
-    description,
-  );
+  // Login failures and descriptions mentioning login can also mean maintenance.
+  // Require a verification signal before asking the user to verify in the App.
+  return containsVerificationFlag(responseData(response));
 }
 
 function hasText(value: unknown) {


### PR DESCRIPTION
台新人工驗證在接回保存的瀏覽器後，重新設定手機 viewport 會觸發 Puppeteer 重載登入頁，破壞先前填妥的表單與驗證碼狀態。人工流程現在略過重複設定，保留登入頁；另外，中信登入失敗只在有明確驗證代碼或旗標時要求重新驗證，避免將維護錯誤誤分類。

- 台新優先讀取登入彈窗，區分人工與自動驗證未確認成功的訊息。
- 補充登入請求與回應次數、受格式限制的結果代碼及 session 檢查資訊，不記錄帳密、驗證碼或完整回應。
- 擴充人工工作階段保留、錯誤診斷與中信維護／驗證分類回歸測試。

驗證：repo root 的 `npm run format:check`、`npm run typecheck`、`npm run test:backend` 全部通過，包含 Worker 443 項、DB 4 項、連接器 self-check 與腳本 16 項測試。

實際驗證限制：使用者已回報自動同步成功；修正後的人工同步尚待實際驗證。Puppeteer 重連仍會套用預設 viewport，需一併確認人工登入在該版面下運作正常。本 PR 未部署，也未包含本機憑證或金鑰。
