### PR TITLE
補回活動頁該月搜尋

### DIFF
--- a/apps/web/e2e/activity-search.spec.ts
+++ b/apps/web/e2e/activity-search.spec.ts
@@ -86,6 +86,8 @@ for (const width of [1440, 390, 320]) {
     await month.selectOption({ index: 1 });
     const selected = await month.inputValue();
     await page.getByRole("tab", { name: "信用卡", exact: true }).click();
+    const monthlySearch = page.getByRole("searchbox", { name: "搜尋該月活動" });
+    await monthlySearch.fill("月報關鍵字");
     const search = page.getByRole("searchbox", { name: "搜尋所有活動" });
     await search.fill("airbnb");
     await page.waitForTimeout(500); // Typing must not trigger the former debounce.
@@ -114,6 +116,7 @@ for (const width of [1440, 390, 320]) {
     await expect(search).toHaveValue("airbnb");
     await page.goBack();
     await expect(month).toHaveValue(selected);
+    await expect(monthlySearch).toHaveValue("月報關鍵字");
     await page.goForward();
     await expect(search).toHaveValue("airbnb");
     if (width < 768)
@@ -240,4 +243,59 @@ test("failed next batch retains results and can be retried", async ({
     page.getByRole("heading", { name: "已載入 35 筆", exact: true }),
   ).toBeVisible();
   await expect(page.getByRole("alert")).toHaveCount(0);
+});
+
+test("monthly search filters selected month without global requests", async ({
+  page,
+}) => {
+  const requests = await mockSearch(page, []);
+  await page.route("**/api/bank**", async (route) => {
+    const month = new URL(route.request().url()).searchParams
+      .get("to")
+      ?.slice(0, 7);
+    await route.fulfill({
+      json: {
+        accounts: [
+          {
+            id: "card",
+            connectorId: "esun",
+            sourceId: "card",
+            currency: "TWD",
+            accountType: "credit_card",
+          },
+        ],
+        transactions: ["咖啡", "午餐"].map((description, index) => ({
+          id: `monthly-${index}`,
+          connectorId: "esun",
+          accountId: "card",
+          sourceId: `monthly-${index}`,
+          postedDate: `${month}-01`,
+          amount: -100 - index,
+          currency: "TWD",
+          description,
+          status: "posted",
+        })),
+      },
+    });
+  });
+  await page.goto("/#/activity");
+  const coffee = page
+    .getByRole("button", { name: "查看 咖啡 活動詳情" })
+    .filter({ visible: true });
+  const lunch = page
+    .getByRole("button", { name: "查看 午餐 活動詳情" })
+    .filter({ visible: true });
+  await expect(coffee).toBeVisible();
+  await expect(lunch).toBeVisible();
+  const search = page.getByRole("searchbox", { name: "搜尋該月活動" });
+  await search.fill("咖啡");
+  await expect(coffee).toBeVisible();
+  await expect(lunch).toHaveCount(0);
+  await page.getByLabel("選擇活動月份").selectOption({ index: 1 });
+  await expect(coffee).toHaveCount(0);
+  await page.getByLabel("選擇活動月份").selectOption({ index: 0 });
+  await expect(coffee).toBeVisible();
+  await search.fill("");
+  await expect(lunch).toBeVisible();
+  expect(requests).toHaveLength(0);
 });

--- a/apps/web/src/features/activity/ActivityPage.svelte
+++ b/apps/web/src/features/activity/ActivityPage.svelte
@@ -116,6 +116,7 @@
   let flow = $state<ActivityFlowFilter>("all");
   let source = $state<ActivitySourceFilter>("all");
   let search = $state("");
+  let monthlySearch = $state("");
   let submittedSearch = $state("");
   let searchTime = $state("all");
   let searchFrom = $state("");
@@ -502,7 +503,7 @@
       categoryId: searching ? searchCategory : undefined,
       flow,
       source,
-      search: submittedSearch,
+      search: searching ? submittedSearch : monthlySearch,
       category: selectedCategory,
     }),
   );
@@ -1135,7 +1136,15 @@
               onclick={clearCategoryFilter}>清除分類</button
             >
           </div>{/if}
-        {#if !searching}<div class="grid min-w-0 gap-1.5">
+        {#if !searching}
+          <Input
+            type="search"
+            aria-label="搜尋該月活動"
+            placeholder="搜尋該月活動"
+            class="h-11"
+            bind:value={monthlySearch}
+          />
+          <div class="grid min-w-0 gap-1.5">
             <span class="text-xs font-semibold text-ink/50">來源</span>
             <TabsList
               aria-label="活動來源"


### PR DESCRIPTION
## 變更

- 活動頁補回「搜尋該月活動」，並保留全域跨歷史搜尋；切換月份及返回月報時維持月內搜尋狀態。
- 新增 E2E 覆蓋月內搜尋、月份切換與不觸發全域搜尋請求的行為。

## 驗證

- `npm run format:check`
- `npm run typecheck`
- `npm run test:unit`（104 tests passed）
- `npm run test:e2e --workspace apps/web -- activity-search.spec.ts`（8 tests passed）
