### PR TITLE
修正：允許 PWA 雙指縮放並設定最小比例

### DIFF
--- a/apps/web/e2e/shell.spec.ts
+++ b/apps/web/e2e/shell.spec.ts
@@ -990,7 +990,7 @@ test("uses app-like scrolling and history only in standalone display mode", asyn
   await expect(page.locator("html")).toHaveClass(/is-standalone/);
   await expect(page.locator("html")).toHaveCSS("overflow", "hidden");
   await expect(page.locator("body")).toHaveCSS("overflow", "hidden");
-  await expect(page.locator("#root")).toHaveCSS("touch-action", "pan-x pan-y");
+  await expect(page.locator("#root")).toHaveCSS("touch-action", "manipulation");
   await expect(page.locator("#root")).toHaveCSS("overflow-y", "auto");
   await expect(page.locator("#root")).toHaveCSS("overscroll-behavior", "none");
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0"
+    />
     <meta name="theme-color" content="#f8fafc" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />

--- a/apps/web/src/shared/actions/swipe-back.ts
+++ b/apps/web/src/shared/actions/swipe-back.ts
@@ -20,7 +20,7 @@ export const swipeBack: Action<HTMLElement, SwipeBackOptions> = (
 
   function applyTouchAction() {
     node.style.touchAction =
-      options.enabled === false ? originalTouchAction : "pan-y";
+      options.enabled === false ? originalTouchAction : "pan-y pinch-zoom";
   }
 
   function reset() {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -157,6 +157,6 @@ html.is-standalone #root {
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: none;
-  /* Keep the installed PWA app-like: allow scrolling, but no gesture zoom. */
-  touch-action: pan-x pan-y;
+  /* Allow pinch zoom while preventing double-tap zoom in the installed PWA. */
+  touch-action: manipulation;
 }


### PR DESCRIPTION
iPhone PWA 偶爾在點選底部活動／資產後放大，原有設定又禁止雙指縮放，導致使用者無法自行縮回。本次允許 PWA 與滑動返回區域使用雙指縮放，保留禁止雙擊放大的設定，並在 viewport 加上 `minimum-scale=1.0`，指定正常比例為縮小下限。偶發放大的根因尚未確認。

驗證：
- `npm run format:check` 通過。
- `npm run typecheck` 通過。
- `npm run test:unit` 通過：23 個檔案、104 個測試。
- PWA 殼層 E2E 通過；活動排除／恢復 E2E 在重載後點擊列表時被明細遮罩阻擋而逾時，尚未執行到滑動返回驗證。
- iPhone PWA 的實際縮放與回彈仍待實機驗證。

文件：無需更新既有文件，本次未改變前端架構、API 或操作流程；已同步更新 CSS 註解與既有 E2E 預期值。
