### PR TITLE
新增軟體服務、生活繳費與其他收入分類及自動規則

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -63,7 +63,15 @@ test.beforeEach(async ({ page }) => {
         { id: "fee", label: "手續費", sortOrder: 11, isSystem: true },
         { id: "insurance", label: "保險", sortOrder: 12, isSystem: true },
         { id: "tax", label: "稅務", sortOrder: 13, isSystem: true },
-        { id: "other", label: "未分類", sortOrder: 14, isSystem: true },
+        { id: "software", label: "軟體服務", sortOrder: 14, isSystem: true },
+        { id: "utilities", label: "生活繳費", sortOrder: 15, isSystem: true },
+        {
+          id: "other-income",
+          label: "其他收入",
+          sortOrder: 16,
+          isSystem: true,
+        },
+        { id: "other", label: "未分類", sortOrder: 17, isSystem: true },
       ];
     else if (path === "/api/classification/rules") body = [];
     else if (path.includes("/connectors/") && path.endsWith("/settings"))

--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -135,6 +135,9 @@
     { id: "insurance", label: "保險" },
     { id: "fee", label: "手續費" },
     { id: "tax", label: "稅務" },
+    { id: "software", label: "軟體服務" },
+    { id: "utilities", label: "生活繳費" },
+    { id: "other-income", label: "其他收入" },
     { id: "other", label: "未分類" },
   ];
   const categoryOptions = $derived(

--- a/apps/worker/src/features/bank/service.ts
+++ b/apps/worker/src/features/bank/service.ts
@@ -74,6 +74,7 @@ async function presentBankTransactions(
         description: transaction.description,
         counterparty: transaction.counterparty,
         sourceId: transaction.sourceId,
+        amount: transaction.amount,
       })),
     );
   } catch (error) {

--- a/apps/worker/src/features/classification/service.ts
+++ b/apps/worker/src/features/classification/service.ts
@@ -17,6 +17,7 @@ export type ClassifiedTransaction = {
   description?: string | null;
   counterparty?: string | null;
   sourceId: string;
+  amount?: number;
 };
 
 export function matchesClassificationRule(
@@ -95,6 +96,15 @@ export async function resolveClassifications(
     let matched: ClassificationResult | undefined;
     for (const rule of rules) {
       if (rule.target_type && rule.target_type !== "bank_transaction") continue;
+      if (
+        rule.id === "system:bank:other-income-keywords" &&
+        !(
+          typeof transaction.amount === "number" &&
+          Number.isFinite(transaction.amount) &&
+          transaction.amount > 0
+        )
+      )
+        continue;
       if (!matchesClassificationRule(rule, transaction)) continue;
       matched = {
         categoryId: rule.category_id,

--- a/apps/worker/tests/features/classification/default-rules.test.ts
+++ b/apps/worker/tests/features/classification/default-rules.test.ts
@@ -1,0 +1,141 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveClassifications } from "../../../src/features/classification/service";
+
+const migrationsDirectory = fileURLToPath(
+  new URL("../../../../../packages/db/migrations/", import.meta.url),
+);
+const migrationFiles = readdirSync(migrationsDirectory)
+  .filter((name) => name.endsWith(".sql"))
+  .sort();
+const databases: DatabaseSync[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+function createDatabase(before = "0040") {
+  const database = new DatabaseSync(":memory:");
+  databases.push(database);
+  database.exec("PRAGMA foreign_keys = ON");
+  for (const file of migrationFiles.filter((name) => name < before)) {
+    database.exec(readFileSync(`${migrationsDirectory}/${file}`, "utf8"));
+  }
+  return database;
+}
+
+function asD1(database: DatabaseSync) {
+  return {
+    prepare(sql: string) {
+      let params: SQLInputValue[] = [];
+      return {
+        bind(...values: SQLInputValue[]) {
+          params = values;
+          return this;
+        },
+        async all() {
+          return { results: database.prepare(sql).all(...params) };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+describe("default classification rules", () => {
+  it("classifies merchant and income descriptions using migrated rule priority", async () => {
+    const cases: Array<[string, number, string]> = [
+      ["OPENAI *CHATGPT SUBSCRO123456 SAN FR", -100, "software"],
+      ["OPENAIO123456 SAN FR", -100, "software"],
+      ["CURSOR, AI POWERED IDEO123456 CURSOR", -100, "software"],
+      ["CLOUDFLAREO123456 SAN FR", -100, "software"],
+      ["GOOGLE*CLOUD EXAMPLEO123456 CC GOO", -100, "software"],
+      ["Microsoft 365", -100, "software"],
+      ["中華電信股份有限公司個人家庭分TAIPEI", -100, "utilities"],
+      ["遠傳電信股份有限公司TAIPEI", -100, "utilities"],
+      ["信用卡消費折抵_遠傳電信股份有限公司", 100, "utilities"],
+      ["轉帳代繳台灣電力電費", -100, "utilities"],
+      ["瓦斯費", -100, "utilities"],
+      ["利息存入", 100, "other-income"],
+      ["利息", 100, "other-income"],
+      ["證券股利匯款", 100, "other-income"],
+      ["租金補貼轉入", 100, "other-income"],
+      ["現金回饋", 100, "other-income"],
+      ["利息", -100, "fee"],
+      ["APPLE.COM/BILL", -100, "other"],
+      ["GOOGLE*YOUTUBE", -100, "other"],
+      ["電腦軟體/PXPAY PLUS CO LTD", -100, "other"],
+      ["OPENAI 國外交易手續費", -100, "fee"],
+      ["遠傳電信購機", -100, "other"],
+      ["現金回饋退款", 100, "other"],
+    ];
+    const transactions = cases.map(([description, amount], index) => ({
+      id: `transaction-${index}`,
+      sourceId: `source-${index}`,
+      description,
+      amount,
+    }));
+    const results = await resolveClassifications(
+      asD1(createDatabase()),
+      transactions,
+    );
+    for (const [index, [description, , categoryId]] of cases.entries()) {
+      expect(results.get(`transaction-${index}`)?.categoryId, description).toBe(
+        categoryId,
+      );
+    }
+    const sourceOnly = await resolveClassifications(asD1(createDatabase()), [
+      {
+        id: "source-only",
+        sourceId: "openai",
+        description: "未辨識交易",
+        amount: -100,
+      },
+    ]);
+    expect(sourceOnly.get("source-only")?.categoryId).toBe("other");
+  });
+
+  it("preserves an existing same-name category and supports migration reruns", async () => {
+    const database = createDatabase("0038");
+    database.exec(
+      "INSERT INTO classification_categories VALUES ('user:software', '軟體服務', 15, 0, 'original', 'original')",
+    );
+    for (let run = 0; run < 2; run++) {
+      for (const file of migrationFiles.filter(
+        (name) => name >= "0038" && name < "0040",
+      )) {
+        database.exec(readFileSync(`${migrationsDirectory}/${file}`, "utf8"));
+      }
+    }
+    expect(
+      database
+        .prepare(
+          "SELECT category_id FROM classification_rules WHERE id = 'system:bank:software-keywords'",
+        )
+        .get()?.category_id,
+    ).toBe("user:software");
+    expect(
+      database
+        .prepare(
+          "SELECT is_system FROM classification_categories WHERE id = 'user:software'",
+        )
+        .get()?.is_system,
+    ).toBe(0);
+  });
+
+  it("keeps demo rules consistent with migrated defaults", () => {
+    const database = createDatabase();
+    const sql =
+      "SELECT * FROM classification_rules WHERE id IN ('system:bank:software-keywords', 'system:bank:utilities-keywords', 'system:bank:other-income-keywords') ORDER BY id";
+    const expected = database.prepare(sql).all();
+    database.exec(
+      readFileSync(
+        new URL("../../../../../packages/db/seeds/demo.sql", import.meta.url),
+        "utf8",
+      ),
+    );
+    expect(expected).toHaveLength(3);
+    expect(database.prepare(sql).all()).toEqual(expected);
+  });
+});

--- a/apps/worker/tests/features/classification/service.test.ts
+++ b/apps/worker/tests/features/classification/service.test.ts
@@ -11,6 +11,44 @@ const transaction = {
   counterparty: "Coffee Shop",
 };
 
+const otherIncomeRule = {
+  id: "system:bank:other-income-keywords",
+  category_id: "other-income",
+  label: "其他收入",
+  target_type: "bank_transaction",
+  field: "any_text",
+  operator: "contains",
+  pattern: "利息",
+  is_system: 1,
+  excluded_from_calculation: 0,
+};
+
+function createClassificationDb(
+  rules: Array<typeof otherIncomeRule> = [otherIncomeRule],
+  overrides: Array<{
+    target_id: string;
+    category_id: string;
+    label: string;
+  }> = [],
+) {
+  return {
+    prepare(sql: string) {
+      return {
+        bind() {
+          return this;
+        },
+        async all() {
+          return {
+            results: sql.includes("classification_overrides")
+              ? overrides
+              : rules,
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
 describe("matchesClassificationRule", () => {
   it("supports field-specific and any-text matching", () => {
     expect(
@@ -114,5 +152,77 @@ describe("resolveClassifications", () => {
     expect(overrideQuery?.values).toEqual([
       JSON.stringify(["tx-card-payment"]),
     ]);
+  });
+
+  it("applies the other-income system rule only to positive amounts", async () => {
+    const result = await resolveClassifications(createClassificationDb(), [
+      {
+        ...transaction,
+        id: "tx-interest-positive",
+        description: "外幣存款利息",
+        amount: 18,
+      },
+    ]);
+
+    expect(result.get("tx-interest-positive")).toMatchObject({
+      categoryId: "other-income",
+      label: "其他收入",
+      source: "system_rule",
+      ruleId: "system:bank:other-income-keywords",
+    });
+  });
+
+  it("falls back when an other-income transaction is non-positive or missing an amount", async () => {
+    const cases = [
+      { id: "tx-interest-negative", amount: -18 },
+      { id: "tx-interest-zero", amount: 0 },
+      { id: "tx-interest-missing" },
+    ] as const;
+
+    for (const input of cases) {
+      const result = await resolveClassifications(createClassificationDb(), [
+        {
+          ...transaction,
+          id: input.id,
+          description: "外幣存款利息",
+          ...("amount" in input ? { amount: input.amount } : {}),
+        },
+      ]);
+
+      expect(result.get(input.id), input.id).toEqual({
+        categoryId: "other",
+        label: "未分類",
+        source: "fallback",
+      });
+    }
+  });
+
+  it("keeps an explicit override before the other-income amount guard", async () => {
+    const result = await resolveClassifications(
+      createClassificationDb(
+        [otherIncomeRule],
+        [
+          {
+            target_id: "tx-interest-negative",
+            category_id: "fee",
+            label: "手續費",
+          },
+        ],
+      ),
+      [
+        {
+          ...transaction,
+          id: "tx-interest-negative",
+          description: "外幣存款利息",
+          amount: -18,
+        },
+      ],
+    );
+
+    expect(result.get("tx-interest-negative")).toMatchObject({
+      categoryId: "fee",
+      label: "手續費",
+      source: "override",
+    });
   });
 });

--- a/packages/db/migrations/0038_add_default_classification_categories.sql
+++ b/packages/db/migrations/0038_add_default_classification_categories.sql
@@ -1,0 +1,9 @@
+INSERT OR IGNORE INTO classification_categories
+  (id, label, sort_order, is_system, created_at, updated_at) VALUES
+  ('software',     '軟體服務', 14, 1, '2026-09-06T00:00:00.000Z', '2026-09-06T00:00:00.000Z'),
+  ('utilities',    '生活繳費', 15, 1, '2026-09-06T00:00:00.000Z', '2026-09-06T00:00:00.000Z'),
+  ('other-income', '其他收入', 16, 1, '2026-09-06T00:00:00.000Z', '2026-09-06T00:00:00.000Z');
+
+UPDATE classification_categories
+SET sort_order = 17, updated_at = '2026-09-06T00:00:00.000Z'
+WHERE id = 'other' AND is_system = 1 AND sort_order = 14;

--- a/packages/db/migrations/0039_add_default_classification_rules.sql
+++ b/packages/db/migrations/0039_add_default_classification_rules.sql
@@ -1,0 +1,23 @@
+INSERT OR IGNORE INTO classification_rules
+  (id, category_id, target_type, field, operator, pattern, priority, enabled, is_system, source, description, created_at, updated_at)
+SELECT 'system:bank:software-keywords', id, 'bank_transaction', 'description', 'regex',
+  '^(?!.*(?:手續費|交易服務費|\bforeign\s+transaction\s+fee\b)).*(?:\b(?:openai|cursor|cloudflare)(?:\b|o[0-9])|\bchatgpt\b|\banthropic\b|\bclaude(?:\.ai|\s+(?:pro|max|subscription))\b|\bgoogle\s*[* ]\s*(?:cloud|one|workspace)\b|\b(?:github|jetbrains|adobe|notion|dropbox)(?:\b|o[0-9])|\b(?:microsoft|office)\s*365\b|\bicloud\b)',
+  108, 1, 1, 'system', '軟體服務商家與產品名稱', '2026-09-06T00:00:00.000Z', '2026-09-06T00:00:00.000Z'
+FROM classification_categories
+WHERE label = '軟體服務' COLLATE NOCASE;
+
+INSERT OR IGNORE INTO classification_rules
+  (id, category_id, target_type, field, operator, pattern, priority, enabled, is_system, source, description, created_at, updated_at)
+SELECT 'system:bank:utilities-keywords', id, 'bank_transaction', 'description', 'regex',
+  '^(?!.*(?:手續費|交易服務費|購機|手機|設備|門市|商城|購物)).*(?:中華電信|遠傳電信|台灣大哥大|台灣之星|亞太電信|台灣電力|台灣自來水|臺北自來水|台北自來水|台電|台水|水費|電費|瓦斯費|天然氣費|電信費|電話費|網路費|寬頻費|\bhinet\b)',
+  108, 1, 1, 'system', '電信、水電、瓦斯與網路費用', '2026-09-06T00:00:00.000Z', '2026-09-06T00:00:00.000Z'
+FROM classification_categories
+WHERE label = '生活繳費' COLLATE NOCASE;
+
+INSERT OR IGNORE INTO classification_rules
+  (id, category_id, target_type, field, operator, pattern, priority, enabled, is_system, source, description, created_at, updated_at)
+SELECT 'system:bank:other-income-keywords', id, 'bank_transaction', 'description', 'regex',
+  '^(?!.*(?:退刷|退款|退貨|折抵|利息調整|利息退還|貸款|借款|融資|循環利息|手續費)).*(?:^利息$|利息存入|存款利息|活存利息|定存利息|股息|股利|配息|現金回饋|回饋金|現金回存|租金補貼|租屋補助|育兒津貼|生育補助|政府補助|稿費|稿酬|接案收入|退稅|^interest$|\binterest\s+(?:credit|income)\b|\bdividends?\b|\bcashback\b)',
+  108, 1, 1, 'system', '正金額的利息、股利、補助、稿費、退稅與現金回饋', '2026-09-06T00:00:00.000Z', '2026-09-06T00:00:00.000Z'
+FROM classification_categories
+WHERE label = '其他收入' COLLATE NOCASE;

--- a/packages/db/seeds/demo.sql
+++ b/packages/db/seeds/demo.sql
@@ -36,7 +36,10 @@ INSERT INTO classification_categories
   ('fee',           '手續費', 11, 1, '2026-06-22T00:00:00.000Z', '2026-06-22T00:00:00.000Z'),
   ('insurance',     '保險',   12, 1, '2026-06-22T00:00:00.000Z', '2026-06-22T00:00:00.000Z'),
   ('tax',           '稅務',   13, 1, '2026-06-22T00:00:00.000Z', '2026-06-22T00:00:00.000Z'),
-  ('other',         '未分類', 14, 1, '2026-06-22T00:00:00.000Z', '2026-07-28T00:00:00.000Z');
+  ('software',      '軟體服務', 14, 1, '2026-09-06T00:00:00.000Z', '2026-09-06T00:00:00.000Z'),
+  ('utilities',     '生活繳費', 15, 1, '2026-09-06T00:00:00.000Z', '2026-09-06T00:00:00.000Z'),
+  ('other-income',  '其他收入', 16, 1, '2026-09-06T00:00:00.000Z', '2026-09-06T00:00:00.000Z'),
+  ('other',         '未分類', 17, 1, '2026-06-22T00:00:00.000Z', '2026-09-06T00:00:00.000Z');
 
 INSERT INTO classification_rules
   (id, category_id, target_type, field, operator, pattern, priority, enabled, is_system, source, description, created_at, updated_at) VALUES
@@ -50,6 +53,30 @@ INSERT INTO classification_rules
   ('system:shared:insurance-keywords', 'insurance',  NULL,               'any_text', 'regex', '健保|勞保|保費|保險|insurance',                                                95, 1, 1, 'system', '保險相關關鍵字',   '2026-06-22T00:00:00.000Z', '2026-06-22T00:00:00.000Z'),
   ('system:bank:creditcard-payment',   'transfer',   'bank_transaction', 'any_text', 'regex', '信用卡.*繳|繳卡費|credit.?card.*(pay|bill|repay)',                            106, 1, 1, 'system', '信用卡繳費',       '2026-06-22T00:00:00.000Z', '2026-06-22T00:00:00.000Z'),
   ('demo:user:rent',                   'housing',    'bank_transaction', 'any_text', 'contains', '房租',                                                                      200, 1, 0, 'demo',   'Demo 自訂房租分類', '2026-06-24T09:00:00.000Z', '2026-06-24T09:00:00.000Z');
+
+INSERT OR IGNORE INTO classification_rules
+  (id, category_id, target_type, field, operator, pattern, priority, enabled, is_system, source, description, created_at, updated_at)
+SELECT 'system:bank:software-keywords', id, 'bank_transaction', 'description', 'regex',
+  '^(?!.*(?:手續費|交易服務費|\bforeign\s+transaction\s+fee\b)).*(?:\b(?:openai|cursor|cloudflare)(?:\b|o[0-9])|\bchatgpt\b|\banthropic\b|\bclaude(?:\.ai|\s+(?:pro|max|subscription))\b|\bgoogle\s*[* ]\s*(?:cloud|one|workspace)\b|\b(?:github|jetbrains|adobe|notion|dropbox)(?:\b|o[0-9])|\b(?:microsoft|office)\s*365\b|\bicloud\b)',
+  108, 1, 1, 'system', '軟體服務商家與產品名稱', '2026-09-06T00:00:00.000Z', '2026-09-06T00:00:00.000Z'
+FROM classification_categories
+WHERE label = '軟體服務' COLLATE NOCASE;
+
+INSERT OR IGNORE INTO classification_rules
+  (id, category_id, target_type, field, operator, pattern, priority, enabled, is_system, source, description, created_at, updated_at)
+SELECT 'system:bank:utilities-keywords', id, 'bank_transaction', 'description', 'regex',
+  '^(?!.*(?:手續費|交易服務費|購機|手機|設備|門市|商城|購物)).*(?:中華電信|遠傳電信|台灣大哥大|台灣之星|亞太電信|台灣電力|台灣自來水|臺北自來水|台北自來水|台電|台水|水費|電費|瓦斯費|天然氣費|電信費|電話費|網路費|寬頻費|\bhinet\b)',
+  108, 1, 1, 'system', '電信、水電、瓦斯與網路費用', '2026-09-06T00:00:00.000Z', '2026-09-06T00:00:00.000Z'
+FROM classification_categories
+WHERE label = '生活繳費' COLLATE NOCASE;
+
+INSERT OR IGNORE INTO classification_rules
+  (id, category_id, target_type, field, operator, pattern, priority, enabled, is_system, source, description, created_at, updated_at)
+SELECT 'system:bank:other-income-keywords', id, 'bank_transaction', 'description', 'regex',
+  '^(?!.*(?:退刷|退款|退貨|折抵|利息調整|利息退還|貸款|借款|融資|循環利息|手續費)).*(?:^利息$|利息存入|存款利息|活存利息|定存利息|股息|股利|配息|現金回饋|回饋金|現金回存|租金補貼|租屋補助|育兒津貼|生育補助|政府補助|稿費|稿酬|接案收入|退稅|^interest$|\binterest\s+(?:credit|income)\b|\bdividends?\b|\bcashback\b)',
+  108, 1, 1, 'system', '正金額的利息、股利、補助、稿費、退稅與現金回饋', '2026-09-06T00:00:00.000Z', '2026-09-06T00:00:00.000Z'
+FROM classification_categories
+WHERE label = '其他收入' COLLATE NOCASE;
 
 INSERT INTO connector_settings
   (id, connector_id, encrypted_config, sync_cursor, created_at, updated_at) VALUES


### PR DESCRIPTION
新增「軟體服務」、「生活繳費」、「其他收入」預設分類與自動分類規則，讓 OpenAI／ChatGPT、Cursor、Cloudflare、Google Cloud、電信帳單與利息入帳有明確歸屬，並同步前端備援清單、Demo 與 E2E 測試資料。

規則比對交易描述；其他收入僅接受正金額，手動分類仍優先。模糊的 Apple／Google 支付名稱不直接分類，另排除明確交易手續費、購機描述及退款／折抵收入。新增 0038、0039 migrations，保留既有同名自訂分類並支援重複套用。

驗證：
- `npm run format:check`
- `npm run typecheck`
- `npm run test:backend`：458 個 Worker 測試、4 個 DB 測試、connector self-checks、16 個部署／同步腳本測試通過。
- `npm run test:unit`：95 個前端單元測試通過。
- 新增規則整合測試涵蓋實際格式的合成交易描述、分類優先權、金額方向、migration 重跑與 Demo 一致性。

尚未執行線上 migration 或部署；啟用時需一併套用 migrations 與新版 Worker，讓其他收入的正金額限制生效。
