### PR TITLE
修正：統一重試雲端瀏覽器建立時的 503 錯誤

### DIFF
--- a/apps/worker/src/connectors/browser.ts
+++ b/apps/worker/src/connectors/browser.ts
@@ -1,0 +1,50 @@
+import puppeteer from "@cloudflare/puppeteer";
+
+const RETRY_DELAYS_MS = [2_000, 5_000] as const;
+
+/** Retry only rejected browser acquisition, before a session or login exists. */
+export async function launchBrowserWithRetry(
+  binding: Parameters<typeof puppeteer.launch>[0],
+  options?: Parameters<typeof puppeteer.launch>[1],
+) {
+  return puppeteer.launch(
+    {
+      async fetch(input, init) {
+        const url = new URL(
+          input instanceof Request ? input.url : String(input),
+        );
+        const method =
+          init?.method ?? (input instanceof Request ? input.method : "GET");
+        // This is the acquisition endpoint used by the pinned Puppeteer SDK.
+        // Session/CDP requests must pass through without retrying.
+        if (
+          method.toUpperCase() !== "POST" ||
+          url.pathname !== "/v1/devtools/browser"
+        ) {
+          return binding.fetch(input, init);
+        }
+
+        const request = new Request(input, init);
+        for (let attempt = 0; ; attempt++) {
+          const response = await binding.fetch(request.clone() as Request);
+          if (response.status !== 503) return response;
+
+          const delayMs = RETRY_DELAYS_MS[attempt];
+          console.warn(
+            JSON.stringify({
+              event: "browser_acquisition_failed",
+              status: response.status,
+              attempt: attempt + 1,
+              retryDelayMs: delayMs ?? null,
+            }),
+          );
+          // Leave the final response intact for Puppeteer's error handling.
+          if (delayMs === undefined) return response;
+          await response.body?.cancel();
+          await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+        }
+      },
+    },
+    options,
+  );
+}

--- a/apps/worker/src/connectors/cathaybk.ts
+++ b/apps/worker/src/connectors/cathaybk.ts
@@ -1,3 +1,4 @@
+import { launchBrowserWithRetry } from "./browser.js";
 import puppeteer, {
   type Browser,
   type CookieParam,
@@ -159,7 +160,7 @@ async function scrapeWithBrowser(
     );
     b = reconnecting
       ? await connectCathayBrowser(browserBinding, config.browserSessionId!)
-      : await puppeteer.launch(browserBinding, {
+      : await launchBrowserWithRetry(browserBinding, {
           keep_alive: OTP_SESSION_TTL_MS,
         });
     const pages = await b.pages();

--- a/apps/worker/src/connectors/esun.ts
+++ b/apps/worker/src/connectors/esun.ts
@@ -1,4 +1,5 @@
-import puppeteer, { type Page } from "@cloudflare/puppeteer";
+import { launchBrowserWithRetry } from "./browser.js";
+import { type Page } from "@cloudflare/puppeteer";
 import type {
   BankAccount,
   BankBalanceSnapshot,
@@ -111,7 +112,7 @@ async function loginWithBrowser(
   config: EsunConfig,
 ) {
   console.log("[esun debug] launching browser");
-  const browser = await puppeteer.launch(browserBinding);
+  const browser = await launchBrowserWithRetry(browserBinding);
   const page = await browser.newPage();
   let txnDupToken: string | undefined;
 

--- a/apps/worker/src/connectors/firstbank.ts
+++ b/apps/worker/src/connectors/firstbank.ts
@@ -1,3 +1,4 @@
+import { launchBrowserWithRetry } from "./browser.js";
 import puppeteer, {
   type Browser,
   type CDPSession,
@@ -2515,7 +2516,7 @@ async function waitForSessionRelease(
 
 async function launchBrowser(browserFetcher: Fetcher): Promise<Browser> {
   try {
-    return await puppeteer.launch(browserFetcher, {
+    return await launchBrowserWithRetry(browserFetcher, {
       keep_alive: CAPTCHA_KEEP_ALIVE_MS,
     });
   } catch (error) {

--- a/apps/worker/src/connectors/hncb.ts
+++ b/apps/worker/src/connectors/hncb.ts
@@ -1,3 +1,4 @@
+import { launchBrowserWithRetry } from "./browser.js";
 import puppeteer, {
   type Browser,
   type Dialog,
@@ -779,7 +780,7 @@ async function acquireBrowser(
 
 async function launchBrowser(browserFetcher: Fetcher): Promise<Browser> {
   try {
-    return await puppeteer.launch(browserFetcher, {
+    return await launchBrowserWithRetry(browserFetcher, {
       keep_alive: CAPTCHA_KEEP_ALIVE_MS,
     });
   } catch (error) {

--- a/apps/worker/src/connectors/sinopac.ts
+++ b/apps/worker/src/connectors/sinopac.ts
@@ -1,3 +1,4 @@
+import { launchBrowserWithRetry } from "./browser.js";
 import puppeteer, {
   type Browser,
   type Dialog,
@@ -503,7 +504,7 @@ async function launchBrowser(
   options?: { keep_alive?: number },
 ) {
   try {
-    return await puppeteer.launch(browser, options);
+    return await launchBrowserWithRetry(browser, options);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (/Browser time limit exceeded for today/i.test(message)) {

--- a/apps/worker/src/connectors/taishin.ts
+++ b/apps/worker/src/connectors/taishin.ts
@@ -1,3 +1,4 @@
+import { launchBrowserWithRetry } from "./browser.js";
 import puppeteer, {
   type Browser,
   type Frame,
@@ -1173,7 +1174,7 @@ async function launchBrowser(
   options?: { keep_alive?: number },
 ): Promise<Browser> {
   try {
-    return await puppeteer.launch(browser, options);
+    return await launchBrowserWithRetry(browser, options);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (/Browser time limit exceeded for today/i.test(message)) {

--- a/apps/worker/tests/connectors/browser.test.ts
+++ b/apps/worker/tests/connectors/browser.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const launch = vi.hoisted(() => vi.fn());
+vi.mock("@cloudflare/puppeteer", () => ({ default: { launch } }));
+import { launchBrowserWithRetry } from "../../src/connectors/browser";
+
+type Binding = Parameters<typeof launchBrowserWithRetry>[0];
+const acquisitionUrl = "https://fake.host/v1/devtools/browser?keep_alive=60000";
+
+describe("browser acquisition retry", () => {
+  beforeEach(() => {
+    launch.mockReset();
+    launch.mockImplementation((binding: Binding) =>
+      binding.fetch(acquisitionUrl, { method: "POST" }),
+    );
+    vi.useFakeTimers();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("returns success immediately and preserves launch options", async () => {
+    const response = new Response("session");
+    const fetch = vi.fn().mockResolvedValue(response);
+    const options = { keep_alive: 60000 };
+    await expect(launchBrowserWithRetry({ fetch }, options)).resolves.toBe(
+      response,
+    );
+    expect(launch).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ fetch: expect.any(Function) }),
+      options,
+    );
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("retries by status regardless of response text and preserves the request", async () => {
+    const failed = new Response("服務暫時不可用", { status: 503 });
+    const response = new Response("session");
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(failed)
+      .mockResolvedValueOnce(response);
+    launch.mockImplementation((binding: Binding) =>
+      binding.fetch(
+        new Request(acquisitionUrl, {
+          method: "POST",
+          headers: { "X-Test": "preserved" },
+          body: "payload",
+        }),
+      ),
+    );
+    const result = launchBrowserWithRetry({ fetch });
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(failed.bodyUsed).toBe(true);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(result).resolves.toBe(response);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    for (const [request] of fetch.mock.calls) {
+      expect(request.url).toBe(acquisitionUrl);
+      expect(request.method).toBe("POST");
+      expect(request.headers.get("X-Test")).toBe("preserved");
+      expect(await request.text()).toBe("payload");
+    }
+    expect(launch).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops after three attempts and leaves the final response readable", async () => {
+    const final = new Response("last failure", { status: 503 });
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("first", { status: 503 }))
+      .mockResolvedValueOnce(new Response("second", { status: 503 }))
+      .mockResolvedValueOnce(final);
+    const result = launchBrowserWithRetry({ fetch });
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(result).resolves.toBe(final);
+    expect(await final.text()).toBe("last failure");
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(launch).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each([401, 429, 500])(
+    "passes through status %s without retry",
+    async (status) => {
+      const response = new Response("error", { status });
+      const fetch = vi.fn().mockResolvedValue(response);
+      await expect(launchBrowserWithRetry({ fetch })).resolves.toBe(response);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(response.bodyUsed).toBe(false);
+    },
+  );
+
+  it.each([
+    ["GET", acquisitionUrl],
+    ["GET", "https://fake.host/v1/devtools/browser/session-id"],
+    ["POST", "https://fake.host/v1/devtools/browser/session-id"],
+  ])("does not retry other requests: %s %s", async (method, url) => {
+    const response = new Response("unavailable", { status: 503 });
+    const fetch = vi.fn().mockResolvedValue(response);
+    const init = { method };
+    launch.mockImplementation((binding: Binding) => binding.fetch(url, init));
+    await expect(launchBrowserWithRetry({ fetch })).resolves.toBe(response);
+    expect(fetch).toHaveBeenCalledExactlyOnceWith(url, init);
+    expect(response.bodyUsed).toBe(false);
+  });
+
+  it("does not retry network exceptions with an unknown acquisition outcome", async () => {
+    const error = new Error("connection lost");
+    const fetch = vi.fn().mockRejectedValue(error);
+    await expect(launchBrowserWithRetry({ fetch })).rejects.toBe(error);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(launch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/worker/tests/connectors/cathaybk-session.test.ts
+++ b/apps/worker/tests/connectors/cathaybk-session.test.ts
@@ -153,7 +153,7 @@ describe("Cathay browser session lifecycle", () => {
       ).rejects.toThrow();
 
       expect(puppeteerMock.launch).toHaveBeenCalledWith(
-        {},
+        expect.objectContaining({ fetch: expect.any(Function) }),
         { keep_alive: 120_000 },
       );
       expect(browser.close).toHaveBeenCalledOnce();

--- a/apps/worker/tests/connectors/firstbank-session.test.ts
+++ b/apps/worker/tests/connectors/firstbank-session.test.ts
@@ -777,7 +777,7 @@ describe("第一銀行 browser session lifecycle", () => {
     const result = await prepareFirstbankCaptcha({} as Fetcher, credentials);
 
     expect(puppeteerMock.launch).toHaveBeenCalledWith(
-      {},
+      expect.objectContaining({ fetch: expect.any(Function) }),
       expect.objectContaining({ keep_alive: expect.any(Number) }),
     );
     expect(browser.sessionId).toHaveBeenCalledOnce();

--- a/docs/004-connector-development.md
+++ b/docs/004-connector-development.md
@@ -82,6 +82,15 @@ Schema 需要涵蓋同步期間會持久化的 secret state，否則 Zod parse �
 
 Connector 不得依賴 Hono、D1、Worker `Env`，也不得直接寫入資料庫。
 
+所有 Browser adapter 建立新瀏覽器時，統一呼叫
+`apps/worker/src/connectors/browser.ts` 的 `launchBrowserWithRetry`，不得直接呼叫
+`puppeteer.launch`。共用 adapter 在 binding `fetch` 層僅針對建立瀏覽器的
+`POST /v1/devtools/browser` 請求依 HTTP status `503` 判斷重試，不比對錯誤文案。
+預設等待 2 秒、5 秒後重試，
+最多嘗試 3 次；耗盡後保留原始錯誤，交由既有同步失敗流程處理。結構化 log
+只記錄狀態碼、嘗試次數與重試延遲。`429` 額度／限流錯誤維持既有處理，
+session 重連、瀏覽器建立後的操作與銀行登入不在此重試範圍內。
+
 ## 正規化資料契約
 
 - Connector 回傳 `SyncResult`，資料必須符合 `@taiwan-fin-hub/core`。


### PR DESCRIPTION
Cloudflare 建立瀏覽器回覆 503 時，原本會直接讓該次銀行同步失敗。這次讓玉山、國泰、永豐、台新、華南與第一銀行共用建立瀏覽器的重試入口，等待 2 秒、5 秒後重試，最多嘗試 3 次。

共用 adapter 在 binding fetch 層，僅針對 POST /v1/devtools/browser 依 Response.status 判斷 503，不依賴 SDK 英文錯誤文案。Puppeteer launch 只呼叫一次；session 連線、銀行登入、其他 HTTP 狀態與網路例外維持原有處理。最後失敗回應完整交回 SDK，重試紀錄只包含狀態碼、次數與延遲。

驗證：
- npm run format:check
- npm run typecheck
- npm run test:backend（Worker 484 項測試通過，含 10 項共用重試測試；DB、connector self-check 與部署腳本測試通過）
- 未部署或觸發實際銀行同步。

文件：更新 docs/004-connector-development.md，規定所有 Browser adapter 使用共用入口並說明重試範圍。沒有變更 schema、部署設定或同步排程，因此其他文件不需更新。
