### PR TITLE
修正活動載入錯誤與同步健康度顯示

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ apps/worker/wrangler.local.toml
 *.tsbuildinfo
 .DS_Store
 research/
+design/
 
 docs/*
 !docs/

--- a/apps/web/e2e/data-health.spec.ts
+++ b/apps/web/e2e/data-health.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test } from "@playwright/test";
+
+for (const state of ["unconfigured", "pending", "healthy", "failed"] as const) {
+  test(`settings reports ${state} sync health accurately`, async ({ page }) => {
+    await page.route("**/api/**", async (route) => {
+      const path = new URL(route.request().url()).pathname;
+      if (!path.startsWith("/api/")) return route.continue();
+      const jobs =
+        state === "unconfigured"
+          ? []
+          : [
+              {
+                id: "esun:all",
+                connectorId: "esun",
+                scope: "all",
+                configured: true,
+                enabled: false,
+                running: false,
+                scheduleMode: "inherit",
+                intervalMinutes: 1440,
+                lastSuccessAt:
+                  state === "pending" ? null : "2026-09-01T00:00:00Z",
+                lastStatus:
+                  state === "failed"
+                    ? "failed"
+                    : state === "healthy"
+                      ? "success"
+                      : null,
+              },
+            ];
+      await route.fulfill({
+        json:
+          path === "/api/runtime"
+            ? { demoMode: true }
+            : path === "/api/bank"
+              ? { accounts: [], transactions: [] }
+              : path === "/api/sync-jobs"
+                ? jobs
+                : path === "/api/notifications/config"
+                  ? { enabled: false }
+                  : [],
+      });
+    });
+    await page.goto("/#/settings");
+    const health = page.locator('[aria-label="資料健康度"]');
+    await expect(health).toContainText(
+      {
+        unconfigured: "尚未設定",
+        pending: "等待首次同步",
+        healthy: "大致正常",
+        failed: "需要處理",
+      }[state],
+    );
+    if (state === "unconfigured") {
+      await expect(health).not.toContainText("0 / 0");
+    } else {
+      await expect(health).toContainText(
+        state === "healthy" ? "1 / 1" : "0 / 1",
+      );
+    }
+    if (state !== "healthy") await expect(health).not.toContainText("大致正常");
+  });
+}
+
+for (const width of [1440, 390]) {
+  test(`activity API failure can recover without misleading empty data at ${width}px`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width, height: 900 });
+    let bankFailed = true;
+    await page.route("**/api/**", async (route) => {
+      const path = new URL(route.request().url()).pathname;
+      if (!path.startsWith("/api/")) {
+        await route.continue();
+        return;
+      }
+      if (path === "/api/bank" && bankFailed) {
+        await route.fulfill({
+          status: 500,
+          json: { error: { code: "TEST_FAILURE", message: "暫時無法載入" } },
+        });
+        return;
+      }
+      await route.fulfill({
+        json:
+          path === "/api/runtime"
+            ? { demoMode: true }
+            : path === "/api/bank"
+              ? { accounts: [], transactions: [] }
+              : [],
+      });
+    });
+    await page.goto("/#/activity");
+    await expect(page.getByRole("alert")).toContainText("部分資料載入失敗", {
+      timeout: 15000,
+    });
+    await expect(
+      page.getByText("沒有符合條件的活動。", { exact: true }),
+    ).not.toBeVisible();
+    bankFailed = false;
+    await page.getByRole("button", { name: /重試|重新載入/ }).click();
+    await expect(page.getByRole("alert")).toHaveCount(0);
+    await expect(
+      page
+        .getByText("沒有符合條件的活動。", { exact: true })
+        .filter({ visible: true }),
+    ).toBeVisible();
+    const overflows = await page.evaluate(
+      () => document.documentElement.scrollWidth > innerWidth,
+    );
+    expect(overflows).toBe(false);
+  });
+}
+
+test("classification rules retains its working form without the duplicate header action", async ({
+  page,
+}) => {
+  await page.route("**/api/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    if (!path.startsWith("/api/")) {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      json:
+        path === "/api/runtime"
+          ? { demoMode: true }
+          : path === "/api/bank"
+            ? { accounts: [], transactions: [] }
+            : path === "/api/notifications/config"
+              ? { enabled: false }
+              : [],
+    });
+  });
+  await page.goto("/#/classification-rules");
+  await expect(page.getByText("＋ 新增規則", { exact: true })).toHaveCount(0);
+  const add = page.getByRole("button", { name: "新增規則", exact: true });
+  await expect(add).toBeVisible();
+  await expect(add).toBeDisabled();
+  await page.getByRole("textbox", { name: "關鍵字", exact: true }).fill("咖啡");
+  await expect(add).toBeEnabled();
+});

--- a/apps/web/src/data/connectors/sync-status.test.ts
+++ b/apps/web/src/data/connectors/sync-status.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   getActionableSyncJobs,
   getConfiguredSyncJobs,
+  getHealthySyncJobs,
+  getPendingSyncJobs,
   getSyncSourceStatus,
+  getSyncSourceStatusLabel,
   isActionableSyncJob,
 } from "./sync-status";
 import type { SyncJobRow } from "./types";
@@ -60,6 +63,26 @@ describe("sync source status", () => {
     ]);
     expect(getSyncSourceStatus(configured)).toBe("healthy");
     expect(getSyncSourceStatus(unconfigured)).toBe("unconfigured");
+  });
+
+  it("keeps configured sources without a successful run out of the healthy count", () => {
+    const pending = job({ configured: true });
+    const healthy = job({
+      id: "sinopac:all",
+      connectorId: "sinopac",
+      configured: true,
+      lastSuccessAt: "2026-08-01T00:00:00.000Z",
+    });
+
+    expect(getSyncSourceStatus(pending)).toBe("not_synced");
+    expect(getSyncSourceStatusLabel("not_synced")).toBe("等待首次同步");
+    expect(getHealthySyncJobs([pending, healthy])).toEqual([healthy]);
+    expect(getPendingSyncJobs([pending, healthy])).toEqual([pending]);
+  });
+
+  it("does not treat an empty source list as a healthy source", () => {
+    expect(getHealthySyncJobs([])).toEqual([]);
+    expect(getPendingSyncJobs([])).toEqual([]);
   });
 
   it("counts at most the all-scope job for each configured source", () => {

--- a/apps/web/src/data/connectors/sync-status.ts
+++ b/apps/web/src/data/connectors/sync-status.ts
@@ -18,6 +18,19 @@ export function getSyncSourceStatus(
   return job?.lastSuccessAt ? "healthy" : "not_synced";
 }
 
+export function getSyncSourceStatusLabel(status: SyncSourceStatus) {
+  switch (status) {
+    case "unconfigured":
+      return "未設定";
+    case "not_synced":
+      return "等待首次同步";
+    case "needs_action":
+      return "需要處理";
+    case "healthy":
+      return "正常";
+  }
+}
+
 export function isActionableSyncJob(
   job: SyncJobStatusInput | undefined,
 ): boolean {
@@ -30,4 +43,16 @@ export function getConfiguredSyncJobs(jobs: SyncJobRow[]) {
 
 export function getActionableSyncJobs(jobs: SyncJobRow[]) {
   return getConfiguredSyncJobs(jobs).filter(isActionableSyncJob);
+}
+
+export function getHealthySyncJobs(jobs: SyncJobRow[]) {
+  return getConfiguredSyncJobs(jobs).filter(
+    (job) => getSyncSourceStatus(job) === "healthy",
+  );
+}
+
+export function getPendingSyncJobs(jobs: SyncJobRow[]) {
+  return getConfiguredSyncJobs(jobs).filter(
+    (job) => getSyncSourceStatus(job) === "not_synced",
+  );
 }

--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -79,6 +79,7 @@
     invoiceTransactionCandidates,
     matchInvoicesToTransactions,
   } from "@/data/activity/matching";
+  import { getActivityDataStatus } from "./model/load-status";
   import {
     formatCompactTwd,
     formatCurrency,
@@ -142,6 +143,33 @@
   ];
   const categoryOptions = $derived(
     $categoryRows.data?.length ? $categoryRows.data : fallbackCategories,
+  );
+  const activityDataStatus = $derived(
+    getActivityDataStatus([
+      {
+        label: "銀行與信用卡",
+        isError: $bank.isError,
+      },
+      {
+        label: "發票",
+        isError: $invoices.isError,
+      },
+      {
+        label: "發票配對",
+        isError: $invoiceMappings.isError,
+      },
+      {
+        label: "投資活動",
+        isError: $trades.isError,
+      },
+    ]),
+  );
+  const activitySummaryIncomplete = $derived(activityDataStatus.hasFailure);
+  const activityRetryPending = $derived(
+    $bank.isFetching ||
+      $invoices.isFetching ||
+      $invoiceMappings.isFetching ||
+      $trades.isFetching,
   );
   const categories = $derived(
     Object.fromEntries(
@@ -501,6 +529,12 @@
     selectedMonth = month;
     selectedCategory = null;
   }
+  function retryActivityData() {
+    if ($bank.isError) void $bank.refetch();
+    if ($invoices.isError) void $invoices.refetch();
+    if ($invoiceMappings.isError) void $invoiceMappings.refetch();
+    if ($trades.isError) void $trades.refetch();
+  }
   function sourceLabel(item: ActivityItem) {
     const label = {
       bank: "銀行",
@@ -647,6 +681,28 @@
     body="正在整理銀行、投資與發票資料。"
   />{:else}
   <div class="grid min-w-0 max-w-full gap-5 overflow-x-clip">
+    {#if activityDataStatus.hasFailure}
+      <div
+        class="flex flex-col gap-3 rounded-xl border border-coral/25 bg-coral/5 px-4 py-3 text-sm text-ink sm:flex-row sm:items-center sm:justify-between"
+        role="alert"
+      >
+        <div class="min-w-0">
+          <p class="font-semibold text-coral">部分資料載入失敗</p>
+          <p class="mt-1 text-xs text-ink/65">
+            {activityDataStatus.failedLabels.join(
+              "、",
+            )}目前無法取得；以下仍顯示已成功載入的資料。
+          </p>
+        </div>
+        <Button
+          class="h-11 shrink-0"
+          variant="outline"
+          disabled={activityRetryPending}
+          onclick={retryActivityData}
+          >{activityRetryPending ? "重試中…" : "重試活動資料"}</Button
+        >
+      </div>
+    {/if}
     <div
       class="hidden min-w-0 grid-cols-2 gap-3 md:grid md:grid-cols-4 md:gap-4"
     >
@@ -656,9 +712,15 @@
             {selectedMonthLabel}收入
           </p>
           <p class="mt-2 truncate text-2xl font-bold text-moss">
-            +{formatCurrency(incomeTotal)}
+            {activitySummaryIncomplete
+              ? "—"
+              : `+${formatCurrency(incomeTotal)}`}
           </p>
-          <p class="mt-1 text-xs text-ink/45">銀行與信用卡活動</p></CardContent
+          <p class="mt-1 text-xs text-ink/45">
+            {activitySummaryIncomplete
+              ? "資料尚未完整載入"
+              : "銀行與信用卡活動"}
+          </p></CardContent
         ></Card
       >
       <Card
@@ -667,10 +729,14 @@
             {selectedMonthLabel}支出
           </p>
           <p class="mt-2 truncate text-2xl font-bold text-coral">
-            −{formatCurrency(expenseTotal)}
+            {activitySummaryIncomplete
+              ? "—"
+              : `−${formatCurrency(expenseTotal)}`}
           </p>
           <p class="mt-1 text-xs text-ink/45">
-            含未配對發票，不計入已排除活動
+            {activitySummaryIncomplete
+              ? "資料尚未完整載入"
+              : "含未配對發票，不計入已排除活動"}
           </p></CardContent
         ></Card
       >
@@ -682,16 +748,24 @@
           <p
             class={`mt-2 truncate text-2xl font-bold ${incomeTotal >= expenseTotal ? "text-moss" : "text-coral"}`}
           >
-            {formatCurrency(incomeTotal - expenseTotal)}
+            {activitySummaryIncomplete
+              ? "—"
+              : formatCurrency(incomeTotal - expenseTotal)}
           </p>
-          <p class="mt-1 text-xs text-ink/45">收入 − 支出</p></CardContent
+          <p class="mt-1 text-xs text-ink/45">
+            {activitySummaryIncomplete ? "資料尚未完整載入" : "收入 − 支出"}
+          </p></CardContent
         ></Card
       >
       <Card
         ><CardContent class="p-5"
           ><p class="text-xs font-semibold text-ink/50">待分類</p>
-          <p class="mt-2 text-2xl font-bold">{pendingCount} 筆</p>
-          <p class="mt-1 text-xs text-ink/45">銀行交易</p></CardContent
+          <p class="mt-2 text-2xl font-bold">
+            {activitySummaryIncomplete ? "—" : `${pendingCount} 筆`}
+          </p>
+          <p class="mt-1 text-xs text-ink/45">
+            {activitySummaryIncomplete ? "資料尚未完整載入" : "銀行交易"}
+          </p></CardContent
         ></Card
       >
     </div>
@@ -725,6 +799,7 @@
             ? selectedCategory.category
             : undefined}
           flowSelected={flow === "income" && !selectedCategory}
+          dataIncomplete={activitySummaryIncomplete}
           onSelect={(category) => chooseCategory("income", category)}
           onSelectFlow={() => chooseChartFlow("income")}
         />
@@ -735,6 +810,7 @@
             ? selectedCategory.category
             : undefined}
           flowSelected={flow === "expense" && !selectedCategory}
+          dataIncomplete={activitySummaryIncomplete}
           onSelect={(category) => chooseCategory("expense", category)}
           onSelectFlow={() => chooseChartFlow("expense")}
         />
@@ -747,42 +823,50 @@
         <Badge variant="secondary">6 個月　收入／支出</Badge></CardHeader
       >
       <CardContent>
-        <div class="grid grid-cols-6 gap-3">
-          {#each cashFlow as point (point.month)}
-            <button
-              aria-pressed={selectedMonth === point.month}
-              class={`grid min-w-0 rounded-xl px-2 pb-2 pt-3 transition ${selectedMonth === point.month ? "bg-steel/10 ring-2 ring-steel/30" : "hover:bg-paper"}`}
-              onclick={() => chooseMonth(point.month)}
-            >
-              <div class="flex h-28 items-end justify-center gap-2">
-                <span
-                  class="w-1/3 rounded-t-lg bg-emerald-700"
-                  style={`height:${Math.max(8, (point.income / maxCashFlow) * 100)}%`}
-                ></span><span
-                  class="w-1/3 rounded-t-lg bg-coral"
-                  style={`height:${Math.max(8, (point.expense / maxCashFlow) * 100)}%`}
-                ></span>
-              </div>
-              <span class="mt-2 text-xs font-semibold"
-                >{Number(point.month.slice(5))} 月</span
-              ><span class="mt-1 truncate text-[10px] text-moss"
-                >+{formatCompactTwd(point.income)}</span
-              ><span class="truncate text-[10px] text-coral"
-                >−{formatCompactTwd(point.expense)}</span
-              >
-            </button>
-          {/each}
-        </div>
-        <div class="mt-3 flex items-center justify-between text-xs text-ink/45">
-          <span
-            ><span class="text-emerald-700">■</span> 收入　<span
-              class="text-coral">■</span
-            > 支出</span
-          ><button
-            class="font-semibold text-steel"
-            onclick={() => chooseMonth(currentMonth)}>回到本月</button
+        {#if activitySummaryIncomplete}
+          <div
+            class="rounded-xl bg-amber-50 p-6 text-center text-sm text-amber-900"
           >
-        </div>
+            活動資料尚未完整載入，現金流趨勢暫不計算。
+          </div>
+        {:else}<div class="grid grid-cols-6 gap-3">
+            {#each cashFlow as point (point.month)}
+              <button
+                aria-pressed={selectedMonth === point.month}
+                class={`grid min-w-0 rounded-xl px-2 pb-2 pt-3 transition ${selectedMonth === point.month ? "bg-steel/10 ring-2 ring-steel/30" : "hover:bg-paper"}`}
+                onclick={() => chooseMonth(point.month)}
+              >
+                <div class="flex h-28 items-end justify-center gap-2">
+                  <span
+                    class="w-1/3 rounded-t-lg bg-emerald-700"
+                    style={`height:${Math.max(8, (point.income / maxCashFlow) * 100)}%`}
+                  ></span><span
+                    class="w-1/3 rounded-t-lg bg-coral"
+                    style={`height:${Math.max(8, (point.expense / maxCashFlow) * 100)}%`}
+                  ></span>
+                </div>
+                <span class="mt-2 text-xs font-semibold"
+                  >{Number(point.month.slice(5))} 月</span
+                ><span class="mt-1 truncate text-[10px] text-moss"
+                  >+{formatCompactTwd(point.income)}</span
+                ><span class="truncate text-[10px] text-coral"
+                  >−{formatCompactTwd(point.expense)}</span
+                >
+              </button>
+            {/each}
+          </div>
+          <div
+            class="mt-3 flex items-center justify-between text-xs text-ink/45"
+          >
+            <span
+              ><span class="text-emerald-700">■</span> 收入　<span
+                class="text-coral">■</span
+              > 支出</span
+            ><button
+              class="font-semibold text-steel"
+              onclick={() => chooseMonth(currentMonth)}>回到本月</button
+            >
+          </div>{/if}
       </CardContent>
     </Card>
 
@@ -848,7 +932,9 @@
           {#if filteredGroups.length === 0}<p
               class="p-8 text-center text-sm text-ink/50"
             >
-              沒有符合條件的活動。
+              {activityDataStatus.hasFailure
+                ? "部分資料目前無法顯示，請重試後再查看。"
+                : "沒有符合條件的活動。"}
             </p>{:else}{#each filteredGroups as group (group.dateKey)}<div
                 class="flex items-center justify-between bg-paper px-4 py-2.5 text-xs"
               >
@@ -905,7 +991,9 @@
           {#if filteredGroups.length === 0}<p
               class="p-8 text-center text-sm text-ink/50"
             >
-              沒有符合條件的活動。
+              {activityDataStatus.hasFailure
+                ? "部分資料目前無法顯示，請重試後再查看。"
+                : "沒有符合條件的活動。"}
             </p>{:else}<table
               class="w-full min-w-[760px] table-fixed text-left text-sm"
             >

--- a/apps/web/src/features/activity/components/ActivityCategoryChart.svelte
+++ b/apps/web/src/features/activity/components/ActivityCategoryChart.svelte
@@ -16,6 +16,7 @@
     slices,
     selectedCategory,
     flowSelected,
+    dataIncomplete = false,
     onSelect,
     onSelectFlow,
   }: {
@@ -23,6 +24,7 @@
     slices: ActivityCategorySlice[];
     selectedCategory?: string;
     flowSelected: boolean;
+    dataIncomplete?: boolean;
     onSelect: (category: string) => void;
     onSelectFlow: () => void;
   } = $props();
@@ -63,11 +65,19 @@
     <p
       class={`shrink-0 text-base font-bold tabular-nums sm:text-lg ${flow === "income" ? "text-moss" : "text-coral"}`}
     >
-      {flow === "income" ? "+" : "−"}{formatCurrency(total)}
+      {#if dataIncomplete}—{:else}{flow === "income"
+          ? "+"
+          : "−"}{formatCurrency(total)}{/if}
     </p>
   </CardHeader>
   <CardContent class="pt-2">
-    {#if slices.length === 0}
+    {#if dataIncomplete}
+      <div
+        class="rounded-xl bg-amber-50 p-6 text-center text-sm text-amber-900"
+      >
+        活動資料尚未完整載入，分類比例暫不計算。
+      </div>
+    {:else if slices.length === 0}
       <div class="rounded-xl bg-paper p-6 text-center text-sm text-ink/45">
         此月份沒有{flow === "income" ? "收入" : "支出"}活動
       </div>

--- a/apps/web/src/features/activity/model/load-status.test.ts
+++ b/apps/web/src/features/activity/model/load-status.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { getActivityDataStatus } from "./load-status";
+
+describe("activity data status", () => {
+  it("names a failed source", () => {
+    expect(
+      getActivityDataStatus([
+        {
+          label: "銀行與信用卡",
+          isError: true,
+        },
+        {
+          label: "發票",
+          isError: false,
+        },
+      ]),
+    ).toMatchObject({
+      failedLabels: ["銀行與信用卡"],
+      hasFailure: true,
+    });
+  });
+
+  it("reports complete data when all sources succeeded", () => {
+    expect(
+      getActivityDataStatus([
+        {
+          label: "銀行與信用卡",
+          isError: false,
+        },
+        {
+          label: "發票",
+          isError: false,
+        },
+      ]),
+    ).toEqual({
+      failedLabels: [],
+      hasFailure: false,
+    });
+  });
+});

--- a/apps/web/src/features/activity/model/load-status.ts
+++ b/apps/web/src/features/activity/model/load-status.ts
@@ -1,0 +1,20 @@
+export interface ActivityDataSourceSnapshot {
+  label: string;
+  isError: boolean;
+}
+
+export interface ActivityDataStatus {
+  failedLabels: string[];
+  hasFailure: boolean;
+}
+
+export function getActivityDataStatus(
+  sources: readonly ActivityDataSourceSnapshot[],
+): ActivityDataStatus {
+  const failed = sources.filter((source) => source.isError);
+
+  return {
+    failedLabels: failed.map((source) => source.label),
+    hasFailure: failed.length > 0,
+  };
+}

--- a/apps/web/src/features/overview/OverviewPage.svelte
+++ b/apps/web/src/features/overview/OverviewPage.svelte
@@ -24,6 +24,8 @@
   import {
     getActionableSyncJobs,
     getConfiguredSyncJobs,
+    getHealthySyncJobs,
+    getPendingSyncJobs,
   } from "@/data/connectors/sync-status";
   import { investmentsQuery } from "@/data/investments/queries";
   import {
@@ -155,33 +157,71 @@
   const monthlyIncome = $derived(monthlyTotals.income);
   const monthlyExpense = $derived(monthlyTotals.expense);
   const monthlyNet = $derived(monthlyIncome - monthlyExpense);
-  const unhealthy = $derived(getActionableSyncJobs($jobs.data ?? []));
-  const configuredSyncJobs = $derived(getConfiguredSyncJobs($jobs.data ?? []));
+  const syncJobsReady = $derived($jobs.isSuccess);
+  const syncJobRows = $derived($jobs.data ?? []);
+  const unhealthy = $derived(getActionableSyncJobs(syncJobRows));
+  const pendingSyncJobs = $derived(getPendingSyncJobs(syncJobRows));
+  const configuredSyncJobs = $derived(getConfiguredSyncJobs(syncJobRows));
+  const healthySyncJobs = $derived(getHealthySyncJobs(syncJobRows));
   const staleJobs = $derived(
-    configuredSyncJobs.filter(
-      (job) =>
-        job.enabled &&
-        !job.running &&
-        !unhealthy.some((unhealthyJob) => unhealthyJob.id === job.id) &&
-        (!job.lastSuccessAt ||
-          Date.now() - new Date(job.lastSuccessAt).getTime() >
-            48 * 60 * 60 * 1000),
-    ),
+    syncJobsReady
+      ? configuredSyncJobs.filter(
+          (job) =>
+            job.enabled &&
+            !job.running &&
+            !unhealthy.some((unhealthyJob) => unhealthyJob.id === job.id) &&
+            Boolean(job.lastSuccessAt) &&
+            Date.now() - new Date(job.lastSuccessAt!).getTime() >
+              48 * 60 * 60 * 1000,
+        )
+      : [],
   );
   const sourceCount = $derived(configuredSyncJobs.length);
-  const healthyCount = $derived(Math.max(sourceCount - unhealthy.length, 0));
+  const healthyCount = $derived(healthySyncJobs.length);
   const insights = $derived.by(() => {
     const items: OverviewInsight[] = [];
 
-    if (unhealthy.length > 0) {
+    if (!syncJobsReady) {
+      items.push({
+        id: "sync-status-unavailable",
+        title: $jobs.isError ? "無法載入同步狀態" : "正在載入同步狀態",
+        detail: $jobs.isError
+          ? "目前無法確認資料來源狀態，請稍後再試"
+          : "正在讀取資料來源狀態",
+        tone: $jobs.isError ? "coral" : "steel",
+        icon: "sync",
+        view: "data-sources",
+      });
+    } else if (sourceCount === 0) {
+      items.push({
+        id: "sync-unconfigured",
+        title: "尚未設定資料來源",
+        detail: "前往資料來源設定連接器後即可開始同步",
+        tone: "steel",
+        icon: "sync",
+        view: "data-sources",
+      });
+    } else if (unhealthy.length > 0) {
       items.push({
         id: "sync",
         title: `${unhealthy.length} 個資料來源需要處理`,
-        detail: `目前 ${healthyCount} / ${sourceCount} 個來源正常`,
+        detail: pendingSyncJobs.length
+          ? `目前 ${healthyCount} 個來源正常，${pendingSyncJobs.length} 個等待首次同步`
+          : `目前 ${healthyCount} / ${sourceCount} 個來源正常`,
         tone: "amber",
         icon: "sync",
         view: "data-sources",
         connectorId: unhealthy[0]?.connectorId,
+      });
+    } else if (pendingSyncJobs.length > 0) {
+      items.push({
+        id: "sync-pending",
+        title: `${pendingSyncJobs.length} 個資料來源等待首次同步`,
+        detail: `目前 ${healthyCount} / ${sourceCount} 個來源正常`,
+        tone: "amber",
+        icon: "sync",
+        view: "data-sources",
+        connectorId: pendingSyncJobs[0]?.connectorId,
       });
     }
 

--- a/apps/web/src/features/settings/SettingsPage.svelte
+++ b/apps/web/src/features/settings/SettingsPage.svelte
@@ -13,6 +13,8 @@
   import {
     getActionableSyncJobs,
     getConfiguredSyncJobs,
+    getHealthySyncJobs,
+    getPendingSyncJobs,
   } from "@/data/connectors/sync-status";
   import { notificationConfigQuery } from "@/data/notifications/queries";
   import type { ConnectorId } from "@/data/connectors/types";
@@ -65,12 +67,17 @@
       ? (connectorTarget ?? null)
       : selectedConnector,
   );
-  const needsAction = $derived(getActionableSyncJobs($jobs.data ?? []).length);
-  const configuredSources = $derived(getConfiguredSyncJobs($jobs.data ?? []));
-  const healthySources = $derived(
-    Math.max(configuredSources.length - needsAction, 0),
+  const syncJobsState = $derived(
+    $jobs.isPending ? "loading" : $jobs.isError ? "error" : "ready",
   );
-  const actionJob = $derived(getActionableSyncJobs($jobs.data ?? []).at(0));
+  const syncJobRows = $derived($jobs.data ?? []);
+  const needsActionJobs = $derived(getActionableSyncJobs(syncJobRows));
+  const pendingSyncJobs = $derived(getPendingSyncJobs(syncJobRows));
+  const configuredSources = $derived(getConfiguredSyncJobs(syncJobRows));
+  const healthySources = $derived(getHealthySyncJobs(syncJobRows));
+  const needsAction = $derived(needsActionJobs.length);
+  const pendingSources = $derived(pendingSyncJobs.length);
+  const actionJob = $derived(needsActionJobs.at(0));
   const actionSource = $derived(
     sources.find((source) => source.id === actionJob?.connectorId),
   );
@@ -127,7 +134,7 @@
   const enabledRuleCount = $derived(
     ($rules.data ?? []).filter((rule) => !rule.isSystem && rule.enabled).length,
   );
-  const recentJobs = $derived(getConfiguredSyncJobs($jobs.data ?? []));
+  const recentJobs = $derived(getConfiguredSyncJobs(syncJobRows));
   const recentSuccessCount = $derived(
     recentJobs.filter((job) => job.lastStatus === "success").length,
   );
@@ -199,6 +206,8 @@
     <MobileMore
       {demoMode}
       jobs={$jobs.data ?? []}
+      jobsLoading={$jobs.isPending}
+      jobsError={$jobs.isError}
       rules={$rules.data ?? []}
       bank={$bank.data ?? { accounts: [], transactions: [] }}
       {navigate}
@@ -417,9 +426,6 @@
             管理自訂分類，也會自動處理帳戶互轉、信用卡年費減免與發票配對。
           </p>
         </div>
-        <span class="rounded-lg bg-steel px-4 py-2 text-sm font-bold text-white"
-          >＋ 新增規則</span
-        >
       </div>
 
       <section
@@ -487,39 +493,81 @@
         class="grid min-w-0 gap-4 lg:grid-cols-[minmax(0,1fr)_340px]"
       >
         <div
-          class={`min-w-0 rounded-xl border bg-card p-5 shadow-xs ${needsAction ? "border-coral/70 border-l-4" : "border-border"}`}
+          class={`min-w-0 rounded-xl border bg-card p-5 shadow-xs ${needsAction ? "border-coral/70 border-l-4" : pendingSources ? "border-amber-200 border-l-4" : "border-border"}`}
         >
           <div class="flex items-center justify-between gap-3">
             <p
-              class={`text-sm font-semibold ${needsAction ? "text-coral" : "text-moss"}`}
+              class={`text-sm font-semibold ${needsAction ? "text-coral" : pendingSources ? "text-amber-700" : syncJobsState === "error" ? "text-coral" : "text-muted-foreground"}`}
             >
-              {needsAction ? `需要處理 · ${needsAction}` : "資料同步狀態"}
+              {#if syncJobsState === "loading"}
+                同步狀態載入中
+              {:else if syncJobsState === "error"}
+                同步狀態暫時無法取得
+              {:else if needsAction}
+                需要處理 · {needsAction}
+              {:else if pendingSources}
+                等待首次同步 · {pendingSources}
+              {:else if configuredSources.length === 0}
+                尚未設定資料來源
+              {:else}
+                資料同步狀態
+              {/if}
             </p>
-            <span class="text-sm font-semibold text-muted-foreground">
-              {needsAction ? "影響資料更新" : "目前正常"}
+            <span
+              class={`text-sm font-semibold ${needsAction || syncJobsState === "error" ? "text-coral" : pendingSources ? "text-amber-700" : "text-muted-foreground"}`}
+            >
+              {#if syncJobsState === "loading"}
+                載入中…
+              {:else if syncJobsState === "error"}
+                無法載入
+              {:else if needsAction}
+                影響資料更新
+              {:else if pendingSources}
+                等待同步
+              {:else if configuredSources.length === 0}
+                尚未設定
+              {:else}
+                目前正常
+              {/if}
             </span>
           </div>
           <h2 class="mt-2 text-xl font-bold">
-            {#if needsAction}
+            {#if syncJobsState === "loading"}
+              正在載入同步狀態…
+            {:else if syncJobsState === "error"}
+              無法載入同步狀態
+            {:else if needsAction}
               {actionSource?.title ?? "資料來源需要處理"}
+            {:else if pendingSources}
+              {pendingSources} 個資料來源等待首次同步
             {:else if configuredSources.length}
-              {healthySources} / {configuredSources.length} 已設定來源正常
+              {healthySources.length} / {configuredSources.length} 已設定來源正常
             {:else}
               尚未設定資料來源
             {/if}
           </h2>
           <p class="mt-1 text-sm text-muted-foreground">
-            {needsAction
-              ? "完成重新驗證後即可恢復自動同步。"
-              : configuredSources.length
-                ? "所有已設定連接器都能正常同步。"
-                : "設定資料來源後即可開始同步。"}
+            {#if syncJobsState === "loading"}
+              請稍候，正在讀取資料來源狀態。
+            {:else if syncJobsState === "error"}
+              無法確認資料來源狀態，請稍後再試。
+            {:else if needsAction}
+              查看來源的錯誤說明，重試同步或完成必要的驗證。
+            {:else if pendingSources}
+              這些來源尚未完成第一次同步，完成後才會列入正常來源。
+            {:else if configuredSources.length}
+              所有已設定連接器都能正常同步。
+            {:else}
+              設定資料來源後即可開始同步。
+            {/if}
           </p>
-          <button
-            class="mt-4 rounded-lg bg-steel px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-steel/90"
-            onclick={() => navigate("data-sources")}
-            >{needsAction ? "查看連接器" : "管理資料來源"}</button
-          >
+          {#if syncJobsState === "ready"}
+            <button
+              class="mt-4 rounded-lg bg-steel px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-steel/90"
+              onclick={() => navigate("data-sources")}
+              >{needsAction ? "查看連接器" : "管理資料來源"}</button
+            >
+          {/if}
         </div>
 
         <div
@@ -531,17 +579,29 @@
               資料健康度
             </p>
             <span
-              class={`text-sm font-semibold ${needsAction ? "text-coral" : "text-moss"}`}
-              >{needsAction ? "需要處理" : "大致正常"}</span
+              class={`text-sm font-semibold ${needsAction || syncJobsState === "error" ? "text-coral" : pendingSources ? "text-amber-700" : "text-muted-foreground"}`}
+              >{#if syncJobsState === "loading"}載入中…{:else if syncJobsState === "error"}無法載入{:else if needsAction}需要處理{:else if pendingSources}等待首次同步{:else if configuredSources.length === 0}尚未設定{:else}大致正常{/if}</span
             >
           </div>
           <p class="mt-2 text-3xl font-bold">
-            {healthySources} / {configuredSources.length}
+            {#if syncJobsState !== "ready"}
+              —
+            {:else if configuredSources.length === 0}
+              尚未設定
+            {:else}
+              {healthySources.length} / {configuredSources.length}
+            {/if}
           </p>
           <p class="mt-1 text-sm text-muted-foreground">
-            {inheritedJobCount} 個排程啟用 · {latestSuccessAt
-              ? `最近成功 ${formatDateTime(latestSuccessAt)}`
-              : "尚無成功紀錄"}
+            {#if syncJobsState === "loading"}
+              正在讀取資料來源狀態。
+            {:else if syncJobsState === "error"}
+              無法取得資料來源狀態。
+            {:else}
+              {inheritedJobCount} 個排程啟用 · {latestSuccessAt
+                ? `最近成功 ${formatDateTime(latestSuccessAt)}`
+                : "尚無成功紀錄"}
+            {/if}
           </p>
         </div>
       </section>

--- a/apps/web/src/features/settings/components/MobileMore.svelte
+++ b/apps/web/src/features/settings/components/MobileMore.svelte
@@ -9,12 +9,17 @@
   import { connectorDefinitions } from "@/data/connectors/definitions";
   import {
     getActionableSyncJobs,
+    getHealthySyncJobs,
+    getPendingSyncJobs,
     getSyncSourceStatus,
+    getSyncSourceStatusLabel,
   } from "@/data/connectors/sync-status";
   import type { ConnectorId, SyncJobRow } from "@/data/connectors/types";
   let {
     demoMode,
     jobs,
+    jobsLoading = false,
+    jobsError = false,
     rules,
     bank,
     navigate,
@@ -23,6 +28,8 @@
     api: ApiClient;
     demoMode: boolean;
     jobs: SyncJobRow[];
+    jobsLoading?: boolean;
+    jobsError?: boolean;
     rules: ClassificationRuleRow[];
     bank: BankData;
     navigate: (view: View) => void;
@@ -36,6 +43,8 @@
     rules.filter((rule) => !rule.isSystem).length,
   );
   const unhealthy = $derived(getActionableSyncJobs(jobs));
+  const healthy = $derived(getHealthySyncJobs(jobs));
+  const pending = $derived(getPendingSyncJobs(jobs));
 </script>
 
 <div class="grid gap-4">
@@ -47,12 +56,27 @@
     ><CardContent class="pt-5"
       ><p class="text-sm font-semibold text-ink/45">資料健康度</p>
       <p class="mt-2 text-2xl font-bold">
-        {Math.max(configuredSources.length - unhealthy.length, 0)} / {configuredSources.length}
-        已設定來源正常
+        {#if jobsLoading}
+          同步狀態載入中…
+        {:else if jobsError}
+          無法載入同步狀態
+        {:else if configuredSources.length === 0}
+          尚未設定資料來源
+        {:else}
+          {healthy.length} / {configuredSources.length} 已設定來源正常
+        {/if}
       </p>
-      {#if unhealthy.length}<p class="mt-2 text-sm font-semibold text-coral">
+      {#if jobsError}
+        <p class="mt-2 text-sm font-semibold text-coral">請稍後再試。</p>
+      {:else if unhealthy.length}
+        <p class="mt-2 text-sm font-semibold text-coral">
           {unhealthy.length} 個來源需要處理
-        </p>{/if}</CardContent
+        </p>
+      {:else if pending.length}
+        <p class="mt-2 text-sm font-semibold text-amber-700">
+          {pending.length} 個來源等待首次同步
+        </p>
+      {/if}</CardContent
     ></Card
   >
   <section>
@@ -136,14 +160,12 @@
             <span class="font-semibold">{source.title}</span><span
               class={getSyncSourceStatus(job) === "needs_action"
                 ? "text-coral"
-                : "text-moss"}
-              >{getSyncSourceStatus(job) === "needs_action"
-                ? "需要處理"
-                : getSyncSourceStatus(job) === "healthy"
-                  ? "正常"
-                  : getSyncSourceStatus(job) === "not_synced"
-                    ? "尚未同步"
-                    : "未設定"}</span
+                : getSyncSourceStatus(job) === "not_synced"
+                  ? "text-amber-700"
+                  : getSyncSourceStatus(job) === "healthy"
+                    ? "text-moss"
+                    : "text-ink/45"}
+              >{getSyncSourceStatusLabel(getSyncSourceStatus(job))}</span
             >
           </button>{/each}
       </div></Card

--- a/apps/web/src/features/settings/components/MobileMore.test.ts
+++ b/apps/web/src/features/settings/components/MobileMore.test.ts
@@ -21,7 +21,7 @@ describe("MobileMore", () => {
     });
 
     const connectorCount = connectorDefinitions.length;
-    expect(getByText("0 / 0 已設定來源正常")).toBeInTheDocument();
+    expect(getByText("尚未設定資料來源")).toBeInTheDocument();
     expect(
       getByText(new RegExp(`${connectorCount} 個\\s*›`)),
     ).toBeInTheDocument();

--- a/apps/web/src/features/settings/components/SourceCard.svelte
+++ b/apps/web/src/features/settings/components/SourceCard.svelte
@@ -10,7 +10,10 @@
   import type { ApiClient } from "@/shared/api/client";
   import { connectorSettingsQuery } from "@/data/connectors/queries";
   import type { ConnectorId, SyncJobRow } from "@/data/connectors/types";
-  import { getSyncSourceStatus } from "@/data/connectors/sync-status";
+  import {
+    getSyncSourceStatus,
+    getSyncSourceStatusLabel,
+  } from "@/data/connectors/sync-status";
   import { formatDateTime } from "@/shared/format/financial";
   let {
     api,
@@ -98,14 +101,7 @@
         ? "destructive"
         : sourceStatus === "healthy"
           ? "success"
-          : "secondary"}
-      >{needsAction
-        ? "需要處理"
-        : sourceStatus === "healthy"
-          ? "正常"
-          : sourceStatus === "not_synced"
-            ? "尚未同步"
-            : "未設定"}</Badge
+          : "secondary"}>{getSyncSourceStatusLabel(sourceStatus)}</Badge
     >
     {#if compactCard}<span
         aria-hidden="true"
@@ -132,14 +128,9 @@
           class="shrink-0 whitespace-nowrap text-sm"
           variant={needsAction
             ? "destructive"
-            : sourceStatus !== "unconfigured"
+            : sourceStatus === "healthy"
               ? "success"
-              : "secondary"}
-          >{needsAction
-            ? "需要處理"
-            : sourceStatus !== "unconfigured"
-              ? "已設定"
-              : "未設定"}</Badge
+              : "secondary"}>{getSyncSourceStatusLabel(sourceStatus)}</Badge
         >
       </div>
       <div

--- a/apps/web/src/features/settings/components/SourceCard.test.ts
+++ b/apps/web/src/features/settings/components/SourceCard.test.ts
@@ -67,4 +67,31 @@ describe("SourceCard", () => {
     ).toBeInTheDocument();
     expect(getByText("需要處理")).toBeInTheDocument();
   });
+
+  it("labels a configured source without a successful run as waiting", () => {
+    const { getByText } = renderSourceCard({
+      id: "sinopac:all",
+      connectorId: "sinopac",
+      configured: true,
+      scope: "all",
+      enabled: true,
+      intervalMinutes: 1440,
+      nextRunAt: "2026-08-22T02:00:00.000Z",
+      scheduleMode: "inherit",
+      preferredTime: "02:00",
+      preferredWeekday: 1,
+      lockedUntil: null,
+      lockedBy: null,
+      lockTrigger: null,
+      lockScope: null,
+      lastRunAt: null,
+      lastSuccessAt: null,
+      lastStatus: null,
+      lastError: null,
+      updatedAt: "2026-08-21T22:00:00.000Z",
+      running: false,
+    });
+
+    expect(getByText("等待首次同步")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
活動資料 API 失敗時，畫面原本仍顯示零收支與「沒有符合條件的活動」；現在顯示失敗來源與重試入口，保留已取得的活動，並暫停呈現不完整的摘要與圖表。

同步健康度改為只計入曾成功同步且目前沒有失敗的來源，區分尚未設定、等待首次同步、正常與需要處理，並正確呈現同步狀態載入中或載入失敗。同步調整總覽、設定與手機來源卡片，避免把首次同步誤報為超過 48 小時未更新。

移除桌面分類規則標題旁重複且無事件的「＋新增規則」，保留下方既有新增表單。

將本機 `design/` 加入 `.gitignore`，設計檔不納入版本控制。

驗證：
- repo root `npm run format:check`
- repo root `npm run typecheck`
- repo root `npm run test:unit`（100 個測試）
- Playwright 本次 7 個案例：四種同步健康狀態、桌面／手機活動載入失敗後重試，以及既有新增規則表單
- `git diff --check`

瀏覽器案例使用模擬 API；未執行真實金融同步或部署。
