### PR TITLE
完成 Drizzle 階段 1–2：schema 比對、隔離 D1 與匯率 repository

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,16 +28,17 @@
 - `apps/worker/src/connectors`：依賴 Browser Rendering、Workers AI 等 Worker bindings 的連接器 adapter。
 - `packages/core`：前後端、資料庫與連接器共用的穩定型別及契約。
 - `packages/connectors`：不依賴 Hono、D1 或 Worker `Env` 的外部資料來源邏輯。
-- `packages/db`：跨 feature 共用的 D1 基礎能力與 migrations。
+- `packages/db`：跨 feature 共用的 D1 基礎能力、Drizzle schema／client 與 migrations。
 - `docs/002-backend-architecture.md`：後端分層、相依方向與維護約定的詳細文件。
 - `docs/003-frontend-architecture.md`：前端分層、相依方向與測試 colocate 約定。
 - `docs/004-connector-development.md`：Connector catalog、連接模式、敏感狀態與新增流程規範。
+- `docs/006-drizzle-adoption-plan.md`：Drizzle 分階段導入計畫；階段 1–2 已落地，後續批次見該文件。
 
 ## 架構約定
 
 - 後端採 feature-oriented Vertical Slice Architecture。
 - `apps/worker/src/index.ts` 是 Composition Root，只負責 middleware、routes、錯誤處理、靜態資源與 scheduled event 的組裝。
-- HTTP concerns 放在 `route.ts`，use case 與商業流程放在 `service.ts`，feature 專用 SQL 放在 `repository.ts`。
+- HTTP concerns 放在 `route.ts`，use case 與商業流程放在 `service.ts`，feature 專用資料存取放在 `repository.ts`；一般 CRUD 預設使用 Drizzle。
 - 共用 API contract 與金融資料型別放在 `packages/core`，不得混入 Hono `Context`、D1 row 或 Puppeteer object。
 - 前端採 feature-first 結構；`features` 可依賴 `data` 與 `shared`，`data`、`shared` 不得反向依賴 feature。
 - 前端單元及元件測試與實作 colocate；Playwright browser tests 放在 `apps/web/e2e`。
@@ -64,14 +65,15 @@
 
 開始修改前，依任務範圍閱讀下表文件的相關章節；跨領域變更須涵蓋所有涉及的文件，不必每次讀完整個 `docs/`。
 
-| 涉及的變更                       | 修改前閱讀，描述受影響時同步更新                                |
-| -------------------------------- | --------------------------------------------------------------- |
-| 後端架構、同步、Queue、排程      | `docs/002-backend-architecture.md`                              |
-| 前端結構、資料查詢、共用元件     | `docs/003-frontend-architecture.md`                             |
-| 連接器、登入、驗證碼、資料正規化 | `docs/004-connector-development.md`；涉及同步流程時也讀後端架構 |
-| 部署、自動更新、環境變數         | `docs/005-deployment.md`、`README.md` 對應章節                  |
-| 資料庫 schema                    | `docs/database-schema.md`、相關 `packages/db/migrations/*.sql`  |
-| 使用方式、支援資料來源、限制     | `README.md` 對應章節                                            |
+| 涉及的變更                              | 修改前閱讀，描述受影響時同步更新                                        |
+| --------------------------------------- | ----------------------------------------------------------------------- |
+| 後端架構、同步、Queue、排程             | `docs/002-backend-architecture.md`                                      |
+| 前端結構、資料查詢、共用元件            | `docs/003-frontend-architecture.md`                                     |
+| 連接器、登入、驗證碼、資料正規化        | `docs/004-connector-development.md`；涉及同步流程時也讀後端架構         |
+| 部署、自動更新、環境變數                | `docs/005-deployment.md`、`README.md` 對應章節                          |
+| 資料庫 schema                           | `docs/database-schema.md`、相關 `packages/db/migrations/*.sql`          |
+| Drizzle schema、client、repository 轉換 | `docs/006-drizzle-adoption-plan.md`、`docs/002-backend-architecture.md` |
+| 使用方式、支援資料來源、限制            | `README.md` 對應章節                                                    |
 
 - 若變更使文件描述不再正確，必須在同一個 PR 更新相關文件；純重構且不影響文件描述時，不必為了更新而更新。
 - Schema 變更須同步維護 `packages/db/schema-metadata.json`，並從 repo root 執行 `npm run db:schema:docs`，提交重新產生的 `docs/database-schema.md`；不得直接手改產生的文件。

--- a/apps/worker/src/features/exchange-rates/repository.ts
+++ b/apps/worker/src/features/exchange-rates/repository.ts
@@ -21,12 +21,14 @@ export async function listExchangeRates(db: D1Database) {
     })
     .from(exchangeRates)
     .where(inArray(exchangeRates.currency, [...SUPPORTED_EXCHANGE_CURRENCIES]))
-    .orderBy(sql`CASE ${exchangeRates.currency}
+    .orderBy(
+      sql`CASE ${exchangeRates.currency}
        WHEN 'USD' THEN 1
        WHEN 'JPY' THEN 2
        WHEN 'EUR' THEN 3
        ELSE 4
-     END`)
+     END`,
+    )
     .all();
 }
 
@@ -36,6 +38,7 @@ export async function replaceExchangeRates(
   now: string,
 ) {
   const database = createDb(db);
+  // Delete + inserts stay in one D1 batch so a failed insert leaves the old rates.
   await database.batch([
     database.delete(exchangeRates),
     ...rates.map(({ currency, rate }) =>

--- a/apps/worker/tests/features/exchange-rates/repository.test.ts
+++ b/apps/worker/tests/features/exchange-rates/repository.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  listExchangeRates,
+  replaceExchangeRates,
+} from "../../../src/features/exchange-rates/repository";
+import { createTestD1 } from "../../../../../packages/db/testing/d1";
+
+describe("exchange-rates repository", () => {
+  let harness: Awaited<ReturnType<typeof createTestD1>>;
+
+  beforeAll(async () => {
+    harness = await createTestD1();
+  }, 60_000);
+
+  afterAll(async () => {
+    await harness?.mf.dispose();
+  });
+
+  beforeEach(async () => {
+    await harness.binding.prepare("DELETE FROM exchange_rates").run();
+  });
+
+  it("lists supported currencies in USD, JPY, EUR order", async () => {
+    await replaceExchangeRates(
+      harness.binding,
+      [
+        { currency: "EUR", rate: 37 },
+        { currency: "USD", rate: 32 },
+        { currency: "JPY", rate: 0.2 },
+      ],
+      "2026-09-12T00:00:00.000Z",
+    );
+    await harness.binding
+      .prepare(
+        `INSERT INTO exchange_rates (currency, rate_to_twd, updated_at)
+         VALUES ('GBP', 40, '2026-09-12T00:00:00.000Z')`,
+      )
+      .run();
+
+    await expect(listExchangeRates(harness.binding)).resolves.toEqual([
+      {
+        currency: "USD",
+        rateTwd: 32,
+        updatedAt: "2026-09-12T00:00:00.000Z",
+      },
+      {
+        currency: "JPY",
+        rateTwd: 0.2,
+        updatedAt: "2026-09-12T00:00:00.000Z",
+      },
+      {
+        currency: "EUR",
+        rateTwd: 37,
+        updatedAt: "2026-09-12T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("replaces the full rate set in one batch", async () => {
+    await replaceExchangeRates(
+      harness.binding,
+      [{ currency: "USD", rate: 30 }],
+      "2026-09-11T00:00:00.000Z",
+    );
+    await replaceExchangeRates(
+      harness.binding,
+      [
+        { currency: "USD", rate: 32 },
+        { currency: "JPY", rate: 0.2 },
+        { currency: "EUR", rate: 37 },
+      ],
+      "2026-09-12T00:00:00.000Z",
+    );
+
+    await expect(listExchangeRates(harness.binding)).resolves.toEqual([
+      {
+        currency: "USD",
+        rateTwd: 32,
+        updatedAt: "2026-09-12T00:00:00.000Z",
+      },
+      {
+        currency: "JPY",
+        rateTwd: 0.2,
+        updatedAt: "2026-09-12T00:00:00.000Z",
+      },
+      {
+        currency: "EUR",
+        rateTwd: 37,
+        updatedAt: "2026-09-12T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("keeps previous rows when a later insert in the replace batch fails", async () => {
+    await replaceExchangeRates(
+      harness.binding,
+      [{ currency: "USD", rate: 30 }],
+      "2026-09-11T00:00:00.000Z",
+    );
+
+    await expect(
+      replaceExchangeRates(
+        harness.binding,
+        [
+          { currency: "JPY", rate: 0.2 },
+          { currency: "USD", rate: 32 },
+          { currency: "USD", rate: 33 },
+        ],
+        "2026-09-12T00:00:00.000Z",
+      ),
+    ).rejects.toThrow();
+
+    await expect(listExchangeRates(harness.binding)).resolves.toEqual([
+      {
+        currency: "USD",
+        rateTwd: 30,
+        updatedAt: "2026-09-11T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("deletes cached rates when asked to replace with an empty list", async () => {
+    await replaceExchangeRates(
+      harness.binding,
+      [{ currency: "USD", rate: 30 }],
+      "2026-09-11T00:00:00.000Z",
+    );
+    await replaceExchangeRates(harness.binding, [], "2026-09-12T00:00:00.000Z");
+    await expect(listExchangeRates(harness.binding)).resolves.toEqual([]);
+  });
+});

--- a/apps/worker/tests/features/exchange-rates/route.test.ts
+++ b/apps/worker/tests/features/exchange-rates/route.test.ts
@@ -6,11 +6,23 @@ function envWithDb() {
   const db = {
     prepare() {
       const statement = {
+        bind() {
+          return statement;
+        },
         async all() {
           return { results: [] };
         },
+        async raw() {
+          return [];
+        },
+        async run() {
+          return { success: true, meta: { changes: 0 } };
+        },
       };
       return statement;
+    },
+    async batch() {
+      return [];
     },
   } as unknown as D1Database;
   return { DB: db } as Env;

--- a/apps/worker/tests/features/exchange-rates/service.test.ts
+++ b/apps/worker/tests/features/exchange-rates/service.test.ts
@@ -8,10 +8,8 @@ import {
 function createDb(results: unknown[] = []) {
   const calls: Array<{ sql: string; values: unknown[] }> = [];
   const batches: unknown[][] = [];
-  const preparedSql: string[] = [];
   const db = {
     prepare(sql: string) {
-      preparedSql.push(sql);
       const statement = {
         bind(...values: unknown[]) {
           calls.push({ sql, values });
@@ -19,6 +17,12 @@ function createDb(results: unknown[] = []) {
         },
         async all() {
           return { results };
+        },
+        async raw() {
+          return results.map((row) => Object.values(row as object));
+        },
+        async run() {
+          return { success: true, meta: { changes: 0 } };
         },
       };
       return statement;
@@ -28,7 +32,7 @@ function createDb(results: unknown[] = []) {
       return [];
     },
   } as unknown as D1Database;
-  return { db, calls, batches, preparedSql };
+  return { db, calls, batches };
 }
 
 const providerPayload = {
@@ -44,7 +48,7 @@ const providerPayload = {
 
 describe("refreshExchangeRates", () => {
   it("converts the TWD-base response into the app's TWD rates", async () => {
-    const { db, calls, batches, preparedSql } = createDb([
+    const { db, calls, batches } = createDb([
       {
         currency: "USD",
         rateTwd: 32.3076,
@@ -78,22 +82,20 @@ describe("refreshExchangeRates", () => {
       }),
     );
     expect(batches).toHaveLength(1);
-    expect(preparedSql[0]).toBe("DELETE FROM exchange_rates");
     expect(batches[0]).toHaveLength(4);
-    expect(
-      calls
-        .filter(({ sql }) => sql.includes("INSERT INTO exchange_rates"))
-        .map(({ values }) => values.slice(0, 2)),
-    ).toEqual([
+    const inserts = calls.filter(
+      ({ values }) => values.length === 3 && typeof values[1] === "number",
+    );
+    expect(inserts.map(({ values }) => values.slice(0, 2))).toEqual([
       ["USD", 1 / providerPayload.rates.USD],
       ["JPY", 1 / providerPayload.rates.JPY],
       ["EUR", 1 / providerPayload.rates.EUR],
     ]);
-    expect(calls[0]?.values[2]).toBe("2026-08-02T00:02:31.000Z");
+    expect(inserts[0]?.values[2]).toBe("2026-08-02T00:02:31.000Z");
   });
 
   it("does not write partial data when a required currency is missing", async () => {
-    const { db, batches, preparedSql } = createDb();
+    const { db, batches } = createDb();
     const fetcher = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -111,7 +113,6 @@ describe("refreshExchangeRates", () => {
       ExchangeRateProviderError,
     );
     expect(batches).toHaveLength(0);
-    expect(preparedSql).not.toContain("DELETE FROM exchange_rates");
   });
 
   it("turns provider HTTP failures into a provider error", async () => {

--- a/docs/002-backend-architecture.md
+++ b/docs/002-backend-architecture.md
@@ -77,6 +77,7 @@ flowchart TD
     FeatureService --> Connectors
     FeatureService --> DB
 
+    FeatureRepository --> DB
     FeatureRepository --> D1
     DB --> D1
     WorkerConnector --> Browser
@@ -150,10 +151,15 @@ Service 可以直接接受 `D1Database` 或 `Env`，不需要額外建立 Depend
 
 Feature 專用的 D1 存取層，負責：
 
-- 集中該 feature 使用的 SQL。
+- 集中該 feature 使用的資料存取。
+- 一般 CRUD 與查詢組合預設使用 `@taiwan-fin-hub/db` 的 Drizzle schema／client。
 - 執行 query、insert、update、delete 與 upsert。
 - 回傳 database row、affected row count 或存在性結果。
-- 建立供 service 組合的 `D1PreparedStatement`。
+- 在仍需原生 statement 時，建立供 service 組合的 `D1PreparedStatement`。
+
+過渡期 repository／service 仍接受 `D1Database`，在 repository 內呼叫 `createDb(binding)`，不另建 DI container，也不建立跨 request／Queue invocation 的全域 client。TypeScript property 使用 camelCase，並明確對應既有 snake_case 欄位；回傳給 service／API 的 shape 由 selection 或 mapper 維持，不把 `$inferSelect` 當成 runtime validation。
+
+複雜 expression、CTE、條件 upsert、跨檔案組成的原生 D1 batch，或轉換後無法保留語意的路徑，可繼續使用參數化 raw SQL，並在呼叫處註明原因。同一 batch 不得混用不相容的 Drizzle query object 與 `D1PreparedStatement`。
 
 Repository 不應：
 
@@ -232,12 +238,16 @@ Middleware 應只處理跨功能的 request concern，不應承擔 feature 商�
 
 真正跨 feature 使用的 D1 基礎能力，目前主要包括：
 
+- `createDb(binding)`：以當次 request／Queue 的 D1 binding 建立 Drizzle client，關閉 query／parameter logging。
+- `src/schema/`：依業務領域描述現有業務表；SQL migrations 仍是 schema 權威。
 - Connector settings。
 - 加密設定與 sync cursor 狀態。
 - Sync job、schedule 與 lock。
 - D1 migrations。
 
-Feature-specific SQL 應放在 feature 的 `repository.ts`，而不是持續擴大 `packages/db/src/index.ts`。
+Drizzle 型別只留在 DB 與 Worker repository 層。`packages/core`、前端與 `packages/connectors` 不依賴 ORM。日期維持既有 TEXT string，金額與 JSON／flag 語意不因導入而改寫。
+
+Feature-specific 查詢應放在 feature 的 `repository.ts`，而不是持續擴大 `packages/db/src/index.ts`。一般 repository 以 Drizzle 為預設寫法；同步 lease、staging promotion 等尚未轉換的路徑仍使用原生 D1。
 
 資料庫 schema 與預設資料必須透過：
 
@@ -245,7 +255,7 @@ Feature-specific SQL 應放在 feature 的 `repository.ts`，而不是持續擴�
 packages/db/migrations/
 ```
 
-管理，不得由 `GET` API 在執行期間自動建立。
+管理，不得由 `GET` API 在執行期間自動建立，也不得對正式環境使用 `drizzle-kit push`。Schema 比對測試以 migration 重播結果為準；隔離 D1 整合測試使用 Miniflare／workerd binding，不連線正式資料庫。
 
 ## HTTP Request 流程
 

--- a/docs/006-drizzle-adoption-plan.md
+++ b/docs/006-drizzle-adoption-plan.md
@@ -1,6 +1,6 @@
 # Drizzle 導入實作計畫
 
-日期：2026-09-12。狀態：待實作；本文件不代表已安裝套件或完成 D1 runtime 驗證。
+日期：2026-09-12。狀態：階段 1–2 已落地（schema／client、語意比對、隔離 D1 整合測試、exchange-rates repository）；階段 3–5 待實作。SQL migrations 仍是 schema 權威，正式環境不使用 `drizzle-kit push`。
 
 ## 目標與建議方案
 
@@ -150,4 +150,4 @@ npm run test:backend
 - [Cloudflare D1 batch](https://developers.cloudflare.com/d1/worker-api/d1-database/#batch)：D1 原子批次行為。
 - [Cloudflare migrations](https://developers.cloudflare.com/d1/reference/migrations/)：Wrangler ledger 與目錄匹配方式；本次已透過 Cloudflare Docs MCP 核對。
 
-本次完成的是本機程式碼／migration 盤點、SQLite 重播與官方文件查核；尚未安裝 Drizzle、執行 Drizzle schema 比對或存取線上 D1。
+階段 1–2 已在隔離環境完成 schema 比對與 Miniflare D1 讀寫／回滾驗證；未連線正式 D1，也未改寫既有 SQL migrations。

--- a/packages/db/src/schema/assets.ts
+++ b/packages/db/src/schema/assets.ts
@@ -1,30 +1,52 @@
 import { sql } from "drizzle-orm";
-import { sqliteTable, text, integer, primaryKey, unique, index } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  primaryKey,
+  unique,
+  index,
+} from "drizzle-orm/sqlite-core";
 
 // Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
 // SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
 
-export const manualAssets = sqliteTable("manual_assets", {
-  id: text("id"),
-  name: text("name").notNull(),
-  category: text("category").notNull(),
-  note: text("note"),
-  createdAt: text("created_at").notNull(),
-  currency: text("currency").notNull().default(sql`'TWD'`),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-]);
+export const manualAssets = sqliteTable(
+  "manual_assets",
+  {
+    id: text("id"),
+    name: text("name").notNull(),
+    category: text("category").notNull(),
+    note: text("note"),
+    createdAt: text("created_at").notNull(),
+    currency: text("currency")
+      .notNull()
+      .default(sql`'TWD'`),
+  },
+  (table) => [primaryKey({ columns: [table.id] })],
+);
 
-export const netWorthHistory = sqliteTable("net_worth_history", {
-  id: text("id"),
-  date: text("date").notNull(),
-  netWorth: integer("net_worth").notNull(),
-  assetType: text("asset_type").notNull().default(sql`'total'`),
-  source: text("source").notNull(),
-  snapshottedAt: text("snapshotted_at").notNull(),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_net_worth_history_page").on(sql`date DESC`, table.source, table.assetType, table.id),
-  index("idx_net_worth_history_date").on(table.date),
-  unique().on(table.source, table.assetType, table.date),
-]);
+export const netWorthHistory = sqliteTable(
+  "net_worth_history",
+  {
+    id: text("id"),
+    date: text("date").notNull(),
+    netWorth: integer("net_worth").notNull(),
+    assetType: text("asset_type")
+      .notNull()
+      .default(sql`'total'`),
+    source: text("source").notNull(),
+    snapshottedAt: text("snapshotted_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_net_worth_history_page").on(
+      sql`date DESC`,
+      sql`source ASC`,
+      sql`asset_type ASC`,
+      sql`id ASC`,
+    ),
+    index("idx_net_worth_history_date").on(table.date),
+    unique().on(table.source, table.assetType, table.date),
+  ],
+);

--- a/packages/db/src/schema/bank.ts
+++ b/packages/db/src/schema/bank.ts
@@ -1,84 +1,134 @@
 import { sql } from "drizzle-orm";
-import { sqliteTable, text, integer, primaryKey, unique, uniqueIndex, index, foreignKey, check } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  primaryKey,
+  unique,
+  uniqueIndex,
+  index,
+  foreignKey,
+  check,
+} from "drizzle-orm/sqlite-core";
 
 // Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
 // SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
 
-export const bankAccounts = sqliteTable("bank_accounts", {
-  id: text("id"),
-  connectorId: text("connector_id").notNull(),
-  sourceId: text("source_id").notNull(),
-  institutionName: text("institution_name"),
-  accountName: text("account_name"),
-  accountType: text("account_type"),
-  currency: text("currency").notNull().default(sql`'TWD'`),
-  rawPayload: text("raw_payload"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  bankCode: text("bank_code"),
-  accountLast4: text("account_last4"),
-  canonicalAccountId: text("canonical_account_id"),
-  creditLimit: integer("credit_limit"),
-  openedDate: text("opened_date"),
-  maturityDate: text("maturity_date"),
-  inactiveAt: text("inactive_at"),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_bank_accounts_match").on(table.bankCode, table.accountLast4, table.currency),
-  unique().on(table.connectorId, table.sourceId),
-  foreignKey({ columns: [table.canonicalAccountId], foreignColumns: [table.id] }),
-  check("bank_accounts_check_1", sql`
+export const bankAccounts = sqliteTable(
+  "bank_accounts",
+  {
+    id: text("id"),
+    connectorId: text("connector_id").notNull(),
+    sourceId: text("source_id").notNull(),
+    institutionName: text("institution_name"),
+    accountName: text("account_name"),
+    accountType: text("account_type"),
+    currency: text("currency")
+      .notNull()
+      .default(sql`'TWD'`),
+    rawPayload: text("raw_payload"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    bankCode: text("bank_code"),
+    accountLast4: text("account_last4"),
+    canonicalAccountId: text("canonical_account_id"),
+    creditLimit: integer("credit_limit"),
+    openedDate: text("opened_date"),
+    maturityDate: text("maturity_date"),
+    inactiveAt: text("inactive_at"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_bank_accounts_match").on(
+      table.bankCode,
+      table.accountLast4,
+      table.currency,
+    ),
+    unique().on(table.connectorId, table.sourceId),
+    foreignKey({
+      columns: [table.canonicalAccountId],
+      foreignColumns: [table.id],
+    }),
+    check(
+      "bank_accounts_check_1",
+      sql`
     account_type IS NULL
     OR account_type IN ('checking', 'savings', 'credit', 'loan', 'settlement_cash', 'time_deposit', 'stored_value', 'unknown')
-  `),
-]);
+  `,
+    ),
+  ],
+);
 
-export const bankBalanceSnapshots = sqliteTable("bank_balance_snapshots", {
-  id: text("id"),
-  connectorId: text("connector_id").notNull(),
-  accountId: text("account_id").notNull(),
-  sourceId: text("source_id").notNull(),
-  balance: integer("balance").notNull(),
-  availableBalance: integer("available_balance"),
-  currency: text("currency").notNull().default(sql`'TWD'`),
-  asOfAt: text("as_of_at").notNull(),
-  rawPayload: text("raw_payload"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  statementBalance: integer("statement_balance"),
-  paymentDueDate: text("payment_due_date"),
-  noPaymentNeeded: integer("no_payment_needed"),
-  statementClosingDate: text("statement_closing_date"),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_bank_balance_snapshots_as_of").on(table.asOfAt),
-  index("idx_bank_balance_snapshots_account_as_of").on(table.accountId, table.asOfAt),
-  unique().on(table.connectorId, table.accountId, table.sourceId),
-  foreignKey({ columns: [table.accountId], foreignColumns: [bankAccounts.id] }),
-]);
+export const bankBalanceSnapshots = sqliteTable(
+  "bank_balance_snapshots",
+  {
+    id: text("id"),
+    connectorId: text("connector_id").notNull(),
+    accountId: text("account_id").notNull(),
+    sourceId: text("source_id").notNull(),
+    balance: integer("balance").notNull(),
+    availableBalance: integer("available_balance"),
+    currency: text("currency")
+      .notNull()
+      .default(sql`'TWD'`),
+    asOfAt: text("as_of_at").notNull(),
+    rawPayload: text("raw_payload"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    statementBalance: integer("statement_balance"),
+    paymentDueDate: text("payment_due_date"),
+    noPaymentNeeded: integer("no_payment_needed"),
+    statementClosingDate: text("statement_closing_date"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_bank_balance_snapshots_as_of").on(table.asOfAt),
+    index("idx_bank_balance_snapshots_account_as_of").on(
+      table.accountId,
+      table.asOfAt,
+    ),
+    unique().on(table.connectorId, table.accountId, table.sourceId),
+    foreignKey({
+      columns: [table.accountId],
+      foreignColumns: [bankAccounts.id],
+    }),
+  ],
+);
 
-export const bankTransactions = sqliteTable("bank_transactions", {
-  id: text("id"),
-  connectorId: text("connector_id").notNull(),
-  accountId: text("account_id").notNull(),
-  sourceId: text("source_id").notNull(),
-  postedDate: text("posted_date"),
-  authorizedAt: text("authorized_at"),
-  amount: integer("amount").notNull(),
-  currency: text("currency").notNull().default(sql`'TWD'`),
-  description: text("description"),
-  counterparty: text("counterparty"),
-  rawPayload: text("raw_payload"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  effectiveDate: text("effective_date").generatedAlwaysAs(sql`COALESCE(posted_date, authorized_at, '')`, { mode: "virtual" }),
-  status: text("status").notNull().default(sql`'posted'`),
-  transferPeerId: text("transfer_peer_id"),
-  matchedTransactionId: text("matched_transaction_id"),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  uniqueIndex("idx_bank_transactions_matched_transaction").on(table.matchedTransactionId).where(sql`matched_transaction_id IS NOT NULL`),
-  index("idx_bank_transactions_transaction_day").on(sql`
+export const bankTransactions = sqliteTable(
+  "bank_transactions",
+  {
+    id: text("id"),
+    connectorId: text("connector_id").notNull(),
+    accountId: text("account_id").notNull(),
+    sourceId: text("source_id").notNull(),
+    postedDate: text("posted_date"),
+    authorizedAt: text("authorized_at"),
+    amount: integer("amount").notNull(),
+    currency: text("currency")
+      .notNull()
+      .default(sql`'TWD'`),
+    description: text("description"),
+    counterparty: text("counterparty"),
+    rawPayload: text("raw_payload"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    effectiveDate: text("effective_date").generatedAlwaysAs(
+      sql`COALESCE(posted_date, authorized_at, '')`,
+      { mode: "virtual" },
+    ),
+    status: text("status")
+      .notNull()
+      .default(sql`'posted'`),
+    transferPeerId: text("transfer_peer_id"),
+    matchedTransactionId: text("matched_transaction_id"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    uniqueIndex("idx_bank_transactions_matched_transaction")
+      .on(table.matchedTransactionId)
+      .where(sql`matched_transaction_id IS NOT NULL`),
+    index("idx_bank_transactions_transaction_day").on(sql`
     CASE
       WHEN length(authorized_at) > 10
         THEN COALESCE(
@@ -88,46 +138,88 @@ export const bankTransactions = sqliteTable("bank_transactions", {
       ELSE substr(COALESCE(authorized_at, posted_date), 1, 10)
     END
   `),
-  index("idx_bank_transactions_status").on(table.connectorId, table.accountId, table.status),
-  index("idx_bank_transactions_effective_updated").on(sql`effective_date DESC`, sql`updated_at DESC`, sql`id DESC`),
-  index("idx_bank_transactions_posted_date").on(table.postedDate),
-  index("idx_bank_transactions_account_posted_date").on(table.accountId, table.postedDate),
-  unique().on(table.connectorId, table.accountId, table.sourceId),
-  foreignKey({ columns: [table.accountId], foreignColumns: [bankAccounts.id] }),
-  check("bank_transactions_check_1", sql`status IN ('pending', 'posted')`),
-]);
+    index("idx_bank_transactions_status").on(
+      table.connectorId,
+      table.accountId,
+      table.status,
+    ),
+    index("idx_bank_transactions_effective_updated").on(
+      sql`effective_date DESC`,
+      sql`updated_at DESC`,
+      sql`id DESC`,
+    ),
+    index("idx_bank_transactions_posted_date").on(table.postedDate),
+    index("idx_bank_transactions_account_posted_date").on(
+      table.accountId,
+      table.postedDate,
+    ),
+    unique().on(table.connectorId, table.accountId, table.sourceId),
+    foreignKey({
+      columns: [table.accountId],
+      foreignColumns: [bankAccounts.id],
+    }),
+    check("bank_transactions_check_1", sql`status IN ('pending', 'posted')`),
+  ],
+);
 
-export const bankTransactionPreferences = sqliteTable("bank_transaction_preferences", {
-  transactionId: text("transaction_id"),
-  excludedFromCalculation: integer("excluded_from_calculation").notNull().default(sql`0`),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-}, (table) => [
-  primaryKey({ columns: [table.transactionId] }),
-  index("idx_bank_transaction_preferences_excluded").on(table.excludedFromCalculation),
-  check("bank_transaction_preferences_check_1", sql`excluded_from_calculation IN (0, 1)`),
-]);
+export const bankTransactionPreferences = sqliteTable(
+  "bank_transaction_preferences",
+  {
+    transactionId: text("transaction_id"),
+    excludedFromCalculation: integer("excluded_from_calculation")
+      .notNull()
+      .default(sql`0`),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.transactionId] }),
+    index("idx_bank_transaction_preferences_excluded").on(
+      table.excludedFromCalculation,
+    ),
+    check(
+      "bank_transaction_preferences_check_1",
+      sql`excluded_from_calculation IN (0, 1)`,
+    ),
+  ],
+);
 
-export const creditCardBills = sqliteTable("credit_card_bills", {
-  id: text("id"),
-  connectorId: text("connector_id").notNull(),
-  accountId: text("account_id").notNull(),
-  sourceId: text("source_id").notNull(),
-  billingPeriod: text("billing_period").notNull(),
-  statementAmount: integer("statement_amount"),
-  minimumPayment: integer("minimum_payment"),
-  paidAmount: integer("paid_amount"),
-  isPaid: integer("is_paid"),
-  paymentDueDate: text("payment_due_date"),
-  statementClosingDate: text("statement_closing_date"),
-  currency: text("currency").notNull().default(sql`'TWD'`),
-  rawPayload: text("raw_payload"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_credit_card_bills_page").on(sql`billing_period DESC`, table.accountId, table.id),
-  index("idx_credit_card_bills_account_period").on(table.accountId, table.billingPeriod),
-  unique().on(table.connectorId, table.accountId, table.billingPeriod),
-  foreignKey({ columns: [table.accountId], foreignColumns: [bankAccounts.id] }),
-]);
+export const creditCardBills = sqliteTable(
+  "credit_card_bills",
+  {
+    id: text("id"),
+    connectorId: text("connector_id").notNull(),
+    accountId: text("account_id").notNull(),
+    sourceId: text("source_id").notNull(),
+    billingPeriod: text("billing_period").notNull(),
+    statementAmount: integer("statement_amount"),
+    minimumPayment: integer("minimum_payment"),
+    paidAmount: integer("paid_amount"),
+    isPaid: integer("is_paid"),
+    paymentDueDate: text("payment_due_date"),
+    statementClosingDate: text("statement_closing_date"),
+    currency: text("currency")
+      .notNull()
+      .default(sql`'TWD'`),
+    rawPayload: text("raw_payload"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_credit_card_bills_page").on(
+      sql`billing_period DESC`,
+      sql`account_id ASC`,
+      sql`id ASC`,
+    ),
+    index("idx_credit_card_bills_account_period").on(
+      table.accountId,
+      table.billingPeriod,
+    ),
+    unique().on(table.connectorId, table.accountId, table.billingPeriod),
+    foreignKey({
+      columns: [table.accountId],
+      foreignColumns: [bankAccounts.id],
+    }),
+  ],
+);

--- a/packages/db/src/schema/classification.ts
+++ b/packages/db/src/schema/classification.ts
@@ -1,54 +1,105 @@
 import { sql } from "drizzle-orm";
-import { sqliteTable, text, integer, primaryKey, unique, uniqueIndex, index, foreignKey, check } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  primaryKey,
+  unique,
+  uniqueIndex,
+  index,
+  foreignKey,
+  check,
+} from "drizzle-orm/sqlite-core";
 
 // Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
 // SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
 
-export const classificationCategories = sqliteTable("classification_categories", {
-  id: text("id"),
-  label: text("label").notNull(),
-  sortOrder: integer("sort_order").notNull().default(sql`0`),
-  isSystem: integer("is_system").notNull().default(sql`1`),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  uniqueIndex("idx_classification_categories_label_nocase").on(sql`label COLLATE NOCASE`),
-]);
+export const classificationCategories = sqliteTable(
+  "classification_categories",
+  {
+    id: text("id"),
+    label: text("label").notNull(),
+    sortOrder: integer("sort_order")
+      .notNull()
+      .default(sql`0`),
+    isSystem: integer("is_system")
+      .notNull()
+      .default(sql`1`),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    uniqueIndex("idx_classification_categories_label_nocase").on(
+      sql`label COLLATE NOCASE`,
+    ),
+  ],
+);
 
-export const classificationOverrides = sqliteTable("classification_overrides", {
-  id: text("id"),
-  targetType: text("target_type").notNull(),
-  targetId: text("target_id").notNull(),
-  categoryId: text("category_id").notNull(),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_classification_overrides_category").on(table.categoryId),
-  unique().on(table.targetType, table.targetId),
-  foreignKey({ columns: [table.categoryId], foreignColumns: [classificationCategories.id] }),
-]);
+export const classificationOverrides = sqliteTable(
+  "classification_overrides",
+  {
+    id: text("id"),
+    targetType: text("target_type").notNull(),
+    targetId: text("target_id").notNull(),
+    categoryId: text("category_id").notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_classification_overrides_category").on(table.categoryId),
+    unique().on(table.targetType, table.targetId),
+    foreignKey({
+      columns: [table.categoryId],
+      foreignColumns: [classificationCategories.id],
+    }),
+  ],
+);
 
-export const classificationRules = sqliteTable("classification_rules", {
-  id: text("id"),
-  categoryId: text("category_id").notNull(),
-  targetType: text("target_type"),
-  field: text("field").notNull(),
-  operator: text("operator").notNull(),
-  pattern: text("pattern").notNull(),
-  priority: integer("priority").notNull().default(sql`100`),
-  enabled: integer("enabled").notNull().default(sql`1`),
-  isSystem: integer("is_system").notNull().default(sql`0`),
-  source: text("source").notNull().default(sql`'user'`),
-  description: text("description"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  excludedFromCalculation: integer("excluded_from_calculation").notNull().default(sql`0`),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_classification_rules_category").on(table.categoryId),
-  index("idx_classification_rules_enabled_priority").on(table.enabled, table.targetType, table.priority),
-  foreignKey({ columns: [table.categoryId], foreignColumns: [classificationCategories.id] }),
-  check("classification_rules_check_1", sql`excluded_from_calculation IN (0, 1)`),
-]);
+export const classificationRules = sqliteTable(
+  "classification_rules",
+  {
+    id: text("id"),
+    categoryId: text("category_id").notNull(),
+    targetType: text("target_type"),
+    field: text("field").notNull(),
+    operator: text("operator").notNull(),
+    pattern: text("pattern").notNull(),
+    priority: integer("priority")
+      .notNull()
+      .default(sql`100`),
+    enabled: integer("enabled")
+      .notNull()
+      .default(sql`1`),
+    isSystem: integer("is_system")
+      .notNull()
+      .default(sql`0`),
+    source: text("source")
+      .notNull()
+      .default(sql`'user'`),
+    description: text("description"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    excludedFromCalculation: integer("excluded_from_calculation")
+      .notNull()
+      .default(sql`0`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_classification_rules_category").on(table.categoryId),
+    index("idx_classification_rules_enabled_priority").on(
+      table.enabled,
+      table.targetType,
+      table.priority,
+    ),
+    foreignKey({
+      columns: [table.categoryId],
+      foreignColumns: [classificationCategories.id],
+    }),
+    check(
+      "classification_rules_check_1",
+      sql`excluded_from_calculation IN (0, 1)`,
+    ),
+  ],
+);

--- a/packages/db/src/schema/exchange-rates.ts
+++ b/packages/db/src/schema/exchange-rates.ts
@@ -3,10 +3,12 @@ import { sqliteTable, text, real, primaryKey } from "drizzle-orm/sqlite-core";
 // Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
 // SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
 
-export const exchangeRates = sqliteTable("exchange_rates", {
-  currency: text("currency"),
-  rateToTwd: real("rate_to_twd").notNull(),
-  updatedAt: text("updated_at").notNull(),
-}, (table) => [
-  primaryKey({ columns: [table.currency] }),
-]);
+export const exchangeRates = sqliteTable(
+  "exchange_rates",
+  {
+    currency: text("currency"),
+    rateToTwd: real("rate_to_twd").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.currency] })],
+);

--- a/packages/db/src/schema/investments.ts
+++ b/packages/db/src/schema/investments.ts
@@ -1,62 +1,105 @@
 import { sql } from "drizzle-orm";
-import { sqliteTable, text, integer, real, primaryKey, unique, index, check } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  real,
+  primaryKey,
+  unique,
+  index,
+  check,
+} from "drizzle-orm/sqlite-core";
 
 // Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
 // SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
 
-export const investmentPositions = sqliteTable("investment_positions", {
-  id: text("id"),
-  connectorId: text("connector_id").notNull(),
-  sourceId: text("source_id").notNull(),
-  assetType: text("asset_type").notNull(),
-  symbol: text("symbol"),
-  name: text("name").notNull(),
-  quantity: real("quantity"),
-  marketValue: integer("market_value"),
-  cashBalance: integer("cash_balance"),
-  currency: text("currency").notNull().default(sql`'TWD'`),
-  asOfDate: text("as_of_date").notNull(),
-  rawPayload: text("raw_payload"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_investment_positions_page").on(sql`as_of_date DESC`, table.assetType, table.name, table.id),
-  index("idx_investment_positions_latest_scope").on(table.connectorId, table.assetType, sql`as_of_date DESC`),
-  index("idx_investment_positions_asset_type").on(table.assetType),
-  index("idx_investment_positions_as_of_date").on(table.asOfDate),
-  unique().on(table.connectorId, table.sourceId, table.asOfDate),
-  check("investment_positions_check_1", sql`asset_type IN ('stock', 'etf', 'fund')`),
-]);
+export const investmentPositions = sqliteTable(
+  "investment_positions",
+  {
+    id: text("id"),
+    connectorId: text("connector_id").notNull(),
+    sourceId: text("source_id").notNull(),
+    assetType: text("asset_type").notNull(),
+    symbol: text("symbol"),
+    name: text("name").notNull(),
+    quantity: real("quantity"),
+    marketValue: integer("market_value"),
+    cashBalance: integer("cash_balance"),
+    currency: text("currency")
+      .notNull()
+      .default(sql`'TWD'`),
+    asOfDate: text("as_of_date").notNull(),
+    rawPayload: text("raw_payload"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_investment_positions_page").on(
+      sql`as_of_date DESC`,
+      sql`asset_type ASC`,
+      sql`name ASC`,
+      sql`id ASC`,
+    ),
+    index("idx_investment_positions_latest_scope").on(
+      table.connectorId,
+      table.assetType,
+      sql`as_of_date DESC`,
+    ),
+    index("idx_investment_positions_asset_type").on(table.assetType),
+    index("idx_investment_positions_as_of_date").on(table.asOfDate),
+    unique().on(table.connectorId, table.sourceId, table.asOfDate),
+    check(
+      "investment_positions_check_1",
+      sql`asset_type IN ('stock', 'etf', 'fund')`,
+    ),
+  ],
+);
 
-export const investmentTransactions = sqliteTable("investment_transactions", {
-  id: text("id"),
-  connectorId: text("connector_id").notNull(),
-  accountId: text("account_id").notNull(),
-  sourceId: text("source_id").notNull(),
-  brokerNo: text("broker_no"),
-  brokerAccount: text("broker_account"),
-  brokerName: text("broker_name"),
-  symbol: text("symbol"),
-  name: text("name"),
-  assetType: text("asset_type"),
-  tradeDate: text("trade_date"),
-  postedDate: text("posted_date"),
-  transactionCode: text("transaction_code"),
-  transactionName: text("transaction_name"),
-  quantity: real("quantity"),
-  price: real("price"),
-  amount: integer("amount"),
-  currency: text("currency").notNull().default(sql`'TWD'`),
-  rawPayload: text("raw_payload"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  effectiveDate: text("effective_date").generatedAlwaysAs(sql`COALESCE(trade_date, posted_date, '')`, { mode: "virtual" }),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_investment_transactions_effective_updated").on(sql`effective_date DESC`, sql`updated_at DESC`, sql`id DESC`),
-  index("idx_investment_transactions_symbol").on(table.symbol),
-  index("idx_investment_transactions_trade_date").on(table.tradeDate),
-  unique().on(table.connectorId, table.accountId, table.sourceId),
-  check("investment_transactions_check_1", sql`asset_type IN ('stock', 'etf', 'fund', 'bond', 'unknown')`),
-]);
+export const investmentTransactions = sqliteTable(
+  "investment_transactions",
+  {
+    id: text("id"),
+    connectorId: text("connector_id").notNull(),
+    accountId: text("account_id").notNull(),
+    sourceId: text("source_id").notNull(),
+    brokerNo: text("broker_no"),
+    brokerAccount: text("broker_account"),
+    brokerName: text("broker_name"),
+    symbol: text("symbol"),
+    name: text("name"),
+    assetType: text("asset_type"),
+    tradeDate: text("trade_date"),
+    postedDate: text("posted_date"),
+    transactionCode: text("transaction_code"),
+    transactionName: text("transaction_name"),
+    quantity: real("quantity"),
+    price: real("price"),
+    amount: integer("amount"),
+    currency: text("currency")
+      .notNull()
+      .default(sql`'TWD'`),
+    rawPayload: text("raw_payload"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    effectiveDate: text("effective_date").generatedAlwaysAs(
+      sql`COALESCE(trade_date, posted_date, '')`,
+      { mode: "virtual" },
+    ),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_investment_transactions_effective_updated").on(
+      sql`effective_date DESC`,
+      sql`updated_at DESC`,
+      sql`id DESC`,
+    ),
+    index("idx_investment_transactions_symbol").on(table.symbol),
+    index("idx_investment_transactions_trade_date").on(table.tradeDate),
+    unique().on(table.connectorId, table.accountId, table.sourceId),
+    check(
+      "investment_transactions_check_1",
+      sql`asset_type IN ('stock', 'etf', 'fund', 'bond', 'unknown')`,
+    ),
+  ],
+);

--- a/packages/db/src/schema/invoices.ts
+++ b/packages/db/src/schema/invoices.ts
@@ -1,61 +1,102 @@
 import { sql } from "drizzle-orm";
-import { sqliteTable, text, integer, real, primaryKey, unique, uniqueIndex, index, foreignKey, check } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  real,
+  primaryKey,
+  unique,
+  uniqueIndex,
+  index,
+  foreignKey,
+  check,
+} from "drizzle-orm/sqlite-core";
 
 // Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
 // SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
 
-export const invoices = sqliteTable("invoices", {
-  id: text("id"),
-  connectorId: text("connector_id").notNull(),
-  sourceId: text("source_id").notNull(),
-  invoiceNumber: text("invoice_number"),
-  invoiceDate: text("invoice_date").notNull(),
-  sellerName: text("seller_name"),
-  amount: integer("amount").notNull(),
-  rawPayload: text("raw_payload"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_invoices_page").on(sql`invoice_date DESC`, sql`updated_at DESC`, sql`id DESC`),
-  index("idx_invoices_invoice_date").on(table.invoiceDate),
-  unique().on(table.connectorId, table.sourceId),
-]);
+export const invoices = sqliteTable(
+  "invoices",
+  {
+    id: text("id"),
+    connectorId: text("connector_id").notNull(),
+    sourceId: text("source_id").notNull(),
+    invoiceNumber: text("invoice_number"),
+    invoiceDate: text("invoice_date").notNull(),
+    sellerName: text("seller_name"),
+    amount: integer("amount").notNull(),
+    rawPayload: text("raw_payload"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_invoices_page").on(
+      sql`invoice_date DESC`,
+      sql`updated_at DESC`,
+      sql`id DESC`,
+    ),
+    index("idx_invoices_invoice_date").on(table.invoiceDate),
+    unique().on(table.connectorId, table.sourceId),
+  ],
+);
 
-export const invoiceLineItems = sqliteTable("invoice_line_items", {
-  id: text("id"),
-  invoiceId: text("invoice_id").notNull(),
-  connectorId: text("connector_id").notNull(),
-  invoiceSourceId: text("invoice_source_id").notNull(),
-  sourceId: text("source_id").notNull(),
-  lineNumber: integer("line_number").notNull(),
-  description: text("description").notNull(),
-  quantity: real("quantity"),
-  unitPrice: integer("unit_price"),
-  amount: integer("amount").notNull(),
-  rawPayload: text("raw_payload"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_invoice_line_items_invoice_source").on(table.connectorId, table.invoiceSourceId),
-  index("idx_invoice_line_items_invoice_id").on(table.invoiceId),
-  unique().on(table.connectorId, table.invoiceSourceId, table.sourceId),
-  foreignKey({ columns: [table.invoiceId], foreignColumns: [invoices.id] }).onDelete("cascade"),
-]);
+export const invoiceLineItems = sqliteTable(
+  "invoice_line_items",
+  {
+    id: text("id"),
+    invoiceId: text("invoice_id").notNull(),
+    connectorId: text("connector_id").notNull(),
+    invoiceSourceId: text("invoice_source_id").notNull(),
+    sourceId: text("source_id").notNull(),
+    lineNumber: integer("line_number").notNull(),
+    description: text("description").notNull(),
+    quantity: real("quantity"),
+    unitPrice: integer("unit_price"),
+    amount: integer("amount").notNull(),
+    rawPayload: text("raw_payload"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_invoice_line_items_invoice_source").on(
+      table.connectorId,
+      table.invoiceSourceId,
+    ),
+    index("idx_invoice_line_items_invoice_id").on(table.invoiceId),
+    unique().on(table.connectorId, table.invoiceSourceId, table.sourceId),
+    foreignKey({
+      columns: [table.invoiceId],
+      foreignColumns: [invoices.id],
+    }).onDelete("cascade"),
+  ],
+);
 
-export const invoiceTransactionPreferences = sqliteTable("invoice_transaction_preferences", {
-  invoiceId: text("invoice_id"),
-  transactionId: text("transaction_id"),
-  decision: text("decision").notNull(),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-}, (table) => [
-  primaryKey({ columns: [table.invoiceId] }),
-  uniqueIndex("idx_invoice_transaction_preferences_linked_transaction").on(table.transactionId).where(sql`decision = 'linked'`),
-  check("invoice_transaction_preferences_check_1", sql`decision IN ('linked', 'separate')`),
-  check("invoice_transaction_preferences_check_2", sql`
+export const invoiceTransactionPreferences = sqliteTable(
+  "invoice_transaction_preferences",
+  {
+    invoiceId: text("invoice_id"),
+    transactionId: text("transaction_id"),
+    decision: text("decision").notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.invoiceId] }),
+    uniqueIndex("idx_invoice_transaction_preferences_linked_transaction")
+      .on(table.transactionId)
+      .where(sql`decision = 'linked'`),
+    check(
+      "invoice_transaction_preferences_check_1",
+      sql`decision IN ('linked', 'separate')`,
+    ),
+    check(
+      "invoice_transaction_preferences_check_2",
+      sql`
     (decision = 'linked' AND transaction_id IS NOT NULL)
     OR decision = 'separate'
-  `),
-]);
+  `,
+    ),
+  ],
+);

--- a/packages/db/src/schema/notifications.ts
+++ b/packages/db/src/schema/notifications.ts
@@ -1,27 +1,47 @@
 import { sql } from "drizzle-orm";
-import { sqliteTable, text, integer, primaryKey, check } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  primaryKey,
+  check,
+} from "drizzle-orm/sqlite-core";
 
 // Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
 // SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
 
-export const pushSubscriptions = sqliteTable("push_subscriptions", {
-  id: text("id"),
-  encryptedSubscription: text("encrypted_subscription").notNull(),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  lastSuccessAt: text("last_success_at"),
-  consecutiveFailures: integer("consecutive_failures").notNull().default(sql`0`),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-]);
+export const pushSubscriptions = sqliteTable(
+  "push_subscriptions",
+  {
+    id: text("id"),
+    encryptedSubscription: text("encrypted_subscription").notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    lastSuccessAt: text("last_success_at"),
+    consecutiveFailures: integer("consecutive_failures")
+      .notNull()
+      .default(sql`0`),
+  },
+  (table) => [primaryKey({ columns: [table.id] })],
+);
 
-export const notificationPreferences = sqliteTable("notification_preferences", {
-  id: text("id"),
-  notifySuccess: integer("notify_success").notNull().default(sql`0`),
-  notifyFailed: integer("notify_failed").notNull().default(sql`1`),
-  notifyNeedsUserAction: integer("notify_needs_user_action").notNull().default(sql`1`),
-  updatedAt: text("updated_at").notNull(),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  check("notification_preferences_check_1", sql`id = 'default'`),
-]);
+export const notificationPreferences = sqliteTable(
+  "notification_preferences",
+  {
+    id: text("id"),
+    notifySuccess: integer("notify_success")
+      .notNull()
+      .default(sql`0`),
+    notifyFailed: integer("notify_failed")
+      .notNull()
+      .default(sql`1`),
+    notifyNeedsUserAction: integer("notify_needs_user_action")
+      .notNull()
+      .default(sql`1`),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    check("notification_preferences_check_1", sql`id = 'default'`),
+  ],
+);

--- a/packages/db/src/schema/settings.ts
+++ b/packages/db/src/schema/settings.ts
@@ -3,15 +3,19 @@ import { sqliteTable, text, primaryKey, unique } from "drizzle-orm/sqlite-core";
 // Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
 // SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
 
-export const connectorSettings = sqliteTable("connector_settings", {
-  id: text("id"),
-  connectorId: text("connector_id").notNull(),
-  encryptedConfig: text("encrypted_config").notNull(),
-  syncCursor: text("sync_cursor"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  publicConfig: text("public_config"),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  unique().on(table.connectorId),
-]);
+export const connectorSettings = sqliteTable(
+  "connector_settings",
+  {
+    id: text("id"),
+    connectorId: text("connector_id").notNull(),
+    encryptedConfig: text("encrypted_config").notNull(),
+    syncCursor: text("sync_cursor"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    publicConfig: text("public_config"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    unique().on(table.connectorId),
+  ],
+);

--- a/packages/db/src/schema/sync.ts
+++ b/packages/db/src/schema/sync.ts
@@ -1,232 +1,434 @@
 import { sql } from "drizzle-orm";
-import { sqliteTable, text, integer, primaryKey, unique, uniqueIndex, index, foreignKey, check } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  primaryKey,
+  unique,
+  uniqueIndex,
+  index,
+  foreignKey,
+  check,
+} from "drizzle-orm/sqlite-core";
 
 // Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
 // SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
 
-export const syncJobs = sqliteTable("sync_jobs", {
-  id: text("id"),
-  connectorId: text("connector_id").notNull(),
-  scope: text("scope").notNull(),
-  enabled: integer("enabled").notNull().default(sql`1`),
-  intervalMinutes: integer("interval_minutes").notNull(),
-  nextRunAt: text("next_run_at").notNull(),
-  lockedUntil: text("locked_until"),
-  lockedBy: text("locked_by"),
-  lockTrigger: text("lock_trigger"),
-  lockScope: text("lock_scope"),
-  lastRunAt: text("last_run_at"),
-  lastSuccessAt: text("last_success_at"),
-  lastStatus: text("last_status"),
-  lastError: text("last_error"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  scheduleMode: text("schedule_mode").notNull().default(sql`'inherit'`),
-  preferredTime: text("preferred_time").notNull().default(sql`'06:00'`),
-  preferredWeekday: integer("preferred_weekday").notNull().default(sql`1`),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_sync_jobs_due").on(table.enabled, table.nextRunAt),
-  unique().on(table.connectorId, table.scope),
-  check("sync_jobs_check_1", sql`lock_trigger IS NULL OR lock_trigger IN ('manual', 'scheduled')`),
-  check("sync_jobs_check_2", sql`schedule_mode IN ('inherit', 'custom')`),
-  check("sync_jobs_check_3", sql`preferred_weekday BETWEEN 0 AND 6`),
-]);
+export const syncJobs = sqliteTable(
+  "sync_jobs",
+  {
+    id: text("id"),
+    connectorId: text("connector_id").notNull(),
+    scope: text("scope").notNull(),
+    enabled: integer("enabled")
+      .notNull()
+      .default(sql`1`),
+    intervalMinutes: integer("interval_minutes").notNull(),
+    nextRunAt: text("next_run_at").notNull(),
+    lockedUntil: text("locked_until"),
+    lockedBy: text("locked_by"),
+    lockTrigger: text("lock_trigger"),
+    lockScope: text("lock_scope"),
+    lastRunAt: text("last_run_at"),
+    lastSuccessAt: text("last_success_at"),
+    lastStatus: text("last_status"),
+    lastError: text("last_error"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    scheduleMode: text("schedule_mode")
+      .notNull()
+      .default(sql`'inherit'`),
+    preferredTime: text("preferred_time")
+      .notNull()
+      .default(sql`'06:00'`),
+    preferredWeekday: integer("preferred_weekday")
+      .notNull()
+      .default(sql`1`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_sync_jobs_due").on(table.enabled, table.nextRunAt),
+    unique().on(table.connectorId, table.scope),
+    check(
+      "sync_jobs_check_1",
+      sql`lock_trigger IS NULL OR lock_trigger IN ('manual', 'scheduled')`,
+    ),
+    check("sync_jobs_check_2", sql`schedule_mode IN ('inherit', 'custom')`),
+    check("sync_jobs_check_3", sql`preferred_weekday BETWEEN 0 AND 6`),
+  ],
+);
 
-export const syncScheduleSettings = sqliteTable("sync_schedule_settings", {
-  id: text("id"),
-  intervalMinutes: integer("interval_minutes").notNull(),
-  preferredTime: text("preferred_time").notNull(),
-  timezone: text("timezone").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  preferredWeekday: integer("preferred_weekday").notNull().default(sql`1`),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  check("sync_schedule_settings_check_1", sql`id = 'default'`),
-  check("sync_schedule_settings_check_2", sql`preferred_weekday BETWEEN 0 AND 6`),
-]);
+export const syncScheduleSettings = sqliteTable(
+  "sync_schedule_settings",
+  {
+    id: text("id"),
+    intervalMinutes: integer("interval_minutes").notNull(),
+    preferredTime: text("preferred_time").notNull(),
+    timezone: text("timezone").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    preferredWeekday: integer("preferred_weekday")
+      .notNull()
+      .default(sql`1`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    check("sync_schedule_settings_check_1", sql`id = 'default'`),
+    check(
+      "sync_schedule_settings_check_2",
+      sql`preferred_weekday BETWEEN 0 AND 6`,
+    ),
+  ],
+);
 
-export const syncWriteStaging = sqliteTable("sync_write_staging", {
-  runId: text("run_id").notNull(),
-  entityType: text("entity_type").notNull(),
-  recordKey: text("record_key").notNull(),
-  payload: text("payload").notNull(),
-  createdAt: text("created_at").notNull(),
-}, (table) => [
-  primaryKey({ columns: [table.runId, table.entityType, table.recordKey] }),
-  index("idx_sync_write_staging_created_at").on(table.createdAt),
-  check("sync_write_staging_check_1", sql`json_valid(payload)`),
-]);
+export const syncWriteStaging = sqliteTable(
+  "sync_write_staging",
+  {
+    runId: text("run_id").notNull(),
+    entityType: text("entity_type").notNull(),
+    recordKey: text("record_key").notNull(),
+    payload: text("payload").notNull(),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.runId, table.entityType, table.recordKey] }),
+    index("idx_sync_write_staging_created_at").on(table.createdAt),
+    check("sync_write_staging_check_1", sql`json_valid(payload)`),
+  ],
+);
 
-export const scheduledSyncBatches = sqliteTable("scheduled_sync_batches", {
-  id: text("id"),
-  scheduleKey: text("schedule_key").notNull().default(sql`'default'`),
-  notificationClaimedAt: text("notification_claimed_at"),
-  createdAt: text("created_at").notNull(),
-  completedAt: text("completed_at"),
-  isBaseline: integer("is_baseline").notNull().default(sql`0`),
-  assetsBeforeTwd: integer("assets_before_twd"),
-  creditCardDebtBeforeTwd: integer("credit_card_debt_before_twd"),
-  missingCurrenciesBefore: text("missing_currencies_before").notNull().default(sql`'[]'`),
-  assetsAfterTwd: integer("assets_after_twd"),
-  creditCardDebtAfterTwd: integer("credit_card_debt_after_twd"),
-  missingCurrenciesAfter: text("missing_currencies_after").notNull().default(sql`'[]'`),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_scheduled_sync_batches_completed").on(sql`completed_at DESC`),
-  uniqueIndex("idx_scheduled_sync_batches_open").on(table.scheduleKey).where(sql`notification_claimed_at IS NULL`),
-  check("scheduled_sync_batches_check_1", sql`schedule_key = 'default'`),
-]);
+export const scheduledSyncBatches = sqliteTable(
+  "scheduled_sync_batches",
+  {
+    id: text("id"),
+    scheduleKey: text("schedule_key")
+      .notNull()
+      .default(sql`'default'`),
+    notificationClaimedAt: text("notification_claimed_at"),
+    createdAt: text("created_at").notNull(),
+    completedAt: text("completed_at"),
+    isBaseline: integer("is_baseline")
+      .notNull()
+      .default(sql`0`),
+    assetsBeforeTwd: integer("assets_before_twd"),
+    creditCardDebtBeforeTwd: integer("credit_card_debt_before_twd"),
+    missingCurrenciesBefore: text("missing_currencies_before")
+      .notNull()
+      .default(sql`'[]'`),
+    assetsAfterTwd: integer("assets_after_twd"),
+    creditCardDebtAfterTwd: integer("credit_card_debt_after_twd"),
+    missingCurrenciesAfter: text("missing_currencies_after")
+      .notNull()
+      .default(sql`'[]'`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_scheduled_sync_batches_completed").on(sql`completed_at DESC`),
+    uniqueIndex("idx_scheduled_sync_batches_open")
+      .on(table.scheduleKey)
+      .where(sql`notification_claimed_at IS NULL`),
+    check("scheduled_sync_batches_check_1", sql`schedule_key = 'default'`),
+  ],
+);
 
-export const scheduledSyncBatchResults = sqliteTable("scheduled_sync_batch_results", {
-  batchId: text("batch_id").notNull(),
-  jobId: text("job_id").notNull(),
-  connectorId: text("connector_id").notNull(),
-  status: text("status"),
-  completedAt: text("completed_at"),
-  newInvoices: integer("new_invoices").notNull().default(sql`0`),
-  newBankTransactions: integer("new_bank_transactions").notNull().default(sql`0`),
-  newInvestmentTransactions: integer("new_investment_transactions").notNull().default(sql`0`),
-  recoveredAt: text("recovered_at"),
-}, (table) => [
-  primaryKey({ columns: [table.batchId, table.jobId] }),
-  foreignKey({ columns: [table.batchId], foreignColumns: [scheduledSyncBatches.id] }).onDelete("cascade"),
-  check("scheduled_sync_batch_results_check_1", sql`status IN ('success', 'failed', 'needs_user_action')`),
-]);
+export const scheduledSyncBatchResults = sqliteTable(
+  "scheduled_sync_batch_results",
+  {
+    batchId: text("batch_id").notNull(),
+    jobId: text("job_id").notNull(),
+    connectorId: text("connector_id").notNull(),
+    status: text("status"),
+    completedAt: text("completed_at"),
+    newInvoices: integer("new_invoices")
+      .notNull()
+      .default(sql`0`),
+    newBankTransactions: integer("new_bank_transactions")
+      .notNull()
+      .default(sql`0`),
+    newInvestmentTransactions: integer("new_investment_transactions")
+      .notNull()
+      .default(sql`0`),
+    recoveredAt: text("recovered_at"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.batchId, table.jobId] }),
+    foreignKey({
+      columns: [table.batchId],
+      foreignColumns: [scheduledSyncBatches.id],
+    }).onDelete("cascade"),
+    check(
+      "scheduled_sync_batch_results_check_1",
+      sql`status IN ('success', 'failed', 'needs_user_action')`,
+    ),
+  ],
+);
 
-export const einvoiceSyncRuns = sqliteTable("einvoice_sync_runs", {
-  id: text("id"),
-  connectorId: text("connector_id").notNull().default(sql`'einvoice'`),
-  trigger: text("trigger").notNull(),
-  syncJobId: text("sync_job_id"),
-  scheduledBatchId: text("scheduled_batch_id"),
-  settingsVersion: text("settings_version"),
-  status: text("status").notNull(),
-  totalItemCount: integer("total_item_count").notNull().default(sql`0`),
-  pendingItemCount: integer("pending_item_count").notNull().default(sql`0`),
-  processingItemCount: integer("processing_item_count").notNull().default(sql`0`),
-  doneItemCount: integer("done_item_count").notNull().default(sql`0`),
-  lineItemCount: integer("line_item_count").notNull().default(sql`0`),
-  newInvoiceCount: integer("new_invoice_count").notNull().default(sql`0`),
-  sessionRefreshCount: integer("session_refresh_count").notNull().default(sql`0`),
-  lastError: text("last_error"),
-  chunkLeaseOwner: text("chunk_lease_owner"),
-  chunkLeaseExpiresAt: text("chunk_lease_expires_at"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  promotedAt: text("promoted_at"),
-  completedAt: text("completed_at"),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_einvoice_sync_runs_completed").on(sql`completed_at DESC`),
-  uniqueIndex("idx_einvoice_sync_runs_one_active").on(table.connectorId).where(sql`status IN ('queued', 'initializing', 'processing')`),
-  foreignKey({ columns: [table.scheduledBatchId], foreignColumns: [scheduledSyncBatches.id] }).onDelete("set null"),
-  foreignKey({ columns: [table.syncJobId], foreignColumns: [syncJobs.id] }).onDelete("set null"),
-  check("einvoice_sync_runs_check_1", sql`connector_id = 'einvoice'`),
-  check("einvoice_sync_runs_check_2", sql`trigger IN ('manual', 'scheduled')`),
-  check("einvoice_sync_runs_check_3", sql`status IN (
+export const einvoiceSyncRuns = sqliteTable(
+  "einvoice_sync_runs",
+  {
+    id: text("id"),
+    connectorId: text("connector_id")
+      .notNull()
+      .default(sql`'einvoice'`),
+    trigger: text("trigger").notNull(),
+    syncJobId: text("sync_job_id"),
+    scheduledBatchId: text("scheduled_batch_id"),
+    settingsVersion: text("settings_version"),
+    status: text("status").notNull(),
+    totalItemCount: integer("total_item_count")
+      .notNull()
+      .default(sql`0`),
+    pendingItemCount: integer("pending_item_count")
+      .notNull()
+      .default(sql`0`),
+    processingItemCount: integer("processing_item_count")
+      .notNull()
+      .default(sql`0`),
+    doneItemCount: integer("done_item_count")
+      .notNull()
+      .default(sql`0`),
+    lineItemCount: integer("line_item_count")
+      .notNull()
+      .default(sql`0`),
+    newInvoiceCount: integer("new_invoice_count")
+      .notNull()
+      .default(sql`0`),
+    sessionRefreshCount: integer("session_refresh_count")
+      .notNull()
+      .default(sql`0`),
+    lastError: text("last_error"),
+    chunkLeaseOwner: text("chunk_lease_owner"),
+    chunkLeaseExpiresAt: text("chunk_lease_expires_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    promotedAt: text("promoted_at"),
+    completedAt: text("completed_at"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_einvoice_sync_runs_completed").on(sql`completed_at DESC`),
+    uniqueIndex("idx_einvoice_sync_runs_one_active")
+      .on(table.connectorId)
+      .where(sql`status IN ('queued', 'initializing', 'processing')`),
+    foreignKey({
+      columns: [table.scheduledBatchId],
+      foreignColumns: [scheduledSyncBatches.id],
+    }).onDelete("set null"),
+    foreignKey({
+      columns: [table.syncJobId],
+      foreignColumns: [syncJobs.id],
+    }).onDelete("set null"),
+    check("einvoice_sync_runs_check_1", sql`connector_id = 'einvoice'`),
+    check(
+      "einvoice_sync_runs_check_2",
+      sql`trigger IN ('manual', 'scheduled')`,
+    ),
+    check(
+      "einvoice_sync_runs_check_3",
+      sql`status IN (
     'queued', 'initializing', 'processing', 'completed', 'failed', 'needs_user_action'
-  )`),
-]);
+  )`,
+    ),
+  ],
+);
 
-export const einvoiceSyncRunItems = sqliteTable("einvoice_sync_run_items", {
-  id: text("id"),
-  runId: text("run_id").notNull(),
-  invoiceSourceId: text("invoice_source_id").notNull(),
-  headerJson: text("header_json").notNull(),
-  normalizedInvoiceJson: text("normalized_invoice_json").notNull(),
-  detailKey: text("detail_key"),
-  detailMetadataJson: text("detail_metadata_json"),
-  detailItemsJson: text("detail_items_json"),
-  lineItemCount: integer("line_item_count").notNull().default(sql`0`),
-  status: text("status").notNull(),
-  attemptCount: integer("attempt_count").notNull().default(sql`0`),
-  lastError: text("last_error"),
-  leaseToken: text("lease_token"),
-  leaseExpiresAt: text("lease_expires_at"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  completedAt: text("completed_at"),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_einvoice_sync_run_items_claim").on(table.runId, table.status, table.leaseExpiresAt, table.createdAt),
-  unique().on(table.runId, table.invoiceSourceId),
-  foreignKey({ columns: [table.runId], foreignColumns: [einvoiceSyncRuns.id] }).onDelete("cascade"),
-  check("einvoice_sync_run_items_check_1", sql`status IN ('pending', 'processing', 'done')`),
-]);
+export const einvoiceSyncRunItems = sqliteTable(
+  "einvoice_sync_run_items",
+  {
+    id: text("id"),
+    runId: text("run_id").notNull(),
+    invoiceSourceId: text("invoice_source_id").notNull(),
+    headerJson: text("header_json").notNull(),
+    normalizedInvoiceJson: text("normalized_invoice_json").notNull(),
+    detailKey: text("detail_key"),
+    detailMetadataJson: text("detail_metadata_json"),
+    detailItemsJson: text("detail_items_json"),
+    lineItemCount: integer("line_item_count")
+      .notNull()
+      .default(sql`0`),
+    status: text("status").notNull(),
+    attemptCount: integer("attempt_count")
+      .notNull()
+      .default(sql`0`),
+    lastError: text("last_error"),
+    leaseToken: text("lease_token"),
+    leaseExpiresAt: text("lease_expires_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    completedAt: text("completed_at"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_einvoice_sync_run_items_claim").on(
+      table.runId,
+      table.status,
+      table.leaseExpiresAt,
+      table.createdAt,
+    ),
+    unique().on(table.runId, table.invoiceSourceId),
+    foreignKey({
+      columns: [table.runId],
+      foreignColumns: [einvoiceSyncRuns.id],
+    }).onDelete("cascade"),
+    check(
+      "einvoice_sync_run_items_check_1",
+      sql`status IN ('pending', 'processing', 'done')`,
+    ),
+  ],
+);
 
-export const tdccSyncRuns = sqliteTable("tdcc_sync_runs", {
-  id: text("id"),
-  connectorId: text("connector_id").notNull().default(sql`'tdcc'`),
-  trigger: text("trigger").notNull(),
-  scope: text("scope").notNull().default(sql`'all'`),
-  syncJobId: text("sync_job_id"),
-  scheduledBatchId: text("scheduled_batch_id"),
-  settingsVersion: text("settings_version"),
-  phase: text("phase").notNull().default(sql`'initialize'`),
-  status: text("status").notNull().default(sql`'queued'`),
-  encryptedConfig: text("encrypted_config"),
-  encryptedSession: text("encrypted_session"),
-  sessionJson: text("session_json"),
-  totalItemCount: integer("total_item_count").notNull().default(sql`0`),
-  pendingItemCount: integer("pending_item_count").notNull().default(sql`0`),
-  processingItemCount: integer("processing_item_count").notNull().default(sql`0`),
-  doneItemCount: integer("done_item_count").notNull().default(sql`0`),
-  failedItemCount: integer("failed_item_count").notNull().default(sql`0`),
-  sessionRefreshCount: integer("session_refresh_count").notNull().default(sql`0`),
-  lastError: text("last_error"),
-  leaseOwner: text("lease_owner"),
-  leaseExpiresAt: text("lease_expires_at"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  promotedAt: text("promoted_at"),
-  completedAt: text("completed_at"),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_tdcc_sync_runs_completed").on(sql`completed_at DESC`),
-  uniqueIndex("idx_tdcc_sync_runs_one_active").on(table.connectorId).where(sql`status IN ('queued', 'initializing', 'processing', 'promoting')`),
-  foreignKey({ columns: [table.scheduledBatchId], foreignColumns: [scheduledSyncBatches.id] }).onDelete("set null"),
-  foreignKey({ columns: [table.syncJobId], foreignColumns: [syncJobs.id] }).onDelete("set null"),
-  check("tdcc_sync_runs_check_1", sql`connector_id = 'tdcc'`),
-  check("tdcc_sync_runs_check_2", sql`trigger IN ('manual', 'scheduled')`),
-  check("tdcc_sync_runs_check_3", sql`scope IN ('all', 'investments', 'bank', 'trades')`),
-  check("tdcc_sync_runs_check_4", sql`phase IN (
+export const tdccSyncRuns = sqliteTable(
+  "tdcc_sync_runs",
+  {
+    id: text("id"),
+    connectorId: text("connector_id")
+      .notNull()
+      .default(sql`'tdcc'`),
+    trigger: text("trigger").notNull(),
+    scope: text("scope")
+      .notNull()
+      .default(sql`'all'`),
+    syncJobId: text("sync_job_id"),
+    scheduledBatchId: text("scheduled_batch_id"),
+    settingsVersion: text("settings_version"),
+    phase: text("phase")
+      .notNull()
+      .default(sql`'initialize'`),
+    status: text("status")
+      .notNull()
+      .default(sql`'queued'`),
+    encryptedConfig: text("encrypted_config"),
+    encryptedSession: text("encrypted_session"),
+    sessionJson: text("session_json"),
+    totalItemCount: integer("total_item_count")
+      .notNull()
+      .default(sql`0`),
+    pendingItemCount: integer("pending_item_count")
+      .notNull()
+      .default(sql`0`),
+    processingItemCount: integer("processing_item_count")
+      .notNull()
+      .default(sql`0`),
+    doneItemCount: integer("done_item_count")
+      .notNull()
+      .default(sql`0`),
+    failedItemCount: integer("failed_item_count")
+      .notNull()
+      .default(sql`0`),
+    sessionRefreshCount: integer("session_refresh_count")
+      .notNull()
+      .default(sql`0`),
+    lastError: text("last_error"),
+    leaseOwner: text("lease_owner"),
+    leaseExpiresAt: text("lease_expires_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    promotedAt: text("promoted_at"),
+    completedAt: text("completed_at"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_tdcc_sync_runs_completed").on(sql`completed_at DESC`),
+    uniqueIndex("idx_tdcc_sync_runs_one_active")
+      .on(table.connectorId)
+      .where(
+        sql`status IN ('queued', 'initializing', 'processing', 'promoting')`,
+      ),
+    foreignKey({
+      columns: [table.scheduledBatchId],
+      foreignColumns: [scheduledSyncBatches.id],
+    }).onDelete("set null"),
+    foreignKey({
+      columns: [table.syncJobId],
+      foreignColumns: [syncJobs.id],
+    }).onDelete("set null"),
+    check("tdcc_sync_runs_check_1", sql`connector_id = 'tdcc'`),
+    check("tdcc_sync_runs_check_2", sql`trigger IN ('manual', 'scheduled')`),
+    check(
+      "tdcc_sync_runs_check_3",
+      sql`scope IN ('all', 'investments', 'bank', 'trades')`,
+    ),
+    check(
+      "tdcc_sync_runs_check_4",
+      sql`phase IN (
       'initialize', 'snapshot', 'positions', 'bank', 'investments',
       'trades', 'promote', 'finalize'
-    )`),
-  check("tdcc_sync_runs_check_5", sql`status IN (
+    )`,
+    ),
+    check(
+      "tdcc_sync_runs_check_5",
+      sql`status IN (
     'queued', 'initializing', 'processing', 'promoting',
     'completed', 'failed', 'needs_user_action'
-  )`),
-  check("tdcc_sync_runs_check_6", sql`session_json IS NULL OR json_valid(session_json)`),
-]);
+  )`,
+    ),
+    check(
+      "tdcc_sync_runs_check_6",
+      sql`session_json IS NULL OR json_valid(session_json)`,
+    ),
+  ],
+);
 
-export const tdccSyncRunItems = sqliteTable("tdcc_sync_run_items", {
-  id: text("id"),
-  runId: text("run_id").notNull(),
-  taskType: text("task_type").notNull(),
-  taskKey: text("task_key").notNull().default(sql`''`),
-  accountId: text("account_id"),
-  pageCursor: text("page_cursor").notNull().default(sql`''`),
-  nextPageCursor: text("next_page_cursor"),
-  pageNumber: integer("page_number").notNull().default(sql`0`),
-  taskJson: text("task_json").notNull().default(sql`'{}'`),
-  payloadJson: text("payload_json"),
-  status: text("status").notNull().default(sql`'pending'`),
-  attemptCount: integer("attempt_count").notNull().default(sql`0`),
-  lastError: text("last_error"),
-  leaseToken: text("lease_token"),
-  leaseExpiresAt: text("lease_expires_at"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-  completedAt: text("completed_at"),
-}, (table) => [
-  primaryKey({ columns: [table.id] }),
-  index("idx_tdcc_sync_run_items_account").on(table.runId, table.accountId, table.taskType, table.pageNumber),
-  index("idx_tdcc_sync_run_items_claim").on(table.runId, table.status, table.leaseExpiresAt, table.createdAt),
-  unique().on(table.runId, table.taskType, table.taskKey, table.pageCursor),
-  foreignKey({ columns: [table.runId], foreignColumns: [tdccSyncRuns.id] }).onDelete("cascade"),
-  check("tdcc_sync_run_items_check_1", sql`json_valid(task_json)`),
-  check("tdcc_sync_run_items_check_2", sql`payload_json IS NULL OR json_valid(payload_json)`),
-  check("tdcc_sync_run_items_check_3", sql`status IN ('pending', 'processing', 'done', 'failed')`),
-]);
+export const tdccSyncRunItems = sqliteTable(
+  "tdcc_sync_run_items",
+  {
+    id: text("id"),
+    runId: text("run_id").notNull(),
+    taskType: text("task_type").notNull(),
+    taskKey: text("task_key")
+      .notNull()
+      .default(sql`''`),
+    accountId: text("account_id"),
+    pageCursor: text("page_cursor")
+      .notNull()
+      .default(sql`''`),
+    nextPageCursor: text("next_page_cursor"),
+    pageNumber: integer("page_number")
+      .notNull()
+      .default(sql`0`),
+    taskJson: text("task_json")
+      .notNull()
+      .default(sql`'{}'`),
+    payloadJson: text("payload_json"),
+    status: text("status")
+      .notNull()
+      .default(sql`'pending'`),
+    attemptCount: integer("attempt_count")
+      .notNull()
+      .default(sql`0`),
+    lastError: text("last_error"),
+    leaseToken: text("lease_token"),
+    leaseExpiresAt: text("lease_expires_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    completedAt: text("completed_at"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.id] }),
+    index("idx_tdcc_sync_run_items_account").on(
+      table.runId,
+      table.accountId,
+      table.taskType,
+      table.pageNumber,
+    ),
+    index("idx_tdcc_sync_run_items_claim").on(
+      table.runId,
+      table.status,
+      table.leaseExpiresAt,
+      table.createdAt,
+    ),
+    unique().on(table.runId, table.taskType, table.taskKey, table.pageCursor),
+    foreignKey({
+      columns: [table.runId],
+      foreignColumns: [tdccSyncRuns.id],
+    }).onDelete("cascade"),
+    check("tdcc_sync_run_items_check_1", sql`json_valid(task_json)`),
+    check(
+      "tdcc_sync_run_items_check_2",
+      sql`payload_json IS NULL OR json_valid(payload_json)`,
+    ),
+    check(
+      "tdcc_sync_run_items_check_3",
+      sql`status IN ('pending', 'processing', 'done', 'failed')`,
+    ),
+  ],
+);

--- a/packages/db/testing/d1.ts
+++ b/packages/db/testing/d1.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from "node:url";
 import { Miniflare, convertV4MiniflareOptions } from "miniflare";
 import { unstable_splitSqlQuery } from "wrangler";
 
-const migrationsDirectory = fileURLToPath(new URL("../migrations/", import.meta.url));
+const migrationsDirectory = fileURLToPath(
+  new URL("../migrations/", import.meta.url),
+);
 
 export function readMigrations() {
   return readdirSync(migrationsDirectory)
@@ -16,19 +18,25 @@ export function readMigrations() {
 export async function createTestD1(
   script = 'export default { fetch() { return new Response("ok"); } };',
 ) {
-  const mf = new Miniflare(convertV4MiniflareOptions({
-    modules: true,
-    script,
-    compatibilityDate: "2026-06-01",
-    d1Databases: ["DB"],
-    d1Persist: false,
-  }));
+  const mf = new Miniflare(
+    convertV4MiniflareOptions({
+      modules: true,
+      script,
+      compatibilityDate: "2026-06-01",
+      d1Databases: { DB: crypto.randomUUID() },
+      logRequests: false,
+    }),
+  );
   try {
     const binding = await mf.getD1Database("DB");
     for (const migration of readMigrations()) {
-      await binding.batch(
-        unstable_splitSqlQuery(migration).map((statement) => binding.prepare(statement)),
-      );
+      const statements = unstable_splitSqlQuery(migration)
+        .map((statement) => statement.trim())
+        .filter((statement) => statement.length > 0)
+        .map((statement) => binding.prepare(statement));
+      if (statements.length > 0) {
+        await binding.batch(statements);
+      }
     }
     return { binding, mf };
   } catch (error) {

--- a/packages/db/tests/client.test.ts
+++ b/packages/db/tests/client.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { createDb } from "../src/client";
+import { connectorSettings, exchangeRates } from "../src/schema";
+import { createTestD1 } from "../testing/d1";
+
+describe("Drizzle D1 client", () => {
+  let harness: Awaited<ReturnType<typeof createTestD1>>;
+
+  beforeAll(async () => {
+    harness = await createTestD1();
+  }, 60_000);
+
+  afterAll(async () => {
+    await harness?.mf.dispose();
+  });
+
+  beforeEach(async () => {
+    await harness.binding.batch([
+      harness.binding.prepare("DELETE FROM exchange_rates"),
+      harness.binding.prepare("DELETE FROM connector_settings"),
+    ]);
+  });
+
+  it("selects aliases, preserves nulls, and upserts a row", async () => {
+    const db = createDb(harness.binding);
+    await db.insert(connectorSettings).values({
+      id: "settings-1",
+      connectorId: "einvoice",
+      encryptedConfig: "encrypted",
+      publicConfig: null,
+      createdAt: "2026-09-12T00:00:00.000Z",
+      updatedAt: "2026-09-12T00:00:00.000Z",
+    });
+    await db
+      .insert(exchangeRates)
+      .values({
+        currency: "USD",
+        rateToTwd: 30,
+        updatedAt: "2026-09-12T00:00:00.000Z",
+      })
+      .onConflictDoUpdate({
+        target: exchangeRates.currency,
+        set: {
+          rateToTwd: 32,
+          updatedAt: "2026-09-12T01:00:00.000Z",
+        },
+      });
+    await db
+      .insert(exchangeRates)
+      .values({
+        currency: "USD",
+        rateToTwd: 31,
+        updatedAt: "2026-09-12T00:30:00.000Z",
+      })
+      .onConflictDoUpdate({
+        target: exchangeRates.currency,
+        set: {
+          rateToTwd: 32,
+          updatedAt: "2026-09-12T01:00:00.000Z",
+        },
+      });
+
+    const [settings] = await db
+      .select({
+        connector: connectorSettings.connectorId,
+        publicConfig: connectorSettings.publicConfig,
+      })
+      .from(connectorSettings)
+      .where(eq(connectorSettings.connectorId, "einvoice"))
+      .all();
+    const [rate] = await db
+      .select({
+        code: sql<string>`${exchangeRates.currency}`,
+        rateTwd: exchangeRates.rateToTwd,
+        updatedAt: exchangeRates.updatedAt,
+      })
+      .from(exchangeRates)
+      .all();
+
+    expect(settings).toEqual({
+      connector: "einvoice",
+      publicConfig: null,
+    });
+    expect(rate).toEqual({
+      code: "USD",
+      rateTwd: 32,
+      updatedAt: "2026-09-12T01:00:00.000Z",
+    });
+  });
+
+  it("rolls back a D1 batch when a later statement fails", async () => {
+    const db = createDb(harness.binding);
+    await db.insert(exchangeRates).values({
+      currency: "USD",
+      rateToTwd: 30,
+      updatedAt: "2026-09-12T00:00:00.000Z",
+    });
+
+    await expect(
+      db.batch([
+        db.insert(exchangeRates).values({
+          currency: "JPY",
+          rateToTwd: 0.2,
+          updatedAt: "2026-09-12T00:00:00.000Z",
+        }),
+        db.insert(exchangeRates).values({
+          currency: "USD",
+          rateToTwd: 31,
+          updatedAt: "2026-09-12T00:00:00.000Z",
+        }),
+      ]),
+    ).rejects.toThrow();
+
+    const rows = await db
+      .select({
+        currency: sql<string>`${exchangeRates.currency}`,
+        rateTwd: exchangeRates.rateToTwd,
+      })
+      .from(exchangeRates)
+      .all();
+    expect(rows).toEqual([{ currency: "USD", rateTwd: 30 }]);
+  });
+});

--- a/packages/db/tests/schema.test.ts
+++ b/packages/db/tests/schema.test.ts
@@ -1,5 +1,8 @@
 import { DatabaseSync } from "node:sqlite";
-import { generateSQLiteDrizzleJson, generateSQLiteMigration } from "drizzle-kit/api";
+import {
+  generateSQLiteDrizzleJson,
+  generateSQLiteMigration,
+} from "drizzle-kit/api";
 import { is, sql, SQL } from "drizzle-orm";
 import { getTableConfig, SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
@@ -11,7 +14,10 @@ function parenthesized(sql: string, start: number) {
   let quoted = false;
   for (let i = start; i < sql.length; i++) {
     if (sql[i] === "'") {
-      if (quoted && sql[i + 1] === "'") { i++; continue; }
+      if (quoted && sql[i + 1] === "'") {
+        i++;
+        continue;
+      }
       quoted = !quoted;
     }
     if (quoted) continue;
@@ -23,52 +29,75 @@ function parenthesized(sql: string, start: number) {
 
 // Normalize SQL identifiers/whitespace only; string literals stay case-sensitive.
 function normalizeSql(sql: string) {
-  return sql.split(/('(?:[^']|'')*')/).map((part, i) =>
-    i % 2 ? part : part.replace(/["`\[\]]/g, "").replace(/\s+/g, "").toLowerCase(),
-  ).join("");
+  return sql
+    .split(/('(?:[^']|'')*')/)
+    .map((part, i) =>
+      i % 2
+        ? part
+        : part
+            .replace(/["`\[\]]/g, "")
+            .replace(/\s+/g, "")
+            .toLowerCase(),
+    )
+    .join("");
 }
 
 function inspect(database: DatabaseSync) {
-  const tables = database.prepare(
-    "SELECT name, sql FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
-  ).all() as Array<{ name: string; sql: string }>;
+  const tables = database
+    .prepare(
+      "SELECT name, sql FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+    )
+    .all() as Array<{ name: string; sql: string }>;
   return tables.map(({ name, sql }) => {
     const columns = database.prepare(`PRAGMA table_xinfo('${name}')`).all();
-    const foreignKeys = database.prepare(`PRAGMA foreign_key_list('${name}')`).all()
+    const foreignKeys = database
+      .prepare(`PRAGMA foreign_key_list('${name}')`)
+      .all()
       .map(({ id: _id, ...fk }) => fk)
       .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
     const checks = [...sql.matchAll(/\bCHECK\s*\(/gi)]
-      .map((match) => normalizeSql(parenthesized(sql, match.index + match[0].length)))
+      .map((match) =>
+        normalizeSql(parenthesized(sql, match.index + match[0].length)),
+      )
       .sort();
-    const generated = [...sql.matchAll(/\bAS\s*\(/gi)]
-      .map((match) => normalizeSql(parenthesized(sql, match.index + match[0].length)));
-    const indexes = database.prepare(`PRAGMA index_list('${name}')`).all().map((index) => {
-      const indexName = String(index.name);
-      const indexSql = database.prepare("SELECT sql FROM sqlite_schema WHERE name = ?").get(indexName)?.sql;
-      const details = database.prepare(`PRAGMA index_xinfo('${indexName}')`).all()
-        .filter((column) => column.key === 1)
-        .map(({ seqno, cid: _cid, ...column }) => ({ seqno, ...column }));
-      // Kit represents inline UNIQUE constraints as named unique indexes.
-      // Keep application index names, compare unnamed constraints by semantics.
-      const isApplicationIndex = indexName.startsWith("idx_");
-      let expression: string | undefined;
-      let where: string | undefined;
-      if (isApplicationIndex && typeof indexSql === "string") {
-        const start = indexSql.indexOf("(");
-        const body = parenthesized(indexSql, start + 1);
-        expression = normalizeSql(body);
-        where = normalizeSql(indexSql.slice(start + body.length + 2));
-      }
-      return {
-        name: isApplicationIndex ? indexName : undefined,
-        unique: index.unique,
-        primary: index.origin === "pk",
-        partial: index.partial,
-        details,
-        expression,
-        where,
-      };
-    }).sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+    const generated = [...sql.matchAll(/\bAS\s*\(/gi)].map((match) =>
+      normalizeSql(parenthesized(sql, match.index + match[0].length)),
+    );
+    const indexes = database
+      .prepare(`PRAGMA index_list('${name}')`)
+      .all()
+      .map((index) => {
+        const indexName = String(index.name);
+        const indexSql = database
+          .prepare("SELECT sql FROM sqlite_schema WHERE name = ?")
+          .get(indexName)?.sql;
+        const details = database
+          .prepare(`PRAGMA index_xinfo('${indexName}')`)
+          .all()
+          .filter((column) => column.key === 1)
+          .map(({ seqno, cid: _cid, ...column }) => ({ seqno, ...column }));
+        // Kit represents inline UNIQUE constraints as named unique indexes.
+        // Keep application index names, compare unnamed constraints by semantics.
+        const isApplicationIndex = indexName.startsWith("idx_");
+        let expression: string | undefined;
+        let where: string | undefined;
+        if (isApplicationIndex && typeof indexSql === "string") {
+          const start = indexSql.indexOf("(");
+          const body = parenthesized(indexSql, start + 1);
+          expression = normalizeSql(body);
+          where = normalizeSql(indexSql.slice(start + body.length + 2));
+        }
+        return {
+          name: isApplicationIndex ? indexName : undefined,
+          unique: index.unique,
+          primary: index.origin === "pk",
+          partial: index.partial,
+          details,
+          expression,
+          where,
+        };
+      })
+      .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
     return { name, columns, foreignKeys, indexes, checks, generated };
   });
 }
@@ -85,17 +114,32 @@ describe("Drizzle schema parity", () => {
       // Kit 0.31 quotes SQLite expression index fragments as column names.
       // Compare table DDL from Kit, and index DDL from Drizzle's own SQL dialect.
       // Production continues to apply the existing reviewed SQL via Wrangler.
-      for (const statement of statements.filter((statement) => !/^CREATE (?:UNIQUE )?INDEX/i.test(statement))) generated.exec(statement);
+      for (const statement of statements.filter(
+        (statement) => !/^CREATE (?:UNIQUE )?INDEX/i.test(statement),
+      ))
+        generated.exec(statement);
       const dialect = new SQLiteSyncDialect();
       for (const table of Object.values(schema)) {
         const config = getTableConfig(table);
         for (const index of config.indexes) {
           const { name, columns, unique, where } = index.config;
-          const query = sql`CREATE ${unique ? sql`UNIQUE ` : sql``}INDEX ${sql.identifier(name)} ON ${sql.identifier(config.name)} (${sql.join(columns.map((column) => is(column, SQL) ? column : sql.identifier(column.name)), sql`, `)})${where ? sql` WHERE ${where}` : sql``}`;
+          const query = sql`CREATE ${unique ? sql`UNIQUE ` : sql``}INDEX ${sql.identifier(name)} ON ${sql.identifier(config.name)} (${sql.join(
+            columns.map((column) =>
+              is(column, SQL) ? column : sql.identifier(column.name),
+            ),
+            sql`, `,
+          )})${where ? sql` WHERE ${where}` : sql``}`;
           generated.exec(dialect.sqlToQuery(query).sql);
         }
         for (const constraint of config.uniqueConstraints) {
-          generated.exec(dialect.sqlToQuery(sql`CREATE UNIQUE INDEX ${sql.identifier(constraint.getName())} ON ${sql.identifier(config.name)} (${sql.join(constraint.columns.map((column) => sql.identifier(column.name)), sql`, `)})`).sql);
+          generated.exec(
+            dialect.sqlToQuery(
+              sql`CREATE UNIQUE INDEX ${sql.identifier(constraint.getName())} ON ${sql.identifier(config.name)} (${sql.join(
+                constraint.columns.map((column) => sql.identifier(column.name)),
+                sql`, `,
+              )})`,
+            ).sql,
+          );
         }
       }
       const expected = inspect(migrated);
@@ -103,7 +147,12 @@ describe("Drizzle schema parity", () => {
       expect(inspect(generated)).toEqual(expected);
       expect(generated.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
       // An unchanged schema must never produce an initialization migration.
-      expect(await generateSQLiteMigration(current, await generateSQLiteDrizzleJson(schema))).toEqual([]);
+      expect(
+        await generateSQLiteMigration(
+          current,
+          await generateSQLiteDrizzleJson(schema),
+        ),
+      ).toEqual([]);
     } finally {
       migrated.close();
       generated.close();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
接續 `codex/activity-invoice-time` 上的 Drizzle WIP（`010e3de`），完成階段 1–2 驗收。既有 SQL migrations 仍是 schema 權威；沒有新增要套用到正式 D1 的 DDL，也沒有使用 `drizzle-kit push`。

## 變更摘要

- 修正混合 DESC／ASC 索引（信用卡帳單、投資部位、淨值歷史），讓 Drizzle schema 與 migration 重播結果語意一致。
- 完成隔離 Miniflare／workerd D1 helper，涵蓋 select、null、alias、upsert 與 batch 中途失敗回滾。
- 以 exchange-rates 作為第一個 repository 切片：`listExchangeRates()`／`replaceExchangeRates()` 使用 Drizzle；delete + insert 維持單一 D1 batch。
- 補上排序、完整取代、insert 失敗後舊資料仍在、空陣列取代等 D1 整合測試。
- 既有 service／route 測試改為驗證綁定值與 batch 行為，不再固定比對 ORM SQL 字串。

## 驗證

已通過：

- `npm run format:check`
- `npm run typecheck`（含 web／worker／db／core／connectors）
- `npm test -w @taiwan-fin-hub/db`（schema 語意比對 + Miniflare D1 client）
- `apps/worker` exchange-rates service／route／repository tests
- GitHub CI `CI / validate`（format、typecheck、`test:backend`、frontend unit tests、build）

查詢次數與原先相同：列表 1 次 select，取代 1 次 D1 batch；`drizzle-orm@0.45.2` 為 Workers 相容套件，未引入 Node-only runtime 依賴。

此 Cloud Agent 環境的 Node 22.14.0 `node:sqlite` 不接受 D1 風格 `?1` 編號參數，因此本機完整 `npm run test:backend` 會在既有的 activity search／sync persistence 測試出現 `column index out of range`。這些檔案相對 `main` 沒有變更；GitHub CI 已通過，確認不是此次切片引入的迴歸。

未連線正式 D1，也未啟動第一銀行／Browser Rendering。

## 文件更新

- `docs/002-backend-architecture.md`：補上 `createDb`、schema、repository 回傳與 raw SQL／batch 使用約定。
- `docs/006-drizzle-adoption-plan.md`：標示階段 1–2 已落地。
- `AGENTS.md`：更新 DB package 與 Drizzle 文件索引。
- 無 schema migration，因此未重產 `docs/database-schema.md`。

## 後續（階段 3+）

- **3A**：`manual-assets`、`notifications`
- **3B**：`classification`、connector settings／cursors
- **3C**：`invoices`、`investments`、`bank` 一般列表／明細
- **3D**：`dashboard`、`net-worth`、`activity` 與聚合；保留 `EXPLAIN QUERY PLAN`
- **4**：同步 lease、staging promotion、durable run；無法保語意時保留原生 SQL
- **5**：Drizzle Kit baseline 與未來 migration 接軌；仍由 Wrangler 套用

請勿合併到 `main` 以外自行部署；此 PR 以 `codex/activity-invoice-time` 為 base。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cee71843-7fa9-497b-9b24-ebcdb32b040a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cee71843-7fa9-497b-9b24-ebcdb32b040a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

