### PR TITLE
以 Drizzle 轉換手動資產與通知 repository（階段 3A）

### DIFF
--- a/apps/worker/src/features/exchange-rates/repository.ts
+++ b/apps/worker/src/features/exchange-rates/repository.ts
@@ -1,4 +1,4 @@
-import { createDb, exchangeRates } from "@taiwan-fin-hub/db";
+import { createDrizzle, exchangeRates } from "@taiwan-fin-hub/db";
 import { inArray, sql } from "drizzle-orm";
 
 export type ExchangeRateRow = Pick<
@@ -12,7 +12,7 @@ export type ExchangeRateRow = Pick<
 export const SUPPORTED_EXCHANGE_CURRENCIES = ["USD", "JPY", "EUR"] as const;
 
 export async function listExchangeRates(db: D1Database) {
-  return createDb(db)
+  return createDrizzle(db)
     .select({
       // The IN predicate excludes the nullable legacy TEXT primary key.
       currency: sql<string>`${exchangeRates.currency}`,
@@ -37,7 +37,7 @@ export async function replaceExchangeRates(
   rates: Array<{ currency: string; rate: number }>,
   now: string,
 ) {
-  const database = createDb(db);
+  const database = createDrizzle(db);
   // Delete + inserts stay in one D1 batch so a failed insert leaves the old rates.
   await database.batch([
     database.delete(exchangeRates),

--- a/apps/worker/src/features/manual-assets/repository.ts
+++ b/apps/worker/src/features/manual-assets/repository.ts
@@ -1,3 +1,11 @@
+import {
+  createDb,
+  manualAssets,
+  netWorthHistory,
+  type AppDatabase,
+} from "@taiwan-fin-hub/db";
+import { and, asc, eq, sql } from "drizzle-orm";
+
 export type ManualAssetRow = {
   id: string;
   name: string;
@@ -14,27 +22,32 @@ export type ManualAssetHistoryRow = {
 };
 
 export async function listManualAssets(db: D1Database) {
-  const assets = await db
-    .prepare(
-      `SELECT id, name, category, note, currency, created_at AS createdAt
-     FROM manual_assets
-     ORDER BY created_at ASC`,
-    )
-    .all<ManualAssetRow>();
-  return assets.results;
+  return createDb(db)
+    .select({
+      id: sql<string>`${manualAssets.id}`,
+      name: manualAssets.name,
+      category: manualAssets.category,
+      note: manualAssets.note,
+      currency: manualAssets.currency,
+      createdAt: manualAssets.createdAt,
+    })
+    .from(manualAssets)
+    .orderBy(asc(manualAssets.createdAt))
+    .all();
 }
 
 export async function listLatestManualAssetValues(db: D1Database) {
-  const history = await db
-    .prepare(
-      `SELECT asset_type AS assetId, net_worth AS value, date
-     FROM net_worth_history
-     WHERE source = 'manual'
-     GROUP BY asset_type
-     HAVING date = MAX(date)`,
-    )
-    .all<ManualAssetHistoryRow>();
-  return history.results;
+  return createDb(db)
+    .select({
+      assetId: sql<string>`${netWorthHistory.assetType}`,
+      value: netWorthHistory.netWorth,
+      date: netWorthHistory.date,
+    })
+    .from(netWorthHistory)
+    .where(eq(netWorthHistory.source, "manual"))
+    .groupBy(netWorthHistory.assetType)
+    .having(sql`${netWorthHistory.date} = max(${netWorthHistory.date})`)
+    .all();
 }
 
 export async function createManualAsset(
@@ -50,21 +63,18 @@ export async function createManualAsset(
     now: string;
   },
 ) {
-  await db.batch([
-    db
-      .prepare(
-        `INSERT INTO manual_assets (id, name, category, note, currency, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
-      )
-      .bind(
-        input.id,
-        input.name,
-        input.category,
-        input.note,
-        input.currency,
-        input.now,
-      ),
-    manualAssetHistoryUpsertStatement(
-      db,
+  const database = createDb(db);
+  await database.batch([
+    database.insert(manualAssets).values({
+      id: input.id,
+      name: input.name,
+      category: input.category,
+      note: input.note,
+      currency: input.currency,
+      createdAt: input.now,
+    }),
+    manualAssetHistoryUpsert(
+      database,
       input.id,
       input.date,
       input.value,
@@ -86,62 +96,65 @@ export async function updateManualAsset(
   },
   now: string,
 ) {
-  const sets: string[] = [];
-  const values: unknown[] = [];
-  if (input.name) {
-    sets.push("name = ?");
-    values.push(input.name);
+  const patch: {
+    name?: string;
+    category?: string;
+    note?: string | null;
+    currency?: string;
+  } = {};
+  if (input.name) patch.name = input.name;
+  if (input.category) patch.category = input.category;
+  if ("note" in input) patch.note = input.note ?? null;
+  if (input.currency) patch.currency = input.currency;
+
+  const database = createDb(db);
+  const assetUpdate =
+    Object.keys(patch).length > 0
+      ? database.update(manualAssets).set(patch).where(eq(manualAssets.id, id))
+      : undefined;
+  const historyUpsert =
+    input.value !== undefined && input.date !== undefined
+      ? manualAssetHistoryUpsert(database, id, input.date, input.value, now)
+      : undefined;
+  if (assetUpdate && historyUpsert) {
+    await database.batch([assetUpdate, historyUpsert]);
+  } else if (assetUpdate) {
+    await assetUpdate;
+  } else if (historyUpsert) {
+    await historyUpsert;
   }
-  if (input.category) {
-    sets.push("category = ?");
-    values.push(input.category);
-  }
-  if ("note" in input) {
-    sets.push("note = ?");
-    values.push(input.note ?? null);
-  }
-  if (input.currency) {
-    sets.push("currency = ?");
-    values.push(input.currency);
-  }
-  const statements: D1PreparedStatement[] = [];
-  if (sets.length > 0) {
-    statements.push(
-      db
-        .prepare(`UPDATE manual_assets SET ${sets.join(", ")} WHERE id = ?`)
-        .bind(...values, id),
-    );
-  }
-  if (input.value !== undefined && input.date !== undefined) {
-    statements.push(
-      manualAssetHistoryUpsertStatement(db, id, input.date, input.value, now),
-    );
-  }
-  if (statements.length > 0) await db.batch(statements);
 }
 
 export async function deleteManualAsset(db: D1Database, id: string) {
-  await db.batch([
-    db
-      .prepare(
-        "DELETE FROM net_worth_history WHERE source = 'manual' AND asset_type = ?",
-      )
-      .bind(id),
-    db.prepare("DELETE FROM manual_assets WHERE id = ?").bind(id),
+  const database = createDb(db);
+  await database.batch([
+    database
+      .delete(netWorthHistory)
+      .where(
+        and(
+          eq(netWorthHistory.source, "manual"),
+          eq(netWorthHistory.assetType, id),
+        ),
+      ),
+    database.delete(manualAssets).where(eq(manualAssets.id, id)),
   ]);
 }
 
 export async function listManualAssetHistory(db: D1Database, id: string) {
-  const rows = await db
-    .prepare(
-      `SELECT date, net_worth AS value
-     FROM net_worth_history
-     WHERE source = 'manual' AND asset_type = ?
-     ORDER BY date ASC`,
+  return createDb(db)
+    .select({
+      date: netWorthHistory.date,
+      value: netWorthHistory.netWorth,
+    })
+    .from(netWorthHistory)
+    .where(
+      and(
+        eq(netWorthHistory.source, "manual"),
+        eq(netWorthHistory.assetType, id),
+      ),
     )
-    .bind(id)
-    .all<{ date: string; value: number }>();
-  return rows.results;
+    .orderBy(asc(netWorthHistory.date))
+    .all();
 }
 
 export async function upsertManualAssetHistory(
@@ -151,7 +164,7 @@ export async function upsertManualAssetHistory(
   value: number,
   now: string,
 ) {
-  await manualAssetHistoryUpsertStatement(db, id, date, value, now).run();
+  await manualAssetHistoryUpsert(createDb(db), id, date, value, now);
 }
 
 export async function deleteManualAssetHistory(
@@ -159,29 +172,43 @@ export async function deleteManualAssetHistory(
   id: string,
   date: string,
 ) {
-  await db
-    .prepare(
-      `DELETE FROM net_worth_history
-     WHERE source = 'manual' AND asset_type = ? AND date = ?`,
-    )
-    .bind(id, date)
-    .run();
+  await createDb(db)
+    .delete(netWorthHistory)
+    .where(
+      and(
+        eq(netWorthHistory.source, "manual"),
+        eq(netWorthHistory.assetType, id),
+        eq(netWorthHistory.date, date),
+      ),
+    );
 }
 
-function manualAssetHistoryUpsertStatement(
-  db: D1Database,
+function manualAssetHistoryUpsert(
+  database: AppDatabase,
   id: string,
   date: string,
   value: number,
   now: string,
 ) {
-  return db
-    .prepare(
-      `INSERT INTO net_worth_history (id, date, net_worth, asset_type, source, snapshotted_at)
-     VALUES (?, ?, ?, ?, 'manual', ?)
-     ON CONFLICT(source, asset_type, date) DO UPDATE SET
-       net_worth = excluded.net_worth,
-       snapshotted_at = excluded.snapshotted_at`,
-    )
-    .bind(`manual:${id}:${date}`, date, value, id, now);
+  return database
+    .insert(netWorthHistory)
+    .values({
+      id: `manual:${id}:${date}`,
+      date,
+      netWorth: value,
+      assetType: id,
+      source: "manual",
+      snapshottedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        netWorthHistory.source,
+        netWorthHistory.assetType,
+        netWorthHistory.date,
+      ],
+      set: {
+        netWorth: value,
+        snapshottedAt: now,
+      },
+    });
 }

--- a/apps/worker/src/features/manual-assets/repository.ts
+++ b/apps/worker/src/features/manual-assets/repository.ts
@@ -1,5 +1,5 @@
 import {
-  createDb,
+  createDrizzle,
   manualAssets,
   netWorthHistory,
   type AppDatabase,
@@ -22,7 +22,7 @@ export type ManualAssetHistoryRow = {
 };
 
 export async function listManualAssets(db: D1Database) {
-  return createDb(db)
+  return createDrizzle(db)
     .select({
       id: sql<string>`${manualAssets.id}`,
       name: manualAssets.name,
@@ -37,7 +37,7 @@ export async function listManualAssets(db: D1Database) {
 }
 
 export async function listLatestManualAssetValues(db: D1Database) {
-  return createDb(db)
+  return createDrizzle(db)
     .select({
       assetId: sql<string>`${netWorthHistory.assetType}`,
       value: netWorthHistory.netWorth,
@@ -63,7 +63,7 @@ export async function createManualAsset(
     now: string;
   },
 ) {
-  const database = createDb(db);
+  const database = createDrizzle(db);
   await database.batch([
     database.insert(manualAssets).values({
       id: input.id,
@@ -107,7 +107,7 @@ export async function updateManualAsset(
   if ("note" in input) patch.note = input.note ?? null;
   if (input.currency) patch.currency = input.currency;
 
-  const database = createDb(db);
+  const database = createDrizzle(db);
   const assetUpdate =
     Object.keys(patch).length > 0
       ? database.update(manualAssets).set(patch).where(eq(manualAssets.id, id))
@@ -126,7 +126,7 @@ export async function updateManualAsset(
 }
 
 export async function deleteManualAsset(db: D1Database, id: string) {
-  const database = createDb(db);
+  const database = createDrizzle(db);
   await database.batch([
     database
       .delete(netWorthHistory)
@@ -141,7 +141,7 @@ export async function deleteManualAsset(db: D1Database, id: string) {
 }
 
 export async function listManualAssetHistory(db: D1Database, id: string) {
-  return createDb(db)
+  return createDrizzle(db)
     .select({
       date: netWorthHistory.date,
       value: netWorthHistory.netWorth,
@@ -164,7 +164,7 @@ export async function upsertManualAssetHistory(
   value: number,
   now: string,
 ) {
-  await manualAssetHistoryUpsert(createDb(db), id, date, value, now);
+  await manualAssetHistoryUpsert(createDrizzle(db), id, date, value, now);
 }
 
 export async function deleteManualAssetHistory(
@@ -172,7 +172,7 @@ export async function deleteManualAssetHistory(
   id: string,
   date: string,
 ) {
-  await createDb(db)
+  await createDrizzle(db)
     .delete(netWorthHistory)
     .where(
       and(

--- a/apps/worker/src/features/notifications/repository.ts
+++ b/apps/worker/src/features/notifications/repository.ts
@@ -1,7 +1,13 @@
+import {
+  createDb,
+  notificationPreferences,
+  pushSubscriptions,
+} from "@taiwan-fin-hub/db";
 import type {
   NotificationPreferences,
   PushSubscriptionInput,
 } from "@taiwan-fin-hub/core";
+import { asc, count, eq, sql } from "drizzle-orm";
 
 export type PushSubscriptionRow = {
   id: string;
@@ -19,15 +25,29 @@ const DEFAULT_PREFERENCES: NotificationPreferences = {
 };
 
 export async function listPushSubscriptions(db: D1Database) {
-  const result = await db
-    .prepare(
-      `SELECT id, encrypted_subscription, created_at, updated_at,
-              last_success_at, consecutive_failures
-       FROM push_subscriptions
-       ORDER BY created_at ASC, id ASC`,
-    )
-    .all<PushSubscriptionRow>();
-  return result.results;
+  const rows = await createDb(db)
+    .select({
+      id: sql<string>`${pushSubscriptions.id}`,
+      encryptedSubscription: pushSubscriptions.encryptedSubscription,
+      createdAt: pushSubscriptions.createdAt,
+      updatedAt: pushSubscriptions.updatedAt,
+      lastSuccessAt: pushSubscriptions.lastSuccessAt,
+      consecutiveFailures: pushSubscriptions.consecutiveFailures,
+    })
+    .from(pushSubscriptions)
+    .orderBy(asc(pushSubscriptions.createdAt), asc(pushSubscriptions.id))
+    .all();
+  return rows.map(
+    (row) =>
+      ({
+        id: row.id,
+        encrypted_subscription: row.encryptedSubscription,
+        created_at: row.createdAt,
+        updated_at: row.updatedAt,
+        last_success_at: row.lastSuccessAt,
+        consecutive_failures: row.consecutiveFailures,
+      }) satisfies PushSubscriptionRow,
+  );
 }
 
 export async function upsertPushSubscription(
@@ -38,64 +58,63 @@ export async function upsertPushSubscription(
     now: string;
   },
 ) {
-  await db
-    .prepare(
-      `INSERT INTO push_subscriptions (
-         id, encrypted_subscription, created_at, updated_at,
-         last_success_at, consecutive_failures
-       ) VALUES (?, ?, ?, ?, NULL, 0)
-       ON CONFLICT(id) DO UPDATE SET
-         encrypted_subscription = excluded.encrypted_subscription,
-         updated_at = excluded.updated_at,
-         consecutive_failures = 0`,
-    )
-    .bind(input.id, input.encryptedSubscription, input.now, input.now)
-    .run();
+  await createDb(db)
+    .insert(pushSubscriptions)
+    .values({
+      id: input.id,
+      encryptedSubscription: input.encryptedSubscription,
+      createdAt: input.now,
+      updatedAt: input.now,
+      lastSuccessAt: null,
+      consecutiveFailures: 0,
+    })
+    .onConflictDoUpdate({
+      target: pushSubscriptions.id,
+      set: {
+        encryptedSubscription: input.encryptedSubscription,
+        updatedAt: input.now,
+        consecutiveFailures: 0,
+      },
+    });
 }
 
 export async function removePushSubscription(db: D1Database, id: string) {
-  await db
-    .prepare("DELETE FROM push_subscriptions WHERE id = ?")
-    .bind(id)
-    .run();
+  await createDb(db)
+    .delete(pushSubscriptions)
+    .where(eq(pushSubscriptions.id, id));
 }
 
 export async function markPushSuccess(db: D1Database, id: string, now: string) {
-  await db
-    .prepare(
-      `UPDATE push_subscriptions
-       SET last_success_at = ?, consecutive_failures = 0, updated_at = ?
-       WHERE id = ?`,
-    )
-    .bind(now, now, id)
-    .run();
+  await createDb(db)
+    .update(pushSubscriptions)
+    .set({
+      lastSuccessAt: now,
+      consecutiveFailures: 0,
+      updatedAt: now,
+    })
+    .where(eq(pushSubscriptions.id, id));
 }
 
 export async function markPushFailure(db: D1Database, id: string, now: string) {
-  await db
-    .prepare(
-      `UPDATE push_subscriptions
-       SET consecutive_failures = consecutive_failures + 1, updated_at = ?
-       WHERE id = ?`,
-    )
-    .bind(now, id)
-    .run();
+  await createDb(db)
+    .update(pushSubscriptions)
+    .set({
+      consecutiveFailures: sql`${pushSubscriptions.consecutiveFailures} + 1`,
+      updatedAt: now,
+    })
+    .where(eq(pushSubscriptions.id, id));
 }
 
 export async function getNotificationPreferences(db: D1Database) {
-  const row = await db
-    .prepare(
-      `SELECT notify_success AS success,
-              notify_failed AS failed,
-              notify_needs_user_action AS needsUserAction
-       FROM notification_preferences
-       WHERE id = 'default'`,
-    )
-    .first<{
-      success: number;
-      failed: number;
-      needsUserAction: number;
-    }>();
+  const row = await createDb(db)
+    .select({
+      success: notificationPreferences.notifySuccess,
+      failed: notificationPreferences.notifyFailed,
+      needsUserAction: notificationPreferences.notifyNeedsUserAction,
+    })
+    .from(notificationPreferences)
+    .where(eq(notificationPreferences.id, "default"))
+    .get();
 
   if (!row) return DEFAULT_PREFERENCES;
   return {
@@ -110,31 +129,31 @@ export async function saveNotificationPreferences(
   preferences: NotificationPreferences,
   now: string,
 ) {
-  await db
-    .prepare(
-      `INSERT INTO notification_preferences (
-         id, notify_success, notify_failed,
-         notify_needs_user_action, updated_at
-       ) VALUES ('default', ?, ?, ?, ?)
-       ON CONFLICT(id) DO UPDATE SET
-         notify_success = excluded.notify_success,
-         notify_failed = excluded.notify_failed,
-         notify_needs_user_action = excluded.notify_needs_user_action,
-         updated_at = excluded.updated_at`,
-    )
-    .bind(
-      preferences.success ? 1 : 0,
-      preferences.failed ? 1 : 0,
-      preferences.needsUserAction ? 1 : 0,
-      now,
-    )
-    .run();
+  await createDb(db)
+    .insert(notificationPreferences)
+    .values({
+      id: "default",
+      notifySuccess: preferences.success ? 1 : 0,
+      notifyFailed: preferences.failed ? 1 : 0,
+      notifyNeedsUserAction: preferences.needsUserAction ? 1 : 0,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: notificationPreferences.id,
+      set: {
+        notifySuccess: preferences.success ? 1 : 0,
+        notifyFailed: preferences.failed ? 1 : 0,
+        notifyNeedsUserAction: preferences.needsUserAction ? 1 : 0,
+        updatedAt: now,
+      },
+    });
 }
 
 export async function countPushSubscriptions(db: D1Database) {
-  const row = await db
-    .prepare("SELECT COUNT(*) AS count FROM push_subscriptions")
-    .first<{ count: number }>();
+  const row = await createDb(db)
+    .select({ count: count() })
+    .from(pushSubscriptions)
+    .get();
   return row?.count ?? 0;
 }
 

--- a/apps/worker/src/features/notifications/repository.ts
+++ b/apps/worker/src/features/notifications/repository.ts
@@ -1,5 +1,5 @@
 import {
-  createDb,
+  createDrizzle,
   notificationPreferences,
   pushSubscriptions,
 } from "@taiwan-fin-hub/db";
@@ -25,7 +25,7 @@ const DEFAULT_PREFERENCES: NotificationPreferences = {
 };
 
 export async function listPushSubscriptions(db: D1Database) {
-  const rows = await createDb(db)
+  const rows = await createDrizzle(db)
     .select({
       id: sql<string>`${pushSubscriptions.id}`,
       encryptedSubscription: pushSubscriptions.encryptedSubscription,
@@ -58,7 +58,7 @@ export async function upsertPushSubscription(
     now: string;
   },
 ) {
-  await createDb(db)
+  await createDrizzle(db)
     .insert(pushSubscriptions)
     .values({
       id: input.id,
@@ -79,13 +79,13 @@ export async function upsertPushSubscription(
 }
 
 export async function removePushSubscription(db: D1Database, id: string) {
-  await createDb(db)
+  await createDrizzle(db)
     .delete(pushSubscriptions)
     .where(eq(pushSubscriptions.id, id));
 }
 
 export async function markPushSuccess(db: D1Database, id: string, now: string) {
-  await createDb(db)
+  await createDrizzle(db)
     .update(pushSubscriptions)
     .set({
       lastSuccessAt: now,
@@ -96,7 +96,7 @@ export async function markPushSuccess(db: D1Database, id: string, now: string) {
 }
 
 export async function markPushFailure(db: D1Database, id: string, now: string) {
-  await createDb(db)
+  await createDrizzle(db)
     .update(pushSubscriptions)
     .set({
       consecutiveFailures: sql`${pushSubscriptions.consecutiveFailures} + 1`,
@@ -106,7 +106,7 @@ export async function markPushFailure(db: D1Database, id: string, now: string) {
 }
 
 export async function getNotificationPreferences(db: D1Database) {
-  const row = await createDb(db)
+  const row = await createDrizzle(db)
     .select({
       success: notificationPreferences.notifySuccess,
       failed: notificationPreferences.notifyFailed,
@@ -129,7 +129,7 @@ export async function saveNotificationPreferences(
   preferences: NotificationPreferences,
   now: string,
 ) {
-  await createDb(db)
+  await createDrizzle(db)
     .insert(notificationPreferences)
     .values({
       id: "default",
@@ -150,7 +150,7 @@ export async function saveNotificationPreferences(
 }
 
 export async function countPushSubscriptions(db: D1Database) {
-  const row = await createDb(db)
+  const row = await createDrizzle(db)
     .select({ count: count() })
     .from(pushSubscriptions)
     .get();

--- a/apps/worker/tests/features/manual-assets/repository.test.ts
+++ b/apps/worker/tests/features/manual-assets/repository.test.ts
@@ -1,111 +1,101 @@
-import { DatabaseSync } from "node:sqlite";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
+  createManualAsset,
+  deleteManualAsset,
+  listLatestManualAssetValues,
   listManualAssetHistory,
+  listManualAssets,
   updateManualAsset,
 } from "../../../src/features/manual-assets/repository";
-
-class SqliteQueryStatement {
-  private values: unknown[] = [];
-
-  constructor(
-    private readonly database: DatabaseSync,
-    private readonly sql: string,
-  ) {}
-
-  bind(...values: unknown[]) {
-    this.values = values;
-    return this;
-  }
-
-  async run() {
-    this.database.prepare(this.sql).run(...(this.values as never[]));
-  }
-
-  async all<T>() {
-    return {
-      results: this.database
-        .prepare(this.sql)
-        .all(...(this.values as never[])) as T[],
-    };
-  }
-}
-
-const databases: DatabaseSync[] = [];
-
-afterEach(() => {
-  for (const database of databases.splice(0)) database.close();
-});
+import { createTestD1 } from "../../../../../packages/db/testing/d1";
 
 describe("manual asset repository", () => {
-  it("lists valuation history from oldest to newest", async () => {
-    const database = new DatabaseSync(":memory:");
-    databases.push(database);
-    database.exec(`
-      CREATE TABLE net_worth_history (
-        id TEXT PRIMARY KEY,
-        date TEXT NOT NULL,
-        net_worth REAL NOT NULL,
-        asset_type TEXT NOT NULL,
-        source TEXT NOT NULL,
-        snapshotted_at TEXT NOT NULL
-      );
-      INSERT INTO net_worth_history
-        (id, date, net_worth, asset_type, source, snapshotted_at)
-      VALUES
-        ('new', '2026-08-03', 4790, 'manual:stock', 'manual', '2026-08-03T00:00:00.000Z'),
-        ('old', '2025-03-03', 3031, 'manual:stock', 'manual', '2025-03-03T00:00:00.000Z');
-    `);
-    const db = {
-      prepare(sql: string) {
-        return new SqliteQueryStatement(database, sql);
-      },
-    } as unknown as D1Database;
+  let harness: Awaited<ReturnType<typeof createTestD1>>;
 
-    await expect(listManualAssetHistory(db, "manual:stock")).resolves.toEqual([
+  beforeAll(async () => {
+    harness = await createTestD1();
+  }, 60_000);
+
+  afterAll(async () => {
+    await harness?.mf.dispose();
+  });
+
+  beforeEach(async () => {
+    await harness.binding.batch([
+      harness.binding.prepare(
+        "DELETE FROM net_worth_history WHERE source = 'manual'",
+      ),
+      harness.binding.prepare("DELETE FROM manual_assets"),
+    ]);
+  });
+
+  it("lists valuation history from oldest to newest", async () => {
+    await createManualAsset(harness.binding, {
+      id: "manual:stock",
+      name: "股票",
+      category: "investment",
+      note: null,
+      currency: "TWD",
+      value: 3031,
+      date: "2025-03-03",
+      now: "2025-03-03T00:00:00.000Z",
+    });
+    await updateManualAsset(
+      harness.binding,
+      "manual:stock",
+      { value: 4790, date: "2026-08-03" },
+      "2026-08-03T00:00:00.000Z",
+    );
+
+    await expect(
+      listManualAssetHistory(harness.binding, "manual:stock"),
+    ).resolves.toEqual([
       { date: "2025-03-03", value: 3031 },
       { date: "2026-08-03", value: 4790 },
     ]);
   });
 
+  it("creates an asset and its first valuation in one batch", async () => {
+    await createManualAsset(harness.binding, {
+      id: "manual:home",
+      name: "房子",
+      category: "real_estate",
+      note: "備註",
+      currency: "TWD",
+      value: 100,
+      date: "2026-08-01",
+      now: "2026-08-01T00:00:00.000Z",
+    });
+
+    await expect(listManualAssets(harness.binding)).resolves.toEqual([
+      {
+        id: "manual:home",
+        name: "房子",
+        category: "real_estate",
+        note: "備註",
+        currency: "TWD",
+        createdAt: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+    await expect(listLatestManualAssetValues(harness.binding)).resolves.toEqual(
+      [{ assetId: "manual:home", value: 100, date: "2026-08-01" }],
+    );
+  });
+
   it("updates asset metadata and its current valuation atomically", async () => {
-    const database = new DatabaseSync(":memory:");
-    databases.push(database);
-    database.exec(`
-      CREATE TABLE manual_assets (
-        id TEXT PRIMARY KEY,
-        name TEXT NOT NULL,
-        category TEXT NOT NULL,
-        note TEXT,
-        currency TEXT NOT NULL
-      );
-      CREATE TABLE net_worth_history (
-        id TEXT PRIMARY KEY,
-        date TEXT NOT NULL,
-        net_worth REAL NOT NULL,
-        asset_type TEXT NOT NULL,
-        source TEXT NOT NULL,
-        snapshotted_at TEXT NOT NULL,
-        UNIQUE(source, asset_type, date)
-      );
-      INSERT INTO manual_assets (id, name, category, note, currency)
-      VALUES ('manual:home', '舊名稱', 'real_estate', '舊備註', 'TWD');
-      INSERT INTO net_worth_history
-        (id, date, net_worth, asset_type, source, snapshotted_at)
-      VALUES
-        ('manual:manual:home:2026-08-01', '2026-08-01', 100, 'manual:home', 'manual', '2026-08-01T00:00:00.000Z');
-    `);
-    const db = {
-      prepare(sql: string) {
-        return new SqliteQueryStatement(database, sql);
-      },
-      async batch(statements: SqliteQueryStatement[]) {
-        for (const statement of statements) await statement.run();
-      },
-    } as unknown as D1Database;
+    await createManualAsset(harness.binding, {
+      id: "manual:home",
+      name: "舊名稱",
+      category: "real_estate",
+      note: "舊備註",
+      currency: "TWD",
+      value: 100,
+      date: "2026-08-01",
+      now: "2026-08-01T00:00:00.000Z",
+    });
 
     await updateManualAsset(
-      db,
+      harness.binding,
       "manual:home",
       {
         name: "新名稱",
@@ -117,23 +107,99 @@ describe("manual asset repository", () => {
       "2026-08-03T12:00:00.000Z",
     );
 
-    expect(database.prepare("SELECT * FROM manual_assets").get()).toMatchObject(
+    await expect(listManualAssets(harness.binding)).resolves.toEqual([
       {
+        id: "manual:home",
         name: "新名稱",
+        category: "real_estate",
         note: null,
         currency: "USD",
+        createdAt: "2026-08-01T00:00:00.000Z",
       },
+    ]);
+    await expect(listLatestManualAssetValues(harness.binding)).resolves.toEqual(
+      [{ assetId: "manual:home", value: 125, date: "2026-08-03" }],
     );
-    expect(
-      database
-        .prepare(
-          "SELECT date, net_worth, snapshotted_at FROM net_worth_history WHERE date = '2026-08-03'",
-        )
-        .get(),
-    ).toEqual({
-      date: "2026-08-03",
-      net_worth: 125,
-      snapshotted_at: "2026-08-03T12:00:00.000Z",
+    await expect(
+      listManualAssetHistory(harness.binding, "manual:home"),
+    ).resolves.toEqual([
+      { date: "2026-08-01", value: 100 },
+      { date: "2026-08-03", value: 125 },
+    ]);
+  });
+
+  it("keeps the previous asset row when a later history insert in the update batch fails", async () => {
+    await createManualAsset(harness.binding, {
+      id: "manual:home",
+      name: "舊名稱",
+      category: "real_estate",
+      note: "舊備註",
+      currency: "TWD",
+      value: 100,
+      date: "2026-08-01",
+      now: "2026-08-01T00:00:00.000Z",
     });
+    await harness.binding
+      .prepare(
+        `INSERT INTO net_worth_history
+           (id, date, net_worth, asset_type, source, snapshotted_at)
+         VALUES
+           ('manual:manual:home:2026-08-03', '2020-01-01', 1, 'other', 'manual', '2020-01-01T00:00:00.000Z')`,
+      )
+      .run();
+
+    await expect(
+      updateManualAsset(
+        harness.binding,
+        "manual:home",
+        {
+          name: "新名稱",
+          note: null,
+          value: 125,
+          date: "2026-08-03",
+        },
+        "2026-08-03T12:00:00.000Z",
+      ),
+    ).rejects.toThrow();
+
+    await expect(listManualAssets(harness.binding)).resolves.toEqual([
+      {
+        id: "manual:home",
+        name: "舊名稱",
+        category: "real_estate",
+        note: "舊備註",
+        currency: "TWD",
+        createdAt: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("deletes an asset and all of its valuations together", async () => {
+    await createManualAsset(harness.binding, {
+      id: "manual:home",
+      name: "房子",
+      category: "real_estate",
+      note: null,
+      currency: "TWD",
+      value: 100,
+      date: "2026-08-01",
+      now: "2026-08-01T00:00:00.000Z",
+    });
+    await updateManualAsset(
+      harness.binding,
+      "manual:home",
+      { value: 125, date: "2026-08-03" },
+      "2026-08-03T00:00:00.000Z",
+    );
+
+    await deleteManualAsset(harness.binding, "manual:home");
+
+    await expect(listManualAssets(harness.binding)).resolves.toEqual([]);
+    await expect(listLatestManualAssetValues(harness.binding)).resolves.toEqual(
+      [],
+    );
+    await expect(
+      listManualAssetHistory(harness.binding, "manual:home"),
+    ).resolves.toEqual([]);
   });
 });

--- a/apps/worker/tests/features/notifications/repository.test.ts
+++ b/apps/worker/tests/features/notifications/repository.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  countPushSubscriptions,
+  getNotificationPreferences,
+  listPushSubscriptions,
+  markPushFailure,
+  saveNotificationPreferences,
+  upsertPushSubscription,
+} from "../../../src/features/notifications/repository";
+import { createTestD1 } from "../../../../../packages/db/testing/d1";
+
+describe("notification repository", () => {
+  let harness: Awaited<ReturnType<typeof createTestD1>>;
+
+  beforeAll(async () => {
+    harness = await createTestD1();
+  }, 60_000);
+
+  afterAll(async () => {
+    await harness?.mf.dispose();
+  });
+
+  beforeEach(async () => {
+    await harness.binding.batch([
+      harness.binding.prepare("DELETE FROM push_subscriptions"),
+      harness.binding.prepare("DELETE FROM notification_preferences"),
+    ]);
+  });
+
+  it("returns built-in preference defaults when no row exists", async () => {
+    await expect(getNotificationPreferences(harness.binding)).resolves.toEqual({
+      success: false,
+      failed: true,
+      needsUserAction: true,
+    });
+  });
+
+  it("stores 0/1 flags and reads them back as booleans", async () => {
+    await saveNotificationPreferences(
+      harness.binding,
+      { success: true, failed: false, needsUserAction: false },
+      "2026-09-12T00:00:00.000Z",
+    );
+
+    await expect(getNotificationPreferences(harness.binding)).resolves.toEqual({
+      success: true,
+      failed: false,
+      needsUserAction: false,
+    });
+  });
+
+  it("keeps last_success_at when a subscription is upserted again", async () => {
+    await upsertPushSubscription(harness.binding, {
+      id: "device-1",
+      encryptedSubscription: "encrypted-a",
+      now: "2026-09-12T00:00:00.000Z",
+    });
+    await harness.binding
+      .prepare(
+        `UPDATE push_subscriptions
+         SET last_success_at = '2026-09-12T01:00:00.000Z', consecutive_failures = 2
+         WHERE id = 'device-1'`,
+      )
+      .run();
+
+    await upsertPushSubscription(harness.binding, {
+      id: "device-1",
+      encryptedSubscription: "encrypted-b",
+      now: "2026-09-12T02:00:00.000Z",
+    });
+
+    await expect(listPushSubscriptions(harness.binding)).resolves.toEqual([
+      {
+        id: "device-1",
+        encrypted_subscription: "encrypted-b",
+        created_at: "2026-09-12T00:00:00.000Z",
+        updated_at: "2026-09-12T02:00:00.000Z",
+        last_success_at: "2026-09-12T01:00:00.000Z",
+        consecutive_failures: 0,
+      },
+    ]);
+  });
+
+  it("increments consecutive failures and counts subscriptions", async () => {
+    await upsertPushSubscription(harness.binding, {
+      id: "device-1",
+      encryptedSubscription: "encrypted",
+      now: "2026-09-12T00:00:00.000Z",
+    });
+    await markPushFailure(
+      harness.binding,
+      "device-1",
+      "2026-09-12T03:00:00.000Z",
+    );
+    await markPushFailure(
+      harness.binding,
+      "device-1",
+      "2026-09-12T04:00:00.000Z",
+    );
+
+    await expect(countPushSubscriptions(harness.binding)).resolves.toBe(1);
+    await expect(listPushSubscriptions(harness.binding)).resolves.toEqual([
+      {
+        id: "device-1",
+        encrypted_subscription: "encrypted",
+        created_at: "2026-09-12T00:00:00.000Z",
+        updated_at: "2026-09-12T04:00:00.000Z",
+        last_success_at: null,
+        consecutive_failures: 2,
+      },
+    ]);
+  });
+});

--- a/apps/worker/tests/features/notifications/route.test.ts
+++ b/apps/worker/tests/features/notifications/route.test.ts
@@ -4,23 +4,22 @@ import { notificationRoutes } from "../../../src/features/notifications/route";
 
 function createDb() {
   const db = {
-    prepare(sql: string) {
+    prepare() {
       const statement = {
         bind() {
           return statement;
         },
         async first() {
-          if (sql.includes("COUNT(*)")) return { count: 0 };
-          if (sql.includes("notification_preferences")) {
-            return { success: 0, failed: 1, needsUserAction: 1 };
-          }
           return null;
         },
         async all() {
           return { results: [] };
         },
+        async raw() {
+          return [];
+        },
         async run() {
-          return { meta: { changes: 1 } };
+          return { success: true, meta: { changes: 0 } };
         },
       };
       return statement;

--- a/apps/worker/tests/features/notifications/service.test.ts
+++ b/apps/worker/tests/features/notifications/service.test.ts
@@ -26,8 +26,20 @@ function createDb(encryptedSubscription: string) {
         async all() {
           return { results: [row] };
         },
+        async raw() {
+          return [
+            [
+              row.id,
+              row.encrypted_subscription,
+              row.created_at,
+              row.updated_at,
+              row.last_success_at,
+              row.consecutive_failures,
+            ],
+          ];
+        },
         async run() {
-          return { meta: { changes: 1 } };
+          return { success: true, meta: { changes: 1 } };
         },
       };
       return statement;

--- a/docs/002-backend-architecture.md
+++ b/docs/002-backend-architecture.md
@@ -157,7 +157,7 @@ Feature 專用的 D1 存取層，負責：
 - 回傳 database row、affected row count 或存在性結果。
 - 在仍需原生 statement 時，建立供 service 組合的 `D1PreparedStatement`。
 
-過渡期 repository／service 仍接受 `D1Database`，在 repository 內呼叫 `createDb(binding)`，不另建 DI container，也不建立跨 request／Queue invocation 的全域 client。TypeScript property 使用 camelCase，並明確對應既有 snake_case 欄位；回傳給 service／API 的 shape 由 selection 或 mapper 維持，不把 `$inferSelect` 當成 runtime validation。
+過渡期 repository／service 仍接受 `D1Database`，在 repository 內呼叫 `createDrizzle(binding)`，不另建 DI container，也不建立跨 request／Queue invocation 的全域 client。TypeScript property 使用 camelCase，並明確對應既有 snake_case 欄位；回傳給 service／API 的 shape 由 selection 或 mapper 維持，不把 `$inferSelect` 當成 runtime validation。
 
 複雜 expression、CTE、條件 upsert、跨檔案組成的原生 D1 batch，或轉換後無法保留語意的路徑，可繼續使用參數化 raw SQL，並在呼叫處註明原因。同一 batch 不得混用不相容的 Drizzle query object 與 `D1PreparedStatement`。
 
@@ -238,7 +238,7 @@ Middleware 應只處理跨功能的 request concern，不應承擔 feature 商�
 
 真正跨 feature 使用的 D1 基礎能力，目前主要包括：
 
-- `createDb(binding)`：以當次 request／Queue 的 D1 binding 建立 Drizzle client，關閉 query／parameter logging。
+- `createDrizzle(binding)`：以當次 request／Queue 的 D1 binding 包成 Drizzle client，關閉 query／parameter logging。不是連線池或 DbContext。
 - `src/schema/`：依業務領域描述現有業務表；SQL migrations 仍是 schema 權威。
 - Connector settings。
 - 加密設定與 sync cursor 狀態。

--- a/docs/006-drizzle-adoption-plan.md
+++ b/docs/006-drizzle-adoption-plan.md
@@ -28,7 +28,7 @@
 
 ## 架構決策
 
-1. 在 `packages/db/src/client.ts` 提供 `createDb(binding: D1Database)`，使用 `drizzle-orm/d1`。從當次 request／Queue invocation 傳入 binding，不建立跨環境的全域 client。
+1. 在 `packages/db/src/client.ts` 提供 `createDrizzle(binding: D1Database)`，使用 `drizzle-orm/d1`。從當次 request／Queue invocation 傳入 binding，不建立跨環境的全域 client。
 2. 在 `packages/db/src/schema/` 依業務領域定義 tables，透過 `schema/index.ts` 匯出。初期完整描述現有 28 張業務表，排除 `d1_migrations` 與平台內部表。
 3. Drizzle 型別留在 DB 與 Worker repository 層。`packages/core` 保持穩定商業契約；前端、`packages/connectors` 不依賴 ORM。
 4. 過渡期沿用 repository／service 接受 `D1Database` 的介面，在 repository 內取得 Drizzle client，避免全面改寫 routes 或新增 DI container。

--- a/docs/006-drizzle-adoption-plan.md
+++ b/docs/006-drizzle-adoption-plan.md
@@ -1,6 +1,6 @@
 # Drizzle 導入實作計畫
 
-日期：2026-09-12。狀態：階段 1–2 已落地（schema／client、語意比對、隔離 D1 整合測試、exchange-rates repository）；階段 3–5 待實作。SQL migrations 仍是 schema 權威，正式環境不使用 `drizzle-kit push`。
+日期：2026-09-12。狀態：階段 1–2 與 3A 已落地（schema／client、exchange-rates、manual-assets、notifications）；階段 3B–5 待實作。SQL migrations 仍是 schema 權威，正式環境不使用 `drizzle-kit push`。
 
 ## 目標與建議方案
 

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,9 +1,10 @@
 import { drizzle } from "drizzle-orm/d1";
 
-export function createDb(binding: D1Database) {
+/** Wrap this invocation's D1 binding as a Drizzle client. Not a connection pool or DbContext. */
+export function createDrizzle(binding: D1Database) {
   // Query builders import their tables explicitly; no relational schema registry
   // or client is retained across requests / Queue invocations.
   return drizzle(binding, { logger: false });
 }
 
-export type AppDatabase = ReturnType<typeof createDb>;
+export type AppDatabase = ReturnType<typeof createDrizzle>;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,4 @@
-export { createDb } from "./client";
+export { createDrizzle } from "./client";
 export type { AppDatabase } from "./client";
 export * from "./schema";
 

--- a/packages/db/tests/client.test.ts
+++ b/packages/db/tests/client.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { eq, sql } from "drizzle-orm";
-import { createDb } from "../src/client";
+import { createDrizzle } from "../src/client";
 import { connectorSettings, exchangeRates } from "../src/schema";
 import { createTestD1 } from "../testing/d1";
 
@@ -23,7 +23,7 @@ describe("Drizzle D1 client", () => {
   });
 
   it("selects aliases, preserves nulls, and upserts a row", async () => {
-    const db = createDb(harness.binding);
+    const db = createDrizzle(harness.binding);
     await db.insert(connectorSettings).values({
       id: "settings-1",
       connectorId: "einvoice",
@@ -90,7 +90,7 @@ describe("Drizzle D1 client", () => {
   });
 
   it("rolls back a D1 batch when a later statement fails", async () => {
-    const db = createDb(harness.binding);
+    const db = createDrizzle(harness.binding);
     await db.insert(exchangeRates).values({
       currency: "USD",
       rateToTwd: 30,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
接續階段 1–2，完成 Drizzle 導入計畫的 **3A**：`manual-assets` 與 `notifications` repository。API shape、TEXT 日期與 0／1 偏好語意維持不變；沒有 schema migration。

## 變更摘要

- 手動資產的列表、最新估值、建立、更新、刪除與歷史 upsert 改為 Drizzle。建立／更新估值／刪除仍走 D1 batch，失敗時舊資料保留。
- 通知的訂閱 CRUD、成功／失敗計數、偏好讀寫與裝置數改為 Drizzle。upsert 不覆蓋 `last_success_at`；缺少偏好列時回傳既有預設值。
- 以隔離 Miniflare D1 補上原子性、note null、偏好 0／1 與失敗次數測試。
- 既有 service／route mock 補上 Drizzle driver 會呼叫的 `.raw()`。
- 將 client factory 由 `createDb(binding)` 改名為 `createDrizzle(binding)`：從既有 D1 取出 Drizzle handle，不是建立資料庫。測試裡的 D1 mock 仍叫區域 `createDb()`。

## 驗證

已通過：

- `npm run format:check`
- `npm run typecheck`
- `npm test -w @taiwan-fin-hub/db`
- `apps/worker` 的 exchange-rates／manual-assets／notifications 測試

未連線正式 D1，也未啟動銀行同步。

## 文件更新

- `docs/006-drizzle-adoption-plan.md`：標示 3A 已落地；factory 名稱改為 `createDrizzle`。
- `docs/002-backend-architecture.md`：同步 `createDrizzle` 說明。

此 PR 疊在 #139 之上。後續 3B 為 classification 與 connector settings。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cee71843-7fa9-497b-9b24-ebcdb32b040a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cee71843-7fa9-497b-9b24-ebcdb32b040a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

