### PR TITLE
修正王道定存生命週期與本金活動

### DIFF
--- a/apps/web/e2e/assets.spec.ts
+++ b/apps/web/e2e/assets.spec.ts
@@ -269,3 +269,63 @@ test("keeps the mobile ledger readable and expandable", async ({ page }) => {
     390,
   );
 });
+
+for (const width of [1280, 390, 320]) {
+  test(`shows time deposit dates separately from sync time at ${width}px`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width, height: 900 });
+    await page.route("**/api/bank", (route) =>
+      route.fulfill({
+        json: {
+          accounts: [
+            {
+              ...bankData.accounts[2],
+              id: "td",
+              currency: "TWD",
+              accountType: "time_deposit",
+              accountName: "新資金9個月新台幣定存年利率2.35% · 末四碼 1900",
+              balance: 52736,
+              openedDate: "2026-09-07",
+              maturityDate: "2027-06-07",
+              asOfAt: "2026-09-08T01:00:00Z",
+            },
+            {
+              ...bankData.accounts[2],
+              id: "legacy-td",
+              accountType: "time_deposit",
+              accountName: "舊定存",
+            },
+          ],
+          transactions: [],
+        },
+      }),
+    );
+    await page.goto("/#/assets");
+    const ledger = page
+      .locator('section[aria-label="資產清冊"]')
+      .filter({ visible: true });
+    if (width < 768)
+      await ledger.getByRole("button", { name: /王道銀行/ }).click();
+    await expect(
+      page
+        .getByText("起息日 2026/9/7 · 到期日 2027/6/7")
+        .filter({ visible: true }),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByText("起息日 尚未取得 · 到期日 尚未取得")
+        .filter({ visible: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/更新 2026\/9\/8/).filter({ visible: true }),
+    ).toBeVisible();
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth),
+    ).toBe(width);
+    await page.screenshot({
+      path: `/tmp/obank-assets-${width}.png`,
+      fullPage: true,
+    });
+  });
+}

--- a/apps/web/src/data/bank/types.ts
+++ b/apps/web/src/data/bank/types.ts
@@ -15,6 +15,8 @@ export interface BankAccountRow {
   paymentDueDate?: string;
   statementClosingDate?: string;
   asOfAt?: string;
+  openedDate?: string;
+  maturityDate?: string;
 }
 
 export interface BankTransactionRow {

--- a/apps/web/src/features/assets/components/InstitutionDetails.svelte
+++ b/apps/web/src/features/assets/components/InstitutionDetails.svelte
@@ -88,6 +88,16 @@
               <p class="break-words text-sm font-semibold">
                 {account.accountName ?? formatBankAccountName(account)}
               </p>
+              {#if account.accountType === "time_deposit"}
+                <p class="mt-1 text-xs text-muted-foreground">
+                  起息日 {account.openedDate
+                    ? formatDate(account.openedDate)
+                    : "尚未取得"}
+                  · 到期日 {account.maturityDate
+                    ? formatDate(account.maturityDate)
+                    : "尚未取得"}
+                </p>
+              {/if}
               <p class="mt-1 text-xs text-muted-foreground">
                 {account.currency}{account.asOfAt
                   ? ` · 更新 ${formatDate(account.asOfAt)}`

--- a/apps/worker/src/features/bank/calculation-service.ts
+++ b/apps/worker/src/features/bank/calculation-service.ts
@@ -4,6 +4,7 @@ import {
 } from "./calculation-repository";
 
 export type CalculationTransaction = {
+  transferPeerId?: string | null;
   accountType?: string | null;
   description?: string | null;
   counterparty?: string | null;
@@ -27,6 +28,8 @@ function calculationText(transaction: CalculationTransaction) {
 export function isDefaultCalculationExcluded(
   transaction: CalculationTransaction,
 ) {
+  if (transaction.accountType === "time_deposit" && transaction.transferPeerId)
+    return true;
   const { compact, words } = calculationText(transaction);
   const paddedWords = ` ${words} `;
 

--- a/apps/worker/src/features/bank/repository.ts
+++ b/apps/worker/src/features/bank/repository.ts
@@ -22,6 +22,7 @@ export type BankTransactionPageRow = {
   effectiveDate: string;
   updatedAt: string;
   calculationPreference: number | null;
+  transferPeerId?: string | null;
 };
 
 export type CreditCardBillPageCursor = {
@@ -41,6 +42,7 @@ const BANK_TRANSACTION_SELECT = `SELECT
       account.bank_code AS bankCode,
       account.account_last4 AS accountLast4,
       txn.source_id AS sourceId,
+      txn.transfer_peer_id AS transferPeerId,
       txn.posted_date AS postedDate,
       txn.authorized_at AS authorizedAt,
       txn.amount,
@@ -72,6 +74,8 @@ export async function listBankAccounts(db: D1Database) {
       account.account_name AS accountName,
       account.account_type AS accountType,
       account.currency,
+      account.opened_date AS openedDate,
+      account.maturity_date AS maturityDate,
       account.bank_code AS bankCode,
       account.account_last4 AS accountLast4,
       balance.balance AS balance,
@@ -88,7 +92,7 @@ export async function listBankAccounts(db: D1Database) {
         ORDER BY latest.as_of_at DESC, latest.updated_at DESC
         LIMIT 1
       )
-    WHERE account.canonical_account_id IS NULL
+    WHERE account.canonical_account_id IS NULL AND account.inactive_at IS NULL
     ORDER BY account.institution_name ASC, account.account_name ASC, account.source_id ASC`,
     )
     .all<Record<string, unknown>>();

--- a/apps/worker/src/features/bank/service.ts
+++ b/apps/worker/src/features/bank/service.ts
@@ -130,6 +130,7 @@ async function presentBankTransactions(
       return {
         ...normalizeBankTransactionDisplay(transaction),
         excludedFromCalculation: resolveCalculationExclusion({
+          transferPeerId: transaction.transferPeerId,
           accountType: transaction.accountType,
           description: transaction.description,
           counterparty: transaction.counterparty,

--- a/apps/worker/src/features/bank/transfer-matching.ts
+++ b/apps/worker/src/features/bank/transfer-matching.ts
@@ -1,5 +1,6 @@
 export type TransferMatchTransaction = {
   id: string;
+  transferPeerId?: string | null;
   accountId: string;
   amount: number;
   currency: string;
@@ -35,9 +36,53 @@ const CREDIT_FEE_REDUCTION_PATTERN = /減免|折抵|回饋|退回|退費/u;
 export function findAutomaticTransferPairs(
   transactions: TransferMatchTransaction[],
 ): Array<readonly [string, string]> {
+  const byId = new Map(
+    transactions.map((transaction) => [transaction.id, transaction]),
+  );
+  const explicitPairs: Array<readonly [string, string]> = [];
+  const reserved = new Set<string>();
+  for (const transaction of transactions) {
+    if (
+      transaction.accountType !== "time_deposit" ||
+      !transaction.transferPeerId
+    )
+      continue;
+    const peer = byId.get(transaction.transferPeerId);
+    if (
+      !peer ||
+      peer.accountType === "time_deposit" ||
+      peer.accountType === "credit" ||
+      transaction.accountId === peer.accountId ||
+      transaction.status !== "posted" ||
+      peer.status !== "posted" ||
+      !Number.isFinite(transaction.amount) ||
+      transaction.amount === 0 ||
+      transaction.amount !== -peer.amount ||
+      transaction.currency !== peer.currency ||
+      !getAutomaticTransferDay(transaction) ||
+      getAutomaticTransferDay(transaction) !== getAutomaticTransferDay(peer) ||
+      reserved.has(peer.id) ||
+      reserved.has(transaction.id)
+    )
+      continue;
+    // Never choose among multiple deposit events claiming the same demand leg.
+    if (
+      transactions.filter((other) => other.transferPeerId === peer.id)
+        .length !== 1
+    )
+      continue;
+    explicitPairs.push([transaction.id, peer.id]);
+    reserved.add(transaction.id);
+    reserved.add(peer.id);
+  }
   const groups = new Map<string, TransferCandidateGroup>();
 
   for (const transaction of transactions) {
+    if (
+      reserved.has(transaction.id) ||
+      transaction.accountType === "time_deposit"
+    )
+      continue;
     if (transaction.status !== "posted") continue;
     if (transaction.accountType === "credit") continue;
     if (!Number.isFinite(transaction.amount) || transaction.amount === 0)
@@ -57,9 +102,12 @@ export function findAutomaticTransferPairs(
     groups.set(key, group);
   }
 
-  return [...groups.values()].flatMap(({ positive, negative }) =>
-    pairCrossAccountCandidates(positive, negative),
-  );
+  return [
+    ...explicitPairs,
+    ...[...groups.values()].flatMap(({ positive, negative }) =>
+      pairCrossAccountCandidates(positive, negative),
+    ),
+  ];
 }
 
 export function getAutomaticTransferDay(

--- a/apps/worker/src/features/dashboard/repository.ts
+++ b/apps/worker/src/features/dashboard/repository.ts
@@ -17,7 +17,7 @@ export async function loadDashboardSummary(db: D1Database) {
         .first<{ count: number; total: number }>(),
       db
         .prepare(
-          "SELECT COUNT(*) AS count FROM bank_accounts WHERE canonical_account_id IS NULL",
+          "SELECT COUNT(*) AS count FROM bank_accounts WHERE canonical_account_id IS NULL AND inactive_at IS NULL",
         )
         .first<{ count: number }>(),
       db
@@ -33,7 +33,7 @@ export async function loadDashboardSummary(db: D1Database) {
            LIMIT 1
          )
          FROM bank_accounts account
-         WHERE account.canonical_account_id IS NULL
+         WHERE account.canonical_account_id IS NULL AND account.inactive_at IS NULL
        )`,
         )
         .first<{ total: number }>(),

--- a/apps/worker/src/features/sync/obank-time-deposits.ts
+++ b/apps/worker/src/features/sync/obank-time-deposits.ts
@@ -1,0 +1,193 @@
+import type {
+  BankAccount,
+  BankTransaction,
+  SyncResult,
+} from "@taiwan-fin-hub/core";
+import {
+  bankBalanceSnapshotRecord,
+  bankTransactionRecord,
+} from "./record-mapper";
+import type { SyncWriteRecord } from "./persistence";
+
+type Account = Omit<BankAccount, "id" | "connectorId">;
+type Transaction = Omit<BankTransaction, "id" | "connectorId">;
+type PreviousDeposit = {
+  sourceId: string;
+  currency: string;
+  balance: number;
+  asOfAt: string;
+};
+
+/** Only a successful, completely parsed account selector may retire deposits. */
+export async function prepareObankTimeDepositWrite(
+  db: D1Database,
+  result: SyncResult<never> & { timeDepositsComplete: true },
+  now: string,
+) {
+  const accounts = result.bankAccounts ?? [];
+  const deposits = accounts.filter(
+    (account) => account.accountType === "time_deposit",
+  );
+  const currentIds = new Set(deposits.map((account) => account.sourceId));
+  const previous = await db
+    .prepare(
+      `SELECT a.source_id AS sourceId, a.currency,
+    b.balance, b.as_of_at AS asOfAt FROM bank_accounts a
+    JOIN bank_balance_snapshots b ON b.id = (
+      SELECT id FROM bank_balance_snapshots WHERE account_id = a.id
+      ORDER BY as_of_at DESC, updated_at DESC LIMIT 1
+    ) WHERE a.connector_id = 'obank' AND a.account_type = 'time_deposit'
+      AND a.inactive_at IS NULL`,
+    )
+    .all<PreviousDeposit>();
+  const missing = previous.results.filter(
+    (account) => !currentIds.has(account.sourceId),
+  );
+  const transactions = result.bankTransactions ?? [];
+  const events = matchObankDepositEvents(
+    accounts,
+    deposits.map((account) => ({
+      sourceId: account.sourceId,
+      currency: account.currency,
+      balance:
+        result.bankBalanceSnapshots?.find(
+          (snapshot) => snapshot.accountId === account.sourceId,
+        )?.balance ?? 0,
+      openedDate: account.openedDate,
+    })),
+    missing,
+    transactions,
+    now,
+  );
+  const records: SyncWriteRecord[] = events.map((transaction) =>
+    bankTransactionRecord("obank", transaction, now),
+  );
+  for (const account of missing) {
+    // Zero from the observation time onward; earlier snapshots remain untouched.
+    records.push(
+      bankBalanceSnapshotRecord(
+        "obank",
+        {
+          accountId: account.sourceId,
+          sourceId: `${account.sourceId}:${now}`,
+          balance: 0,
+          currency: account.currency,
+          asOfAt: now,
+          raw: { reason: "absent_from_complete_time_deposit_list" },
+        },
+        now,
+      ),
+    );
+  }
+  return {
+    records,
+    afterPromoteStatements: [
+      db
+        .prepare(
+          `UPDATE bank_accounts SET inactive_at = ?, updated_at = ?
+      WHERE connector_id = 'obank' AND account_type = 'time_deposit'
+        AND inactive_at IS NULL
+        AND source_id NOT IN (SELECT value FROM json_each(?))`,
+        )
+        .bind(now, now, JSON.stringify([...currentIds])),
+    ],
+  };
+}
+
+/** Match only a unique principal leg in the sole demand account for that currency.
+ * Opening has a bank-supplied contract date. Withdrawal additionally requires a
+ * disappearance between two successful snapshots; its date is the demand leg's
+ * posting date, not a claimed bank settlement date. Ambiguities stay unpaired.
+ */
+export function matchObankDepositEvents(
+  accounts: Account[],
+  deposits: Array<{
+    sourceId: string;
+    currency: string;
+    balance: number;
+    openedDate?: string;
+  }>,
+  missing: PreviousDeposit[],
+  transactions: Transaction[],
+  now: string,
+): Transaction[] {
+  const candidates: Array<{
+    deposit: string;
+    kind: "opened" | "withdrawn";
+    transaction: Transaction;
+  }> = [];
+  const today = new Date(Date.parse(now) + 8 * 3600_000)
+    .toISOString()
+    .slice(0, 10);
+  const findDemand = (currency: string) => {
+    const matches = accounts.filter(
+      (account) =>
+        account.accountType === "savings" && account.currency === currency,
+    );
+    return matches.length === 1 ? matches[0].sourceId : undefined;
+  };
+  for (const deposit of [
+    ...deposits.map((d) => ({
+      ...d,
+      kind: "opened" as const,
+      asOfAt: undefined,
+    })),
+    ...missing.map((d) => ({
+      ...d,
+      kind: "withdrawn" as const,
+      openedDate: undefined,
+    })),
+  ]) {
+    if (!(deposit.balance > 0)) continue;
+    const demandId = findDemand(deposit.currency);
+    if (!demandId) continue;
+    const lastSeenDay = deposit.asOfAt
+      ? new Date(Date.parse(deposit.asOfAt) + 8 * 3600_000)
+          .toISOString()
+          .slice(0, 10)
+      : undefined;
+    const matches = transactions.filter(
+      (transaction) =>
+        transaction.accountId === demandId &&
+        transaction.currency === deposit.currency &&
+        transaction.status === "posted" &&
+        transaction.amount ===
+          (deposit.kind === "opened" ? -deposit.balance : deposit.balance) &&
+        !!transaction.postedDate &&
+        transaction.postedDate <= today &&
+        (deposit.kind === "opened"
+          ? !!deposit.openedDate &&
+            transaction.postedDate === deposit.openedDate
+          : // Day-only postings cannot establish ordering within the last-seen day.
+            !!lastSeenDay && transaction.postedDate > lastSeenDay),
+    );
+    if (matches.length === 1)
+      candidates.push({
+        deposit: deposit.sourceId,
+        kind: deposit.kind,
+        transaction: matches[0],
+      });
+  }
+  return candidates
+    .filter(
+      (candidate) =>
+        candidates.filter(
+          (other) =>
+            other.transaction.sourceId === candidate.transaction.sourceId,
+        ).length === 1,
+    )
+    .map(({ deposit, kind, transaction }) => ({
+      accountId: deposit,
+      sourceId: `${deposit}:${kind}:${transaction.postedDate}`,
+      postedDate: transaction.postedDate,
+      amount: -transaction.amount,
+      currency: transaction.currency,
+      description: kind === "opened" ? "定存成立（本金轉入）" : "定存本金轉回",
+      status: "posted" as const,
+      transferPeer: {
+        accountId: transaction.accountId,
+        sourceId: transaction.sourceId,
+      },
+      raw: { derivedFrom: "time_deposit_and_demand_transaction", event: kind },
+    }));
+}

--- a/apps/worker/src/features/sync/persistence.ts
+++ b/apps/worker/src/features/sync/persistence.ts
@@ -101,6 +101,9 @@ const ENTITY_CONFIG: Record<SyncEntityType, EntityConfig> = {
       "account_type",
       "currency",
       "credit_limit",
+      "opened_date",
+      "maturity_date",
+      "inactive_at",
       "bank_code",
       "account_last4",
       "raw_payload",
@@ -114,6 +117,9 @@ const ENTITY_CONFIG: Record<SyncEntityType, EntityConfig> = {
       "account_type",
       "currency",
       "credit_limit",
+      "opened_date",
+      "maturity_date",
+      "inactive_at",
       "bank_code",
       "account_last4",
       "raw_payload",
@@ -167,6 +173,7 @@ const ENTITY_CONFIG: Record<SyncEntityType, EntityConfig> = {
       "description",
       "counterparty",
       "status",
+      "transfer_peer_id",
       "raw_payload",
       "created_at",
       "updated_at",
@@ -180,6 +187,7 @@ const ENTITY_CONFIG: Record<SyncEntityType, EntityConfig> = {
       "description",
       "counterparty",
       "status",
+      "transfer_peer_id",
       "raw_payload",
       "updated_at",
     ],
@@ -490,6 +498,8 @@ function promotionStatement(
       }
       if (entityType !== "bank_transaction")
         return `${column} = excluded.${column}`;
+      if (column === "transfer_peer_id")
+        return "transfer_peer_id = COALESCE(excluded.transfer_peer_id, bank_transactions.transfer_peer_id)";
       if (column === "status")
         return "status = CASE WHEN bank_transactions.status = 'posted' OR excluded.status = 'posted' THEN 'posted' ELSE 'pending' END";
       if (column === "authorized_at")

--- a/apps/worker/src/features/sync/record-mapper.ts
+++ b/apps/worker/src/features/sync/record-mapper.ts
@@ -88,6 +88,9 @@ export function bankAccountRecord(
       account_type: account.accountType ?? null,
       currency: account.currency || "TWD",
       credit_limit: account.creditLimit ?? null,
+      opened_date: account.openedDate ?? null,
+      maturity_date: account.maturityDate ?? null,
+      inactive_at: account.inactiveAt ?? null,
       bank_code: bankCode,
       account_last4: last4,
       raw_payload: JSON.stringify(account.raw ?? account),
@@ -154,6 +157,13 @@ export function bankTransactionRecord(
       description: transaction.description ?? null,
       counterparty: transaction.counterparty ?? null,
       status: transaction.status ?? "posted",
+      transfer_peer_id: transaction.transferPeer
+        ? stableId(
+            connectorId,
+            transaction.transferPeer.accountId,
+            transaction.transferPeer.sourceId,
+          )
+        : null,
       raw_payload: JSON.stringify(transaction.raw ?? transaction),
       created_at: now,
       updated_at: now,

--- a/apps/worker/src/features/sync/service.ts
+++ b/apps/worker/src/features/sync/service.ts
@@ -1,3 +1,4 @@
+import { prepareObankTimeDepositWrite } from "./obank-time-deposits";
 import {
   EInvoiceProtocolUnavailableError,
   createCtbcConnector,
@@ -1149,7 +1150,13 @@ export async function syncObank(
   );
 
   const now = new Date().toISOString();
+  const timeDepositWrite = await prepareObankTimeDepositWrite(
+    env.DB,
+    result,
+    now,
+  );
   const records: SyncWriteRecord[] = [
+    ...timeDepositWrite.records,
     ...bankAccounts.map((account) =>
       bankAccountRecord(connectorId, account, now),
     ),
@@ -1185,10 +1192,12 @@ export async function syncObank(
 
   const newRecords = await persistStagedSyncWrite(env.DB, {
     records,
-    afterPromoteStatements:
-      bankAccounts.length > 0
+    afterPromoteStatements: [
+      ...timeDepositWrite.afterPromoteStatements,
+      ...(bankAccounts.length > 0
         ? [linkCanonicalBankAccountsStatement(env.DB)]
-        : [],
+        : []),
+    ],
     finalizeStatements,
   });
   if (bankBalanceSnapshots.length > 0) {
@@ -1199,6 +1208,7 @@ export async function syncObank(
     connectorId,
     scope,
     records:
+      timeDepositWrite.records.length +
       bankAccounts.length +
       bankBalanceSnapshots.length +
       bankTransactions.length,

--- a/apps/worker/tests/connectors/obank.test.ts
+++ b/apps/worker/tests/connectors/obank.test.ts
@@ -44,6 +44,35 @@ describe("O-Bank App API connector", () => {
     );
   });
 
+  it("reads contract dates from the selected detail without replacing the summary identity", () => {
+    const summary = timeDepositResponse();
+    const before = parseObankData({
+      demandDeposits: {},
+      timeDeposits: summary,
+    });
+    const result = parseObankData({
+      demandDeposits: {},
+      timeDeposits: summary,
+      timeDepositDetails: [
+        {
+          rsData: {
+            tdDetail: {
+              tdAccountNumber: "98765432109876",
+              contractDate: "2026/09/07",
+              maturityDate: "2027/06/07",
+            },
+          },
+        },
+      ],
+    });
+    expect(result.bankAccounts[0]).toMatchObject({
+      sourceId: before.bankAccounts[0].sourceId,
+      openedDate: "2026-09-07",
+      maturityDate: "2027-06-07",
+    });
+    expect(result.bankTransactions).toEqual([]);
+  });
+
   it("requires complete credentials without including submitted secrets in errors", () => {
     return expect(
       prepareObankCaptcha({
@@ -59,136 +88,178 @@ describe("O-Bank App API connector", () => {
     );
   });
 
-  it("runs the public bootstrap, RSA login, read-only queries and logout", async () => {
-    const keyPair = forge.pki.rsa.generateKeyPair({ bits: 512, e: 0x10001 });
-    const publicPem = forge.pki.publicKeyToPem(keyPair.publicKey);
-    const calls: Array<{ url: string; body: string; headers: Headers }> = [];
-    const fetcher = vi.fn(async (input: RequestInfo | URL, init = {}) => {
-      const url = String(input);
-      const body = typeof init.body === "string" ? init.body : "";
-      const headers = new Headers(init.headers);
-      calls.push({ url, body, headers });
+  it.each([
+    "complete",
+    "empty",
+    "missing-list",
+    "wrong-detail",
+    "failed-detail",
+  ])(
+    "validates the full read-only query before reporting success: %s",
+    async (scenario) => {
+      const keyPair = forge.pki.rsa.generateKeyPair({ bits: 512, e: 0x10001 });
+      const publicPem = forge.pki.publicKeyToPem(keyPair.publicKey);
+      const calls: Array<{ url: string; body: string; headers: Headers }> = [];
+      const fetcher = vi.fn(async (input: RequestInfo | URL, init = {}) => {
+        const url = String(input);
+        const body = typeof init.body === "string" ? init.body : "";
+        const headers = new Headers(init.headers);
+        calls.push({ url, body, headers });
 
-      if (url.endsWith("/ChannelAdapter/getChannel")) {
-        return jsonResponse({ channel: "IB" });
-      }
-      if (url.endsWith("/oauth/token")) {
-        return jsonResponse({ access_token: "public-test-token" });
-      }
-      if (url.endsWith("/invalidateSession")) {
-        return jsonResponse({ statusCode: "0000" });
-      }
+        if (url.endsWith("/ChannelAdapter/getChannel")) {
+          return jsonResponse({ channel: "IB" });
+        }
+        if (url.endsWith("/oauth/token")) {
+          return jsonResponse({ access_token: "public-test-token" });
+        }
+        if (url.endsWith("/invalidateSession")) {
+          return jsonResponse({ statusCode: "0000" });
+        }
 
-      const procedure = url.split("/").at(-1);
-      const payload = body ? (JSON.parse(body) as unknown[]) : [];
-      if (procedure === "emptyLogin") {
-        return jsonResponse({ authStatus: "required", auth: "true" });
-      }
-      if (procedure === "submitCredentials") {
-        const metadata = payload[0] as { rqData?: { force?: string } };
-        return metadata.rqData?.force === "1"
-          ? jsonResponse({
-              authStatus: "complete",
-              token: "secure-token",
-            })
-          : jsonResponse({
-              authStatus: "required",
-              rsData: { resultType: "3" },
-              token: "duplicate-login-token",
+        const procedure = url.split("/").at(-1);
+        const payload = body ? (JSON.parse(body) as unknown[]) : [];
+        if (procedure === "emptyLogin") {
+          return jsonResponse({ authStatus: "required", auth: "true" });
+        }
+        if (procedure === "submitCredentials") {
+          const metadata = payload[0] as { rqData?: { force?: string } };
+          return metadata.rqData?.force === "1"
+            ? jsonResponse({
+                authStatus: "complete",
+                token: "secure-token",
+              })
+            : jsonResponse({
+                authStatus: "required",
+                rsData: { resultType: "3" },
+                token: "duplicate-login-token",
+              });
+        }
+
+        const resource = String(payload[0] ?? "");
+        if (resource === "common/CMN01003/010") {
+          return jsonResponse({
+            isSuccessful: true,
+            rsData: { params: { e2e: publicPem } },
+          });
+        }
+        if (resource === "common/CMN01001/010") {
+          return jsonResponse({
+            isSuccessful: true,
+            rsData: { img: "data:image/png;base64,AQID" },
+          });
+        }
+        if (
+          resource === "fco/FCO02001/012" ||
+          resource === "common/CMN01004/010"
+        ) {
+          return jsonResponse({ isSuccessful: true, rsData: {} });
+        }
+        if (resource === "common/EndToEnd/020") {
+          return jsonResponse({
+            isSuccessful: true,
+            rsData: { timeFactor: "1700000000000" },
+          });
+        }
+        if (resource === "fao/FAO01012/010") {
+          const metadata = payload[1] as { rqData?: { queryType?: string } };
+          return jsonResponse(
+            metadata.rqData?.queryType === "customDisplay"
+              ? transactionResponse()
+              : demandDepositResponse(),
+          );
+        }
+        if (resource === "fao/FAO01022/020") {
+          const metadata = payload[1] as {
+            rqData?: { tdAccountNumber?: string };
+          };
+          if (scenario === "empty")
+            return jsonResponse({
+              isSuccessful: true,
+              rsData: { repeats: [] },
             });
-      }
-
-      const resource = String(payload[0] ?? "");
-      if (resource === "common/CMN01003/010") {
-        return jsonResponse({
-          isSuccessful: true,
-          rsData: { params: { e2e: publicPem } },
-        });
-      }
-      if (resource === "common/CMN01001/010") {
-        return jsonResponse({
-          isSuccessful: true,
-          rsData: { img: "data:image/png;base64,AQID" },
-        });
-      }
-      if (
-        resource === "fco/FCO02001/012" ||
-        resource === "common/CMN01004/010"
-      ) {
-        return jsonResponse({ isSuccessful: true, rsData: {} });
-      }
-      if (resource === "common/EndToEnd/020") {
-        return jsonResponse({
-          isSuccessful: true,
-          rsData: { timeFactor: "1700000000000" },
-        });
-      }
-      if (resource === "fao/FAO01012/010") {
-        const metadata = payload[1] as { rqData?: { queryType?: string } };
-        return jsonResponse(
-          metadata.rqData?.queryType === "customDisplay"
-            ? transactionResponse()
-            : demandDepositResponse(),
-        );
-      }
-      if (resource === "fao/FAO01022/020") {
-        return jsonResponse(timeDepositResponse());
-      }
-      throw new Error(`Unexpected O-Bank test request: ${url} ${body}`);
-    });
-
-    const connector = createObankConnector(fetcher, async () => "A1b2");
-    const result = await connector.sync(
-      {
-        userId: "A123456789",
-        account: "test-account",
-        password: "test-password",
-      },
-      undefined,
-      { forceLogin: true },
-    );
-
-    expect(result.bankAccounts).toHaveLength(2);
-    expect(result.bankTransactions).toHaveLength(1);
-    expect(calls.some((call) => call.url.endsWith("/invalidateSession"))).toBe(
-      true,
-    );
-    const adapterCalls = calls.filter((call) =>
-      call.url.includes("AuthenticationAdapter"),
-    );
-    expect(
-      adapterCalls.every((call) =>
-        /^[0-9a-f]{32}$/.test(call.headers.get("checksum") ?? ""),
-      ),
-    ).toBe(true);
-    expect(
-      adapterCalls.every((call) =>
-        call.headers.get("authorization")?.startsWith("Bearer "),
-      ),
-    ).toBe(true);
-    expect(calls.map((call) => call.body).join("\n")).not.toContain(
-      "test-password",
-    );
-    expect(calls.map((call) => call.body).join("\n")).not.toContain(
-      "test-account",
-    );
-    await expect(
-      connector.sync({
-        userId: "A123456789",
-        account: "test-account",
-        password: "test-password",
-      }),
-    ).rejects.toBeInstanceOf(ObankMultipleLoginError);
-    const loginForces = calls
-      .filter((call) => call.url.endsWith("/submitCredentials"))
-      .map((call) => {
-        const payload = JSON.parse(call.body) as [
-          { rqData?: { force?: string } },
-        ];
-        return payload[0]?.rqData?.force;
+          if (scenario === "missing-list")
+            return jsonResponse({ isSuccessful: true, rsData: {} });
+          if (metadata.rqData?.tdAccountNumber && scenario === "failed-detail")
+            return jsonResponse({ isSuccessful: false });
+          const response = timeDepositResponse();
+          if (metadata.rqData?.tdAccountNumber && scenario === "wrong-detail")
+            response.rsData.repeats[0].tdDetail.tdAccountNumber = "wrong";
+          return jsonResponse({
+            ...response,
+            rsData: {
+              ...response.rsData,
+              tdDetail: response.rsData.repeats[0].tdDetail,
+            },
+          });
+        }
+        throw new Error(`Unexpected O-Bank test request: ${url} ${body}`);
       });
-    expect(loginForces).toEqual(["0", "1", "0"]);
-  });
+
+      const connector = createObankConnector(fetcher, async () => "A1b2");
+      const pending = connector.sync(
+        {
+          userId: "A123456789",
+          account: "test-account",
+          password: "test-password",
+        },
+        undefined,
+        { forceLogin: true },
+      );
+
+      if (!["complete", "empty"].includes(scenario)) {
+        await expect(pending).rejects.toThrow();
+        return;
+      }
+      const result = await pending;
+      expect(result.timeDepositsComplete).toBe(true);
+      expect(result.bankAccounts).toHaveLength(scenario === "empty" ? 1 : 2);
+      expect(result.bankTransactions).toHaveLength(1);
+      const tdRequests = calls.filter((call) =>
+        call.body.includes("fao/FAO01022/020"),
+      );
+      expect(tdRequests).toHaveLength(scenario === "empty" ? 1 : 2);
+      if (scenario === "complete")
+        expect(tdRequests[1].body).toContain("98765432109876");
+      expect(
+        calls.some((call) => call.url.endsWith("/invalidateSession")),
+      ).toBe(true);
+      const adapterCalls = calls.filter((call) =>
+        call.url.includes("AuthenticationAdapter"),
+      );
+      expect(
+        adapterCalls.every((call) =>
+          /^[0-9a-f]{32}$/.test(call.headers.get("checksum") ?? ""),
+        ),
+      ).toBe(true);
+      expect(
+        adapterCalls.every((call) =>
+          call.headers.get("authorization")?.startsWith("Bearer "),
+        ),
+      ).toBe(true);
+      expect(calls.map((call) => call.body).join("\n")).not.toContain(
+        "test-password",
+      );
+      expect(calls.map((call) => call.body).join("\n")).not.toContain(
+        "test-account",
+      );
+      await expect(
+        connector.sync({
+          userId: "A123456789",
+          account: "test-account",
+          password: "test-password",
+        }),
+      ).rejects.toBeInstanceOf(ObankMultipleLoginError);
+      const loginForces = calls
+        .filter((call) => call.url.endsWith("/submitCredentials"))
+        .map((call) => {
+          const payload = JSON.parse(call.body) as [
+            { rqData?: { force?: string } },
+          ];
+          return payload[0]?.rqData?.force;
+        });
+      expect(loginForces).toEqual(["0", "1", "0"]);
+    },
+  );
 });
 
 function demandDepositResponse() {

--- a/apps/worker/tests/features/bank/service.test.ts
+++ b/apps/worker/tests/features/bank/service.test.ts
@@ -196,3 +196,33 @@ describe("bank transaction presentation", () => {
     });
   });
 });
+
+it("keeps derived deposit principal excluded when the demand leg is manually classified", async () => {
+  const demand = transaction({
+    id: "demand",
+    accountId: "demand-account",
+    amount: -52736,
+  });
+  const deposit = transaction({
+    id: "deposit",
+    accountId: "deposit-account",
+    accountType: "time_deposit",
+    amount: 52736,
+    transferPeerId: "demand",
+  });
+  const range = { from: "2026-08-01", to: "2026-09-01" };
+  const overrides = [
+    { target_id: "demand", category_id: "other", label: "未分類" },
+  ];
+  const result = await getBankRange(
+    createDb([deposit], [deposit, demand], overrides),
+    range,
+  );
+  expect(result.transactions[0].excludedFromCalculation).toBe(true);
+  const included = { ...deposit, calculationPreference: 0 };
+  const explicit = await getBankRange(
+    createDb([included], [included, demand], overrides),
+    range,
+  );
+  expect(explicit.transactions[0].excludedFromCalculation).toBe(false);
+});

--- a/apps/worker/tests/features/sync/obank-time-deposits.test.ts
+++ b/apps/worker/tests/features/sync/obank-time-deposits.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { matchObankDepositEvents } from "../../../src/features/sync/obank-time-deposits";
+import { findAutomaticTransferPairs } from "../../../src/features/bank/transfer-matching";
+
+const savings = {
+  sourceId: "savings",
+  accountType: "savings" as const,
+  currency: "TWD",
+};
+const now = "2026-09-07T13:31:07Z";
+const transaction = {
+  accountId: "savings",
+  sourceId: "debit",
+  postedDate: "2026-09-07",
+  amount: -52736,
+  currency: "TWD",
+  status: "posted" as const,
+  description: "Account",
+};
+const deposit = {
+  sourceId: "deposit",
+  currency: "TWD",
+  balance: 52736,
+  openedDate: "2026-09-07",
+};
+
+describe("O-Bank time deposit principal events", () => {
+  it("creates a stable opening event linked to the unique demand leg", () => {
+    const events = matchObankDepositEvents(
+      [savings],
+      [deposit],
+      [],
+      [transaction],
+      now,
+    );
+    expect(events).toMatchObject([
+      {
+        amount: 52736,
+        description: "定存成立（本金轉入）",
+        transferPeer: { accountId: "savings", sourceId: "debit" },
+      },
+    ]);
+    expect(
+      matchObankDepositEvents([savings], [deposit], [], [transaction], now),
+    ).toEqual(events);
+  });
+  it("leaves missing dates, duplicate amounts and multiple demand accounts unpaired", () => {
+    expect(
+      matchObankDepositEvents(
+        [savings],
+        [{ ...deposit, openedDate: undefined }],
+        [],
+        [transaction],
+        now,
+      ),
+    ).toEqual([]);
+    expect(
+      matchObankDepositEvents(
+        [savings],
+        [deposit, { ...deposit, sourceId: "other" }],
+        [],
+        [transaction],
+        now,
+      ),
+    ).toEqual([]);
+    expect(
+      matchObankDepositEvents(
+        [savings],
+        [deposit],
+        [],
+        [transaction, { ...transaction, sourceId: "other" }],
+        now,
+      ),
+    ).toEqual([]);
+    expect(
+      matchObankDepositEvents(
+        [savings, { ...savings, sourceId: "other" }],
+        [deposit],
+        [],
+        [transaction],
+        now,
+      ),
+    ).toEqual([]);
+  });
+  it("matches a missing deposit principal after its last sighting, retaining separate interest", () => {
+    const missing = [
+      {
+        sourceId: "old",
+        currency: "TWD",
+        balance: 30550,
+        asOfAt: "2026-09-01T02:06:05Z",
+      },
+    ];
+    const credit = {
+      ...transaction,
+      sourceId: "credit",
+      postedDate: "2026-09-05",
+      amount: 30550,
+    };
+    const interest = { ...credit, sourceId: "interest", amount: 485 };
+    expect(
+      matchObankDepositEvents([savings], [], missing, [credit, interest], now),
+    ).toMatchObject([
+      {
+        amount: -30550,
+        postedDate: "2026-09-05",
+        transferPeer: { sourceId: "credit" },
+      },
+    ]);
+    expect(
+      matchObankDepositEvents(
+        [savings],
+        [],
+        [{ ...missing[0], asOfAt: "2026-09-05T01:00:00Z" }],
+        [credit],
+        now,
+      ),
+    ).toEqual([]);
+    expect(
+      matchObankDepositEvents(
+        [savings],
+        [],
+        missing,
+        [{ ...credit, amount: 31035 }],
+        now,
+      ),
+    ).toEqual([]);
+  });
+  it("reserves the linked peer and never matches an unlinked time deposit by amount alone", () => {
+    const debit = { ...transaction, id: "debit", accountType: "savings" };
+    const event = {
+      ...debit,
+      id: "event",
+      accountId: "td",
+      accountType: "time_deposit",
+      amount: 52736,
+      transferPeerId: "debit",
+    };
+    const unrelated = {
+      ...event,
+      id: "unrelated",
+      accountType: "savings",
+      transferPeerId: undefined,
+    };
+    expect(findAutomaticTransferPairs([debit, event, unrelated])).toEqual([
+      ["event", "debit"],
+    ]);
+    expect(
+      findAutomaticTransferPairs([
+        debit,
+        { ...event, transferPeerId: undefined },
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/apps/worker/tests/features/sync/persistence.test.ts
+++ b/apps/worker/tests/features/sync/persistence.test.ts
@@ -1,3 +1,10 @@
+import { prepareObankTimeDepositWrite } from "../../../src/features/sync/obank-time-deposits";
+import {
+  bankAccountRecord as mapAccount,
+  bankBalanceSnapshotRecord as mapBalance,
+} from "../../../src/features/sync/record-mapper";
+import { listBankAccounts } from "../../../src/features/bank/repository";
+import { calculateBankDepositValue } from "../../../src/features/net-worth/repository";
 import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { DatabaseSync } from "node:sqlite";
@@ -29,6 +36,10 @@ class SqliteStatement {
 
   async run() {
     return this.execute();
+  }
+
+  async all<T>() {
+    return this.execute() as unknown as { results: T[] };
   }
 
   async first<T>() {
@@ -881,5 +892,75 @@ describe("staged sync persistence", () => {
         )
         .get(),
     ).toMatchObject({ cursor: "old-cursor" });
+  });
+});
+
+describe("O-Bank complete deposit snapshots", () => {
+  it("retires missing deposits atomically, preserves history and reactivates a returned account", async () => {
+    const sqlite = createDb();
+    const db = sqlite as unknown as D1Database;
+    const before = "2026-09-01T02:06:05Z";
+    const now = "2026-09-07T13:31:07Z";
+    const account = {
+      sourceId: "td",
+      accountType: "time_deposit" as const,
+      currency: "TWD",
+      openedDate: "2026-01-01",
+      maturityDate: "2026-09-05",
+    };
+    const balance = {
+      accountId: "td",
+      sourceId: "td:first",
+      balance: 30550,
+      currency: "TWD",
+      asOfAt: before,
+    };
+    await persistStagedSyncWrite(db, {
+      records: [
+        mapAccount("obank", account, before),
+        mapBalance("obank", balance, before),
+      ],
+    });
+    const result = {
+      records: [],
+      bankAccounts: [],
+      timeDepositsComplete: true as const,
+    };
+    const write = await prepareObankTimeDepositWrite(db, result, now);
+    // A failure in the same batch must roll back both zero balances and status.
+    await expect(
+      persistStagedSyncWrite(db, {
+        ...write,
+        finalizeStatements: [
+          db.prepare("INSERT INTO missing_table VALUES (1)"),
+        ],
+      }),
+    ).rejects.toThrow();
+    expect(await listBankAccounts(db)).toHaveLength(1);
+    expect(await calculateBankDepositValue(db, "2026-09-07")).toBe(30550);
+    await persistStagedSyncWrite(db, write);
+    expect(await listBankAccounts(db)).toEqual([]);
+    expect(await calculateBankDepositValue(db, "2026-09-01")).toBe(30550);
+    expect(await calculateBankDepositValue(db, "2026-09-07")).toBe(0);
+    expect(
+      (await prepareObankTimeDepositWrite(db, result, now)).records,
+    ).toEqual([]);
+    await persistStagedSyncWrite(db, {
+      records: [
+        mapAccount("obank", account, now),
+        mapBalance(
+          "obank",
+          {
+            ...balance,
+            sourceId: "td:returned",
+            asOfAt: "2026-09-08T01:00:00Z",
+          },
+          now,
+        ),
+      ],
+    });
+    expect(await listBankAccounts(db)).toMatchObject([
+      { openedDate: "2026-01-01", maturityDate: "2026-09-05", balance: 30550 },
+    ]);
   });
 });

--- a/docs/004-connector-development.md
+++ b/docs/004-connector-development.md
@@ -164,3 +164,13 @@ npm run build
 ```
 
 若新增的是全新資料 entity，還必須同步更新 core contract、D1 migration、`SyncEntityType`、promotion order、entity config、record mapper 與 persistence test。
+
+## 王道定存生命週期
+
+王道公開網頁的 [FAO01012 controller](https://www.o-bank.com/ebank/apps/services/www/ibmb/desktopbrowser/default/html/FAO/FAO01012.js) 以 `repeats` 建立完整存單選擇器，再以 `tdAccountNumber` 查詢各筆 `tdDetail`；[頁面欄位](https://www.o-bank.com/ebank/apps/services/www/ibmb/desktopbrowser/default/html/FAO/FAO01012_010.html) 使用 `contractDate`（起息日）與 `maturityDate`（到期日）。連接器沿用清單的帳戶識別碼與餘額，明細只補日期，不保存完整存單號碼。
+
+- 僅完整清單及逐筆明細全部成功後，才撤下未再出現的定存。缺少清單、明細不符或解析不完整時整次同步失敗；明確空陣列可撤下全部舊定存。
+- `inactive_at` 是確認來源不再列出存單的時間，不是實際結清日。同期寫入零餘額快照，與狀態變更一同提交；保留之前的餘額歷史。到期日不作為自動結清條件，來源重新列出時恢復有效。
+- 成立活動須有銀行起息日及唯一的同幣別活存扣款；本金轉回須有前次有效快照、存單消失與其間唯一的活存本金入帳。同幣別有多個活存帳戶、同額候選不唯一、同日無法判定先後或本金利息合併入帳時，不推算活動。
+- 衍生活動以 `transfer_peer_id` 綁定該活存交易，優先一對一配對；定存不參加一般同額配對。本金排除收支，另筆利息保留原有分類及計算。缺少來源日期或交易證據的歷史資料不自動補造。
+- 本地 migration 與 fixture 測試不代表真實銀行同步成功；部署 migration 後仍須一次實際同步取得日期與更新有效清單。

--- a/packages/connectors/src/obank-mobile-api.ts
+++ b/packages/connectors/src/obank-mobile-api.ts
@@ -162,7 +162,7 @@ export function createObankConnector(
       config: ObankConfig,
       _cursor?: string,
       options: ObankSyncOptions = {},
-    ): Promise<SyncResult<never>> {
+    ): Promise<SyncResult<never> & { timeDepositsComplete: true }> {
       const credentials = requireObankCredentials(config);
       let session: ObankMobileFirstSession;
       let captcha = config.captcha;
@@ -211,6 +211,10 @@ export function createObankConnector(
           { page: "td", linkFromTxnId: "FAO01012_010" },
           "FAO01022",
         );
+        const timeDepositDetails = await fetchTimeDepositDetails(
+          session,
+          timeDeposits,
+        );
         const transactionResponses = await fetchDemandDepositTransactions(
           session,
           demandDeposits,
@@ -218,9 +222,18 @@ export function createObankConnector(
         const payloads: ObankPayloads = {
           demandDeposits,
           timeDeposits,
+          timeDepositDetails,
           transactionResponses,
         };
         const parsed = parseObankData(payloads, new Date());
+        if (
+          parsed.bankAccounts.filter(
+            (account) => account.accountType === "time_deposit",
+          ).length !== timeDepositDetails.length
+        )
+          throw new ObankProtocolError(
+            "王道銀行定存清單無法完整對應，未更新定存狀態。",
+          );
         if (
           parsed.bankAccounts.length === 0 ||
           parsed.bankBalanceSnapshots.length === 0
@@ -233,6 +246,7 @@ export function createObankConnector(
         return {
           records: [],
           ...parsed,
+          timeDepositsComplete: true,
           cursor: JSON.stringify({ syncedAt: new Date().toISOString() }),
         };
       } catch (error) {
@@ -555,6 +569,48 @@ class ObankMobileFirstSession {
       "; ",
     );
   }
+}
+
+// The public FAO01012 controller uses repeats as the complete account selector,
+// then requests tdDetail for each selected tdAccountNumber (no pagination).
+async function fetchTimeDepositDetails(
+  session: ObankMobileFirstSession,
+  payload: JsonRecord,
+) {
+  const data = recordAt(payload, "rsData");
+  if (!Array.isArray(data.repeats))
+    throw new ObankProtocolError(
+      "王道銀行定存清單格式無法辨識，未更新定存狀態。",
+    );
+  const details: JsonRecord[] = [];
+  const seen = new Set<string>();
+  for (const value of data.repeats) {
+    if (!isRecord(value))
+      throw new ObankProtocolError("王道銀行定存清單資料不完整。");
+    const summary = isRecord(value.tdDetail) ? value.tdDetail : value;
+    const number = stringValue(summary.tdAccountNumber);
+    if (!number || seen.has(number))
+      throw new ObankProtocolError("王道銀行定存識別資料不完整。");
+    seen.add(number);
+    const response = await session.secureResource(
+      TIME_DEPOSIT_RESOURCE,
+      { tdAccountNumber: number, linkFromTxnId: "FAO01012_010" },
+      "FAO01022",
+    );
+    const detail = recordAt(recordAt(response, "rsData"), "tdDetail");
+    if (detail.tdAccountNumber !== number)
+      throw new ObankProtocolError(
+        "王道銀行定存明細與帳戶不符，未更新定存狀態。",
+      );
+    const parsed = parseObankData({
+      demandDeposits: {},
+      timeDeposits: { repeats: [{ ...summary, ...detail }] },
+    });
+    if (parsed.bankAccounts.length !== 1)
+      throw new ObankProtocolError("王道銀行定存明細無法完整解析。");
+    details.push(response);
+  }
+  return details;
 }
 
 async function fetchDemandDepositTransactions(

--- a/packages/connectors/src/obank.ts
+++ b/packages/connectors/src/obank.ts
@@ -28,6 +28,7 @@ export type ObankPayloads = {
   demandDeposits: unknown;
   timeDeposits?: unknown;
   transactionResponses?: unknown[];
+  timeDepositDetails?: unknown[];
 };
 
 export type ObankData = {
@@ -47,6 +48,8 @@ type ParsedAccount = {
   currency: string;
   balance: number;
   availableBalance?: number;
+  openedDate?: string;
+  maturityDate?: string;
 };
 
 export function parseObankData(
@@ -54,7 +57,10 @@ export function parseObankData(
   now = new Date(),
 ): ObankData {
   const demandAccounts = parseDemandDepositAccounts(payloads.demandDeposits);
-  const timeDepositAccounts = parseTimeDepositAccounts(payloads.timeDeposits);
+  const timeDepositAccounts = parseTimeDepositAccounts(
+    payloads.timeDeposits,
+    payloads.timeDepositDetails,
+  );
   const accounts = dedupeBySourceId([
     ...demandAccounts,
     ...timeDepositAccounts,
@@ -82,6 +88,8 @@ export function parseObankData(
           ? "王道銀行定存"
           : "王道銀行存款帳戶"),
     accountType: account.type,
+    openedDate: account.openedDate,
+    maturityDate: account.maturityDate,
     currency: account.currency,
     raw: sanitizeAccount(account),
   }));
@@ -192,7 +200,10 @@ function parseDemandDepositAccounts(payload: unknown): ParsedAccount[] {
   });
 }
 
-function parseTimeDepositAccounts(payload: unknown): ParsedAccount[] {
+function parseTimeDepositAccounts(
+  payload: unknown,
+  details: unknown[] = [],
+): ParsedAccount[] {
   const response = responseData(payload);
   const repeats = firstArray(response, [
     "repeats",
@@ -202,54 +213,75 @@ function parseTimeDepositAccounts(payload: unknown): ParsedAccount[] {
   ]);
   return repeats.flatMap((value) => {
     if (!isRecord(value)) return [];
-    const detail = isRecord(value.tdDetail) ? value.tdDetail : value;
-    const externalId = firstString(detail, [
-      "tdAccountItemNo",
-      "accountItemNo",
-      "tdAccountNumber",
-      "accountNo",
-    ]);
-    const accountNumber = firstString(detail, [
-      "tdAccountNumber",
-      "accountNo",
-      "displayAccountNo",
-    ]);
-    const currency = normalizeCurrency(
-      firstString(detail, ["currency", "curr", "curry"]),
-    );
-    const balance = firstNumber(detail, [
-      "workingBalance",
-      "principalAmount",
-      "amount",
-      "displayWorkingBalance",
-      "displayAmount",
-    ]);
-    if (!externalId || !currency || balance == null) return [];
-    const digits = digitsOnly(accountNumber || externalId);
-    return [
-      {
-        sourceId: accountSourceId(
-          "time-deposit",
-          externalId,
-          digits.slice(-4),
-          currency,
-        ),
-        externalId,
-        last4: digits.slice(-4) || undefined,
-        last5: digits.slice(-5) || undefined,
-        name:
-          firstString(detail, [
-            "productName",
-            "depositName",
-            "accountName",
-            "displayProductType",
-          ]) || "王道銀行定存",
-        type: "time_deposit" as const,
-        currency,
-        balance,
-      },
-    ];
+    const summary = isRecord(value.tdDetail) ? value.tdDetail : value;
+    const detail = details
+      .map(responseData)
+      .map((row) => row.tdDetail)
+      .find(
+        (row) =>
+          isRecord(row) && row.tdAccountNumber === summary.tdAccountNumber,
+      );
+    // Keep the existing selector identity and balance; detail supplies dates only.
+    const merged = isRecord(detail)
+      ? {
+          ...summary,
+          contractDate: detail.contractDate ?? summary.contractDate,
+          maturityDate: detail.maturityDate ?? summary.maturityDate,
+        }
+      : summary;
+    return parseTimeDepositAccount(merged);
   });
+}
+
+function parseTimeDepositAccount(detail: JsonRecord): ParsedAccount[] {
+  const externalId = firstString(detail, [
+    "tdAccountItemNo",
+    "accountItemNo",
+    "tdAccountNumber",
+    "accountNo",
+  ]);
+  const accountNumber = firstString(detail, [
+    "tdAccountNumber",
+    "accountNo",
+    "displayAccountNo",
+  ]);
+  const currency = normalizeCurrency(
+    firstString(detail, ["currency", "curr", "curry"]),
+  );
+  const balance = firstNumber(detail, [
+    "workingBalance",
+    "principalAmount",
+    "amount",
+    "displayWorkingBalance",
+    "displayAmount",
+  ]);
+  if (!externalId || !currency || balance == null) return [];
+  const digits = digitsOnly(accountNumber || externalId);
+  return [
+    {
+      sourceId: accountSourceId(
+        "time-deposit",
+        externalId,
+        digits.slice(-4),
+        currency,
+      ),
+      externalId,
+      last4: digits.slice(-4) || undefined,
+      last5: digits.slice(-5) || undefined,
+      name:
+        firstString(detail, [
+          "productName",
+          "depositName",
+          "accountName",
+          "displayProductType",
+        ]) || "王道銀行定存",
+      type: "time_deposit" as const,
+      openedDate: normalizeDate(firstString(detail, ["contractDate"])),
+      maturityDate: normalizeDate(firstString(detail, ["maturityDate"])),
+      currency,
+      balance,
+    },
+  ];
 }
 
 function parseTransactionResponse(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -125,6 +125,9 @@ export interface BankAccount {
   accountName?: string;
   accountType?: BankAccountType;
   currency: string;
+  openedDate?: string;
+  maturityDate?: string;
+  inactiveAt?: string;
   creditLimit?: number;
   raw?: unknown;
 }
@@ -148,6 +151,7 @@ export interface BankBalanceSnapshot {
 export type BankTransactionStatus = "pending" | "posted";
 
 export interface BankTransaction {
+  transferPeer?: { accountId: string; sourceId: string };
   id: string;
   connectorId: string;
   accountId: string;

--- a/packages/db/migrations/0041_time_deposit_lifecycle.sql
+++ b/packages/db/migrations/0041_time_deposit_lifecycle.sql
@@ -1,0 +1,5 @@
+ALTER TABLE bank_accounts ADD COLUMN opened_date TEXT;
+ALTER TABLE bank_accounts ADD COLUMN maturity_date TEXT;
+-- Observation time, not the bank's actual settlement date.
+ALTER TABLE bank_accounts ADD COLUMN inactive_at TEXT;
+ALTER TABLE bank_transactions ADD COLUMN transfer_peer_id TEXT;


### PR DESCRIPTION
王道定存原先只保存帳戶與餘額：起息日與到期日沒有顯示，存單從銀行清單消失後仍沿用舊餘額計入資產，活存轉定存也缺少可配對的本金活動。

本次補上逐筆定存明細與日期顯示；只有完整清單及全部明細成功後，才將未再出現的存單標記為不再有效，並在同一次交易寫入零餘額快照，保留先前資產歷史。到期日不作為自動結清條件，存單重新出現時可恢復有效。

成立與本金轉回活動僅在日期、幣別、本金及活存帳戶能唯一對應時建立，透過明確交易關聯排除本金收支；另筆利息保留原有計算。重複同步不新增相同活動，使用者手動分類活存交易也不會讓衍生本金預設變成收入。

限制：無法配對的存單目前只退出資產清單，不會另建獨立的退出狀態活動；不推算實際結清日，也不拆分本金利息合併入帳。

上線須套用 `0041_time_deposit_lifecycle.sql`，再成功同步王道，才能補入日期及更新有效清單。

驗證：

- `npm run format:check`
- `npm run typecheck`
- `npm run test:backend`
- `npm run test:unit`
- 資產頁既有 E2E 與新增定存日期 E2E 通過；已檢查 1280、390、320px。
- 回歸涵蓋空清單、明細失敗／不符、原子回滾、歷史保留、存單恢復、唯一配對及手動計算偏好。
