### PR TITLE
新增活動精確時間顯示與排序

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -1,5 +1,18 @@
 import { expect, test, type Page } from "@playwright/test";
 
+function taipeiMonth() {
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat("en", {
+      timeZone: "Asia/Taipei",
+      year: "numeric",
+      month: "2-digit",
+    })
+      .formatToParts(new Date())
+      .map(({ type, value }) => [type, value]),
+  );
+  return `${parts.year}-${parts.month}`;
+}
+
 test.beforeEach(async ({ page }) => {
   await page.route("**/api/**", async (route) => {
     const path = new URL(route.request().url()).pathname;
@@ -656,7 +669,7 @@ test("shows this month's cash flow on the overview and opens activity", async ({
 test("filters activity by cash flow and keeps source filters composable", async ({
   page,
 }) => {
-  const month = new Date().toISOString().slice(0, 7);
+  const month = taipeiMonth();
   await page.route("**/api/bank**", async (route) => {
     await route.fulfill({
       status: 200,
@@ -753,6 +766,155 @@ test("filters activity by cash flow and keeps source filters composable", async 
   await sourceFilters.getByRole("tab", { name: "信用卡" }).click();
   await expect(activityRows).toHaveCount(1);
   await expect(activityRows).toContainText("信用卡消費");
+});
+
+test("shows reliable activity times and sorts them on desktop and mobile", async ({
+  page,
+}) => {
+  const month = taipeiMonth();
+  const activityDate = `${month}-10`;
+  const invoice = {
+    id: "invoice-time-only",
+    connectorId: "einvoice",
+    sourceId: "invoice-time-only-source",
+    invoiceDate: `${activityDate}T23:45:00+08:00`,
+    invoiceNumber: "TIME-0001",
+    sellerName: "發票時間不應套用",
+    amount: 860,
+  };
+
+  await page.route("**/api/bank**", async (route) => {
+    await route.fulfill({
+      json: {
+        accounts: [
+          {
+            id: "time-card",
+            connectorId: "sinopac",
+            sourceId: "time-card-source",
+            institutionName: "測試銀行",
+            accountName: "時間測試卡",
+            accountType: "credit",
+            currency: "TWD",
+          },
+        ],
+        transactions: [
+          {
+            id: "legacy-date-only",
+            connectorId: "sinopac",
+            accountId: "time-card",
+            sourceId: "legacy-date-only-source",
+            postedDate: `${month}-11T00:00:00.000Z`,
+            amount: -50,
+            currency: "TWD",
+            description: "舊資料活動",
+            status: "posted",
+            excludedFromCalculation: false,
+          },
+          {
+            id: "timed-activity",
+            connectorId: "sinopac",
+            accountId: "time-card",
+            sourceId: "timed-activity-source",
+            postedDate: activityDate,
+            authorizedAt: `${activityDate}T14:30:00+08:00`,
+            amount: -120,
+            currency: "TWD",
+            description: "有時間活動",
+            status: "posted",
+            excludedFromCalculation: false,
+          },
+          {
+            id: "midnight-activity",
+            connectorId: "sinopac",
+            accountId: "time-card",
+            sourceId: "midnight-activity-source",
+            postedDate: activityDate,
+            authorizedAt: `${activityDate}T00:00:00+08:00`,
+            amount: -100,
+            currency: "TWD",
+            description: "真午夜活動",
+            status: "posted",
+            excludedFromCalculation: false,
+          },
+          {
+            id: "matched-date-only",
+            connectorId: "sinopac",
+            accountId: "time-card",
+            sourceId: "matched-date-only-source",
+            postedDate: activityDate,
+            amount: -860,
+            currency: "TWD",
+            description: "無授權時間配對",
+            status: "posted",
+            excludedFromCalculation: false,
+          },
+        ],
+      },
+    });
+  });
+  await page.route("**/api/invoices**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    await route.fulfill({
+      json: path === "/api/invoices" ? [invoice] : { ...invoice, items: [] },
+    });
+  });
+
+  await page.goto("/#/activity");
+
+  const desktopRows = page.locator("tbody tr");
+  await expect(desktopRows).toHaveCount(4);
+  await expect(desktopRows.filter({ hasText: "有時間活動" })).toContainText(
+    "14:30",
+  );
+  await expect(desktopRows.filter({ hasText: "真午夜活動" })).toContainText(
+    "00:00",
+  );
+  await expect(desktopRows.filter({ hasText: "舊資料活動" })).not.toContainText(
+    "00:00",
+  );
+  await expect(
+    desktopRows.filter({ hasText: "無授權時間配對" }),
+  ).not.toContainText("23:45");
+
+  const desktopRowTexts = await desktopRows.allTextContents();
+  expect(desktopRowTexts.findIndex((text) => text.includes("舊資料活動"))).toBe(
+    0,
+  );
+  expect(
+    desktopRowTexts.findIndex((text) => text.includes("有時間活動")),
+  ).toBeLessThan(
+    desktopRowTexts.findIndex((text) => text.includes("真午夜活動")),
+  );
+  expect(
+    desktopRowTexts.findIndex((text) => text.includes("真午夜活動")),
+  ).toBeLessThan(
+    desktopRowTexts.findIndex((text) => text.includes("無授權時間配對")),
+  );
+
+  await desktopRows.filter({ hasText: "無授權時間配對" }).click();
+  const desktopDetail = page.getByRole("dialog", { name: "活動明細" });
+  await expect(desktopDetail).toBeVisible();
+  await expect(desktopDetail).not.toContainText("23:45");
+  await page.getByRole("button", { name: "關閉活動明細" }).click();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.reload();
+  const mobileTimed = page.getByRole("button", {
+    name: "查看 有時間活動 活動詳情",
+  });
+  const mobileMidnight = page.getByRole("button", {
+    name: "查看 真午夜活動 活動詳情",
+  });
+  const mobileLegacy = page.getByRole("button", {
+    name: "查看 舊資料活動 活動詳情",
+  });
+  const mobileMatched = page.getByRole("button", {
+    name: "查看 無授權時間配對 活動詳情",
+  });
+  await expect(mobileTimed).toContainText("14:30");
+  await expect(mobileMidnight).toContainText("00:00");
+  await expect(mobileLegacy).not.toContainText("00:00");
+  await expect(mobileMatched).not.toContainText("23:45");
 });
 
 test("uses app-like scrolling and history only in standalone display mode", async ({

--- a/apps/web/src/data/activity/matching.ts
+++ b/apps/web/src/data/activity/matching.ts
@@ -165,7 +165,9 @@ function expenseDay(transaction: BankTransactionRow) {
     transaction.currency !== "TWD"
   )
     return undefined;
-  return dayNumber(transaction.authorizedAt ?? transaction.postedDate);
+  return transaction.authorizedAt
+    ? dayNumber(transaction.authorizedAt)
+    : dateOnlyNumber(transaction.postedDate);
 }
 
 function dayNumber(value?: string) {
@@ -183,6 +185,15 @@ function dayNumber(value?: string) {
       86_400_000
     );
   }
+  const match = value?.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return undefined;
+  return (
+    Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])) /
+    86_400_000
+  );
+}
+
+function dateOnlyNumber(value?: string) {
   const match = value?.match(/^(\d{4})-(\d{2})-(\d{2})/);
   if (!match) return undefined;
   return (

--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -52,9 +52,15 @@
     PendingCategoryUpdate,
   } from "./model/types";
   import {
+    activityDateKey,
     activityStatusLabel,
+    compareActivityItems,
+    currentActivityMonthKey,
+    formatActivityDate,
     formatActivityDateGroup,
+    formatActivityTime,
     groupActivitiesByDate,
+    isActivityDateTime,
   } from "./model/list";
   import {
     filterActivities,
@@ -84,9 +90,13 @@
   import { recentMonthRange, recentMonthKeys } from "@/shared/date-range";
   import { swipeBack } from "@/shared/actions/swipe-back";
   let { api }: { api: ApiClient } = $props();
-  const initialSelectedMonth = new Date().toISOString().slice(0, 7);
+  const initialSelectedMonth = currentActivityMonthKey();
+  // Keep API ranges and month options anchored to the same Taipei month key.
+  const activityMonthAnchor = new Date(
+    `${initialSelectedMonth}-15T12:00:00+08:00`,
+  );
   let selectedMonth = $state(initialSelectedMonth);
-  const activityRange = recentMonthRange(6);
+  const activityRange = recentMonthRange(6, activityMonthAnchor);
   const bank = createQuery(bankRangeQuery(() => api, activityRange));
   const invoices = createQuery(invoicesRangeQuery(() => api, activityRange));
   const invoiceMappings = createQuery(
@@ -178,6 +188,7 @@
           id: t.id,
           source: isCard ? ("card" as const) : ("bank" as const),
           date: t.authorizedAt ?? t.postedDate ?? "",
+          dateHasTime: isActivityDateTime(t.authorizedAt),
           title: t.description ?? t.counterparty ?? "銀行交易",
           subtitle: [
             institutionName,
@@ -208,6 +219,7 @@
           id: i.id,
           source: "invoice" as const,
           date: i.invoiceDate,
+          dateHasTime: isActivityDateTime(i.invoiceDate),
           title: i.sellerName ?? "電子發票",
           subtitle: i.invoiceNumber ?? "",
           institutionName: "電子發票",
@@ -230,6 +242,7 @@
           id: t.id,
           source: "investment" as const,
           date: normalizeFinancialDate(t.tradeDate ?? t.postedDate),
+          dateHasTime: false,
           title: t.name ?? t.symbol ?? "投資交易",
           subtitle: accountName,
           institutionName: "投資",
@@ -240,7 +253,7 @@
           status: "已完成",
         };
       }),
-    ].sort((a, b) => b.date.localeCompare(a.date)),
+    ].sort(compareActivityItems),
   );
   const detailItem = $derived(
     rawItems.find((item) => activityKey(item) === detailKey),
@@ -249,12 +262,12 @@
   const detailInvoice = createQuery(
     toStore(() => invoiceDetailQuery(() => api, detailInvoiceId)),
   );
-  const cashFlowMonths = recentMonthKeys(6);
+  const cashFlowMonths = recentMonthKeys(6, activityMonthAnchor);
   const months = [...cashFlowMonths].reverse();
   const monthlyCalculatedItems = $derived(
     rawItems.filter(
       (item) =>
-        item.date.startsWith(selectedMonth) &&
+        activityDateKey(item).startsWith(selectedMonth) &&
         (item.source === "bank" ||
           item.source === "card" ||
           item.source === "invoice"),
@@ -272,7 +285,7 @@
   const expenseTotal = $derived(
     expenseSlices.reduce((sum, slice) => sum + slice.amount, 0),
   );
-  const currentMonth = new Date().toISOString().slice(0, 7);
+  const currentMonth = currentActivityMonthKey();
   const selectedMonthLabel = $derived(`${Number(selectedMonth.slice(5))} 月`);
   const pendingCount = $derived(
     countPendingActivityItems(rawItems, selectedMonth),
@@ -281,7 +294,7 @@
     cashFlowMonths.map((month) => {
       const items = rawItems.filter(
         (item) =>
-          item.date.startsWith(month) &&
+          activityDateKey(item).startsWith(month) &&
           (item.source === "bank" ||
             item.source === "card" ||
             item.source === "invoice"),
@@ -842,7 +855,8 @@
               </div>
               <div class="divide-y divide-ink/8">
                 {#each group.items as item (item.source + "-" + item.id)}{@const amount =
-                    activityDisplayAmount(item)}
+                    activityDisplayAmount(item)}{@const time =
+                    formatActivityTime(item)}
                   <button
                     aria-label={`查看 ${item.title} 活動詳情`}
                     class={`flex w-full min-w-0 items-center gap-3 px-4 py-3.5 text-left transition hover:bg-paper ${item.excludedFromCalculation ? "bg-ink/[0.025]" : ""}`}
@@ -850,8 +864,13 @@
                   >
                     <div class="min-w-0 flex-1">
                       <p class="truncate text-sm font-semibold">{item.title}</p>
+                      {#if time}<p
+                          class="mt-0.5 text-[11px] font-medium tabular-nums text-ink/45"
+                        >
+                          {time}
+                        </p>{/if}
                       <p
-                        class="mt-1 truncate text-xs font-semibold text-ink/75"
+                        class="mt-0.5 truncate text-xs font-semibold text-ink/75"
                       >
                         {item.institutionName ?? sourceLabel(item)}
                       </p>
@@ -917,7 +936,8 @@
                 >
                 <tbody class="divide-y divide-ink/8"
                   >{#each group.items as item (item.source + "-" + item.id)}{@const amount =
-                      activityDisplayAmount(item)}<tr
+                      activityDisplayAmount(item)}{@const time =
+                      formatActivityTime(item)}<tr
                       aria-label={`查看 ${item.title} 活動詳情`}
                       class={`cursor-pointer transition hover:bg-paper focus-visible:outline-2 focus-visible:outline-steel ${item.excludedFromCalculation ? "bg-ink/[0.025]" : ""}`}
                       onclick={() => openDetail(item)}
@@ -931,6 +951,11 @@
                       tabindex="0"
                       ><td class="min-w-0 px-5 py-3.5"
                         ><p class="truncate font-semibold">{item.title}</p>
+                        {#if time}<p
+                            class="mt-1 text-xs font-medium tabular-nums text-ink/45"
+                          >
+                            {time}
+                          </p>{/if}
                         {#if item.transactionId && item.invoiceId && itemMappingDifference(item) > 0}<Badge
                             variant="secondary"
                             class="mt-1 bg-amber-50 text-amber-800"
@@ -1025,7 +1050,7 @@
                     {detailItem.title}
                   </h3>
                   <p class="mt-1 text-sm text-ink/50">
-                    {formatDate(detailItem.date)}{#if transaction}
+                    {formatActivityDate(detailItem)}{#if transaction}
                       · {mappingAccount(transaction)}
                     {/if}
                   </p>

--- a/apps/web/src/features/activity/model/filter.test.ts
+++ b/apps/web/src/features/activity/model/filter.test.ts
@@ -104,4 +104,19 @@ describe("activity filters", () => {
       }),
     ).toEqual([matchedCardInvoice]);
   });
+
+  it("filters by the Taipei date when a timestamp crosses UTC midnight", () => {
+    const taipeiAugust = item("taipei-august", {
+      date: "2026-07-31T16:30:00Z",
+      dateHasTime: true,
+    });
+
+    expect(
+      filterActivities([taipeiAugust], {
+        ...defaultFilters,
+        month: "2026-08",
+      }),
+    ).toEqual([taipeiAugust]);
+    expect(filterActivities([taipeiAugust], defaultFilters)).toEqual([]);
+  });
 });

--- a/apps/web/src/features/activity/model/filter.ts
+++ b/apps/web/src/features/activity/model/filter.ts
@@ -1,4 +1,5 @@
 import { activityCashFlow, type ActivityFlow } from "./chart";
+import { activityDateKey } from "./list";
 import type { ActivityItem } from "./types";
 
 export type ActivityFlowFilter = "all" | ActivityFlow;
@@ -41,7 +42,7 @@ export function filterActivities(
         itemFlow === filters.category.flow);
 
     return (
-      item.date.startsWith(filters.month) &&
+      activityDateKey(item).startsWith(filters.month) &&
       matchesFlow &&
       matchesSource &&
       matchesSearch &&

--- a/apps/web/src/features/activity/model/list.test.ts
+++ b/apps/web/src/features/activity/model/list.test.ts
@@ -1,16 +1,21 @@
 import { describe, expect, it } from "vitest";
 import {
+  activityDateKey,
   activityStatusLabel,
+  compareActivityItems,
+  formatActivityDate,
+  formatActivityTime,
   formatActivityDateGroup,
   groupActivitiesByDate,
 } from "./list";
 import type { ActivityItem } from "./types";
 
-function item(id: string, date: string): ActivityItem {
+function item(id: string, date: string, dateHasTime = false): ActivityItem {
   return {
     id,
     source: "bank",
     date,
+    dateHasTime,
     title: id,
     subtitle: "",
     currency: "TWD",
@@ -31,6 +36,48 @@ describe("activity list", () => {
       ["2026-07-28", 2],
       ["2026-07-27", 1],
     ]);
+  });
+
+  it("uses Taipei date keys and sorts reliable times before date-only items", () => {
+    const late = item("late", "2026-07-28T06:00:00Z", true);
+    const early = item("early", "2026-07-28T07:00:00+08:00", true);
+    const dateOnly = item("date-only", "2026-07-28");
+    const items = [
+      dateOnly,
+      early,
+      late,
+      item("next-day-utc", "2026-07-28T16:30:00Z", true),
+    ].sort(compareActivityItems);
+    const groups = groupActivitiesByDate(items);
+
+    expect(groups.map(({ dateKey }) => dateKey)).toEqual([
+      "2026-07-29",
+      "2026-07-28",
+    ]);
+    expect(groups[1]?.items.map(({ id }) => id)).toEqual([
+      "late",
+      "early",
+      "date-only",
+    ]);
+    expect(activityDateKey(late)).toBe("2026-07-28");
+    expect(formatActivityTime(late)).toBe("14:00");
+    expect(formatActivityDate(late)).toBe("7 月 28 日・週二 · 14:00");
+  });
+
+  it("does not infer a bank time from a legacy posted-date midnight", () => {
+    const legacy = item("legacy", "2026-07-28T00:00:00.000Z");
+
+    expect(formatActivityTime(legacy)).toBeUndefined();
+    expect(formatActivityDate(legacy)).toBe("7 月 28 日・週二");
+  });
+
+  it("allows an explicitly marked authorized timestamp", () => {
+    const authorized = {
+      ...item("authorized", "2026-07-28T01:05:00.000Z"),
+      dateHasTime: true,
+    };
+
+    expect(formatActivityTime(authorized)).toBe("09:05");
   });
 
   it("formats date groups and transaction statuses for display", () => {

--- a/apps/web/src/features/activity/model/list.ts
+++ b/apps/web/src/features/activity/model/list.ts
@@ -1,8 +1,110 @@
 import type { ActivityItem } from "./types";
 
+const TAIPEI_TIME_ZONE = "Asia/Taipei";
+const ISO_DATE_PREFIX = /^(\d{4})-(\d{2})-(\d{2})/;
+const ISO_DATE_TIME_WITH_OFFSET =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2})$/;
+const TAIPEI_DATE_FORMATTER = new Intl.DateTimeFormat("en", {
+  timeZone: TAIPEI_TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+const TAIPEI_TIME_FORMATTER = new Intl.DateTimeFormat("en", {
+  timeZone: TAIPEI_TIME_ZONE,
+  hour: "2-digit",
+  minute: "2-digit",
+  hourCycle: "h23",
+});
+
 export interface ActivityDateGroup {
   dateKey: string;
   items: ActivityItem[];
+}
+
+/**
+ * Returns whether a value is an ISO timestamp with an explicit offset.
+ * Date-only values and local timestamps are deliberately treated as dates.
+ */
+export function isActivityDateTime(value?: string): value is string {
+  return value != null && ISO_DATE_TIME_WITH_OFFSET.test(value);
+}
+
+export function activityDateKey(
+  item: Pick<ActivityItem, "date" | "dateHasTime" | "source">,
+) {
+  const timestamp = activityTimestamp(item);
+  if (timestamp != null) {
+    const parts = Object.fromEntries(
+      TAIPEI_DATE_FORMATTER.formatToParts(new Date(timestamp)).map(
+        ({ type, value }) => [type, value],
+      ),
+    );
+    return `${parts.year}-${parts.month}-${parts.day}`;
+  }
+  return item.date.match(ISO_DATE_PREFIX)?.[0] ?? "";
+}
+
+export function activityTimestamp(
+  item: Pick<ActivityItem, "date" | "dateHasTime" | "source">,
+) {
+  if (!hasReliableActivityTime(item)) return undefined;
+  const timestamp = Date.parse(item.date);
+  return Number.isNaN(timestamp) ? undefined : timestamp;
+}
+
+export function formatActivityTime(
+  item: Pick<ActivityItem, "date" | "dateHasTime" | "source">,
+) {
+  const timestamp = activityTimestamp(item);
+  if (timestamp == null) return undefined;
+  const parts = Object.fromEntries(
+    TAIPEI_TIME_FORMATTER.formatToParts(new Date(timestamp)).map(
+      ({ type, value }) => [type, value],
+    ),
+  );
+  return `${parts.hour}:${parts.minute}`;
+}
+
+export function formatActivityDate(item: ActivityItem) {
+  const date = formatActivityDateGroup(activityDateKey(item));
+  const time = formatActivityTime(item);
+  return time ? `${date} · ${time}` : date;
+}
+
+export function currentActivityMonthKey(now = new Date()) {
+  const parts = Object.fromEntries(
+    TAIPEI_DATE_FORMATTER.formatToParts(now).map(({ type, value }) => [
+      type,
+      value,
+    ]),
+  );
+  return `${parts.year}-${parts.month}`;
+}
+
+export function compareActivityItems(left: ActivityItem, right: ActivityItem) {
+  const leftDateKey = activityDateKey(left);
+  const rightDateKey = activityDateKey(right);
+  if (leftDateKey !== rightDateKey) {
+    if (!leftDateKey) return 1;
+    if (!rightDateKey) return -1;
+    return rightDateKey.localeCompare(leftDateKey);
+  }
+
+  const leftTimestamp = activityTimestamp(left);
+  const rightTimestamp = activityTimestamp(right);
+  if (leftTimestamp != null && rightTimestamp != null) {
+    if (leftTimestamp !== rightTimestamp) return rightTimestamp - leftTimestamp;
+  } else if (leftTimestamp != null) {
+    return -1;
+  } else if (rightTimestamp != null) {
+    return 1;
+  }
+
+  return `${left.source}\u0000${left.id}`.localeCompare(
+    `${right.source}\u0000${right.id}`,
+    "en",
+  );
 }
 
 export function groupActivitiesByDate(
@@ -10,7 +112,7 @@ export function groupActivitiesByDate(
 ): ActivityDateGroup[] {
   const groups = new Map<string, ActivityItem[]>();
   for (const item of items) {
-    const dateKey = item.date.match(/^\d{4}-\d{2}-\d{2}/)?.[0] ?? "";
+    const dateKey = activityDateKey(item);
     const group = groups.get(dateKey);
     if (group) group.push(item);
     else groups.set(dateKey, [item]);
@@ -39,4 +141,16 @@ export function activityStatusLabel(
   if (item.status === "pending") return "待入帳";
   if (item.status === "posted") return "已入帳";
   return item.status;
+}
+
+function hasReliableActivityTime(
+  item: Pick<ActivityItem, "date" | "dateHasTime" | "source">,
+) {
+  if (item.dateHasTime != null) {
+    return item.dateHasTime && isActivityDateTime(item.date);
+  }
+  // Legacy view-model callers may not provide the marker. Never infer a
+  // bank/card time from postedDate; invoice timestamps are independently
+  // authoritative when they carry an explicit offset.
+  return item.source === "invoice" && isActivityDateTime(item.date);
 }

--- a/apps/web/src/features/activity/model/matching.test.ts
+++ b/apps/web/src/features/activity/model/matching.test.ts
@@ -217,7 +217,7 @@ describe("invoice transaction matching", () => {
     const nextTaipeiDay = transaction({
       accountType: "credit",
       postedDate: "2026-07-06T16:00:00.000Z",
-      authorizedAt: undefined,
+      authorizedAt: "2026-07-06T16:00:00.000Z",
       amount: 50,
     });
     const targetInvoice = invoice({
@@ -232,6 +232,23 @@ describe("invoice transaction matching", () => {
     expect(
       invoiceTransactionCandidates([nextTaipeiDay], targetInvoice),
     ).toEqual([]);
+  });
+
+  it("uses the posted-date prefix for a legacy transaction without authorization time", () => {
+    const legacy = transaction({
+      accountType: "credit",
+      postedDate: "2026-07-06T16:00:00.000Z",
+      authorizedAt: undefined,
+      amount: 50,
+    });
+    const targetInvoice = invoice({
+      invoiceDate: "2026-07-06T04:39:18.000Z",
+      amount: 50,
+    });
+
+    expect(
+      invoiceTransactionCandidates([legacy], targetInvoice).map(({ id }) => id),
+    ).toEqual(["transaction-1"]);
   });
 
   it("does not match when the amount or date differs", () => {

--- a/apps/web/src/features/activity/model/pending.ts
+++ b/apps/web/src/features/activity/model/pending.ts
@@ -1,4 +1,5 @@
 import type { ActivityItem } from "./types";
+import { activityDateKey } from "./list";
 
 export function countPendingActivityItems(
   items: ActivityItem[],
@@ -6,7 +7,7 @@ export function countPendingActivityItems(
 ) {
   return items.filter(
     (item) =>
-      item.date.startsWith(month) &&
+      activityDateKey(item).startsWith(month) &&
       (item.source === "bank" || item.source === "card") &&
       (item.status === "pending" || item.categoryId === "other"),
   ).length;

--- a/apps/web/src/features/activity/model/types.ts
+++ b/apps/web/src/features/activity/model/types.ts
@@ -2,6 +2,8 @@ export interface ActivityItem {
   id: string;
   source: "bank" | "card" | "investment" | "invoice";
   date: string;
+  /** Only true when the selected source value contains a reliable timestamp. */
+  dateHasTime?: boolean;
   title: string;
   subtitle: string;
   institutionName?: string;

--- a/apps/worker/src/connectors/cathaybk.ts
+++ b/apps/worker/src/connectors/cathaybk.ts
@@ -1254,7 +1254,7 @@ async function scrapeDeposits(
       `[cathaybk] account ${maskAccountNumber(acct.acctNo)}: ${details.length} tx (period=${periodLabel(lookbackDays)})`,
     );
 
-    appendDepositTransactions(
+    appendCathayDepositTransactions(
       bankTransactions,
       details,
       sourceId,
@@ -1285,7 +1285,7 @@ async function scrapeDeposits(
   };
 }
 
-function appendDepositTransactions(
+export function appendCathayDepositTransactions(
   target: Scraped["bankTransactions"],
   details: TransferDetail[],
   accountId: string,
@@ -1293,7 +1293,9 @@ function appendDepositTransactions(
 ) {
   const seen = new Map<string, number>();
   for (const d of details) {
-    const date = normalizeDateStr(d.txnDateTime ?? d.accountDate);
+    const sourceDate = d.txnDateTime ?? d.accountDate;
+    const date = normalizeDateStr(sourceDate);
+    const authorizedAt = normalizeCathayAuthorizedAt(sourceDate);
     // incomeAmt = money in (positive), expendAmt = money out (positive value = debit)
     const income = typeof d.incomeAmt === "number" ? d.incomeAmt : 0;
     const expend = typeof d.expendAmt === "number" ? d.expendAmt : 0;
@@ -1308,6 +1310,7 @@ function appendDepositTransactions(
       accountId,
       sourceId: `${key}:${occ}`,
       postedDate: date,
+      authorizedAt,
       amount,
       currency,
       description: desc,
@@ -1585,6 +1588,9 @@ export async function scrapeCreditCards(page: Page): Promise<Scraped> {
       for (const trade of section.tradeData ?? []) {
         if (!trade.amount) continue;
         const date = normalizeDateStr(trade.consumeDate ?? month.billDate);
+        const authorizedAt = normalizeCathayAuthorizedAt(
+          trade.consumeDate ?? month.billDate,
+        );
         const desc = trade.transDesc || "國泰信用卡消費";
         const key = [date, sourceId, trade.amount, desc].join(":");
         const occ = (seen.get(key) ?? 0) + 1;
@@ -1593,6 +1599,7 @@ export async function scrapeCreditCards(page: Page): Promise<Scraped> {
           accountId: sourceId,
           sourceId: `${key}:${occ}`,
           postedDate: date,
+          authorizedAt,
           amount: trade.amount < 0 ? trade.amount : -trade.amount,
           currency: "TWD",
           description: desc,
@@ -1627,4 +1634,64 @@ function normalizeDateStr(value: unknown): string {
   if (/^\d{4}-\d{2}-\d{2}T/.test(s)) return s;
   if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return `${s}T00:00:00.000Z`;
   return s || new Date().toISOString();
+}
+
+/**
+ * Normalizes a Cathay transaction timestamp for authorizedAt without
+ * inventing midnight for date-only rows.  Timestamps without an explicit
+ * offset are bank-local Taiwan time; timestamps with an offset keep that
+ * offset in canonical ISO form.  Invalid source values return undefined.
+ */
+export function normalizeCathayAuthorizedAt(
+  value: unknown,
+): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const source = value.trim().replace(/\//g, "-");
+  if (!source) return undefined;
+
+  const match = source.match(
+    /^(\d{4}-\d{2}-\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(Z|[+-]\d{2}:?\d{2})?)?$/,
+  );
+  if (!match) return undefined;
+
+  const [, date, hour, minute, second, fraction, zone] = match;
+  if (!isValidCathayDate(date)) return undefined;
+  if (!hour) return date;
+
+  const hours = Number(hour);
+  const minutes = Number(minute);
+  const seconds = Number(second ?? "0");
+  if (hours > 23 || minutes > 59 || seconds > 59) return undefined;
+
+  const normalizedZone = normalizeCathayOffset(zone);
+  if (!normalizedZone) return undefined;
+  const normalizedFraction = fraction
+    ? `.${fraction.slice(0, 3).padEnd(3, "0")}`
+    : "";
+  return `${date}T${hour}:${minute}:${String(seconds).padStart(2, "0")}${normalizedFraction}${normalizedZone}`;
+}
+
+function normalizeCathayOffset(value: string | undefined): string | undefined {
+  if (!value) return "+08:00";
+  if (value === "Z") return value;
+  const match = value.match(/^([+-])(\d{2}):?(\d{2})$/);
+  if (!match) return undefined;
+  const hours = Number(match[2]);
+  const minutes = Number(match[3]);
+  if (hours > 23 || minutes > 59) return undefined;
+  return `${match[1]}${match[2]}:${match[3]}`;
+}
+
+function isValidCathayDate(value: string): boolean {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
 }

--- a/apps/worker/src/connectors/esun.ts
+++ b/apps/worker/src/connectors/esun.ts
@@ -572,10 +572,14 @@ export function normalizeEsunTimelineTransactions(
 
       for (const txn of month.txnList ?? []) {
         const lifecycle = txn.acfg?.trim() ?? "";
-        const authorizedAt = normalizeEsunMonthDay(
+        // Keep the legacy normalized value in the identity key.  The public
+        // authorizedAt value may now be date-only, but changing this key
+        // would turn every existing card transaction into a new row.
+        const identityAuthorizedAt = normalizeEsunMonthDay(
           year,
           txn.consumerDt ?? txn.postingDt ?? "",
         );
+        const authorizedAt = identityAuthorizedAt.slice(0, 10);
         const postedDate =
           lifecycle === "未入帳"
             ? undefined
@@ -589,7 +593,7 @@ export function normalizeEsunTimelineTransactions(
         const amount = signedCreditCardAmount(rawAmount, description);
         const accountId = creditCardSourceId(txn.cardNo);
         const sourceKey = [
-          authorizedAt,
+          identityAuthorizedAt,
           accountId,
           description,
           rawAmount,
@@ -825,7 +829,7 @@ async function scrapeDepositAccounts(
     console.log(
       `[esun debug] tw account ${maskAccountNumber(account)}: fetched ${rows.length} transaction rows`,
     );
-    appendDepositTransactions(bankTransactions, rows, accountId, currency);
+    appendEsunDepositTransactions(bankTransactions, rows, accountId, currency);
     newWatermarks[account] = watermarks[account];
   }
 
@@ -876,7 +880,7 @@ async function scrapeDepositAccounts(
     );
     for (const detail of rows) {
       const currency = detail.displayCurrency?.trim() || primaryCurrency;
-      appendDepositTransactions(
+      appendEsunDepositTransactions(
         bankTransactions,
         [detail],
         depositSourceId(account, currency),
@@ -960,7 +964,7 @@ async function fetchAccountTransactionPages(
   return rows;
 }
 
-function appendDepositTransactions(
+export function appendEsunDepositTransactions(
   target: Scraped["bankTransactions"],
   rows: EsunTxDetailRow[],
   accountId: string,
@@ -970,6 +974,10 @@ function appendDepositTransactions(
 
   for (const detail of rows) {
     const postedDate = normalizeEsunTxDateTime(detail.txDate, detail.txTime);
+    const authorizedAt = normalizeEsunAuthorizedAt(
+      detail.txDate,
+      detail.txTime,
+    );
     const isCredit = detail.showCrFlag !== "hide";
     const amount = parseTwd(detail.amt ?? "0") * (isCredit ? 1 : -1);
     const description = detail.chc?.trim() || "玉山銀行交易";
@@ -990,6 +998,7 @@ function appendDepositTransactions(
       accountId,
       sourceId: `${sourceKey}:${occurrence}`,
       postedDate,
+      authorizedAt,
       amount,
       currency: detail.displayCurrency?.trim() || defaultCurrency,
       description,
@@ -1014,6 +1023,49 @@ function normalizeEsunTxDateTime(
   const date = txDate?.trim().replace(/\//g, "-") || "";
   const time = txTime?.trim() || "00:00:00";
   return `${date}T${time}.000Z`;
+}
+
+/**
+ * Normalizes the source's local Taiwan transaction time for display.
+ *
+ * `postedDate` and its source key intentionally keep the legacy `.000Z`
+ * representation above so a parser precision upgrade cannot create rows.
+ * A missing or malformed time therefore remains a date-only authorizedAt.
+ */
+export function normalizeEsunAuthorizedAt(
+  txDate: string | null | undefined,
+  txTime: string | null | undefined,
+): string | undefined {
+  const date = normalizeEsunDate(txDate);
+  if (!date) return undefined;
+
+  const time = txTime?.trim();
+  if (!time) return date;
+
+  const match = time.match(/^(\d{1,2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?$/);
+  if (!match) return date;
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  const seconds = Number(match[3] ?? "0");
+  if (hours > 23 || minutes > 59 || seconds > 59) {
+    return date;
+  }
+
+  const fraction = match[4] ? `.${match[4].padEnd(3, "0")}` : "";
+  return `${date}T${String(hours).padStart(2, "0")}:${match[2]}:${String(seconds).padStart(2, "0")}${fraction}+08:00`;
+}
+
+function normalizeEsunDate(
+  value: string | null | undefined,
+): string | undefined {
+  const date = value?.trim().replace(/\//g, "-") ?? "";
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return undefined;
+  const parsed = new Date(`${date}T00:00:00Z`);
+  return Number.isFinite(parsed.getTime()) &&
+    parsed.toISOString().startsWith(date)
+    ? date
+    : undefined;
 }
 
 function parseTwd(text: string): number {

--- a/apps/worker/src/connectors/sinopac.ts
+++ b/apps/worker/src/connectors/sinopac.ts
@@ -1194,8 +1194,23 @@ function parseSinoCardTransactions(
 
   const postedTransactions = assignSinoCardSourceIds(posted);
   const pendingTransactions = assignSinoCardSourceIds(pending);
+  const postedByMatchKey = groupSinoCardTransactions(postedTransactions);
+  const pendingByMatchKey = groupSinoCardTransactions(pendingTransactions);
+  const upgradedPostedTransactions = postedTransactions.map((transaction) => {
+    const postedMatches = postedByMatchKey.get(transaction.matchKey) ?? [];
+    const pendingMatches = pendingByMatchKey.get(transaction.matchKey) ?? [];
+    const pendingAuthorizedAt = pendingMatches[0]?.authorizedAt;
+    if (
+      postedMatches.length === 1 &&
+      pendingMatches.length === 1 &&
+      pendingAuthorizedAt?.includes("T")
+    ) {
+      return { ...transaction, authorizedAt: pendingAuthorizedAt };
+    }
+    return transaction;
+  });
   const postedCounts = new Map<string, number>();
-  for (const transaction of postedTransactions) {
+  for (const transaction of upgradedPostedTransactions) {
     postedCounts.set(
       transaction.matchKey,
       (postedCounts.get(transaction.matchKey) ?? 0) + 1,
@@ -1208,9 +1223,21 @@ function parseSinoCardTransactions(
     return occurrence > (postedCounts.get(transaction.matchKey) ?? 0);
   });
 
-  return [...postedTransactions, ...unmatchedPending].map(
+  return [...upgradedPostedTransactions, ...unmatchedPending].map(
     ({ matchKey: _matchKey, ...transaction }) => transaction,
   );
+}
+
+function groupSinoCardTransactions(
+  transactions: SinoCardTransactionCandidate[],
+) {
+  const grouped = new Map<string, SinoCardTransactionCandidate[]>();
+  for (const transaction of transactions) {
+    const group = grouped.get(transaction.matchKey) ?? [];
+    group.push(transaction);
+    grouped.set(transaction.matchKey, group);
+  }
+  return grouped;
 }
 
 function sinoCardResultRecords(payload: unknown, key: "Items" | "Detail") {

--- a/apps/worker/src/features/activity/service.ts
+++ b/apps/worker/src/features/activity/service.ts
@@ -45,7 +45,7 @@ export async function linkInvoiceToTransaction(
 
   const invoiceDay = financialDay(invoice.invoiceDate);
   const transactionDay = financialDay(
-    transaction.authorizedAt ?? transaction.postedDate,
+    transaction.authorizedAt ?? transaction.postedDate?.slice(0, 10),
   );
   if (!invoiceDay || invoiceDay !== transactionDay)
     throw new MappingDateMismatchError();

--- a/apps/worker/src/features/bank/repository.ts
+++ b/apps/worker/src/features/bank/repository.ts
@@ -56,6 +56,11 @@ const BANK_TRANSACTION_SELECT = `SELECT
     LEFT JOIN bank_transaction_preferences preference
       ON preference.transaction_id = txn.id`;
 
+// authorized_at has explicit precision; legacy posted_date is a financial date.
+const BANK_TRANSACTION_DAY = `CASE WHEN length(txn.authorized_at) > 10
+  THEN COALESCE(date(txn.authorized_at, '+8 hours'), substr(txn.authorized_at, 1, 10))
+  ELSE substr(COALESCE(txn.authorized_at, txn.posted_date), 1, 10) END`;
+
 export async function listBankAccounts(db: D1Database) {
   const rows = await db
     .prepare(
@@ -121,8 +126,8 @@ export async function listBankTransactionsInRange(
     .prepare(
       `${BANK_TRANSACTION_SELECT}
        WHERE account.canonical_account_id IS NULL
-         AND COALESCE(txn.authorized_at, txn.posted_date) >= ?
-         AND COALESCE(txn.authorized_at, txn.posted_date) < ?
+         AND (${BANK_TRANSACTION_DAY}) >= ?
+         AND (${BANK_TRANSACTION_DAY}) < ?
        ORDER BY txn.effective_date DESC, txn.updated_at DESC, txn.id DESC`,
     )
     .bind(range.from, range.to)
@@ -158,7 +163,7 @@ export async function listBankTransactionsForTransferMatching(
   const dayClause =
     matchDays.length > 0
       ? `
-         AND substr(COALESCE(txn.authorized_at, txn.posted_date), 1, 10) IN (
+         AND (${BANK_TRANSACTION_DAY}) IN (
            SELECT value FROM json_each(?)
          )`
       : "";

--- a/apps/worker/src/features/bank/transfer-matching.ts
+++ b/apps/worker/src/features/bank/transfer-matching.ts
@@ -65,7 +65,13 @@ export function findAutomaticTransferPairs(
 export function getAutomaticTransferDay(
   transaction: Pick<TransferMatchTransaction, "authorizedAt" | "postedDate">,
 ) {
-  return storedFinancialDay(transaction.authorizedAt ?? transaction.postedDate);
+  const { authorizedAt, postedDate } = transaction;
+  if (authorizedAt && /(?:Z|[+-]\d{2}:\d{2})$/.test(authorizedAt)) {
+    const parsed = Date.parse(authorizedAt);
+    if (Number.isFinite(parsed))
+      return new Date(parsed + 8 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  }
+  return storedFinancialDay(authorizedAt ?? postedDate);
 }
 
 export function findAutomaticTransferTransactionIds(
@@ -134,10 +140,7 @@ function storedFinancialDay(value?: string | null) {
   if (!value) return undefined;
 
   const dateOnly = value.trim().match(/^\d{4}-\d{2}-\d{2}/)?.[0];
-  // Bank connectors store the financial date in the timestamp prefix, and
-  // Activity groups rows by that same prefix. Do not reinterpret it through
-  // the runtime timezone: TDCC timestamps can represent a Taiwan local time
-  // while carrying a UTC-looking suffix.
+  // Date-only authorizations and legacy posting dates retain their calendar day.
   if (dateOnly) return dateOnly;
 
   const parsed = new Date(value);

--- a/apps/worker/src/features/invoices/repository.ts
+++ b/apps/worker/src/features/invoices/repository.ts
@@ -1,6 +1,10 @@
 import type { ConnectorId } from "@taiwan-fin-hub/core";
 import type { MonthDateRange } from "../../platform/month-range";
 
+const INVOICE_DAY = `CASE WHEN length(invoice_date) > 10
+  THEN COALESCE(date(invoice_date, '+8 hours'), substr(invoice_date, 1, 10))
+  ELSE invoice_date END`;
+
 export type InvoicePageCursor = {
   invoiceDate: string;
   updatedAt: string;
@@ -76,7 +80,7 @@ export async function listInvoicesInRange(
       amount,
       updated_at AS updatedAt
     FROM invoices
-    WHERE invoice_date >= ? AND invoice_date < ?
+    WHERE (${INVOICE_DAY}) >= ? AND (${INVOICE_DAY}) < ?
     ORDER BY invoice_date DESC, updated_at DESC, id DESC`,
     )
     .bind(range.from, range.to)

--- a/apps/worker/src/features/sync/einvoice-run-repository.ts
+++ b/apps/worker/src/features/sync/einvoice-run-repository.ts
@@ -726,7 +726,10 @@ export async function promoteEinvoiceRunRecords(
          WHERE source.run_id = ? AND source.status = 'done' AND ${guard}
          ON CONFLICT(connector_id, source_id) DO UPDATE SET
            invoice_number = excluded.invoice_number,
-           invoice_date = excluded.invoice_date,
+           invoice_date = CASE
+             WHEN length(invoices.invoice_date) > 10 AND length(excluded.invoice_date) = 10
+               AND date(invoices.invoice_date, '+8 hours') = excluded.invoice_date
+             THEN invoices.invoice_date ELSE excluded.invoice_date END,
            seller_name = excluded.seller_name,
            amount = excluded.amount,
            raw_payload = excluded.raw_payload,

--- a/apps/worker/src/features/sync/persistence.ts
+++ b/apps/worker/src/features/sync/persistence.ts
@@ -474,6 +474,11 @@ function promotionStatement(
     .join(", ");
   const updates = config.updateColumns
     .map((column) => {
+      if (entityType === "invoice" && column === "invoice_date")
+        return `invoice_date = CASE
+          WHEN length(invoices.invoice_date) > 10 AND length(excluded.invoice_date) = 10
+            AND date(invoices.invoice_date, '+8 hours') = excluded.invoice_date
+          THEN invoices.invoice_date ELSE excluded.invoice_date END`;
       if (entityType === "credit_card_bill") {
         if (column === "paid_amount")
           return "paid_amount = COALESCE(excluded.paid_amount, credit_card_bills.paid_amount)";
@@ -489,8 +494,17 @@ function promotionStatement(
         return "status = CASE WHEN bank_transactions.status = 'posted' OR excluded.status = 'posted' THEN 'posted' ELSE 'pending' END";
       if (column === "authorized_at")
         return `authorized_at = CASE
+          WHEN length(bank_transactions.authorized_at) > 10
+            AND (excluded.authorized_at IS NULL OR (
+              length(excluded.authorized_at) = 10
+              AND date(bank_transactions.authorized_at, '+8 hours') = excluded.authorized_at
+            ))
+            THEN bank_transactions.authorized_at
           WHEN bank_transactions.status = 'pending' AND excluded.status = 'posted'
-            THEN COALESCE(bank_transactions.authorized_at, excluded.authorized_at)
+            THEN CASE WHEN length(excluded.authorized_at) > 10
+              AND length(bank_transactions.authorized_at) <= 10
+              THEN excluded.authorized_at
+              ELSE COALESCE(bank_transactions.authorized_at, excluded.authorized_at) END
           WHEN bank_transactions.status = 'posted' AND excluded.status = 'pending'
             THEN bank_transactions.authorized_at
           ELSE excluded.authorized_at

--- a/apps/worker/src/features/sync/tdcc-sync-service.ts
+++ b/apps/worker/src/features/sync/tdcc-sync-service.ts
@@ -4,6 +4,7 @@ import {
   ensureTdccSession,
   initializeTdccSnapshot,
   normalizeBankTransactionDetails,
+  normalizeTdccBankAuthorizedAt,
   normalizeTdccSnapshot,
   parseTdccConfig,
   parseTdccTradePageItems,
@@ -756,6 +757,7 @@ async function bankTransactionsFromRun(env: Env, run: TdccRunRow) {
     accountId: string;
     sourceId: string;
     postedDate?: string;
+    authorizedAt?: string;
     amount: number;
     currency: string;
     description?: string;
@@ -784,6 +786,7 @@ async function bankTransactionsFromRun(env: Env, run: TdccRunRow) {
         accountId,
         sourceId: transaction.txnId,
         postedDate: transaction.occurredAt,
+        authorizedAt: normalizeTdccBankAuthorizedAt(transaction.occurredAt),
         amount: Number.isFinite(amount) ? amount : 0,
         currency: task.currency,
         ...(transaction.memo ? { description: transaction.memo } : {}),

--- a/apps/worker/tests/connectors/cathaybk-session.test.ts
+++ b/apps/worker/tests/connectors/cathaybk-session.test.ts
@@ -13,11 +13,13 @@ import {
   CathayOtpChannelRequiredError,
   CathayOtpRequiredError,
   CathayVerificationRequiredError,
+  appendCathayDepositTransactions,
   captureCathayTrustedState,
   completeCathayTrustedDeviceSetup,
   createCathaybkConnector,
   dismissCathaySystemMessageIfPresent,
   loginCathay,
+  normalizeCathayAuthorizedAt,
   restoreCathayTrustedState,
   sendCathayOtp,
   scrapeCreditCards,
@@ -507,6 +509,43 @@ describe("Cathay credit cards", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("Cathay transaction timestamps", () => {
+  it("uses Taiwan time at true midnight without changing the source identity", () => {
+    const target: Parameters<typeof appendCathayDepositTransactions>[0] = [];
+
+    appendCathayDepositTransactions(
+      target,
+      [
+        {
+          txnDateTime: "2026/07/05T00:00:00",
+          incomeAmt: 252,
+          description: "薪資",
+        },
+      ],
+      "bank:cathaybk:1234",
+      "TWD",
+    );
+
+    expect(target[0]).toMatchObject({
+      authorizedAt: "2026-07-05T00:00:00+08:00",
+      postedDate: "2026-07-05T00:00:00",
+      sourceId: "2026-07-05T00:00:00:bank:cathaybk:1234:252:薪資:1",
+    });
+  });
+
+  it("normalizes offsets and leaves date-only values without fake midnight", () => {
+    expect(normalizeCathayAuthorizedAt("2026/07/05T01:02:03+0800")).toBe(
+      "2026-07-05T01:02:03+08:00",
+    );
+    expect(normalizeCathayAuthorizedAt("2026-07-05T01:02:03Z")).toBe(
+      "2026-07-05T01:02:03Z",
+    );
+    expect(normalizeCathayAuthorizedAt("2026/07/05")).toBe("2026-07-05");
+    expect(normalizeCathayAuthorizedAt("2026-07-05T25:02:03")).toBeUndefined();
+    expect(normalizeCathayAuthorizedAt("2026-02-30T01:02:03")).toBeUndefined();
   });
 });
 

--- a/apps/worker/tests/connectors/esun.test.ts
+++ b/apps/worker/tests/connectors/esun.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  appendEsunDepositTransactions,
   esunCreditBalanceAccountId,
+  normalizeEsunAuthorizedAt,
   normalizeEsunTimelineTransactions,
   type EsunTimelinePage,
   type EsunTimelineTransaction,
@@ -56,7 +58,7 @@ describe("E.SUN credit card timeline normalization", () => {
     expect(rows[0]).toMatchObject({
       amount: -252,
       status: "posted",
-      authorizedAt: "2026-07-05T00:00:00.000Z",
+      authorizedAt: "2026-07-05",
       postedDate: "2026-07-05T00:00:00.000Z",
     });
     expect((rows[0].raw as EsunTimelineTransaction).acfg).toBe("已入帳");
@@ -133,7 +135,7 @@ describe("E.SUN credit card timeline normalization", () => {
         sourceId:
           "2026-07-05T00:00:00.000Z:credit:esun:1204:全支付﹘全聯:252:TWD:1",
         status: "posted",
-        authorizedAt: "2026-07-05T00:00:00.000Z",
+        authorizedAt: "2026-07-05",
         postedDate: "2026-07-07T00:00:00.000Z",
       }),
     ]);
@@ -156,5 +158,42 @@ describe("E.SUN credit card timeline normalization", () => {
       { accountId: "credit:esun:1204", status: "posted" },
       { accountId: "credit:esun:9876", status: "posted" },
     ]);
+  });
+});
+
+describe("E.SUN deposit transaction timestamps", () => {
+  it("adds a Taiwan offset while keeping the legacy source identity", () => {
+    const target: Parameters<typeof appendEsunDepositTransactions>[0] = [];
+
+    appendEsunDepositTransactions(
+      target,
+      [
+        {
+          txDate: "2026/07/05",
+          txTime: "00:00:00",
+          amt: "252",
+          chc: "全支付",
+          balance: "1000",
+          showCrFlag: "show",
+        },
+      ],
+      "bank:esun:1234",
+      "TWD",
+    );
+
+    expect(target[0]).toMatchObject({
+      authorizedAt: "2026-07-05T00:00:00+08:00",
+      postedDate: "2026-07-05T00:00:00.000Z",
+      sourceId: "2026-07-05T00:00:00.000Z:bank:esun:1234:全支付:252:1000:::1",
+    });
+  });
+
+  it("keeps a missing source time at date precision", () => {
+    expect(normalizeEsunAuthorizedAt("2026/07/05", undefined)).toBe(
+      "2026-07-05",
+    );
+    expect(normalizeEsunAuthorizedAt("2026/07/05", "25:00:00")).toBe(
+      "2026-07-05",
+    );
   });
 });

--- a/apps/worker/tests/connectors/sinopac.test.ts
+++ b/apps/worker/tests/connectors/sinopac.test.ts
@@ -395,7 +395,7 @@ describe("sinopac App JSON parser", () => {
     expect(result.bankTransactions).toEqual([
       expect.objectContaining({
         sourceId: "sinopac:card:tx:v2:TWD:2026-07-19:-260:8000:1",
-        authorizedAt: "2026-07-19",
+        authorizedAt: "2026-07-19T18:35:13+08:00",
         postedDate: "2026-07-22",
         description: "連支＊餐廳",
         amount: -260,
@@ -415,6 +415,40 @@ describe("sinopac App JSON parser", () => {
     expect(result.bankTransactions[1]?.raw).toMatchObject({
       CardNo: "************1234",
     });
+  });
+
+  it("does not guess a pending time when a match key has multiple pending rows", () => {
+    const duplicatePendingPayload = structuredClone(sinoCardLatestPayload);
+    duplicatePendingPayload.Result.Items = [
+      duplicatePendingPayload.Result.Items[0],
+      {
+        ...duplicatePendingPayload.Result.Items[0],
+        AuthTime: "19:00:00",
+      },
+    ];
+
+    const result = parseSinopacCardData(
+      {
+        latest: duplicatePendingPayload,
+        outstanding: sinoCardOutstandingPayload,
+        summary: mobileSummaryPayload,
+        bills: mobileBillPayload,
+      },
+      new Date("2026-07-22T12:00:00.000Z"),
+    );
+
+    expect(result.bankTransactions).toEqual([
+      expect.objectContaining({
+        sourceId: "sinopac:card:tx:v2:TWD:2026-07-19:-260:8000:1",
+        authorizedAt: "2026-07-19",
+        status: "posted",
+      }),
+      expect.objectContaining({
+        sourceId: "sinopac:card:tx:v2:TWD:2026-07-19:-260:8000:2",
+        authorizedAt: "2026-07-19T19:00:00+08:00",
+        status: "pending",
+      }),
+    ]);
   });
 
   it("uses the App and SinoCard endpoints without acquiring a browser when session cookies exist", async () => {

--- a/apps/worker/tests/features/activity/route.test.ts
+++ b/apps/worker/tests/features/activity/route.test.ts
@@ -45,7 +45,7 @@ function createDb() {
       {
         id: "transaction-next-taipei-day",
         postedDate: "2026-07-06T16:00:00.000Z",
-        authorizedAt: null,
+        authorizedAt: "2026-07-06T16:00:00.000Z",
         amount: 50,
         currency: "TWD",
         accountType: "credit",

--- a/apps/worker/tests/features/bank/repository.test.ts
+++ b/apps/worker/tests/features/bank/repository.test.ts
@@ -4,8 +4,10 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   listBankTransactionsForTransferMatching,
+  listBankTransactionsInRange,
   type BankTransactionPageRow,
 } from "../../../src/features/bank/repository";
+import { listInvoicesInRange } from "../../../src/features/invoices/repository";
 
 class SqliteD1 {
   readonly database = new DatabaseSync(":memory:");
@@ -78,6 +80,42 @@ function createDb() {
 }
 
 describe("bank transaction transfer candidates", () => {
+  it("uses Taipei dates for precise bank and invoice timestamps at month boundaries", async () => {
+    const db = createDb();
+    db.database.exec(`
+      UPDATE bank_transactions SET authorized_at = '2026-08-31T16:30:00.000Z'
+        WHERE id = 'out';
+      UPDATE bank_transactions SET authorized_at = '2026-08-31T15:59:00.000Z'
+        WHERE id = 'in';
+      INSERT INTO invoices
+        (id, connector_id, source_id, invoice_date, amount, created_at, updated_at)
+      VALUES
+        ('sep', 'einvoice', 'sep', '2026-08-31T16:30:00.000Z', 100, '2026-09-01', '2026-09-01'),
+        ('aug', 'einvoice', 'aug', '2026-08-31T15:59:00.000Z', 100, '2026-09-01', '2026-09-01'),
+        ('date', 'einvoice', 'date', '2026-09-01', 100, '2026-09-01', '2026-09-01');
+    `);
+    const range = { from: "2026-09-01", to: "2026-10-01" };
+    expect(
+      (
+        await listBankTransactionsInRange(db as unknown as D1Database, range)
+      ).map((row) => row.id),
+    ).toEqual(["out"]);
+    expect(
+      (await listInvoicesInRange(db as unknown as D1Database, range))
+        .map((row) => row.id)
+        .sort(),
+    ).toEqual(["date", "sep"]);
+    expect(
+      (
+        await listBankTransactionsForTransferMatching(
+          db as unknown as D1Database,
+          [{ amount: -10_000, currency: "TWD" }],
+          ["2026-09-01"],
+        )
+      ).map((row) => row.id),
+    ).toEqual(["out"]);
+  });
+
   it("loads posted rows sharing a visible amount and currency", async () => {
     const db = createDb();
     const rows = await listBankTransactionsForTransferMatching(

--- a/apps/worker/tests/features/bank/transfer-matching.test.ts
+++ b/apps/worker/tests/features/bank/transfer-matching.test.ts
@@ -122,7 +122,7 @@ describe("automatic bank transfer matching", () => {
     );
   });
 
-  it("uses authorizedAt before postedDate for the stored financial day", () => {
+  it("uses the Taipei authorization day before the posting day", () => {
     const transactions = [
       transaction({
         id: "out",
@@ -140,9 +140,9 @@ describe("automatic bank transfer matching", () => {
       }),
     ];
 
-    expect(getAutomaticTransferDay(transactions[0])).toBe("2026-08-22");
+    expect(getAutomaticTransferDay(transactions[0])).toBe("2026-08-23");
     expect(findAutomaticTransferTransactionIds(transactions)).toEqual(
-      new Set(["in", "out"]),
+      new Set(),
     );
   });
 

--- a/apps/worker/tests/features/sync/activity-time-migration.test.ts
+++ b/apps/worker/tests/features/sync/activity-time-migration.test.ts
@@ -1,0 +1,372 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+const migrationsDirectory = fileURLToPath(
+  new URL("../../../../../packages/db/migrations/", import.meta.url),
+);
+const migrationFile = "0037_activity_time_precision.sql";
+const databases: DatabaseSync[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+function createDatabase() {
+  const database = new DatabaseSync(":memory:");
+  database.exec("PRAGMA foreign_keys = ON");
+  for (const file of readdirSync(migrationsDirectory)
+    .filter((name) => name.endsWith(".sql") && name < migrationFile)
+    .sort()) {
+    database.exec(readFileSync(`${migrationsDirectory}/${file}`, "utf8"));
+  }
+
+  const accounts = [
+    ["account-esun", "esun"],
+    ["account-cathay", "cathaybk"],
+    ["account-ctbc", "ctbc"],
+    ["account-tdcc", "tdcc"],
+    ["account-firstbank", "firstbank"],
+  ] as const;
+  const insertAccount = database.prepare(
+    `INSERT INTO bank_accounts
+      (id, connector_id, source_id, account_type, currency, created_at, updated_at)
+     VALUES (?, ?, ?, 'savings', 'TWD', '2026-01-01', '2026-01-01')`,
+  );
+  for (const [id, connectorId] of accounts) {
+    insertAccount.run(id, connectorId, `${connectorId}:source`);
+  }
+
+  databases.push(database);
+  return database;
+}
+
+function insertTransaction(
+  database: DatabaseSync,
+  input: {
+    id: string;
+    connectorId: string;
+    accountId: string;
+    sourceId: string;
+    postedDate: string;
+    authorizedAt?: string | null;
+    amount?: number;
+    rawPayload: string;
+  },
+) {
+  database
+    .prepare(
+      `INSERT INTO bank_transactions
+        (id, connector_id, account_id, source_id, posted_date, authorized_at,
+         amount, currency, description, raw_payload, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 'TWD', 'fixture', ?, '2026-01-01', '2026-01-02')`,
+    )
+    .run(
+      input.id,
+      input.connectorId,
+      input.accountId,
+      input.sourceId,
+      input.postedDate,
+      input.authorizedAt ?? null,
+      input.amount ?? -252,
+      input.rawPayload,
+    );
+}
+
+function insertInvoice(
+  database: DatabaseSync,
+  input: {
+    id: string;
+    sourceId: string;
+    invoiceDate: string;
+    rawPayload: string;
+  },
+) {
+  database
+    .prepare(
+      `INSERT INTO invoices
+        (id, connector_id, source_id, invoice_number, invoice_date, amount,
+         raw_payload, created_at, updated_at)
+       VALUES (?, 'einvoice', ?, ?, ?, 100, ?, '2026-01-01', '2026-01-01')`,
+    )
+    .run(
+      input.id,
+      input.sourceId,
+      input.id,
+      input.invoiceDate,
+      input.rawPayload,
+    );
+}
+
+function applyMigration(database: DatabaseSync) {
+  database.exec(
+    readFileSync(`${migrationsDirectory}/${migrationFile}`, "utf8"),
+  );
+}
+
+function insertFixtures(database: DatabaseSync) {
+  insertTransaction(database, {
+    id: "esun-card-fake-midnight",
+    connectorId: "esun",
+    accountId: "account-esun",
+    sourceId: "esun-card-fake",
+    postedDate: "2026-07-05T00:00:00.000Z",
+    authorizedAt: "2026-07-05T00:00:00.000Z",
+    rawPayload: JSON.stringify({ consumerDt: "07/05" }),
+  });
+  insertTransaction(database, {
+    id: "esun-deposit-full",
+    connectorId: "esun",
+    accountId: "account-esun",
+    sourceId: "esun-deposit-full",
+    postedDate: "2026-07-05T00:00:00.000Z",
+    rawPayload: JSON.stringify({ txDate: "2026/07/05", txTime: "13:14:15" }),
+  });
+  insertTransaction(database, {
+    id: "esun-deposit-no-time",
+    connectorId: "esun",
+    accountId: "account-esun",
+    sourceId: "esun-deposit-no-time",
+    postedDate: "2026-07-06T00:00:00.000Z",
+    rawPayload: JSON.stringify({ txDate: "2026/07/06" }),
+  });
+  insertTransaction(database, {
+    id: "cathay-full",
+    connectorId: "cathaybk",
+    accountId: "account-cathay",
+    sourceId: "cathay-full",
+    postedDate: "2026-07-05T12:34:56.000Z",
+    rawPayload: JSON.stringify({ txnDateTime: "2026/07/05T12:34:56" }),
+  });
+  insertTransaction(database, {
+    id: "cathay-no-time",
+    connectorId: "cathaybk",
+    accountId: "account-cathay",
+    sourceId: "cathay-no-time",
+    postedDate: "2026-07-06T00:00:00.000Z",
+    rawPayload: JSON.stringify({ txnDateTime: "2026/07/06" }),
+  });
+  insertTransaction(database, {
+    id: "cathay-bad-raw",
+    connectorId: "cathaybk",
+    accountId: "account-cathay",
+    sourceId: "cathay-bad-raw",
+    postedDate: "2026-07-07",
+    rawPayload: "not-json",
+  });
+  insertTransaction(database, {
+    id: "ctbc-full",
+    connectorId: "ctbc",
+    accountId: "account-ctbc",
+    sourceId: "ctbc-full",
+    postedDate: "2026-07-05",
+    rawPayload: JSON.stringify({ txnDateTime: "2026/07/05 12:34:56" }),
+  });
+  insertTransaction(database, {
+    id: "tdcc-true-midnight",
+    connectorId: "tdcc",
+    accountId: "account-tdcc",
+    sourceId: "tdcc-true-midnight",
+    postedDate: "2026-07-05",
+    rawPayload: JSON.stringify({ occurredAt: "2026-07-05T00:00:00" }),
+  });
+  insertTransaction(database, {
+    id: "tdcc-missing-time",
+    connectorId: "tdcc",
+    accountId: "account-tdcc",
+    sourceId: "tdcc-missing-time",
+    postedDate: "1970-01-01",
+    rawPayload: JSON.stringify({ occurredAt: "1970-01-01T00:00:00" }),
+  });
+  insertTransaction(database, {
+    id: "firstbank-full",
+    connectorId: "firstbank",
+    accountId: "account-firstbank",
+    sourceId: "firstbank-full",
+    postedDate: "2026-07-05",
+    authorizedAt: "2026-07-05T12:34:56",
+    rawPayload: "{}",
+  });
+  insertTransaction(database, {
+    id: "firstbank-invalid-date",
+    connectorId: "firstbank",
+    accountId: "account-firstbank",
+    sourceId: "firstbank-invalid-date",
+    postedDate: "2026-02-30",
+    authorizedAt: "2026-02-30T12:34:56",
+    rawPayload: "{}",
+  });
+
+  insertInvoice(database, {
+    id: "invoice-legacy-midnight",
+    sourceId: "invoice-legacy-midnight",
+    invoiceDate: "2026-07-05T00:00:00.000Z",
+    rawPayload: JSON.stringify({ invoice: { invNum: "AA000001" } }),
+  });
+  insertInvoice(database, {
+    id: "invoice-legacy-clock",
+    sourceId: "invoice-legacy-clock",
+    invoiceDate: "2026-07-05T12:34:56.000Z",
+    rawPayload: JSON.stringify({
+      invoice: { invNum: "AA000003", invDate: "2026-07-05T12:34:56.000Z" },
+    }),
+  });
+  insertInvoice(database, {
+    id: "invoice-new-midnight",
+    sourceId: "invoice-new-midnight",
+    invoiceDate: "2026-07-05T00:00:00.000Z",
+    rawPayload: JSON.stringify({
+      invoice: {
+        invNum: "AA000002",
+        invoiceDate: "2026-07-05T00:00:00+08:00",
+      },
+    }),
+  });
+
+  database.exec(`
+    INSERT INTO bank_transaction_preferences
+      (transaction_id, excluded_from_calculation, created_at, updated_at)
+    VALUES ('esun-deposit-full', 1, '2026-01-01', '2026-01-02');
+    INSERT INTO classification_overrides
+      (id, target_type, target_id, category_id, created_at, updated_at)
+    VALUES ('override-esun-full', 'bank_transaction', 'esun-deposit-full',
+            'salary', '2026-01-01', '2026-01-02');
+    INSERT INTO invoice_transaction_preferences
+      (invoice_id, transaction_id, decision, created_at, updated_at)
+    VALUES ('invoice-legacy-midnight', 'esun-deposit-full', 'linked',
+            '2026-01-01', '2026-01-02');
+  `);
+}
+
+describe("activity time precision migration", () => {
+  it("recovers only proven source times and preserves row identity and links", () => {
+    const database = createDatabase();
+    insertFixtures(database);
+
+    const beforeTransactions = database
+      .prepare(
+        `SELECT id, source_id, posted_date, amount, raw_payload
+         FROM bank_transactions ORDER BY id`,
+      )
+      .all();
+    const beforeCount = database
+      .prepare("SELECT COUNT(*) AS count FROM bank_transactions")
+      .get();
+
+    expect(() => applyMigration(database)).not.toThrow();
+
+    expect(
+      database
+        .prepare(
+          `SELECT id, source_id, posted_date, amount, raw_payload
+           FROM bank_transactions ORDER BY id`,
+        )
+        .all(),
+    ).toEqual(beforeTransactions);
+    expect(
+      database.prepare("SELECT COUNT(*) AS count FROM bank_transactions").get(),
+    ).toEqual(beforeCount);
+
+    expect(
+      database
+        .prepare(
+          `SELECT id, authorized_at AS authorizedAt
+           FROM bank_transactions ORDER BY id`,
+        )
+        .all(),
+    ).toEqual([
+      { id: "cathay-bad-raw", authorizedAt: null },
+      {
+        id: "cathay-full",
+        authorizedAt: "2026-07-05T12:34:56+08:00",
+      },
+      { id: "cathay-no-time", authorizedAt: "2026-07-06" },
+      {
+        id: "ctbc-full",
+        authorizedAt: "2026-07-05T12:34:56+08:00",
+      },
+      {
+        id: "esun-card-fake-midnight",
+        authorizedAt: "2026-07-05",
+      },
+      {
+        id: "esun-deposit-full",
+        authorizedAt: "2026-07-05T13:14:15+08:00",
+      },
+      { id: "esun-deposit-no-time", authorizedAt: "2026-07-06" },
+      {
+        id: "firstbank-full",
+        authorizedAt: "2026-07-05T12:34:56+08:00",
+      },
+      {
+        id: "firstbank-invalid-date",
+        authorizedAt: "2026-02-30T12:34:56",
+      },
+      {
+        id: "tdcc-missing-time",
+        authorizedAt: "1970-01-01",
+      },
+      {
+        id: "tdcc-true-midnight",
+        authorizedAt: "2026-07-05T00:00:00+08:00",
+      },
+    ]);
+
+    expect(
+      database
+        .prepare(
+          `SELECT id, invoice_date AS invoiceDate
+           FROM invoices ORDER BY id`,
+        )
+        .all(),
+    ).toEqual([
+      { id: "invoice-legacy-clock", invoiceDate: "2026-07-05" },
+      { id: "invoice-legacy-midnight", invoiceDate: "2026-07-05" },
+      {
+        id: "invoice-new-midnight",
+        invoiceDate: "2026-07-05T00:00:00.000Z",
+      },
+    ]);
+
+    expect(
+      database
+        .prepare(
+          `SELECT transaction_id AS transactionId, excluded_from_calculation AS excluded
+           FROM bank_transaction_preferences`,
+        )
+        .all(),
+    ).toEqual([{ transactionId: "esun-deposit-full", excluded: 1 }]);
+    expect(
+      database
+        .prepare(
+          `SELECT target_id AS targetId, category_id AS categoryId
+           FROM classification_overrides`,
+        )
+        .all(),
+    ).toEqual([{ targetId: "esun-deposit-full", categoryId: "salary" }]);
+    expect(
+      database
+        .prepare(
+          `SELECT invoice_id AS invoiceId, transaction_id AS transactionId
+           FROM invoice_transaction_preferences`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        invoiceId: "invoice-legacy-midnight",
+        transactionId: "esun-deposit-full",
+      },
+    ]);
+
+    applyMigration(database);
+    expect(
+      database.prepare("SELECT COUNT(*) AS count FROM bank_transactions").get(),
+    ).toEqual(beforeCount);
+    expect(
+      database
+        .prepare("SELECT authorized_at FROM bank_transactions WHERE id = ?")
+        .get("esun-deposit-full"),
+    ).toEqual({ authorized_at: "2026-07-05T13:14:15+08:00" });
+  });
+});

--- a/apps/worker/tests/features/sync/einvoice-run-repository.test.ts
+++ b/apps/worker/tests/features/sync/einvoice-run-repository.test.ts
@@ -882,6 +882,41 @@ describe("durable e-invoice sync runs", () => {
     });
   });
 
+  it("retains a known invoice time when a refreshed header contains only its Taipei date", async () => {
+    const { database, db } = createDb();
+    insertEinvoiceSettings(database);
+    database.exec(`INSERT INTO invoices
+      (id, connector_id, source_id, invoice_date, amount, created_at, updated_at)
+      VALUES ('invoice-time', 'einvoice', 'invoice-time', '2026-07-31T16:00:00.000Z', 80, 'old', 'old')`);
+    const run = await createProcessingEinvoiceRun(database, db, {
+      runId: "run-time",
+      settingsVersion: "version-1",
+      items: [
+        {
+          invoiceSourceId: "invoice-time",
+          header: header("time"),
+          normalizedInvoice: {
+            sourceId: "invoice-time",
+            invoiceDate: "2026-08-01",
+            amount: 80,
+          },
+          detailItems: [],
+        },
+      ],
+    });
+    await promoteEinvoiceRunRecords(db, {
+      runId: run.id,
+      expectedSettingsUpdatedAt: "version-1",
+      cursor: "cursor-time",
+      now: "2026-08-12T01:00:00.000Z",
+    });
+    expect(
+      database.prepare("SELECT id, invoice_date FROM invoices").all(),
+    ).toEqual([
+      { id: "invoice-time", invoice_date: "2026-07-31T16:00:00.000Z" },
+    ]);
+  });
+
   it("promotes completed invoices and lines with stable records and makes replay a no-op", async () => {
     const { database, db } = createDb();
     insertEinvoiceSettings(database);

--- a/apps/worker/tests/features/sync/persistence.test.ts
+++ b/apps/worker/tests/features/sync/persistence.test.ts
@@ -770,6 +770,44 @@ describe("staged sync persistence", () => {
     ).toEqual({ count: 2 });
   });
 
+  it("keeps source time through date-only refreshes and accepts newly available time", async () => {
+    const db = createDb();
+    await persistStagedSyncWrite(db as unknown as D1Database, {
+      records: [
+        bankAccountRecord(0),
+        bankTransactionRecord("purchase-time", "posted", {
+          authorizedAt: "2026-07-05T14:35:00+08:00",
+          postedDate: "2026-07-07",
+        }),
+        bankTransactionRecord("purchase-date", "pending", {
+          authorizedAt: "2026-07-05",
+        }),
+      ],
+    });
+    await persistStagedSyncWrite(db as unknown as D1Database, {
+      records: [
+        bankTransactionRecord("purchase-time", "posted", {
+          authorizedAt: "2026-07-05",
+          postedDate: "2026-07-07",
+        }),
+        bankTransactionRecord("purchase-date", "posted", {
+          authorizedAt: "2026-07-05T00:00:00+08:00",
+          postedDate: "2026-07-07",
+        }),
+      ],
+    });
+    expect(
+      db.database
+        .prepare(
+          "SELECT source_id AS sourceId, authorized_at AS authorizedAt FROM bank_transactions ORDER BY source_id",
+        )
+        .all(),
+    ).toEqual([
+      { sourceId: "purchase-date", authorizedAt: "2026-07-05T00:00:00+08:00" },
+      { sourceId: "purchase-time", authorizedAt: "2026-07-05T14:35:00+08:00" },
+    ]);
+  });
+
   it("preserves confirmed credit card payment data when a later sync omits it", async () => {
     const db = createDb();
 

--- a/docs/004-connector-development.md
+++ b/docs/004-connector-development.md
@@ -88,6 +88,8 @@ Connector 不得依賴 Hono、D1、Worker `Env`，也不得直接寫入資料庫
 - `sourceId` 必須在重複同步間穩定。一般交易不得使用本次同步時間產生 ID。
 - `BankBalanceSnapshot.accountId`、`BankTransaction.accountId` 與 `CreditCardBill.accountId` 必須等於對應 `BankAccount.sourceId`。
 - 日期使用 ISO 8601；帳單期間使用 `YYYY-MM`；幣別使用大寫代碼。
+- `BankTransaction.authorizedAt` 與 `Invoice.invoiceDate`：來源只有日期時使用 `YYYY-MM-DD`；來源確實提供時間時使用含明確時區的 ISO timestamp。不得以補上的午夜或同步時間假造交易時間；台灣來源未標時區的交易時間以 `+08:00` 解讀。
+- 補充交易時間時須保留既有 `sourceId` 算法；`postedDate` 維持入帳日期用途。未入帳轉已入帳或重新同步只提供日期時，須保留同筆交易原有的可靠時間。
 - 支出與負債為負，退款與入帳為正。
 - `raw` 只能保留遮罩或白名單資料，主要功能不得依賴 raw shape。
 - 一般 connector 的資料必須經 `record-mapper.ts` 與 staged persistence；durable-run

--- a/packages/connectors/src/ctbc.ts
+++ b/packages/connectors/src/ctbc.ts
@@ -209,6 +209,7 @@ function parseDepositTransactions(
       const sourceAccountId =
         accountSourceIds.get(accountId) ?? depositSourceId(accountId);
       const postedDate = normalizeDate(value.trnDtFull) ?? undefined;
+      const authorizedAt = normalizeTaipeiDateTime(value.trnDtFull);
       const description =
         optionalString(value.memo1) ||
         optionalString(value.passBookMemo) ||
@@ -229,6 +230,7 @@ function parseDepositTransactions(
           accountId: sourceAccountId,
           sourceId: `ctbc:deposit:tx:${stableHash(sourceKey)}:${occurrence}`,
           postedDate,
+          ...(authorizedAt ? { authorizedAt } : {}),
           amount,
           currency: TWD,
           description,
@@ -411,10 +413,12 @@ function parseRealtimeTransactions(payload: unknown) {
   const items = arrayAt(responseData(payload), "allItems");
   return items.flatMap<CtbcCardTransactionCandidate>((value) => {
     if (!isRecord(value)) return [];
-    const authorizedAt =
+    const transactionDate =
       normalizeDate(value.txnDate) ?? normalizeDate(value.txnDateTime);
+    const authorizedAt =
+      normalizeTaipeiDateTime(value.txnDateTime) ?? transactionDate;
     const rawAmount = numberValue(value.txnAmt);
-    if (!authorizedAt || rawAmount == null || rawAmount === 0) return [];
+    if (!transactionDate || rawAmount == null || rawAmount === 0) return [];
     const description = optionalString(value.merchName) || "中國信託信用卡消費";
     const transactionType = optionalString(value.txnType) ?? "";
     const refund =
@@ -426,7 +430,10 @@ function parseRealtimeTransactions(payload: unknown) {
     const cardLast4 =
       last4(stringValue(value.cardNoSuffixFour)) ??
       last4(stringValue(value.cardNo));
-    const matchKey = [TWD, authorizedAt, amount, cardLast4].join(":");
+    // Keep the established date-only match/source identity.  The realtime
+    // timestamp is display metadata and must not create a second transaction
+    // when the same authorization later appears in the posted feed.
+    const matchKey = [TWD, transactionDate, amount, cardLast4].join(":");
     return [
       {
         accountId: creditCardSourceId(TWD),
@@ -525,7 +532,14 @@ function reconcileCreditCardLifecycle(
     if (candidates.length !== 1) return transaction;
     const candidate = candidates[0]!;
     consumedPending.add(candidate);
-    return { ...transaction, identityKey: candidate.identityKey };
+    return {
+      ...transaction,
+      identityKey: candidate.identityKey,
+      authorizedAt: preferredAuthorizedAt(
+        transaction.authorizedAt,
+        candidate.authorizedAt,
+      ),
+    };
   });
   const all = [
     ...reconciledPosted,
@@ -540,6 +554,20 @@ function reconcileCreditCardLifecycle(
       sourceId: `ctbc:card:tx:${stableHash(identityKey)}:${occurrence}`,
     };
   });
+}
+
+function preferredAuthorizedAt(
+  postedAuthorizedAt: string | undefined,
+  pendingAuthorizedAt: string | undefined,
+) {
+  const postedHasTime = hasTimeComponent(postedAuthorizedAt);
+  const pendingHasTime = hasTimeComponent(pendingAuthorizedAt);
+  if (pendingHasTime && !postedHasTime) return pendingAuthorizedAt;
+  return postedAuthorizedAt;
+}
+
+function hasTimeComponent(value: string | undefined) {
+  return Boolean(value && /T\d{2}:\d{2}(?::\d{2})?/.test(value));
 }
 
 function merchantsMatch(left: string | undefined, right: string | undefined) {
@@ -587,6 +615,7 @@ function sanitizeDepositTransaction(value: JsonRecord, accountId: string) {
   return {
     accountLast4: last4(accountId),
     trnDtFull: normalizeDate(value.trnDtFull),
+    authorizedAt: normalizeTaipeiDateTime(value.trnDtFull),
     memo1: optionalString(value.memo1),
     memo2: optionalString(value.memo2),
     passBookMemo: optionalString(value.passBookMemo),
@@ -704,9 +733,10 @@ function periodFromParts(year: number, month: number) {
 }
 
 function normalizeDate(value: unknown) {
-  const text = stringValue(value).trim().replace(/\./g, "/");
-  const separated = /^(\d{3,4})[/-](\d{1,2})[/-](\d{1,2})/.exec(text);
-  const compact = /^(\d{3,4})(\d{2})(\d{2})$/.exec(text);
+  const text = stringValue(value).trim();
+  const dateText = (text.split(/[T\s]/, 1)[0] ?? "").replace(/\./g, "/");
+  const separated = /^(\d{3,4})[/-](\d{1,2})[/-](\d{1,2})$/.exec(dateText);
+  const compact = /^(\d{3,4})(\d{2})(\d{2})$/.exec(dateText);
   const parts = separated ?? compact;
   if (!parts) return undefined;
   const year =
@@ -725,6 +755,52 @@ function normalizeDate(value: unknown) {
   )
     return undefined;
   return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+/**
+ * Normalize a provider date-time without changing the date-only identity used
+ * by existing CTBC transactions.  CTBC's mobile responses normally omit an
+ * offset and represent Taipei local time; an explicit provider offset is
+ * retained when one is present.
+ */
+function normalizeTaipeiDateTime(value: unknown) {
+  const text = stringValue(value).trim();
+  const time =
+    /^(.+?)[T ](\d{1,2})[:：](\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(?:\s*(Z|[+-]\d{2}:?\d{2}))?$/.exec(
+      text,
+    );
+  if (!time) return undefined;
+  const date = normalizeDate(time[1]);
+  if (!date) return undefined;
+  const hour = Number(time[2]);
+  const minute = Number(time[3]);
+  const second = Number(time[4] ?? 0);
+  if (hour > 23 || minute > 59 || second > 59) return undefined;
+  const suffix = normalizeOffset(time[6]);
+  if (!suffix) return undefined;
+  const fraction = time[5] ? "." + time[5].slice(0, 3).padEnd(3, "0") : "";
+  return (
+    date +
+    "T" +
+    String(hour).padStart(2, "0") +
+    ":" +
+    String(minute).padStart(2, "0") +
+    ":" +
+    String(second).padStart(2, "0") +
+    fraction +
+    suffix
+  );
+}
+
+function normalizeOffset(value: string | undefined): string | undefined {
+  if (!value) return "+08:00";
+  if (value === "Z") return "Z";
+  const match = /^([+-]\d{2}):?(\d{2})$/.exec(value);
+  if (!match) return undefined;
+  const hours = Number(match[1].slice(1));
+  const minutes = Number(match[2]);
+  if (hours > 23 || minutes > 59) return undefined;
+  return match[1] + ":" + match[2];
 }
 
 function normalizeCurrency(value: unknown) {

--- a/packages/connectors/src/firstbank.ts
+++ b/packages/connectors/src/firstbank.ts
@@ -148,9 +148,9 @@ export function parseFirstbankData(
     : emptyDepositParse();
   const bankTransactions = payloads.transactionHistoryHtml
     ? parseTransactionHistoryHtml(
-      payloads.transactionHistoryHtml,
-      deposits.accounts,
-    )
+        payloads.transactionHistoryHtml,
+        deposits.accounts,
+      )
     : [];
   const cards = parseCreditCards(
     payloads.cardBill,
@@ -545,14 +545,14 @@ function parseTransactionRow(
   header: TransactionHeader,
 ):
   | {
-    amount: number;
-    currency?: string;
-    balance?: number;
-    postedDate: string;
-    authorizedAt: string;
-    description: string;
-    status: "pending" | "posted";
-  }
+      amount: number;
+      currency?: string;
+      balance?: number;
+      postedDate: string;
+      authorizedAt: string;
+      description: string;
+      status: "pending" | "posted";
+    }
   | undefined {
   const date = normalizeDateTime(cells[header.date]);
   if (!date) return undefined;

--- a/packages/connectors/src/firstbank.ts
+++ b/packages/connectors/src/firstbank.ts
@@ -148,9 +148,9 @@ export function parseFirstbankData(
     : emptyDepositParse();
   const bankTransactions = payloads.transactionHistoryHtml
     ? parseTransactionHistoryHtml(
-        payloads.transactionHistoryHtml,
-        deposits.accounts,
-      )
+      payloads.transactionHistoryHtml,
+      deposits.accounts,
+    )
     : [];
   const cards = parseCreditCards(
     payloads.cardBill,
@@ -431,7 +431,7 @@ function parseTransactionHistoryHtml(
       }
       const identity = [
         account.sourceId,
-        parsed.authorizedAt,
+        legacyAuthorizedAt(parsed.authorizedAt),
         parsed.amount,
         currency,
         parsed.balance ?? "",
@@ -545,14 +545,14 @@ function parseTransactionRow(
   header: TransactionHeader,
 ):
   | {
-      amount: number;
-      currency?: string;
-      balance?: number;
-      postedDate: string;
-      authorizedAt: string;
-      description: string;
-      status: "pending" | "posted";
-    }
+    amount: number;
+    currency?: string;
+    balance?: number;
+    postedDate: string;
+    authorizedAt: string;
+    description: string;
+    status: "pending" | "posted";
+  }
   | undefined {
   const date = normalizeDateTime(cells[header.date]);
   if (!date) return undefined;
@@ -1292,16 +1292,48 @@ function normalizeDateTime(value: unknown) {
   const text = stripTags(String(value ?? "")).trim();
   const date = normalizeDate(text);
   if (!date) return undefined;
-  const time = /(?:T|\s+)(\d{1,2})[:：](\d{2})(?:[:：](\d{2}))?/.exec(text);
+  const time =
+    /^(.+?)[T ](\d{1,2})[:：](\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(?:\s*(Z|[+-]\d{2}:?\d{2}))?$/.exec(
+      text,
+    );
   if (!time) return { date, dateTime: date };
-  const hour = Number(time[1]);
-  const minute = Number(time[2]);
-  const second = Number(time[3] ?? 0);
+  const datePart = normalizeDate(time[1]);
+  if (!datePart || datePart !== date) return undefined;
+  const hour = Number(time[2]);
+  const minute = Number(time[3]);
+  const second = Number(time[4] ?? 0);
   if (hour > 23 || minute > 59 || second > 59) return undefined;
+  const suffix = normalizeOffset(time[6]);
+  if (!suffix) return undefined;
+  const fraction = time[5] ? "." + time[5].slice(0, 3).padEnd(3, "0") : "";
   return {
     date,
-    dateTime: `${date}T${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}:${String(second).padStart(2, "0")}`,
+    dateTime:
+      date +
+      "T" +
+      String(hour).padStart(2, "0") +
+      ":" +
+      String(minute).padStart(2, "0") +
+      ":" +
+      String(second).padStart(2, "0") +
+      fraction +
+      suffix,
   };
+}
+
+function legacyAuthorizedAt(value: string) {
+  return value.replace(/(?:Z|[+-]\d{2}:?\d{2})$/, "").replace(/\.\d{1,9}$/, "");
+}
+
+function normalizeOffset(value: string | undefined): string | undefined {
+  if (!value) return "+08:00";
+  if (value === "Z") return "Z";
+  const match = /^([+-]\d{2}):?(\d{2})$/.exec(value);
+  if (!match) return undefined;
+  const hours = Number(match[1].slice(1));
+  const minutes = Number(match[2]);
+  if (hours > 23 || minutes > 59) return undefined;
+  return match[1] + ":" + match[2];
 }
 
 function normalizeBillingPeriod(value: unknown): string | undefined {

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -30,6 +30,7 @@ export {
   ensureTdccSession,
   initializeTdccSnapshot,
   normalizeTdccSnapshot,
+  normalizeTdccBankAuthorizedAt,
   stockAccountsFromPayload,
   parseTdccStockAccounts,
   parseTdccStockHoldings,
@@ -286,7 +287,7 @@ export const einvoiceConnector: Connector<
       records: config.records.map((record) => ({
         sourceId: record.sourceId,
         invoiceNumber: record.invoiceNumber,
-        invoiceDate: record.invoiceDate,
+        invoiceDate: normalizeInvoiceDate(record.invoiceDate),
         sellerName: record.sellerName,
         amount: record.amount,
         raw: record.raw ?? record,
@@ -385,7 +386,7 @@ export async function initializeEInvoiceSync(
         invoice: {
           sourceId,
           invoiceNumber: invoice.invNum || undefined,
-          invoiceDate: normalizeInvoiceDate(invoice.invDate),
+          invoiceDate: invoice.invoiceDate,
           sellerName: invoice.sellerName,
           amount: Math.max(0, Math.trunc(invoice.amount)),
           raw: { invoice, period },
@@ -557,6 +558,7 @@ function getV2Invoices(payload: unknown) {
           `v2-${index}`,
         invNum: firstStringValue(item.invNum, item.invoiceNumber),
         invDate: invoiceDate.iso,
+        invoiceDate: invoiceDate.normalized,
         detailInvDate: invoiceDate.apiDate,
         sellerName:
           firstStringValue(item.sellerName, item.seller, item.sellerNameE) ||
@@ -574,8 +576,15 @@ function getV2Invoices(payload: unknown) {
 
 function parseV2InvoiceDate(value: unknown) {
   if (typeof value === "string" && value.trim()) {
-    const iso = normalizeInvoiceDate(value);
-    return { iso, apiDate: formatTaipeiApiDate(new Date(iso)) };
+    const iso = legacyInvoiceIdentityDate(value);
+    const normalized = normalizeInvoiceDate(value);
+    return {
+      iso,
+      apiDate: /^\d{4}-\d{2}-\d{2}$/.test(normalized)
+        ? normalized.replace(/-/g, "/")
+        : formatTaipeiApiDate(new Date(normalized)),
+      normalized,
+    };
   }
 
   const record =
@@ -585,7 +594,11 @@ function parseV2InvoiceDate(value: unknown) {
   const epoch = Number(record?.time);
   if (Number.isFinite(epoch) && epoch > 0) {
     const date = new Date(epoch);
-    return { iso: date.toISOString(), apiDate: formatTaipeiApiDate(date) };
+    return {
+      iso: date.toISOString(),
+      apiDate: formatTaipeiApiDate(date),
+      normalized: date.toISOString(),
+    };
   }
 
   const rocYear = Number(record?.year);
@@ -598,10 +611,14 @@ function parseV2InvoiceDate(value: unknown) {
   ) {
     const year = rocYear < 1911 ? rocYear + 1911 : rocYear;
     const apiDate = `${year}/${String(month).padStart(2, "0")}/${String(day).padStart(2, "0")}`;
-    return { iso: normalizeInvoiceDate(apiDate), apiDate };
+    return {
+      iso: legacyInvoiceIdentityDate(apiDate),
+      apiDate,
+      normalized: normalizeInvoiceDate(apiDate),
+    };
   }
 
-  return { iso: "", apiDate: "" };
+  return { iso: "", apiDate: "", normalized: "" };
 }
 
 function formatTaipeiApiDate(date: Date) {
@@ -697,6 +714,36 @@ function invoiceSourceId(invNum: string, invDate: string, fallback: string) {
 }
 
 function normalizeInvoiceDate(value: string) {
+  const normalized = value
+    .trim()
+    .replace(/\//g, "-")
+    .replace(" ", "T")
+    .replace(
+      /^(\d{4})-(\d{1,2})-(\d{1,2})(?=T|$)/,
+      (_, year: string, month: string, day: string) =>
+        `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`,
+    );
+  if (/^\d{4}-\d{2}-\d{2}$/.test(normalized)) return normalized;
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(normalized)) return normalized;
+  const day = normalized.slice(0, 10);
+  const calendarDate = new Date(`${day}T00:00:00Z`);
+  if (
+    !Number.isFinite(calendarDate.getTime()) ||
+    !calendarDate.toISOString().startsWith(day) ||
+    Number(normalized.slice(11, 13)) >= 24
+  )
+    return day;
+  const timestamp = /(?:Z|[+-]\d{2}:\d{2})$/i.test(normalized)
+    ? normalized
+    : `${normalized}+08:00`;
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime())
+    ? normalized.slice(0, 10)
+    : date.toISOString();
+}
+
+// Keep the original source-id representation even when display dates gain precision.
+function legacyInvoiceIdentityDate(value: string) {
   const normalized = value.trim().replace(/\//g, "-");
   const withTime = /^\d{4}-\d{2}-\d{2}$/.test(normalized)
     ? `${normalized}T00:00:00`

--- a/packages/connectors/src/skbank.ts
+++ b/packages/connectors/src/skbank.ts
@@ -299,6 +299,12 @@ function parseSkbankTransactions(
         accountId,
         sourceId: `skbank:${currency === "TWD" ? "deposit" : "foreign"}:tx:${stableHash(sourceIdentity)}`,
         postedDate,
+        // 新光交易明細的時間沒有時區標記，但 API 回傳的是台灣本地時間。
+        // sourceId 仍使用未帶 offset 的既有 identity，避免既有交易重複；
+        // authorizedAt 才保存可供活動排序與顯示的完整時間。
+        ...(transactionTimestamp
+          ? { authorizedAt: `${transactionTimestamp}+08:00` }
+          : {}),
         amount,
         currency,
         description,
@@ -342,6 +348,7 @@ function sanitizeTwdTransaction(
     remark: sanitizeOptionalString(detail.Remark, accountNumber),
     summary: sanitizeOptionalString(detail.Summary, accountNumber),
     transactionDate: normalizeTransactionDate(detail.TransactionDate),
+    transactionDateTime: normalizeTransactionTimestamp(detail.TransactionDate),
   };
 }
 
@@ -358,6 +365,7 @@ function sanitizeForeignTransaction(
     memo: sanitizeOptionalString(detail.Memo, accountNumber),
     summary: sanitizeOptionalString(detail.Summary, accountNumber),
     transactionDate: normalizeTransactionDate(detail.TransactionDate),
+    transactionDateTime: normalizeTransactionTimestamp(detail.TransactionDate),
   };
 }
 

--- a/packages/connectors/src/taishin.ts
+++ b/packages/connectors/src/taishin.ts
@@ -326,7 +326,10 @@ function mergeTransactionLifecycle(
 ) {
   const pendingByMatchKey = groupByMatchKey(pending);
   const postedByMatchKey = groupByMatchKey(posted);
-  const postedIdentityKeys = new Map<TransactionCandidate, string>();
+  const postedIdentityKeys = new Map<
+    TransactionCandidate,
+    { identityKey: string; authorizedAt?: string }
+  >();
   const consumedPending = new Set<TransactionCandidate>();
 
   for (const [matchKey, postedGroup] of postedByMatchKey) {
@@ -350,7 +353,13 @@ function mergeTransactionLifecycle(
       );
       if (matchingPosted.length !== 1) continue;
 
-      postedIdentityKeys.set(postedTransaction, pendingTransaction.identityKey);
+      postedIdentityKeys.set(postedTransaction, {
+        identityKey: pendingTransaction.identityKey,
+        authorizedAt: preferredAuthorizedAt(
+          postedTransaction.authorizedAt,
+          pendingTransaction.authorizedAt,
+        ),
+      });
       consumedPending.add(pendingTransaction);
     }
   }
@@ -363,7 +372,13 @@ function mergeTransactionLifecycle(
         candidate.identityKey === postedTransaction.identityKey,
     );
     if (!pendingTransaction) continue;
-    postedIdentityKeys.set(postedTransaction, pendingTransaction.identityKey);
+    postedIdentityKeys.set(postedTransaction, {
+      identityKey: pendingTransaction.identityKey,
+      authorizedAt: preferredAuthorizedAt(
+        postedTransaction.authorizedAt,
+        pendingTransaction.authorizedAt,
+      ),
+    });
     consumedPending.add(pendingTransaction);
   }
 
@@ -371,21 +386,44 @@ function mergeTransactionLifecycle(
     ...posted.map((transaction) => ({
       transaction,
       identityKey:
-        postedIdentityKeys.get(transaction) ?? transaction.identityKey,
+        postedIdentityKeys.get(transaction)?.identityKey ??
+        transaction.identityKey,
+      authorizedAt:
+        postedIdentityKeys.get(transaction)?.authorizedAt ??
+        transaction.authorizedAt,
     })),
     ...pending
       .filter((transaction) => !consumedPending.has(transaction))
       .map((transaction) => ({
         transaction,
         identityKey: transaction.identityKey,
+        authorizedAt: transaction.authorizedAt,
       })),
   ];
   const occurrences = new Map<string, number>();
-  return candidates.map(({ transaction, identityKey }) => {
+  return candidates.map(({ transaction, identityKey, authorizedAt }) => {
     const occurrence = (occurrences.get(identityKey) ?? 0) + 1;
     occurrences.set(identityKey, occurrence);
-    return assignSourceId(transaction, identityKey, occurrence);
+    return assignSourceId(
+      { ...transaction, authorizedAt },
+      identityKey,
+      occurrence,
+    );
   });
+}
+
+function preferredAuthorizedAt(
+  postedAuthorizedAt: string | undefined,
+  pendingAuthorizedAt: string | undefined,
+) {
+  const postedHasTime = hasTimeComponent(postedAuthorizedAt);
+  const pendingHasTime = hasTimeComponent(pendingAuthorizedAt);
+  if (pendingHasTime && !postedHasTime) return pendingAuthorizedAt;
+  return postedAuthorizedAt;
+}
+
+function hasTimeComponent(value: string | undefined) {
+  return Boolean(value && /T\d{2}:\d{2}(?::\d{2})?/.test(value));
 }
 
 function assignSourceId(

--- a/packages/connectors/src/tdcc.ts
+++ b/packages/connectors/src/tdcc.ts
@@ -597,6 +597,7 @@ async function runTdccLogin(
       accountId,
       sourceId: tx.txnId,
       postedDate: tx.occurredAt,
+      authorizedAt: normalizeTdccBankAuthorizedAt(tx.occurredAt),
       amount: tx.amount,
       currency: entry.currency.toUpperCase(),
       description: tx.memo,
@@ -1296,7 +1297,9 @@ function toBankTransaction(
     accountId: accountSourceId,
     sourceId,
     postedDate,
-    authorizedAt,
+    authorizedAt: movement.authorizedAt
+      ? normalizeTdccBankAuthorizedAt(movement.authorizedAt)
+      : undefined,
     amount,
     currency: movement.currency || "TWD",
     description: movement.description,
@@ -1343,9 +1346,33 @@ function parseOptionalTdccNumber(value: string) {
   return value && Number.isFinite(parsed) ? parsed : undefined;
 }
 
-// ponytail: manual exports use 7-digit ROC dates ("1130615" = 2024/06/15); the
-// live API also returns 8-digit Gregorian dates and 13/14-digit timestamps
-// (ROC/Gregorian year + time-of-day suffix) — same ROC-offset rule throughout.
+export function normalizeTdccBankAuthorizedAt(value: string) {
+  const local = value.trim().replace(/\//g, "-");
+  if (local === "1970-01-01T00:00:00") return "1970-01-01";
+  if (/^\d{4}-\d{2}-\d{2}$/.test(local)) return local;
+  if (
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2})?$/.test(
+      local,
+    )
+  ) {
+    const timestamp = /(?:Z|[+-]\d{2}:\d{2})$/.test(local)
+      ? local
+      : `${local}+08:00`;
+    const day = local.slice(0, 10);
+    const calendarDate = new Date(`${day}T00:00:00Z`);
+    if (
+      Number.isFinite(Date.parse(timestamp)) &&
+      Number(local.slice(11, 13)) < 24 &&
+      Number.isFinite(calendarDate.getTime()) &&
+      calendarDate.toISOString().startsWith(day)
+    )
+      return timestamp;
+    return day;
+  }
+  return normalizeTdccDate(value).slice(0, 10);
+}
+
+// Manual exports use compact ROC dates; preserve the legacy identity conversion.
 function normalizeTdccDate(value: string) {
   const trimmed = value.trim();
 

--- a/packages/connectors/tests/selfcheck/ctbc.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/ctbc.selfcheck.ts
@@ -41,7 +41,7 @@ const payloads = {
         {
           sourceAccountId: "123456789012",
           acctId: "987654321000",
-          trnDtFull: "2026/07/20",
+          trnDtFull: "2026/07/20 11:22:33",
           memo1: "薪資入帳",
           crAmt: "25,000",
           dbAmt: "0",
@@ -183,6 +183,41 @@ assert.equal(result.bankTransactions[2]?.amount, -350);
 assert.equal(result.bankTransactions[3]?.amount, 120);
 assert.equal(result.bankTransactions[4]?.amount, -500);
 assert.equal(result.bankTransactions[4]?.status, "posted");
+assert.equal(result.bankTransactions[0]?.postedDate, "2026-07-20");
+assert.equal(
+  result.bankTransactions[0]?.authorizedAt,
+  "2026-07-20T11:22:33+08:00",
+);
+assert.equal(
+  result.bankTransactions[2]?.authorizedAt,
+  "2026-07-08T12:00:00+08:00",
+);
+const utcMillisPayloads = {
+  ...payloads,
+  realtime: {
+    ...payloads.realtime,
+    rsData: {
+      ...payloads.realtime.rsData,
+      allItems: payloads.realtime.rsData.allItems.map((item, index) =>
+        index === 0
+          ? { ...item, txnDateTime: "2026-07-08T12:00:00.000Z" }
+          : item,
+      ),
+    },
+  },
+};
+const utcMillisResult = parseCtbcData(
+  utcMillisPayloads,
+  new Date("2026-07-29T00:00:00.000Z"),
+);
+assert.equal(
+  utcMillisResult.bankTransactions[2]?.authorizedAt,
+  "2026-07-08T12:00:00.000Z",
+);
+assert.equal(
+  utcMillisResult.bankTransactions[2]?.sourceId,
+  result.bankTransactions[2]?.sourceId,
+);
 assert.equal(result.bankTransactions[5]?.amount, -500);
 assert.equal(result.bankTransactions[5]?.status, "pending");
 assert.notEqual(

--- a/packages/connectors/tests/selfcheck/einvoice-v2.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/einvoice-v2.selfcheck.ts
@@ -296,6 +296,56 @@ async function main() {
       ).length,
     EINVOICE_SYNC_PERIODS,
   );
+  const dateClient = new EInvoiceV2Client({
+    androidId: "synthetic-android-id",
+    fetchImpl: async (input, init) =>
+      String(input).endsWith("/einvoice/carriers/query-invoices-header")
+        ? json({
+            result: 0,
+            payload: {
+              data: [
+                { invNum: "DATE", invDate: "2026/07/01", amount: 1 },
+                { invNum: "LOCAL", invDate: "2026/07/01 00:00:00", amount: 1 },
+                {
+                  invNum: "OBJECT",
+                  invDate: { year: "115", month: "7", date: "1" },
+                  amount: 1,
+                },
+                {
+                  invNum: "EPOCH",
+                  invDate: { time: Date.parse("2026-06-30T16:00:00Z") },
+                  amount: 1,
+                },
+                { invNum: "LATE", invDate: "2026/07/01 23:30:00", amount: 1 },
+              ],
+            },
+          })
+        : fakeFetch(input, init),
+  });
+  const dateHeaders = (
+    await initializeEInvoiceSync(primitiveConfig, { client: dateClient })
+  ).headers.slice(0, 5);
+  assert.deepEqual(
+    dateHeaders.map((header) => header.invoice.invoiceDate),
+    [
+      "2026-07-01",
+      "2026-06-30T16:00:00.000Z",
+      "2026-07-01",
+      "2026-06-30T16:00:00.000Z",
+      "2026-07-01T15:30:00.000Z",
+    ],
+  );
+  assert.equal(
+    dateHeaders[0].sourceId,
+    `DATE:${new Date("2026-07-01T00:00:00").toISOString()}`,
+  );
+  assert.equal(
+    dateHeaders[1].sourceId,
+    `LOCAL:${new Date("2026-07-01T00:00:00").toISOString()}`,
+  );
+  assert.ok(
+    dateHeaders.every((header) => header.detailInvDate === "2026/07/01"),
+  );
   console.log("einvoice-v2.selfcheck: ok");
 }
 

--- a/packages/connectors/tests/selfcheck/firstbank.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/firstbank.selfcheck.ts
@@ -166,9 +166,21 @@ assert.equal(
 );
 assert.equal(
   parsed.bankTransactions.find(
+    (transaction) => transaction.description === "購物",
+  )?.authorizedAt,
+  "2026-08-20T09:10:11+08:00",
+);
+assert.equal(
+  parsed.bankTransactions.find(
     (transaction) => transaction.description === "薪資",
   )?.amount,
   2000,
+);
+assert.equal(
+  parsed.bankTransactions.find(
+    (transaction) => transaction.description === "薪資",
+  )?.authorizedAt,
+  "2026-08-21T10:20:30+08:00",
 );
 assert.equal(
   parsed.bankTransactions.find((transaction) =>
@@ -176,6 +188,30 @@ assert.equal(
   )?.amount,
   -200,
 );
+assert.equal(
+  parsed.bankTransactions.find((transaction) =>
+    transaction.description.includes("待入帳"),
+  )?.authorizedAt,
+  "2026-08-25",
+);
+const utcMillisParsed = parseFirstbankData(
+  {
+    ...payloads,
+    transactionHistoryHtml: transactionHistoryHtml.replace(
+      "2026/08/20 09:10:11",
+      "2026-08-20T09:10:11.000Z",
+    ),
+  },
+  now,
+);
+const originalShopping = parsed.bankTransactions.find(
+  (transaction) => transaction.description === "購物",
+);
+const utcMillisShopping = utcMillisParsed.bankTransactions.find(
+  (transaction) => transaction.description === "購物",
+);
+assert.equal(utcMillisShopping?.authorizedAt, "2026-08-20T09:10:11.000Z");
+assert.equal(utcMillisShopping?.sourceId, originalShopping?.sourceId);
 assert.equal(parsed.creditCardBills.length, 1);
 assert.deepEqual(parsed.creditCardBills[0], {
   ...parsed.creditCardBills[0],

--- a/packages/connectors/tests/selfcheck/skbank.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/skbank.selfcheck.ts
@@ -414,6 +414,15 @@ assert.equal(foreignParsed.bankAccounts[3]?.accountType, "time_deposit");
 assert.match(foreignParsed.bankAccounts[2]?.sourceId ?? "", /:USD$/);
 assert.equal(foreignParsed.bankTransactions[0]?.amount, -12.34);
 assert.equal(foreignParsed.bankTransactions[0]?.postedDate, "2022-07-18");
+assert.equal(
+  foreignParsed.bankTransactions[0]?.authorizedAt,
+  "2022-07-18T10:28:20+08:00",
+);
+assert.equal(
+  (foreignParsed.bankTransactions[0]?.raw as { transactionDateTime?: string })
+    .transactionDateTime,
+  "2022-07-18T10:28:20",
+);
 assert.doesNotMatch(
   JSON.stringify(foreignParsed),
   /7000000000001234|7000000000005678|InwardAccountNumber/,

--- a/packages/connectors/tests/selfcheck/taishin.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/taishin.selfcheck.ts
@@ -105,6 +105,15 @@ assert.equal(
   result.bankTransactions.find(({ status }) => status === "pending")?.amount,
   -1404,
 );
+assert.equal(
+  result.bankTransactions.find(
+    (transaction) =>
+      transaction.description === "測試商店" &&
+      transaction.amount === -350 &&
+      transaction.authorizedAt?.includes("12:30:00"),
+  )?.authorizedAt,
+  "2026-07-08T12:30:00+08:00",
+);
 assert.doesNotMatch(JSON.stringify(result), /A123456789|4111111111113108/);
 
 console.log("Taishin connector self-check passed.");

--- a/packages/connectors/tests/selfcheck/tdcc.selfcheck.ts
+++ b/packages/connectors/tests/selfcheck/tdcc.selfcheck.ts
@@ -4,6 +4,7 @@
 import assert from "node:assert/strict";
 import {
   createTdccConnector,
+  normalizeTdccBankAuthorizedAt,
   parseTdccTradePageItems,
   parseTdccConfig,
   TdccOtpExpiredError,
@@ -15,6 +16,15 @@ import {
 } from "../../src/tdcc-epassbook-client";
 
 const calls: string[] = [];
+assert.equal(
+  normalizeTdccBankAuthorizedAt("2026-07-01T00:00:00"),
+  "2026-07-01T00:00:00+08:00",
+);
+assert.equal(
+  normalizeTdccBankAuthorizedAt("1970-01-01T00:00:00"),
+  "1970-01-01",
+);
+assert.equal(normalizeTdccBankAuthorizedAt("2026-07-01"), "2026-07-01");
 const tspPageTokens: string[] = [];
 let mode:
   | "flag_otp"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ export interface Invoice {
   connectorId: string;
   sourceId: string;
   invoiceNumber?: string;
+  /** YYYY-MM-DD when time is unknown; otherwise an ISO timestamp with timezone. */
   invoiceDate: string;
   sellerName?: string;
   amount: number;
@@ -152,6 +153,7 @@ export interface BankTransaction {
   accountId: string;
   sourceId: string;
   postedDate?: string;
+  /** Transaction/authorization date, with a timezone only when source time is known. */
   authorizedAt?: string;
   amount: number;
   currency: string;

--- a/packages/db/migrations/0037_activity_time_precision.sql
+++ b/packages/db/migrations/0037_activity_time_precision.sql
@@ -1,0 +1,87 @@
+-- Reuse authorized_at for source-provided transaction time. Never rewrite
+-- source_id/posted_date: historical connector identities contain their old values.
+-- Raw payloads are consulted only for this one-time, source-specific recovery.
+
+UPDATE bank_transactions
+SET authorized_at = substr(authorized_at, 1, 10)
+WHERE connector_id = 'esun'
+  AND authorized_at LIKE '%T00:00:00.000Z'
+  AND (json_type(CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+                 '$.consumerDt') = 'text'
+    OR json_type(CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+                 '$.postingDt') = 'text');
+
+-- E.SUN deposits previously labelled Taiwan local clock values as UTC.
+WITH source AS (
+  SELECT id, substr(posted_date, 1, 10) AS day,
+    trim(CAST(json_extract(raw_payload, '$.txTime') AS TEXT)) AS clock
+  FROM bank_transactions
+  WHERE connector_id = 'esun' AND authorized_at IS NULL
+    AND json_type(CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+                  '$.txDate') = 'text'
+), recovered AS (
+  SELECT id, CASE
+    WHEN (clock GLOB '[0-2][0-9]:[0-5][0-9]' OR
+          clock GLOB '[0-2][0-9]:[0-5][0-9]:[0-5][0-9]')
+      AND substr(clock, 1, 2) < '24'
+    THEN day || 'T' || clock || CASE WHEN length(clock) = 5 THEN ':00' ELSE '' END || '+08:00'
+    ELSE day END AS authorized_at
+  FROM source WHERE date(day, '+0 days') = day
+)
+UPDATE bank_transactions
+SET authorized_at = recovered.authorized_at
+FROM recovered WHERE bank_transactions.id = recovered.id;
+
+-- These sources kept the original full timestamp in a known raw field.
+WITH source AS (
+  SELECT id, replace(replace(trim(CAST(CASE connector_id
+      WHEN 'cathaybk' THEN COALESCE(json_extract(raw_payload, '$.txnDateTime'),
+                                  json_extract(raw_payload, '$.accountDate'),
+                                  json_extract(raw_payload, '$.consumeDate'))
+      WHEN 'ctbc' THEN json_extract(raw_payload, '$.txnDateTime')
+      WHEN 'tdcc' THEN json_extract(raw_payload, '$.occurredAt')
+    END AS TEXT)), '/', '-'), ' ', 'T') AS value
+  FROM bank_transactions
+  WHERE connector_id IN ('cathaybk', 'ctbc', 'tdcc')
+    AND (authorized_at IS NULL OR length(authorized_at) = 10)
+    AND json_valid(raw_payload)
+), recovered AS (
+  SELECT id, CASE
+    WHEN value = '1970-01-01T00:00:00' THEN '1970-01-01'
+    WHEN length(value) = 10 AND date(value, '+0 days') = value THEN value
+    WHEN value GLOB '????-??-??T[0-2][0-9]:[0-5][0-9]*'
+      AND substr(value, 12, 2) < '24'
+      AND date(substr(value, 1, 10), '+0 days') = substr(value, 1, 10)
+      AND datetime(value) IS NOT NULL
+    THEN CASE WHEN length(value) IN (16, 19, 23) AND value NOT LIKE '%Z'
+      THEN value || '+08:00' ELSE value END
+    ELSE NULL END AS authorized_at
+  FROM source
+)
+UPDATE bank_transactions
+SET authorized_at = recovered.authorized_at
+FROM recovered
+WHERE bank_transactions.id = recovered.id AND recovered.authorized_at IS NOT NULL;
+
+-- First Bank preserved local transaction clocks without an offset.
+UPDATE bank_transactions
+SET authorized_at = authorized_at || '+08:00'
+WHERE connector_id = 'firstbank' AND length(authorized_at) = 19
+  AND authorized_at GLOB '????-??-??T[0-2][0-9]:[0-5][0-9]:[0-5][0-9]'
+  AND substr(authorized_at, 12, 2) < '24'
+  AND date(substr(authorized_at, 1, 10), '+0 days') = substr(authorized_at, 1, 10)
+  AND datetime(authorized_at) IS NOT NULL;
+
+-- Legacy v2 invoice raw headers lost both source precision and timezone:
+-- local clock strings and epoch timestamps were normalized in the same field.
+-- Keep only the Taipei date until a sync supplies the original date shape.
+-- New headers include invoice.invoiceDate and must retain genuine midnight.
+UPDATE invoices
+SET invoice_date = date(invoice_date, '+8 hours')
+WHERE connector_id = 'einvoice'
+  AND json_type(CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+                '$.invoice') = 'object'
+  AND json_extract(CASE WHEN json_valid(raw_payload) THEN raw_payload ELSE '{}' END,
+                   '$.invoice.invoiceDate') IS NULL
+  AND date(invoice_date, '+8 hours') IS NOT NULL
+  AND length(invoice_date) > 10;


### PR DESCRIPTION
活動紀錄目前未顯示時分，且不同來源的日期字串、時區與補上的午夜值會影響同日排序。這次沿用 `authorized_at`／`invoice_date` 保存來源實際提供的精度，在手機與桌面的活動名稱下顯示 `HH:mm`，並依台灣日期與時間由新到舊排列；同日只有日期的紀錄置於最後。

- 補齊銀行來源的時間解析與明確時區，保留既有 `sourceId` 算法，避免提升時間精度後產生重複交易。
- 未入帳轉已入帳、或重新同步只回傳日期時，保留同筆交易已有的可靠時間；多筆不明確的對應不猜測時間。
- 月份篩選、日期分組、發票配對與 API 範圍查詢使用一致的日期語意；銀行與發票合併顯示時不以發票時間代替銀行時間。

資料 migration：新增 `0037_activity_time_precision.sql`，從保留的原始欄位回補玉山、國泰、中信即時信用卡與集保交割戶時間，替第一銀行既有本地時間補上時區，並移除已知的假午夜。銀行交易 ID、入帳日期、金額及使用者關聯保持不變。

舊版電子發票已失去來源精度及時區格式，migration 會將這些紀錄的 `invoice_date` 保留為台灣日期，原始 payload 保留；只有後續再次取得該筆來源資料時才能補回可靠時間。新光與中信存款等已丟失時分秒的歷史資料也無法直接回補，超出同步查詢範圍的資料不會自動恢復。

驗證：
- repo root：`npm run format:check`、`npm run typecheck`、`npm run test:backend`、`npm run test:unit`。
- 本次實作同一份程式內容已通過 `npm run build` 與活動時間的手機／桌面相關 Playwright E2E。
- SQLite migration 測試涵蓋回補、未知時間、真正午夜、非法資料、ID／金額／關聯保留及重跑冪等性。

尚未部署、套用線上 migration 或執行實際銀行同步；上述驗證均為本機或合成資料測試。
