### PR TITLE
docs: 更新同步架構與定存資料庫文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 
 **需要：** [Cloudflare 帳號](https://dash.cloudflare.com/signup)、[GitHub 帳號](https://github.com/signup)
 
-> 玉山、國泰、永豐與台新會使用 [Browser Run](https://developers.cloudflare.com/browser-run/pricing/)。Workers Free Plan 目前每日包含 10 分鐘瀏覽器使用量；實際額度以 Cloudflare 最新方案為準。
+> 玉山、國泰、永豐、台新、華南與第一銀行會使用 [Browser Run](https://developers.cloudflare.com/browser-run/pricing/)。Workers Free Plan 目前每日包含 10 分鐘瀏覽器使用量；實際額度以 Cloudflare 最新方案為準。
 
 ### 步驟一：一鍵部署
 

--- a/docs/001-cron-sync-design.md
+++ b/docs/001-cron-sync-design.md
@@ -1,4 +1,8 @@
-# Cron Job Design
+# Cron Job Design（歷史設計）
+
+> 本文件為最初 v1 提案與後續補記，保留作為歷史背景，不作為現行實作規範。
+> 現行排程、Queue 分段同步與報告修復行為統一維護於
+> [`002-backend-architecture.md`](002-backend-architecture.md)；新增行為請更新該文件。
 
 > 現況更新：Cron 目前只負責向 Cloudflare Queue 送出啟動訊息；每個 connector
 > 由獨立的 Queue consumer invocation 執行，完成後延遲 20 秒 enqueue 下一個工作。

--- a/docs/002-backend-architecture.md
+++ b/docs/002-backend-architecture.md
@@ -11,7 +11,7 @@
 - 組裝各 feature routes。
 - 設定統一錯誤處理。
 - 提供前端靜態資源。
-- 接收 Cloudflare scheduled event。
+- 接收 Cloudflare scheduled event 與 Queue message batch。
 
 入口檔不得放置 SQL、connector 實作或具體商業流程。
 
@@ -373,7 +373,10 @@ apps/worker/src/features/sync/
 - `repository.ts`：同步流程使用的 query 與 prepared statement。
 - `schedule-route.ts`：排程設定 API。
 - `schedule-service.ts`：排程設定 use case。
-- `scheduler.ts`：Cron tick 與到期工作 dispatch。
+- `scheduler.ts`：到期工作選取、預設排程批次與同步 dispatch。
+- `scheduler-queue.ts`：Cron 啟動訊息、Queue consumer 與分段同步 continuation。
+- `einvoice-sync-service.ts` / `einvoice-run-repository.ts`：電子發票 durable run 與明細工作。
+- `tdcc-sync-service.ts` / `tdcc-run-repository.ts`：集保 durable run、分頁工作與結果彙整。
 
 同步資料流：
 
@@ -411,7 +414,7 @@ sequenceDiagram
 
 - Lease 為 30 分鐘。
 - 執行期間每 5 分鐘續租。
-- 工作完成或失敗後必須在 `finally` 釋放。
+- 一般同步工作完成或失敗後必須在 `finally` 釋放。durable run 的 connector lock 跨 invocation 維持，由成功寫入或失敗結案流程釋放；每段另有 owner-scoped run lease。
 - Lock acquisition 失敗時回傳或記錄「已有同步執行中」，不得平行執行同一 connector。
 
 Cron trigger 只負責向 `SYNC_QUEUE` 送出 scheduler 啟動訊息。Queue consumer
@@ -436,6 +439,24 @@ promotion 前後的重送皆可冪等。
 暫時錯誤由 Queue retry，session 失效會清除 session 後重新初始化；需要使用者操作或重試
 耗盡才將 run 結案為 `needs_user_action` 或 `failed`，不寫入部分完成的明細。
 
+### 集保分段同步
+
+集保的手動 API 與排程由 `startTdccSyncRun` 建立／取得 active run，再 enqueue
+`run-tdcc-chunk`。`tdcc_sync_runs` 保存 scope、設定版本、加密認證與 session；
+`tdcc_sync_run_items` 保存銀行與投資交易的分頁工作及結果。同一 connector 的
+`all`、`investments`、`bank`、`trades` 共用 active run 限制與 canonical lock。
+
+手動啟動會先初始化登入以回報 OTP 等互動需求；排程由 Queue 初始化且不主動寄送
+OTP。API 的排入同步回應不代表全部資料已完成，前端須追蹤 sync job lifecycle。
+每個 chunk 取得 owner-scoped run lease、更新 connector lock，最多 claim 一個
+分頁 item；仍有 pending 或 processing work 時 enqueue 下一段。item 更新使用
+claim token，chunk 的 `finally` 只釋放該 owner 的 run lease。
+
+分頁結果完成後彙整並透過 `sync_write_staging` 與 staged persistence 寫入正式表，
+寫入前檢查設定版本，並在 promotion batch 更新 connector 狀態、cursor 與 sync job。
+後續處理排程結果、手動報告修復與 run 結案；`promoting`、`promoted_at` 用於辨識
+promotion 與 finalize 的進度。暫時錯誤使用 Queue retry，需要互動或重試耗盡時結案。
+
 ## 同步結果通知
 
 同步結果通知位於 `apps/worker/src/features/notifications/`，不放入 sync repository。
@@ -447,7 +468,13 @@ promotion 前後的重送皆可冪等。
 
 排程同步更新 `sync_jobs` 後才呼叫通知 service。通知是 best-effort；發送失敗只記錄 log，不得將成功同步改成失敗。瀏覽器 subscription payload 使用既有設定加密金鑰保存。
 
-使用預設排程（`schedule_mode = inherit`）的工作採「一輪一批次」。沒有進行中的批次且至少一個繼承工作到期時，scheduler 會以單一 D1 batch transaction 建立 header，並固定快照當下所有啟用且不需使用者處理的繼承工作。批次進行期間，每次 Queue consumer invocation 只從尚未完成的固定成員中挑選一個目前未鎖定且不需使用者處理的工作；已完成的成員不會在同一輪再次執行，新啟用的工作則等下一輪。排程結果會在釋放 connector lock 前直接寫入成員，避免重複 Queue 訊息遺漏結果；停用、改為自訂排程或進入 `needs_user_action` 的非執行中成員會被略過。只有所有固定成員都有結果或被略過時，scheduler 才以條件式更新取得一次推播發送權並關閉批次，下一輪才能建立。建立新輪次時會清理超過 30 天的已結案批次。手動同步不完成或改寫批次成員，自訂排程維持逐工作推播。
+使用預設排程（`schedule_mode = inherit`）的工作採「一輪一批次」。沒有進行中的批次且至少一個繼承工作到期時，scheduler 會以單一 D1 batch transaction 建立 header，並固定快照當下所有啟用且不需使用者處理的繼承工作。批次進行期間，每次 Queue consumer invocation 只從尚未完成的固定成員中挑選一個目前未鎖定且不需使用者處理的工作；已完成的成員不會在同一輪再次執行，新啟用的工作則等下一輪。排程結果會在釋放 connector lock 前直接寫入成員，避免重複 Queue 訊息遺漏結果；停用、改為自訂排程或進入 `needs_user_action` 的非執行中成員會被略過。只有所有固定成員都有結果或被略過時，scheduler 才以條件式更新取得一次推播發送權並關閉批次，下一輪才能建立。建立新輪次時會清理超過 30 天的已結案批次。手動同步不完成或改寫進行中的批次成員；自訂排程維持逐工作推播。
+
+手動完整同步成功後，可修復最近一筆已結案預設排程報告中同一 connector 的
+`failed` 或 `needs_user_action` 來源。修復保留原排程完成時間，另記錄
+`recovered_at`，並一次性累加新增筆數、更新報告的 after-snapshot。同步式手動流程
+會在開始前固定可修復的批次，避免誤改執行期間才結案的新輪次；集保部分 scope
+同步不修復 `all` 的批次結果。
 
 每次 Queue scheduler invocation：
 

--- a/docs/004-connector-development.md
+++ b/docs/004-connector-development.md
@@ -20,14 +20,14 @@ Connector 採三層 registry：
 
 新增 connector 前先選擇最接近的連接模式：
 
-| Mode                      | 適用情境                                                 | 現有範例             |
-| ------------------------- | -------------------------------------------------------- | -------------------- |
-| `api_credentials`         | 帳密登入外部 API，可自行更新 token                       | 電子發票、中信、新光 |
-| `api_captcha_session`     | App API 登入含 CAPTCHA，challenge 僅短暫加密保存         | 王道銀行             |
-| `api_device_otp`          | API 登入，首次裝置需要 OTP                               | 集保 e 存摺          |
-| `browser_per_sync`        | 每次同步都必須以 Browser 登入與擷取                      | 國泰世華             |
-| `browser_session`         | Browser 只負責登入，後續使用可復用的 HTTP session        | 玉山                 |
-| `browser_captcha_session` | Browser 登入含 CAPTCHA，可由 AI 或人工完成並復用 session | 永豐、台新           |
+| Mode                      | 適用情境                                                 | 現有範例                   |
+| ------------------------- | -------------------------------------------------------- | -------------------------- |
+| `api_credentials`         | 帳密登入外部 API，可自行更新 token                       | 電子發票、中信、新光       |
+| `api_captcha_session`     | App API 登入含 CAPTCHA，challenge 僅短暫加密保存         | 王道銀行                   |
+| `api_device_otp`          | API 登入，首次裝置需要 OTP                               | 集保 e 存摺                |
+| `browser_per_sync`        | 每次同步都必須以 Browser 登入與擷取                      | 國泰世華                   |
+| `browser_session`         | Browser 只負責登入，後續使用可復用的 HTTP session        | 玉山                       |
+| `browser_captcha_session` | Browser 登入含 CAPTCHA，可由 AI 或人工完成並復用 session | 永豐、台新、華南、第一銀行 |
 
 不要為單一銀行建立新的通用框架。只有登入生命週期真的不同時才新增 mode，並同時補上 catalog 說明及共同測試。
 
@@ -98,13 +98,31 @@ Connector 不得依賴 Hono、D1、Worker `Env`，也不得直接寫入資料庫
 
 ## 路由、排程與 challenge
 
-- 一般同步使用 `runConnectorSync`，不要在 route 或 scheduler 新增 connector switch。
+- 一般同步使用 `runConnectorSync`，不要在 route 或 scheduler 新增 connector switch。電子發票與集保的手動／排程入口使用各自的 durable-run service 啟動 Queue 流程。
 - 所有 scope 必須先宣告在 `connectorCatalog`；排程工作目前固定使用 `all`。
 - 同一 connector 的所有 scope 共用 canonical lock。
 - 需要 CAPTCHA／OTP 時，runtime registry 提供 `prepareChallenge`，route 只處理輸入驗證與 HTTP error mapping。
 - 排程不得主動寄送 OTP；需要互動時標記 `needs_user_action`。
 - 若外部服務支援接管其他登入中的裝置，必須明確定義手動與排程的 `force` policy，並在介面與使用文件提示可能中斷使用者目前的工作階段。
 - 新 connector 必須透過 D1 migration 建立 `<connectorId>:all` sync job，預設停用。
+
+### 集保分段同步
+
+集保與電子發票同樣使用 durable run。手動與排程入口呼叫 `startTdccSyncRun`，
+並 enqueue `run-tdcc-chunk`，不以一般單次同步流程取代分段處理。
+
+- `tdcc_sync_runs` 保存 run lifecycle、scope、設定版本及加密認證／session；
+  `tdcc_sync_run_items` 保存 `bank_page`、`trade_page` 工作與結果。
+- 手動啟動先初始化登入以處理 OTP；排程初始化不主動寄送 OTP。
+- 同一 connector 的所有 scope 共用 active run 限制與 canonical lock；每個 chunk
+  另取得 owner-scoped run lease，每次最多 claim 一個分頁 item，以 claim token
+  更新或釋放該 item，尚有工作時 enqueue continuation。
+- 分頁結果完成後彙整，透過一般 staging 與 promotion 寫入金融資料，並檢查設定版本、
+  更新 cursor；後續完成排程結果、手動完整同步的報告修復與 run 結案。
+- 暫時錯誤交給 Queue retry；需要互動或重試耗盡時終止。不得把每段 run lease 的
+  釋放當成整個 connector 同步完成。
+
+詳細流程與檔案責任參考[後端架構](002-backend-architecture.md#集保分段同步)。
 
 ### 電子發票分段明細同步
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -11,16 +11,16 @@
 - Tables：28
 - Explicit indexes：40
 - Other objects：0
-- Migrations：38
+- Migrations：39
 
 ## Tables
 
 | Table | 用途 | Columns | Foreign keys | Indexes |
 | --- | --- | ---: | ---: | ---: |
-| [`bank_accounts`](#bank_accounts) | 各銀行與信用卡連接器同步回來的帳戶主檔；同一個實體帳戶可能同時存在多個來源記錄。 | 14 | 1 | 1 |
+| [`bank_accounts`](#bank_accounts) | 各銀行與信用卡連接器同步回來的帳戶主檔；同一個實體帳戶可能同時存在多個來源記錄。 | 17 | 1 | 1 |
 | [`bank_balance_snapshots`](#bank_balance_snapshots) | 帳戶在特定時間點的餘額快照，供資產總值與歷史圖表計算。 | 15 | 1 | 2 |
 | [`bank_transaction_preferences`](#bank_transaction_preferences) | 使用者對銀行交易計算方式的個別偏好。 | 4 | 0 | 1 |
-| [`bank_transactions`](#bank_transactions) | 銀行帳戶、信用卡與其他存款型連接器同步回來的交易明細。 | 15 | 1 | 5 |
+| [`bank_transactions`](#bank_transactions) | 銀行帳戶、信用卡與其他存款型連接器同步回來的交易明細。 | 16 | 1 | 5 |
 | [`classification_categories`](#classification_categories) | 交易與發票使用的分類字典，包含系統預設分類與使用者分類。 | 6 | 0 | 1 |
 | [`classification_overrides`](#classification_overrides) | 使用者對單筆目標資料指定的分類覆寫。 | 6 | 1 | 1 |
 | [`classification_rules`](#classification_rules) | 以文字條件自動判斷交易或其他資料分類的規則。 | 14 | 1 | 2 |
@@ -69,6 +69,9 @@
 | 12 | `account_last4` | 帳號末四碼，用於顯示與帳戶比對。 | TEXT | YES | — | — | — |
 | 13 | `canonical_account_id` | 指向同一實體的主要帳戶；NULL 表示此記錄本身就是主要帳戶。 | TEXT | YES | — | — | — |
 | 14 | `credit_limit` | 信用卡或授信帳戶的額度；非授信帳戶通常為 NULL。 | INTEGER | YES | — | — | — |
+| 15 | `opened_date` | 銀行提供的定存起息日；來源未提供時為 NULL。 | TEXT | YES | — | — | — |
+| 16 | `maturity_date` | 銀行提供的定存到期日；不作為自動結清的判定條件。 | TEXT | YES | — | — | — |
+| 17 | `inactive_at` | 同步確認來源不再列出定存的觀測時間，不是銀行實際結清日；有效帳戶為 NULL。 | TEXT | YES | — | — | — |
 
 #### Foreign keys
 
@@ -102,7 +105,7 @@ CREATE TABLE "bank_accounts" (
   bank_code TEXT,
   account_last4 TEXT,
   canonical_account_id TEXT REFERENCES "bank_accounts" (id),
-  credit_limit INTEGER,
+  credit_limit INTEGER, opened_date TEXT, maturity_date TEXT, inactive_at TEXT,
   UNIQUE (connector_id, source_id)
 )
 ```
@@ -227,6 +230,7 @@ CREATE TABLE bank_transaction_preferences (
 | 13 | `updated_at` | 交易最後更新的時間。 | TEXT | NO | — | — | — |
 | 14 | `effective_date` | 由 posted_date 優先、authorized_at 備援產生的查詢排序日期。 | TEXT | YES | — | — | virtual |
 | 15 | `status` | 交易狀態，目前限制為 pending 或 posted。 | TEXT | NO | 'posted' | — | — |
+| 16 | `transfer_peer_id` | 定存衍生活動所配對之活存交易的系統識別碼，供本金轉帳一對一配對；沒有明確配對時為 NULL。 | TEXT | YES | — | — | — |
 
 #### Foreign keys
 
@@ -262,7 +266,7 @@ CREATE TABLE "bank_transactions" (
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
   effective_date TEXT AS (COALESCE(posted_date, authorized_at, '')),
-  status TEXT NOT NULL DEFAULT 'posted' CHECK (status IN ('pending', 'posted')),
+  status TEXT NOT NULL DEFAULT 'posted' CHECK (status IN ('pending', 'posted')), transfer_peer_id TEXT,
   UNIQUE (connector_id, account_id, source_id)
 )
 ```
@@ -1537,6 +1541,7 @@ Migration 是 schema 演進的 source of truth；若要了解某欄位的變更�
 - [`0038_add_default_classification_categories.sql`](../packages/db/migrations/0038_add_default_classification_categories.sql)
 - [`0039_add_default_classification_rules.sql`](../packages/db/migrations/0039_add_default_classification_rules.sql)
 - [`0040_bank_transaction_day_index.sql`](../packages/db/migrations/0040_bank_transaction_day_index.sql)
+- [`0041_time_deposit_lifecycle.sql`](../packages/db/migrations/0041_time_deposit_lifecycle.sql)
 
 ## 程式碼導覽
 

--- a/packages/db/schema-metadata.json
+++ b/packages/db/schema-metadata.json
@@ -17,7 +17,10 @@
         "bank_code": "金融機構代碼，用於跨連接器辨識同一帳戶。",
         "account_last4": "帳號末四碼，用於顯示與帳戶比對。",
         "canonical_account_id": "指向同一實體的主要帳戶；NULL 表示此記錄本身就是主要帳戶。",
-        "credit_limit": "信用卡或授信帳戶的額度；非授信帳戶通常為 NULL。"
+        "credit_limit": "信用卡或授信帳戶的額度；非授信帳戶通常為 NULL。",
+        "opened_date": "銀行提供的定存起息日；來源未提供時為 NULL。",
+        "maturity_date": "銀行提供的定存到期日；不作為自動結清的判定條件。",
+        "inactive_at": "同步確認來源不再列出定存的觀測時間，不是銀行實際結清日；有效帳戶為 NULL。"
       }
     },
     "bank_balance_snapshots": {
@@ -69,7 +72,8 @@
         "created_at": "交易首次寫入的時間。",
         "updated_at": "交易最後更新的時間。",
         "effective_date": "由 posted_date 優先、authorized_at 備援產生的查詢排序日期。",
-        "status": "交易狀態，目前限制為 pending 或 posted。"
+        "status": "交易狀態，目前限制為 pending 或 posted。",
+        "transfer_peer_id": "定存衍生活動所配對之活存交易的系統識別碼，供本金轉帳一對一配對；沒有明確配對時為 NULL。"
       }
     },
     "classification_categories": {


### PR DESCRIPTION
目前文件尚未完整反映集保分段同步、手動同步修復報告及定存生命週期欄位，可能讓維護者依照過時流程修改程式。

本 PR 更新：
- 補齊四個定存相關欄位的 schema metadata，使用 `npm run db:schema:docs` 從隔離 local D1 重新產生資料庫文件，納入 0041 migration。
- 補上集保 durable run、Queue 分頁、跨 invocation 鎖定與完成流程，以及相關檔案責任。
- 區分進行中排程批次與已結案報告，說明手動完整同步的修復行為。
- 補上華南與第一銀行的 Browser Run 用量提醒及連接模式範例。
- 將 Cron v1 文件明確標示為歷史設計，指向現行架構文件。

依使用者要求，未修改 `POLICY_AUDS` 相關內容。本次僅修改文件與欄位描述，沒有修改 runtime 程式或 migration。

驗證：
- `npm run db:schema:docs`：通過。
- `npm run format:check`：全 repo 通過。
- `npm run typecheck`：通過。
- `npm run test:backend`：Worker 474、DB 4 項測試通過；連接器步驟因環境不允許 tsx CLI 建立 IPC socket（EPERM）中止。
- 以 `node --import tsx` 依原 script 順序執行相同九份 connector self-check：全部通過，未修改測試或 package scripts。
- `npm run test:deploy`：16 項通過。
- `git diff --check`：通過。