### PR TITLE
以 Drizzle 轉換發票、投資與銀行一般列表查詢（階段 3C）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 - `docs/002-backend-architecture.md`：後端分層、相依方向與維護約定的詳細文件。
 - `docs/003-frontend-architecture.md`：前端分層、相依方向與測試 colocate 約定。
 - `docs/004-connector-development.md`：Connector catalog、連接模式、敏感狀態與新增流程規範。
-- `docs/006-drizzle-adoption-plan.md`：Drizzle 分階段導入計畫；階段 1–2 與 3A–3B 已落地，後續批次見該文件。
+- `docs/006-drizzle-adoption-plan.md`：Drizzle 分階段導入計畫；階段 1–2 與 3A–3C 已落地，後續批次見該文件。
 
 ## 架構約定
 

--- a/apps/worker/src/features/bank/repository.ts
+++ b/apps/worker/src/features/bank/repository.ts
@@ -6,7 +6,7 @@ import {
   bankTransactions,
   creditCardBills,
 } from "@taiwan-fin-hub/db";
-import { and, asc, desc, eq, isNull, ne, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, ne, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/sqlite-core";
 import type { TransactionPageCursor } from "../investments/repository";
 import type { MonthDateRange } from "../../platform/month-range";
@@ -15,7 +15,6 @@ const txn = alias(bankTransactions, "txn");
 const account = alias(bankAccounts, "account");
 const preference = alias(bankTransactionPreferences, "preference");
 const balance = alias(bankBalanceSnapshots, "balance");
-const latestBalance = alias(bankBalanceSnapshots, "latest");
 const bill = alias(creditCardBills, "b");
 const billAccount = alias(bankAccounts, "a");
 
@@ -26,47 +25,61 @@ const bankTransactionDay = sql`CASE WHEN length(txn.authorized_at) > 10
 
 const visibleBankTransactionFilter = and(
   isNull(account.canonicalAccountId),
-  or(ne(txn.status, "pending"), isNull(txn.matchedTransactionId)),
+  sql`(${txn.status} <> 'pending' OR ${txn.matchedTransactionId} IS NULL)`,
 );
 
 const bankTransactionColumns = {
-  id: sql<string>`${txn.id}`,
-  connectorId: txn.connectorId,
-  accountId: txn.accountId,
-  accountSourceId: account.sourceId,
-  accountName: account.accountName,
-  institutionName: account.institutionName,
-  accountType: account.accountType,
-  bankCode: account.bankCode,
-  accountLast4: account.accountLast4,
-  sourceId: txn.sourceId,
-  transferPeerId: txn.transferPeerId,
-  postedDate: txn.postedDate,
-  authorizedAt: txn.authorizedAt,
-  amount: txn.amount,
-  currency: txn.currency,
-  description: txn.description,
-  counterparty: txn.counterparty,
-  status: sql<"pending" | "posted">`${txn.status}`,
-  effectiveDate: sql<string>`${txn.effectiveDate}`,
-  updatedAt: txn.updatedAt,
-  calculationPreference: preference.excludedFromCalculation,
+  id: sql<string>`${txn.id}`.as("id"),
+  connectorId: sql<string>`${txn.connectorId}`.as("connectorId"),
+  accountId: sql<string>`${txn.accountId}`.as("accountId"),
+  accountSourceId: sql<string>`${account.sourceId}`.as("accountSourceId"),
+  accountName: sql<string>`${account.accountName}`.as("accountName"),
+  institutionName: sql<string>`${account.institutionName}`.as(
+    "institutionName",
+  ),
+  accountType: sql<string>`${account.accountType}`.as("accountType"),
+  bankCode: sql<string>`${account.bankCode}`.as("bankCode"),
+  accountLast4: sql<string>`${account.accountLast4}`.as("accountLast4"),
+  sourceId: sql<string>`${txn.sourceId}`.as("sourceId"),
+  transferPeerId: sql<string | null>`${txn.transferPeerId}`.as(
+    "transferPeerId",
+  ),
+  postedDate: sql<string | null>`${txn.postedDate}`.as("postedDate"),
+  authorizedAt: sql<string | null>`${txn.authorizedAt}`.as("authorizedAt"),
+  amount: sql<number>`${txn.amount}`.as("amount"),
+  currency: sql<string>`${txn.currency}`.as("currency"),
+  description: sql<string | null>`${txn.description}`.as("description"),
+  counterparty: sql<string | null>`${txn.counterparty}`.as("counterparty"),
+  status: sql<"pending" | "posted">`${txn.status}`.as("status"),
+  effectiveDate: sql<string>`${txn.effectiveDate}`.as("effectiveDate"),
+  updatedAt: sql<string>`${txn.updatedAt}`.as("updatedAt"),
+  calculationPreference: sql<
+    number | null
+  >`${preference.excludedFromCalculation}`.as("calculationPreference"),
 };
 
 const creditCardBillColumns = {
-  id: sql<string>`${bill.id}`,
-  connectorId: bill.connectorId,
-  accountId: bill.accountId,
-  accountSourceId: billAccount.sourceId,
-  sourceId: bill.sourceId,
-  billingPeriod: bill.billingPeriod,
-  statementAmount: bill.statementAmount,
-  minimumPayment: bill.minimumPayment,
-  paidAmount: bill.paidAmount,
-  isPaid: bill.isPaid,
-  paymentDueDate: bill.paymentDueDate,
-  statementClosingDate: bill.statementClosingDate,
-  currency: bill.currency,
+  id: sql<string>`${bill.id}`.as("id"),
+  connectorId: sql<string>`${bill.connectorId}`.as("connectorId"),
+  accountId: sql<string>`${bill.accountId}`.as("accountId"),
+  accountSourceId: sql<string>`${billAccount.sourceId}`.as("accountSourceId"),
+  sourceId: sql<string>`${bill.sourceId}`.as("sourceId"),
+  billingPeriod: sql<string>`${bill.billingPeriod}`.as("billingPeriod"),
+  statementAmount: sql<number | null>`${bill.statementAmount}`.as(
+    "statementAmount",
+  ),
+  minimumPayment: sql<number | null>`${bill.minimumPayment}`.as(
+    "minimumPayment",
+  ),
+  paidAmount: sql<number | null>`${bill.paidAmount}`.as("paidAmount"),
+  isPaid: sql<number | null>`${bill.isPaid}`.as("isPaid"),
+  paymentDueDate: sql<string | null>`${bill.paymentDueDate}`.as(
+    "paymentDueDate",
+  ),
+  statementClosingDate: sql<string | null>`${bill.statementClosingDate}`.as(
+    "statementClosingDate",
+  ),
+  currency: sql<string>`${bill.currency}`.as("currency"),
 };
 
 export type BankTransactionPageRow = {
@@ -149,10 +162,10 @@ export async function listBankAccounts(db: D1Database) {
       eq(
         balance.id,
         sql`(
-          SELECT ${latestBalance.id}
-          FROM ${latestBalance}
-          WHERE ${latestBalance.accountId} = ${account.id}
-          ORDER BY ${latestBalance.asOfAt} DESC, ${latestBalance.updatedAt} DESC
+          SELECT latest.id
+          FROM bank_balance_snapshots latest
+          WHERE latest.account_id = ${account.id}
+          ORDER BY latest.as_of_at DESC, latest.updated_at DESC
           LIMIT 1
         )`,
       ),

--- a/apps/worker/src/features/bank/repository.ts
+++ b/apps/worker/src/features/bank/repository.ts
@@ -1,5 +1,73 @@
+import {
+  createDrizzle,
+  bankAccounts,
+  bankBalanceSnapshots,
+  bankTransactionPreferences,
+  bankTransactions,
+  creditCardBills,
+} from "@taiwan-fin-hub/db";
+import { and, asc, desc, eq, isNull, ne, or, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/sqlite-core";
 import type { TransactionPageCursor } from "../investments/repository";
 import type { MonthDateRange } from "../../platform/month-range";
+
+const txn = alias(bankTransactions, "txn");
+const account = alias(bankAccounts, "account");
+const preference = alias(bankTransactionPreferences, "preference");
+const balance = alias(bankBalanceSnapshots, "balance");
+const latestBalance = alias(bankBalanceSnapshots, "latest");
+const bill = alias(creditCardBills, "b");
+const billAccount = alias(bankAccounts, "a");
+
+// Must match idx_bank_transactions_transaction_day so range scans stay indexed.
+const bankTransactionDay = sql`CASE WHEN length(txn.authorized_at) > 10
+  THEN COALESCE(date(txn.authorized_at, '+8 hours'), substr(txn.authorized_at, 1, 10))
+  ELSE substr(COALESCE(txn.authorized_at, txn.posted_date), 1, 10) END`;
+
+const visibleBankTransactionFilter = and(
+  isNull(account.canonicalAccountId),
+  or(ne(txn.status, "pending"), isNull(txn.matchedTransactionId)),
+);
+
+const bankTransactionColumns = {
+  id: sql<string>`${txn.id}`,
+  connectorId: txn.connectorId,
+  accountId: txn.accountId,
+  accountSourceId: account.sourceId,
+  accountName: account.accountName,
+  institutionName: account.institutionName,
+  accountType: account.accountType,
+  bankCode: account.bankCode,
+  accountLast4: account.accountLast4,
+  sourceId: txn.sourceId,
+  transferPeerId: txn.transferPeerId,
+  postedDate: txn.postedDate,
+  authorizedAt: txn.authorizedAt,
+  amount: txn.amount,
+  currency: txn.currency,
+  description: txn.description,
+  counterparty: txn.counterparty,
+  status: sql<"pending" | "posted">`${txn.status}`,
+  effectiveDate: sql<string>`${txn.effectiveDate}`,
+  updatedAt: txn.updatedAt,
+  calculationPreference: preference.excludedFromCalculation,
+};
+
+const creditCardBillColumns = {
+  id: sql<string>`${bill.id}`,
+  connectorId: bill.connectorId,
+  accountId: bill.accountId,
+  accountSourceId: billAccount.sourceId,
+  sourceId: bill.sourceId,
+  billingPeriod: bill.billingPeriod,
+  statementAmount: bill.statementAmount,
+  minimumPayment: bill.minimumPayment,
+  paidAmount: bill.paidAmount,
+  isPaid: bill.isPaid,
+  paymentDueDate: bill.paymentDueDate,
+  statementClosingDate: bill.statementClosingDate,
+  currency: bill.currency,
+};
 
 export type BankTransactionPageRow = {
   id: string;
@@ -31,72 +99,71 @@ export type CreditCardBillPageCursor = {
   id: string;
 };
 
-const BANK_TRANSACTION_SELECT = `SELECT
-      txn.id,
-      txn.connector_id AS connectorId,
-      txn.account_id AS accountId,
-      account.source_id AS accountSourceId,
-      account.account_name AS accountName,
-      account.institution_name AS institutionName,
-      account.account_type AS accountType,
-      account.bank_code AS bankCode,
-      account.account_last4 AS accountLast4,
-      txn.source_id AS sourceId,
-      txn.transfer_peer_id AS transferPeerId,
-      txn.posted_date AS postedDate,
-      txn.authorized_at AS authorizedAt,
-      txn.amount,
-      txn.currency,
-      txn.description,
-      txn.counterparty,
-      txn.status,
-      txn.effective_date AS effectiveDate,
-      txn.updated_at AS updatedAt,
-      preference.excluded_from_calculation AS calculationPreference
-    FROM bank_transactions txn
-    JOIN bank_accounts account ON account.id = txn.account_id
-    LEFT JOIN bank_transaction_preferences preference
-      ON preference.transaction_id = txn.id`;
+export type CreditCardBillPageRow = {
+  id: string;
+  connectorId: string;
+  accountId: string;
+  accountSourceId: string;
+  sourceId: string;
+  billingPeriod: string;
+  statementAmount: number | null;
+  minimumPayment: number | null;
+  paidAmount: number | null;
+  isPaid: number | null;
+  paymentDueDate: string | null;
+  statementClosingDate: string | null;
+  currency: string;
+};
 
-// authorized_at has explicit precision; legacy posted_date is a financial date.
-const BANK_TRANSACTION_DAY = `CASE WHEN length(txn.authorized_at) > 10
-  THEN COALESCE(date(txn.authorized_at, '+8 hours'), substr(txn.authorized_at, 1, 10))
-  ELSE substr(COALESCE(txn.authorized_at, txn.posted_date), 1, 10) END`;
+function bankTransactionQuery(db: D1Database) {
+  return createDrizzle(db)
+    .select(bankTransactionColumns)
+    .from(txn)
+    .innerJoin(account, eq(account.id, txn.accountId))
+    .leftJoin(preference, eq(preference.transactionId, txn.id));
+}
 
 export async function listBankAccounts(db: D1Database) {
-  const rows = await db
-    .prepare(
-      `SELECT
-      account.id,
-      account.connector_id AS connectorId,
-      account.source_id AS sourceId,
-      account.institution_name AS institutionName,
-      account.account_name AS accountName,
-      account.account_type AS accountType,
-      account.currency,
-      account.opened_date AS openedDate,
-      account.maturity_date AS maturityDate,
-      account.bank_code AS bankCode,
-      account.account_last4 AS accountLast4,
-      balance.balance AS balance,
-      balance.available_balance AS availableBalance,
-      balance.payment_due_date AS paymentDueDate,
-      balance.statement_closing_date AS statementClosingDate,
-      balance.as_of_at AS asOfAt
-    FROM bank_accounts account
-    LEFT JOIN bank_balance_snapshots balance
-      ON balance.id = (
-        SELECT latest.id
-        FROM bank_balance_snapshots latest
-        WHERE latest.account_id = account.id
-        ORDER BY latest.as_of_at DESC, latest.updated_at DESC
-        LIMIT 1
-      )
-    WHERE account.canonical_account_id IS NULL AND account.inactive_at IS NULL
-    ORDER BY account.institution_name ASC, account.account_name ASC, account.source_id ASC`,
+  return createDrizzle(db)
+    .select({
+      id: sql<string>`${account.id}`,
+      connectorId: account.connectorId,
+      sourceId: account.sourceId,
+      institutionName: account.institutionName,
+      accountName: account.accountName,
+      accountType: account.accountType,
+      currency: account.currency,
+      openedDate: account.openedDate,
+      maturityDate: account.maturityDate,
+      bankCode: account.bankCode,
+      accountLast4: account.accountLast4,
+      balance: balance.balance,
+      availableBalance: balance.availableBalance,
+      paymentDueDate: balance.paymentDueDate,
+      statementClosingDate: balance.statementClosingDate,
+      asOfAt: balance.asOfAt,
+    })
+    .from(account)
+    .leftJoin(
+      balance,
+      eq(
+        balance.id,
+        sql`(
+          SELECT ${latestBalance.id}
+          FROM ${latestBalance}
+          WHERE ${latestBalance.accountId} = ${account.id}
+          ORDER BY ${latestBalance.asOfAt} DESC, ${latestBalance.updatedAt} DESC
+          LIMIT 1
+        )`,
+      ),
     )
-    .all<Record<string, unknown>>();
-  return rows.results;
+    .where(and(isNull(account.canonicalAccountId), isNull(account.inactiveAt)))
+    .orderBy(
+      asc(account.institutionName),
+      asc(account.accountName),
+      asc(account.sourceId),
+    )
+    .all();
 }
 
 export async function listBankTransactions(
@@ -104,22 +171,18 @@ export async function listBankTransactions(
   limit: number,
   cursor?: TransactionPageCursor,
 ) {
-  const cursorClause = cursor
-    ? "AND (txn.effective_date, txn.updated_at, txn.id) < (?, ?, ?)"
-    : "";
-  const statement = db.prepare(
-    `${BANK_TRANSACTION_SELECT}
-    WHERE account.canonical_account_id IS NULL AND (txn.status <> 'pending' OR txn.matched_transaction_id IS NULL)
-    ${cursorClause}
-    ORDER BY txn.effective_date DESC, txn.updated_at DESC, txn.id DESC
-    LIMIT ?`,
-  );
-  const rows = await (
-    cursor
-      ? statement.bind(cursor.effectiveDate, cursor.updatedAt, cursor.id, limit)
-      : statement.bind(limit)
-  ).all<BankTransactionPageRow>();
-  return rows.results;
+  return bankTransactionQuery(db)
+    .where(
+      and(
+        visibleBankTransactionFilter,
+        cursor
+          ? sql`(${txn.effectiveDate}, ${txn.updatedAt}, ${txn.id}) < (${cursor.effectiveDate}, ${cursor.updatedAt}, ${cursor.id})`
+          : undefined,
+      ),
+    )
+    .orderBy(desc(txn.effectiveDate), desc(txn.updatedAt), desc(txn.id))
+    .limit(limit)
+    .all();
 }
 
 export async function listBankTransactionsInRange(
@@ -127,16 +190,20 @@ export async function listBankTransactionsInRange(
   range: MonthDateRange,
   days?: string[],
 ) {
-  const rows = await db
-    .prepare(
-      `${BANK_TRANSACTION_SELECT}
-       WHERE account.canonical_account_id IS NULL AND (txn.status <> 'pending' OR txn.matched_transaction_id IS NULL)
-         AND ${days ? `(${BANK_TRANSACTION_DAY}) IN (SELECT value FROM json_each(?))` : `(${BANK_TRANSACTION_DAY}) >= ? AND (${BANK_TRANSACTION_DAY}) < ?`}
-       ORDER BY txn.effective_date DESC, txn.updated_at DESC, txn.id DESC`,
+  return bankTransactionQuery(db)
+    .where(
+      and(
+        visibleBankTransactionFilter,
+        days
+          ? sql`(${bankTransactionDay}) IN (SELECT value FROM json_each(${JSON.stringify(days)}))`
+          : and(
+              sql`(${bankTransactionDay}) >= ${range.from}`,
+              sql`(${bankTransactionDay}) < ${range.to}`,
+            ),
+      ),
     )
-    .bind(...(days ? [JSON.stringify(days)] : [range.from, range.to]))
-    .all<BankTransactionPageRow>();
-  return rows.results;
+    .orderBy(desc(txn.effectiveDate), desc(txn.updatedAt), desc(txn.id))
+    .all();
 }
 
 export async function listBankTransactionsForTransferMatching(
@@ -164,32 +231,26 @@ export async function listBankTransactionsForTransferMatching(
   if (amounts.length === 0 || currencies.length === 0) return [];
 
   const matchDays = [...new Set(days.filter(Boolean))];
-  const dayClause =
-    matchDays.length > 0
-      ? `
-         AND (${BANK_TRANSACTION_DAY}) IN (
-           SELECT value FROM json_each(?)
-         )`
-      : "";
-  const values = [JSON.stringify(amounts), JSON.stringify(currencies)];
-  if (matchDays.length > 0) values.push(JSON.stringify(matchDays));
-
-  const rows = await db
-    .prepare(
-      `${BANK_TRANSACTION_SELECT}
-       WHERE account.canonical_account_id IS NULL AND (txn.status <> 'pending' OR txn.matched_transaction_id IS NULL)
-         AND txn.status = 'posted'
-         AND txn.amount <> 0
-         AND ABS(txn.amount) IN (
-           SELECT CAST(value AS INTEGER) FROM json_each(?)
-         )
-         AND UPPER(TRIM(txn.currency)) IN (
-           SELECT UPPER(TRIM(value)) FROM json_each(?)
-         )${dayClause}`,
+  return bankTransactionQuery(db)
+    .where(
+      and(
+        visibleBankTransactionFilter,
+        eq(txn.status, "posted"),
+        ne(txn.amount, 0),
+        sql`ABS(txn.amount) IN (
+          SELECT CAST(value AS INTEGER) FROM json_each(${JSON.stringify(amounts)})
+        )`,
+        sql`UPPER(TRIM(txn.currency)) IN (
+          SELECT UPPER(TRIM(value)) FROM json_each(${JSON.stringify(currencies)})
+        )`,
+        matchDays.length > 0
+          ? sql`(${bankTransactionDay}) IN (
+              SELECT value FROM json_each(${JSON.stringify(matchDays)})
+            )`
+          : undefined,
+      ),
     )
-    .bind(...values)
-    .all<BankTransactionPageRow>();
-  return rows.results;
+    .all();
 }
 
 export async function listCreditCardBills(
@@ -197,89 +258,40 @@ export async function listCreditCardBills(
   limit: number,
   cursor?: CreditCardBillPageCursor,
 ) {
-  const cursorClause = cursor
-    ? `WHERE (
-        b.billing_period < ?
-        OR (
-          b.billing_period = ?
-          AND (b.account_id, b.id) > (?, ?)
-        )
-      )`
-    : "";
-  const statement = db.prepare(
-    `SELECT
-      b.id,
-      b.connector_id AS connectorId,
-      b.account_id AS accountId,
-      a.source_id AS accountSourceId,
-      b.source_id AS sourceId,
-      b.billing_period AS billingPeriod,
-      b.statement_amount AS statementAmount,
-      b.minimum_payment AS minimumPayment,
-      b.paid_amount AS paidAmount,
-      b.is_paid AS isPaid,
-      b.payment_due_date AS paymentDueDate,
-      b.statement_closing_date AS statementClosingDate,
-      b.currency
-    FROM credit_card_bills b
-    JOIN bank_accounts a ON a.id = b.account_id
-    ${cursorClause}
-    ORDER BY b.billing_period DESC, b.account_id ASC, b.id ASC
-    LIMIT ?`,
-  );
-  const rows = await (
-    cursor
-      ? statement.bind(
-          cursor.billingPeriod,
-          cursor.billingPeriod,
-          cursor.accountId,
-          cursor.id,
-          limit,
-        )
-      : statement.bind(limit)
-  ).all<
-    Record<string, unknown> & {
-      id: string;
-      accountId: string;
-      billingPeriod: string;
-    }
-  >();
-  return rows.results;
+  return createDrizzle(db)
+    .select(creditCardBillColumns)
+    .from(bill)
+    .innerJoin(billAccount, eq(billAccount.id, bill.accountId))
+    .where(
+      cursor
+        ? sql`(
+            ${bill.billingPeriod} < ${cursor.billingPeriod}
+            OR (
+              ${bill.billingPeriod} = ${cursor.billingPeriod}
+              AND (${bill.accountId}, ${bill.id}) > (${cursor.accountId}, ${cursor.id})
+            )
+          )`
+        : undefined,
+    )
+    .orderBy(desc(bill.billingPeriod), asc(bill.accountId), asc(bill.id))
+    .limit(limit)
+    .all();
 }
 
 export async function listCreditCardBillsInRange(
   db: D1Database,
   range: MonthDateRange,
 ) {
-  const rows = await db
-    .prepare(
-      `SELECT
-      b.id,
-      b.connector_id AS connectorId,
-      b.account_id AS accountId,
-      a.source_id AS accountSourceId,
-      b.source_id AS sourceId,
-      b.billing_period AS billingPeriod,
-      b.statement_amount AS statementAmount,
-      b.minimum_payment AS minimumPayment,
-      b.paid_amount AS paidAmount,
-      b.is_paid AS isPaid,
-      b.payment_due_date AS paymentDueDate,
-      b.statement_closing_date AS statementClosingDate,
-      b.currency
-    FROM credit_card_bills b
-    JOIN bank_accounts a ON a.id = b.account_id
-    WHERE b.billing_period >= substr(?, 1, 7)
-      AND b.billing_period < substr(?, 1, 7)
-    ORDER BY b.billing_period DESC, b.account_id ASC, b.id ASC`,
+  return createDrizzle(db)
+    .select(creditCardBillColumns)
+    .from(bill)
+    .innerJoin(billAccount, eq(billAccount.id, bill.accountId))
+    .where(
+      and(
+        sql`${bill.billingPeriod} >= substr(${range.from}, 1, 7)`,
+        sql`${bill.billingPeriod} < substr(${range.to}, 1, 7)`,
+      ),
     )
-    .bind(range.from, range.to)
-    .all<
-      Record<string, unknown> & {
-        id: string;
-        accountId: string;
-        billingPeriod: string;
-      }
-    >();
-  return rows.results;
+    .orderBy(desc(bill.billingPeriod), asc(bill.accountId), asc(bill.id))
+    .all();
 }

--- a/apps/worker/src/features/investments/repository.ts
+++ b/apps/worker/src/features/investments/repository.ts
@@ -1,5 +1,36 @@
-import type { ActivityTrade } from "@taiwan-fin-hub/core";
+import {
+  createDrizzle,
+  investmentPositions,
+  investmentTransactions,
+} from "@taiwan-fin-hub/db";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/sqlite-core";
 import type { MonthDateRange } from "../../platform/month-range";
+
+const latestPosition = alias(investmentPositions, "p2");
+
+const investmentTransactionColumns = {
+  id: sql<string>`${investmentTransactions.id}`,
+  connectorId: investmentTransactions.connectorId,
+  accountId: investmentTransactions.accountId,
+  sourceId: investmentTransactions.sourceId,
+  brokerNo: investmentTransactions.brokerNo,
+  brokerAccount: investmentTransactions.brokerAccount,
+  brokerName: investmentTransactions.brokerName,
+  symbol: investmentTransactions.symbol,
+  name: investmentTransactions.name,
+  assetType: investmentTransactions.assetType,
+  tradeDate: investmentTransactions.tradeDate,
+  postedDate: investmentTransactions.postedDate,
+  transactionCode: investmentTransactions.transactionCode,
+  transactionName: investmentTransactions.transactionName,
+  quantity: investmentTransactions.quantity,
+  price: investmentTransactions.price,
+  amount: investmentTransactions.amount,
+  currency: investmentTransactions.currency,
+  effectiveDate: sql<string>`${investmentTransactions.effectiveDate}`,
+  updatedAt: investmentTransactions.updatedAt,
+};
 
 export type InvestmentPageCursor = {
   asOfDate: string;
@@ -31,49 +62,51 @@ export async function listLatestInvestmentPositions(
   limit: number,
   cursor?: InvestmentPageCursor,
 ) {
-  const cursorClause = cursor
-    ? `AND (
-        investment_positions.as_of_date < ?
-        OR (
-          investment_positions.as_of_date = ?
-          AND (investment_positions.asset_type, investment_positions.name, investment_positions.id) > (?, ?, ?)
-        )
-      )`
-    : "";
-  const statement = db.prepare(
-    `SELECT
-      id,
-      asset_type AS assetType,
-      symbol,
-      name,
-      quantity,
-      market_value AS marketValue,
-      cash_balance AS cashBalance,
-      currency,
-      as_of_date AS asOfDate
-    FROM investment_positions
-    WHERE as_of_date = (
-      SELECT MAX(p2.as_of_date) FROM investment_positions p2
-      WHERE p2.connector_id = investment_positions.connector_id
-        AND p2.asset_type = investment_positions.asset_type
+  return createDrizzle(db)
+    .select({
+      id: sql<string>`${investmentPositions.id}`,
+      assetType: investmentPositions.assetType,
+      symbol: investmentPositions.symbol,
+      name: investmentPositions.name,
+      quantity: investmentPositions.quantity,
+      marketValue: investmentPositions.marketValue,
+      cashBalance: investmentPositions.cashBalance,
+      currency: investmentPositions.currency,
+      asOfDate: investmentPositions.asOfDate,
+    })
+    .from(investmentPositions)
+    .where(
+      and(
+        // Latest as_of_date is per connector + asset type, not a global max.
+        eq(
+          investmentPositions.asOfDate,
+          sql`(
+            SELECT MAX(${latestPosition.asOfDate})
+            FROM ${latestPosition}
+            WHERE ${latestPosition.connectorId} = ${investmentPositions.connectorId}
+              AND ${latestPosition.assetType} = ${investmentPositions.assetType}
+          )`,
+        ),
+        cursor
+          ? sql`(
+              ${investmentPositions.asOfDate} < ${cursor.asOfDate}
+              OR (
+                ${investmentPositions.asOfDate} = ${cursor.asOfDate}
+                AND (${investmentPositions.assetType}, ${investmentPositions.name}, ${investmentPositions.id})
+                  > (${cursor.assetType}, ${cursor.name}, ${cursor.id})
+              )
+            )`
+          : undefined,
+      ),
     )
-    ${cursorClause}
-    ORDER BY as_of_date DESC, asset_type ASC, name ASC, id ASC
-    LIMIT ?`,
-  );
-  const rows = await (
-    cursor
-      ? statement.bind(
-          cursor.asOfDate,
-          cursor.asOfDate,
-          cursor.assetType,
-          cursor.name,
-          cursor.id,
-          limit,
-        )
-      : statement.bind(limit)
-  ).all<InvestmentPositionRow>();
-  return rows.results;
+    .orderBy(
+      desc(investmentPositions.asOfDate),
+      asc(investmentPositions.assetType),
+      asc(investmentPositions.name),
+      asc(investmentPositions.id),
+    )
+    .limit(limit)
+    .all();
 }
 
 export async function listInvestmentTransactions(
@@ -81,48 +114,21 @@ export async function listInvestmentTransactions(
   limit: number,
   cursor?: TransactionPageCursor,
 ) {
-  const cursorClause = cursor
-    ? "WHERE (effective_date, updated_at, id) < (?, ?, ?)"
-    : "";
-  const statement = db.prepare(
-    `SELECT
-      id,
-      connector_id AS connectorId,
-      account_id AS accountId,
-      source_id AS sourceId,
-      broker_no AS brokerNo,
-      broker_account AS brokerAccount,
-      broker_name AS brokerName,
-      symbol,
-      name,
-      asset_type AS assetType,
-      trade_date AS tradeDate,
-      posted_date AS postedDate,
-      transaction_code AS transactionCode,
-      transaction_name AS transactionName,
-      quantity,
-      price,
-      amount,
-      currency,
-      effective_date AS effectiveDate,
-      updated_at AS updatedAt
-    FROM investment_transactions
-    ${cursorClause}
-    ORDER BY effective_date DESC, updated_at DESC, id DESC
-    LIMIT ?`,
-  );
-  const rows = await (
-    cursor
-      ? statement.bind(cursor.effectiveDate, cursor.updatedAt, cursor.id, limit)
-      : statement.bind(limit)
-  ).all<
-    Record<string, unknown> & {
-      id: string;
-      effectiveDate: string;
-      updatedAt: string;
-    }
-  >();
-  return rows.results;
+  return createDrizzle(db)
+    .select(investmentTransactionColumns)
+    .from(investmentTransactions)
+    .where(
+      cursor
+        ? sql`(${investmentTransactions.effectiveDate}, ${investmentTransactions.updatedAt}, ${investmentTransactions.id}) < (${cursor.effectiveDate}, ${cursor.updatedAt}, ${cursor.id})`
+        : undefined,
+    )
+    .orderBy(
+      desc(investmentTransactions.effectiveDate),
+      desc(investmentTransactions.updatedAt),
+      desc(investmentTransactions.id),
+    )
+    .limit(limit)
+    .all();
 }
 
 export async function listInvestmentTransactionsInRange(
@@ -130,40 +136,21 @@ export async function listInvestmentTransactionsInRange(
   range: MonthDateRange,
   days?: string[],
 ) {
-  const rows = await db
-    .prepare(
-      `SELECT
-      id,
-      connector_id AS connectorId,
-      account_id AS accountId,
-      source_id AS sourceId,
-      broker_no AS brokerNo,
-      broker_account AS brokerAccount,
-      broker_name AS brokerName,
-      symbol,
-      name,
-      asset_type AS assetType,
-      trade_date AS tradeDate,
-      posted_date AS postedDate,
-      transaction_code AS transactionCode,
-      transaction_name AS transactionName,
-      quantity,
-      price,
-      amount,
-      currency,
-      effective_date AS effectiveDate,
-      updated_at AS updatedAt
-    FROM investment_transactions
-    WHERE ${days ? "substr(effective_date, 1, 10) IN (SELECT value FROM json_each(?))" : "effective_date >= ? AND effective_date < ?"}
-    ORDER BY effective_date DESC, updated_at DESC, id DESC`,
+  return createDrizzle(db)
+    .select(investmentTransactionColumns)
+    .from(investmentTransactions)
+    .where(
+      days
+        ? sql`substr(${investmentTransactions.effectiveDate}, 1, 10) IN (SELECT value FROM json_each(${JSON.stringify(days)}))`
+        : and(
+            sql`${investmentTransactions.effectiveDate} >= ${range.from}`,
+            sql`${investmentTransactions.effectiveDate} < ${range.to}`,
+          ),
     )
-    .bind(...(days ? [JSON.stringify(days)] : [range.from, range.to]))
-    .all<
-      ActivityTrade & {
-        id: string;
-        effectiveDate: string;
-        updatedAt: string;
-      }
-    >();
-  return rows.results;
+    .orderBy(
+      desc(investmentTransactions.effectiveDate),
+      desc(investmentTransactions.updatedAt),
+      desc(investmentTransactions.id),
+    )
+    .all();
 }

--- a/apps/worker/src/features/investments/repository.ts
+++ b/apps/worker/src/features/investments/repository.ts
@@ -4,10 +4,7 @@ import {
   investmentTransactions,
 } from "@taiwan-fin-hub/db";
 import { and, asc, desc, eq, sql } from "drizzle-orm";
-import { alias } from "drizzle-orm/sqlite-core";
 import type { MonthDateRange } from "../../platform/month-range";
-
-const latestPosition = alias(investmentPositions, "p2");
 
 const investmentTransactionColumns = {
   id: sql<string>`${investmentTransactions.id}`,
@@ -81,10 +78,10 @@ export async function listLatestInvestmentPositions(
         eq(
           investmentPositions.asOfDate,
           sql`(
-            SELECT MAX(${latestPosition.asOfDate})
-            FROM ${latestPosition}
-            WHERE ${latestPosition.connectorId} = ${investmentPositions.connectorId}
-              AND ${latestPosition.assetType} = ${investmentPositions.assetType}
+            SELECT MAX(p2.as_of_date)
+            FROM investment_positions p2
+            WHERE p2.connector_id = ${investmentPositions.connectorId}
+              AND p2.asset_type = ${investmentPositions.assetType}
           )`,
         ),
         cursor

--- a/apps/worker/src/features/invoices/repository.ts
+++ b/apps/worker/src/features/invoices/repository.ts
@@ -1,9 +1,22 @@
 import type { ConnectorId } from "@taiwan-fin-hub/core";
+import { createDrizzle, invoiceLineItems, invoices } from "@taiwan-fin-hub/db";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
 import type { MonthDateRange } from "../../platform/month-range";
 
-const INVOICE_DAY = `CASE WHEN length(invoice_date) > 10
-  THEN COALESCE(date(invoice_date, '+8 hours'), substr(invoice_date, 1, 10))
-  ELSE invoice_date END`;
+// Taipei calendar day for precise timestamps; date-only TEXT stays unchanged.
+const invoiceDay = sql`CASE WHEN length(${invoices.invoiceDate}) > 10
+  THEN COALESCE(date(${invoices.invoiceDate}, '+8 hours'), substr(${invoices.invoiceDate}, 1, 10))
+  ELSE ${invoices.invoiceDate} END`;
+
+const invoiceSummaryColumns = {
+  id: sql<string>`${invoices.id}`,
+  connectorId: sql<ConnectorId>`${invoices.connectorId}`,
+  sourceId: invoices.sourceId,
+  invoiceNumber: invoices.invoiceNumber,
+  invoiceDate: invoices.invoiceDate,
+  sellerName: invoices.sellerName,
+  amount: invoices.amount,
+};
 
 export type InvoicePageCursor = {
   invoiceDate: string;
@@ -38,30 +51,24 @@ export async function listInvoices(
   limit: number,
   cursor?: InvoicePageCursor,
 ) {
-  const cursorClause = cursor
-    ? "WHERE (invoice_date, updated_at, id) < (?, ?, ?)"
-    : "";
-  const statement = db.prepare(
-    `SELECT
-      id,
-      connector_id AS connectorId,
-      source_id AS sourceId,
-      invoice_number AS invoiceNumber,
-      invoice_date AS invoiceDate,
-      seller_name AS sellerName,
-      amount,
-      updated_at AS updatedAt
-    FROM invoices
-    ${cursorClause}
-    ORDER BY invoice_date DESC, updated_at DESC, id DESC
-    LIMIT ?`,
-  );
-  const rows = await (
-    cursor
-      ? statement.bind(cursor.invoiceDate, cursor.updatedAt, cursor.id, limit)
-      : statement.bind(limit)
-  ).all<InvoiceRow>();
-  return rows.results;
+  return createDrizzle(db)
+    .select({
+      ...invoiceSummaryColumns,
+      updatedAt: invoices.updatedAt,
+    })
+    .from(invoices)
+    .where(
+      cursor
+        ? sql`(${invoices.invoiceDate}, ${invoices.updatedAt}, ${invoices.id}) < (${cursor.invoiceDate}, ${cursor.updatedAt}, ${cursor.id})`
+        : undefined,
+    )
+    .orderBy(
+      desc(invoices.invoiceDate),
+      desc(invoices.updatedAt),
+      desc(invoices.id),
+    )
+    .limit(limit)
+    .all();
 }
 
 export async function listInvoicesInRange(
@@ -69,63 +76,60 @@ export async function listInvoicesInRange(
   range: MonthDateRange,
   days?: string[],
 ) {
-  const rows = await db
-    .prepare(
-      `SELECT
-      id,
-      connector_id AS connectorId,
-      source_id AS sourceId,
-      invoice_number AS invoiceNumber,
-      invoice_date AS invoiceDate,
-      seller_name AS sellerName,
-      amount,
-      updated_at AS updatedAt
-    FROM invoices
-    WHERE ${days ? `(${INVOICE_DAY}) IN (SELECT value FROM json_each(?))` : `(${INVOICE_DAY}) >= ? AND (${INVOICE_DAY}) < ?`}
-    ORDER BY invoice_date DESC, updated_at DESC, id DESC`,
+  return createDrizzle(db)
+    .select({
+      ...invoiceSummaryColumns,
+      updatedAt: invoices.updatedAt,
+    })
+    .from(invoices)
+    .where(
+      days
+        ? sql`(${invoiceDay}) IN (SELECT value FROM json_each(${JSON.stringify(days)}))`
+        : and(
+            sql`(${invoiceDay}) >= ${range.from}`,
+            sql`(${invoiceDay}) < ${range.to}`,
+          ),
     )
-    .bind(...(days ? [JSON.stringify(days)] : [range.from, range.to]))
-    .all<InvoiceRow>();
-  return rows.results;
+    .orderBy(
+      desc(invoices.invoiceDate),
+      desc(invoices.updatedAt),
+      desc(invoices.id),
+    )
+    .all();
 }
 
 export async function listInvoiceItems(db: D1Database, invoiceIds: string[]) {
   if (invoiceIds.length === 0) return [];
-  const placeholders = invoiceIds.map(() => "?").join(", ");
-  const rows = await db
-    .prepare(
-      `SELECT
-      id,
-      invoice_id AS invoiceId,
-      source_id AS sourceId,
-      line_number AS lineNumber,
-      description,
-      quantity,
-      unit_price AS unitPrice,
-      amount
-    FROM invoice_line_items
-    WHERE invoice_id IN (${placeholders})
-    ORDER BY invoice_id ASC, line_number ASC, source_id ASC`,
+  return createDrizzle(db)
+    .select({
+      id: sql<string>`${invoiceLineItems.id}`,
+      invoiceId: invoiceLineItems.invoiceId,
+      sourceId: invoiceLineItems.sourceId,
+      lineNumber: invoiceLineItems.lineNumber,
+      description: invoiceLineItems.description,
+      quantity: invoiceLineItems.quantity,
+      unitPrice: invoiceLineItems.unitPrice,
+      amount: invoiceLineItems.amount,
+    })
+    .from(invoiceLineItems)
+    .where(
+      sql`${invoiceLineItems.invoiceId} IN (SELECT value FROM json_each(${JSON.stringify(invoiceIds)}))`,
     )
-    .bind(...invoiceIds)
-    .all<InvoiceItemRow>();
-  return rows.results;
+    .orderBy(
+      asc(invoiceLineItems.invoiceId),
+      asc(invoiceLineItems.lineNumber),
+      asc(invoiceLineItems.sourceId),
+    )
+    .all();
 }
 
 export async function findInvoice(db: D1Database, invoiceId: string) {
-  return db
-    .prepare(
-      `SELECT
-      id,
-      connector_id AS connectorId,
-      source_id AS sourceId,
-      invoice_number AS invoiceNumber,
-      invoice_date AS invoiceDate,
-      seller_name AS sellerName,
-      amount
-    FROM invoices
-    WHERE id = ?`,
-    )
-    .bind(invoiceId)
-    .first<Omit<InvoiceRow, "updatedAt">>();
+  return (
+    (await createDrizzle(db)
+      .select(invoiceSummaryColumns)
+      .from(invoices)
+      .where(eq(invoices.id, invoiceId))
+      .limit(1)
+      .get()) ?? null
+  );
 }

--- a/apps/worker/tests/features/activity/search.test.ts
+++ b/apps/worker/tests/features/activity/search.test.ts
@@ -46,6 +46,11 @@ function fixture() {
         async all() {
           return { results: database.prepare(sql).all(...(values as never[])) };
         },
+        async raw() {
+          const statement = database.prepare(sql);
+          statement.setReturnArrays(true);
+          return statement.all(...(values as never[]));
+        },
         async first() {
           return database.prepare(sql).get(...(values as never[])) ?? null;
         },
@@ -67,7 +72,7 @@ describe("global activity search", () => {
       queries.filter((sql) => sql.includes("WITH candidates")),
     ).toHaveLength(1);
     expect(
-      queries.filter((sql) => sql.includes("LEFT JOIN bank_balance_snapshots")),
+      queries.filter((sql) => /bank_balance_snapshots/i.test(sql)),
     ).toHaveLength(1);
     const invoiceOnly = await searchActivity(db, {
       q: "airbnb",

--- a/apps/worker/tests/features/activity/search.test.ts
+++ b/apps/worker/tests/features/activity/search.test.ts
@@ -13,6 +13,18 @@ const databases: DatabaseSync[] = [];
 afterEach(() => {
   for (const db of databases.splice(0)) db.close();
 });
+
+/** This Node sqlite bind API only accepts anonymous `?`; expand D1 `?1` placeholders. */
+function expandNumberedParams(sql: string, values: unknown[]) {
+  const expanded: unknown[] = [];
+  const rewritten = sql.replace(/\?(\d+)/g, (_, index) => {
+    expanded.push(values[Number(index) - 1]);
+    return "?";
+  });
+  return expanded.length > 0
+    ? { sql: rewritten, values: expanded }
+    : { sql, values };
+}
 function fixture() {
   const database = new DatabaseSync(":memory:");
   databases.push(database);
@@ -44,15 +56,27 @@ function fixture() {
           return result;
         },
         async all() {
-          return { results: database.prepare(sql).all(...(values as never[])) };
+          const query = expandNumberedParams(sql, values);
+          return {
+            results: database
+              .prepare(query.sql)
+              .all(...(query.values as never[])),
+          };
         },
         async raw() {
-          const statement = database.prepare(sql);
-          statement.setReturnArrays(true);
-          return statement.all(...(values as never[]));
+          const query = expandNumberedParams(sql, values);
+          return (
+            database
+              .prepare(query.sql)
+              .all(...(query.values as never[])) as Record<string, unknown>[]
+          ).map((row) => Object.values(row));
         },
         async first() {
-          return database.prepare(sql).get(...(values as never[])) ?? null;
+          const query = expandNumberedParams(sql, values);
+          return (
+            database.prepare(query.sql).get(...(query.values as never[])) ??
+            null
+          );
         },
       };
       return result;

--- a/apps/worker/tests/features/bank/repository.test.ts
+++ b/apps/worker/tests/features/bank/repository.test.ts
@@ -3,8 +3,12 @@ import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  listBankAccounts,
+  listBankTransactions,
   listBankTransactionsForTransferMatching,
   listBankTransactionsInRange,
+  listCreditCardBills,
+  listCreditCardBillsInRange,
   type BankTransactionPageRow,
 } from "../../../src/features/bank/repository";
 import { listInvoicesInRange } from "../../../src/features/invoices/repository";
@@ -41,6 +45,16 @@ class SqliteD1 {
             .prepare(sql)
             .all(...(values as never[])) as T[],
         };
+      },
+      async raw() {
+        const prepared = this.database.prepare(sql);
+        prepared.setReturnArrays(true);
+        return prepared.all(...(values as never[]));
+      },
+      async first<T>() {
+        return (
+          (this.database.prepare(sql).get(...(values as never[])) as T) ?? null
+        );
       },
       database: this.database,
     };
@@ -163,5 +177,112 @@ describe("bank transaction transfer candidates", () => {
     );
 
     expect(rows).toEqual([]);
+  });
+});
+
+describe("bank list and detail queries", () => {
+  it("joins the latest balance and hides canonical or inactive accounts", async () => {
+    const db = createDb();
+    db.database.exec(`
+      INSERT INTO bank_accounts
+        (id, connector_id, source_id, institution_name, account_name, account_type,
+         currency, canonical_account_id, inactive_at, opened_date, maturity_date,
+         created_at, updated_at)
+      VALUES
+        ('canonical', 'tdcc', 'canonical', '測試銀行', '別名', 'savings', 'TWD',
+         'account-a', NULL, NULL, NULL, '2026-08-22', '2026-08-22'),
+        ('inactive', 'tdcc', 'inactive', '測試銀行', '停用', 'savings', 'TWD',
+         NULL, '2026-08-01', NULL, NULL, '2026-08-22', '2026-08-22');
+      INSERT INTO bank_balance_snapshots
+        (id, connector_id, account_id, source_id, balance, currency, as_of_at,
+         created_at, updated_at)
+      VALUES
+        ('old', 'tdcc', 'account-a', 'old', 100, 'TWD', '2026-08-01', '2026-08-01', '2026-08-01'),
+        ('new', 'tdcc', 'account-a', 'new', 250, 'TWD', '2026-08-22', '2026-08-22', '2026-08-22');
+    `);
+    const rows = await listBankAccounts(db as unknown as D1Database);
+    expect(rows.map((row) => row.id).sort()).toEqual([
+      "account-a",
+      "account-b",
+      "account-c",
+    ]);
+    expect(rows.find((row) => row.id === "account-a")).toMatchObject({
+      balance: 250,
+      openedDate: null,
+      maturityDate: null,
+    });
+    expect(rows.find((row) => row.id === "account-b")).toMatchObject({
+      balance: null,
+      availableBalance: null,
+      asOfAt: null,
+    });
+  });
+
+  it("hides matched pending rows and keeps unmatched pending plus user prefs", async () => {
+    const db = createDb();
+    db.database.exec(`
+      UPDATE bank_transactions SET matched_transaction_id = 'out' WHERE id = 'pending';
+      INSERT INTO bank_transactions
+        (id, connector_id, account_id, source_id, posted_date, amount, currency,
+         status, created_at, updated_at)
+      VALUES
+        ('open-pending', 'tdcc', 'account-a', 'open-pending', '2026-08-21', -50, 'TWD',
+         'pending', '2026-08-21', '2026-08-21');
+      INSERT INTO bank_transaction_preferences
+        (transaction_id, excluded_from_calculation, created_at, updated_at)
+      VALUES ('out', 1, '2026-08-22', '2026-08-22');
+    `);
+    const rows = await listBankTransactions(db as unknown as D1Database, 20);
+    expect(rows.map((row) => row.id)).toEqual([
+      "other-day",
+      "late",
+      "out",
+      "in",
+      "open-pending",
+    ]);
+    expect(rows.find((row) => row.id === "out")).toMatchObject({
+      status: "posted",
+      calculationPreference: 1,
+    });
+    expect(rows.find((row) => row.id === "open-pending")).toMatchObject({
+      status: "pending",
+      calculationPreference: null,
+    });
+    expect(rows.some((row) => row.id === "pending")).toBe(false);
+    const next = await listBankTransactions(db as unknown as D1Database, 2, {
+      effectiveDate: "2026-08-22",
+      updatedAt: "2026-08-22",
+      id: "out",
+    });
+    expect(next.map((row) => row.id)).toEqual(["in", "open-pending"]);
+  });
+
+  it("pages credit-card bills and filters by YYYY-MM TEXT boundaries", async () => {
+    const db = createDb();
+    db.database.exec(`
+      INSERT INTO credit_card_bills (
+        id, connector_id, account_id, source_id, billing_period, currency,
+        created_at, updated_at
+      ) VALUES
+        ('jul', 'tdcc', 'account-a', 'jul', '2026-07', 'TWD', '2026-07-01', '2026-07-01'),
+        ('aug-b', 'tdcc', 'account-b', 'aug-b', '2026-08', 'TWD', '2026-08-01', '2026-08-01'),
+        ('aug-a', 'tdcc', 'account-a', 'aug-a', '2026-08', 'TWD', '2026-08-01', '2026-08-01');
+    `);
+    const first = await listCreditCardBills(db as unknown as D1Database, 2);
+    expect(first.map((row) => row.id)).toEqual(["aug-a", "aug-b"]);
+    const next = await listCreditCardBills(db as unknown as D1Database, 2, {
+      billingPeriod: first[1].billingPeriod,
+      accountId: first[1].accountId,
+      id: first[1].id,
+    });
+    expect(next.map((row) => row.id)).toEqual(["jul"]);
+    expect(
+      (
+        await listCreditCardBillsInRange(db as unknown as D1Database, {
+          from: "2026-08-01",
+          to: "2026-09-01",
+        })
+      ).map((row) => row.id),
+    ).toEqual(["aug-a", "aug-b"]);
   });
 });

--- a/apps/worker/tests/features/bank/repository.test.ts
+++ b/apps/worker/tests/features/bank/repository.test.ts
@@ -47,9 +47,12 @@ class SqliteD1 {
         };
       },
       async raw() {
-        const prepared = this.database.prepare(sql);
-        prepared.setReturnArrays(true);
-        return prepared.all(...(values as never[]));
+        return (
+          this.database.prepare(sql).all(...(values as never[])) as Record<
+            string,
+            unknown
+          >[]
+        ).map((row) => Object.values(row));
       },
       async first<T>() {
         return (

--- a/apps/worker/tests/features/bank/service.test.ts
+++ b/apps/worker/tests/features/bank/service.test.ts
@@ -28,6 +28,32 @@ function transaction(
   };
 }
 
+function bankTransactionRawValues(row: BankTransactionPageRow) {
+  return [
+    row.id,
+    row.connectorId,
+    row.accountId,
+    row.accountSourceId,
+    row.accountName,
+    row.institutionName,
+    row.accountType,
+    row.bankCode,
+    row.accountLast4,
+    row.sourceId,
+    row.transferPeerId ?? null,
+    row.postedDate,
+    row.authorizedAt,
+    row.amount,
+    row.currency,
+    row.description,
+    row.counterparty,
+    row.status,
+    row.effectiveDate,
+    row.updatedAt,
+    row.calculationPreference,
+  ];
+}
+
 function createDb(
   visibleTransactions: BankTransactionPageRow[],
   candidateTransactions: BankTransactionPageRow[],
@@ -46,7 +72,12 @@ function createDb(
           return statement;
         },
         async raw() {
-          return (await this.all()).results.map((row) => Object.values(row));
+          const { results } = await this.all();
+          return results.map((row) =>
+            "effectiveDate" in row && "accountSourceId" in row
+              ? bankTransactionRawValues(row as BankTransactionPageRow)
+              : Object.values(row),
+          );
         },
         async all() {
           if (sql.includes("ABS(txn.amount)"))
@@ -56,7 +87,11 @@ function createDb(
           if (sql.includes("classification_overrides"))
             return { results: classificationOverrides };
           if (sql.includes("classification_rules")) return { results: [] };
-          if (sql.includes("FROM bank_accounts")) return { results: [] };
+          if (
+            sql.includes("bank_accounts") &&
+            !sql.includes("bank_transactions")
+          )
+            return { results: [] };
           throw new Error(`Unexpected query: ${sql} (${values.join(",")})`);
         },
       };

--- a/apps/worker/tests/features/classification/default-rules.test.ts
+++ b/apps/worker/tests/features/classification/default-rules.test.ts
@@ -36,9 +36,9 @@ function asD1(database: DatabaseSync) {
           return this;
         },
         async raw() {
-          const statement = database.prepare(sql);
-          statement.setReturnArrays(true);
-          return statement.all(...params);
+          return (
+            database.prepare(sql).all(...params) as Record<string, unknown>[]
+          ).map((row) => Object.values(row));
         },
         async all() {
           return { results: database.prepare(sql).all(...params) };

--- a/apps/worker/tests/features/investments/repository.test.ts
+++ b/apps/worker/tests/features/investments/repository.test.ts
@@ -1,0 +1,161 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createTestD1 } from "../../../../../packages/db/testing/d1";
+import * as repository from "../../../src/features/investments/repository";
+
+const now = "2026-09-12T00:00:00.000Z";
+
+describe("investment repository", () => {
+  let harness: Awaited<ReturnType<typeof createTestD1>>;
+  beforeAll(async () => {
+    harness = await createTestD1();
+  }, 60_000);
+  afterAll(async () => {
+    await harness?.mf.dispose();
+  });
+  beforeEach(async () => {
+    await harness.binding.batch([
+      harness.binding.prepare("DELETE FROM investment_transactions"),
+      harness.binding.prepare("DELETE FROM investment_positions"),
+    ]);
+  });
+
+  async function position(input: {
+    id: string;
+    connectorId?: string;
+    sourceId: string;
+    assetType: "stock" | "etf" | "fund";
+    name: string;
+    asOfDate: string;
+  }) {
+    await harness.binding
+      .prepare(
+        `INSERT INTO investment_positions (
+          id, connector_id, source_id, asset_type, name, currency,
+          as_of_date, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, 'TWD', ?, ?, ?)`,
+      )
+      .bind(
+        input.id,
+        input.connectorId ?? "tdcc",
+        input.sourceId,
+        input.assetType,
+        input.name,
+        input.asOfDate,
+        now,
+        now,
+      )
+      .run();
+  }
+
+  async function trade(input: {
+    id: string;
+    sourceId: string;
+    tradeDate?: string | null;
+    postedDate?: string | null;
+    updatedAt?: string;
+    name?: string;
+  }) {
+    await harness.binding
+      .prepare(
+        `INSERT INTO investment_transactions (
+          id, connector_id, account_id, source_id, name, currency,
+          trade_date, posted_date, created_at, updated_at
+        ) VALUES (?, 'tdcc', 'broker', ?, ?, 'TWD', ?, ?, ?, ?)`,
+      )
+      .bind(
+        input.id,
+        input.sourceId,
+        input.name ?? input.id,
+        input.tradeDate ?? null,
+        input.postedDate ?? null,
+        now,
+        input.updatedAt ?? now,
+      )
+      .run();
+  }
+
+  it("lists the latest position per connector and asset type with keyset pagination", async () => {
+    const db = harness.binding;
+    await position({
+      id: "old-stock",
+      sourceId: "2330-old",
+      assetType: "stock",
+      name: "台積電",
+      asOfDate: "2026-08-01",
+    });
+    await position({
+      id: "new-stock-b",
+      sourceId: "2330-b",
+      assetType: "stock",
+      name: "台積電B",
+      asOfDate: "2026-09-01",
+    });
+    await position({
+      id: "new-stock-a",
+      sourceId: "2330-a",
+      assetType: "stock",
+      name: "台積電A",
+      asOfDate: "2026-09-01",
+    });
+    await position({
+      id: "fund",
+      connectorId: "manual",
+      sourceId: "fund-1",
+      assetType: "fund",
+      name: "現金",
+      asOfDate: "2026-07-01",
+    });
+    const first = await repository.listLatestInvestmentPositions(db, 2);
+    expect(first.map((row) => row.id)).toEqual(["new-stock-a", "new-stock-b"]);
+    const next = await repository.listLatestInvestmentPositions(db, 2, {
+      asOfDate: first[1].asOfDate,
+      assetType: first[1].assetType,
+      name: first[1].name,
+      id: first[1].id,
+    });
+    expect(next.map((row) => row.id)).toEqual(["fund"]);
+    expect(next.some((row) => row.id === "old-stock")).toBe(false);
+  });
+
+  it("pages transactions by effective_date and filters TEXT date ranges", async () => {
+    const db = harness.binding;
+    await trade({
+      id: "aug",
+      sourceId: "aug",
+      tradeDate: "2026-08-31",
+    });
+    await trade({
+      id: "sep-old",
+      sourceId: "sep-old",
+      postedDate: "2026-09-01",
+      updatedAt: "2026-09-01T01:00:00.000Z",
+    });
+    await trade({
+      id: "sep-new",
+      sourceId: "sep-new",
+      tradeDate: "2026-09-01",
+      updatedAt: "2026-09-01T02:00:00.000Z",
+    });
+    const first = await repository.listInvestmentTransactions(db, 2);
+    expect(first.map((row) => row.id)).toEqual(["sep-new", "sep-old"]);
+    const next = await repository.listInvestmentTransactions(db, 2, {
+      effectiveDate: first[1].effectiveDate,
+      updatedAt: first[1].updatedAt,
+      id: first[1].id,
+    });
+    expect(next.map((row) => row.id)).toEqual(["aug"]);
+    const range = { from: "2026-09-01", to: "2026-10-01" };
+    expect(
+      (await repository.listInvestmentTransactionsInRange(db, range)).map(
+        (row) => row.id,
+      ),
+    ).toEqual(["sep-new", "sep-old"]);
+    expect(
+      (
+        await repository.listInvestmentTransactionsInRange(db, range, [
+          "2026-09-01",
+        ])
+      ).map((row) => row.id),
+    ).toEqual(["sep-new", "sep-old"]);
+  });
+});

--- a/apps/worker/tests/features/invoices/repository.test.ts
+++ b/apps/worker/tests/features/invoices/repository.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createTestD1 } from "../../../../../packages/db/testing/d1";
+import * as repository from "../../../src/features/invoices/repository";
+
+const now = "2026-09-12T00:00:00.000Z";
+
+describe("invoice repository", () => {
+  let harness: Awaited<ReturnType<typeof createTestD1>>;
+  beforeAll(async () => {
+    harness = await createTestD1();
+  }, 60_000);
+  afterAll(async () => {
+    await harness?.mf.dispose();
+  });
+  beforeEach(async () => {
+    await harness.binding.batch([
+      harness.binding.prepare("DELETE FROM invoice_line_items"),
+      harness.binding.prepare("DELETE FROM invoices"),
+    ]);
+  });
+
+  async function invoice(input: {
+    id: string;
+    sourceId: string;
+    invoiceDate: string;
+    amount?: number;
+    sellerName?: string | null;
+    invoiceNumber?: string | null;
+    updatedAt?: string;
+  }) {
+    await harness.binding
+      .prepare(
+        `INSERT INTO invoices (
+          id, connector_id, source_id, invoice_number, invoice_date,
+          seller_name, amount, created_at, updated_at
+        ) VALUES (?, 'einvoice', ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        input.id,
+        input.sourceId,
+        input.invoiceNumber ?? null,
+        input.invoiceDate,
+        input.sellerName ?? null,
+        input.amount ?? 100,
+        now,
+        input.updatedAt ?? now,
+      )
+      .run();
+  }
+
+  it("pages by invoice_date, updated_at and id and finds a detail row", async () => {
+    const db = harness.binding;
+    await invoice({
+      id: "c",
+      sourceId: "c",
+      invoiceDate: "2026-09-01",
+      updatedAt: "2026-09-01T01:00:00.000Z",
+    });
+    await invoice({
+      id: "b",
+      sourceId: "b",
+      invoiceDate: "2026-09-01",
+      updatedAt: "2026-09-01T02:00:00.000Z",
+    });
+    await invoice({
+      id: "a",
+      sourceId: "a",
+      invoiceDate: "2026-09-02",
+    });
+    await expect(repository.findInvoice(db, "missing")).resolves.toBeNull();
+    await expect(repository.findInvoice(db, "a")).resolves.toMatchObject({
+      id: "a",
+      connectorId: "einvoice",
+      sourceId: "a",
+      invoiceNumber: null,
+      sellerName: null,
+      amount: 100,
+    });
+    expect(await repository.findInvoice(db, "a")).not.toHaveProperty(
+      "updatedAt",
+    );
+    const first = await repository.listInvoices(db, 2);
+    expect(first.map((row) => row.id)).toEqual(["a", "b"]);
+    const next = await repository.listInvoices(db, 2, {
+      invoiceDate: first[1].invoiceDate,
+      updatedAt: first[1].updatedAt,
+      id: first[1].id,
+    });
+    expect(next.map((row) => row.id)).toEqual(["c"]);
+  });
+
+  it("uses Taipei calendar days for precise timestamps at month boundaries", async () => {
+    const db = harness.binding;
+    await invoice({
+      id: "sep",
+      sourceId: "sep",
+      invoiceDate: "2026-08-31T16:30:00.000Z",
+    });
+    await invoice({
+      id: "aug",
+      sourceId: "aug",
+      invoiceDate: "2026-08-31T15:59:00.000Z",
+    });
+    await invoice({
+      id: "date",
+      sourceId: "date",
+      invoiceDate: "2026-09-01",
+    });
+    const range = { from: "2026-09-01", to: "2026-10-01" };
+    expect(
+      (await repository.listInvoicesInRange(db, range))
+        .map((row) => row.id)
+        .sort(),
+    ).toEqual(["date", "sep"]);
+    expect(
+      (await repository.listInvoicesInRange(db, range, ["2026-09-01"]))
+        .map((row) => row.id)
+        .sort(),
+    ).toEqual(["date", "sep"]);
+  });
+
+  it("lists line items in invoice, line and source order", async () => {
+    const db = harness.binding;
+    await invoice({
+      id: "inv-b",
+      sourceId: "inv-b",
+      invoiceDate: "2026-09-01",
+    });
+    await invoice({
+      id: "inv-a",
+      sourceId: "inv-a",
+      invoiceDate: "2026-09-01",
+    });
+    await db
+      .prepare(
+        `INSERT INTO invoice_line_items (
+          id, invoice_id, connector_id, invoice_source_id, source_id,
+          line_number, description, quantity, unit_price, amount,
+          created_at, updated_at
+        ) VALUES
+          ('b2', 'inv-b', 'einvoice', 'inv-b', 'b2', 1, '後', NULL, NULL, 2, ?, ?),
+          ('a2', 'inv-a', 'einvoice', 'inv-a', 'a2', 2, '二', 1, 20, 20, ?, ?),
+          ('a1', 'inv-a', 'einvoice', 'inv-a', 'a1', 1, '一', 2, 10, 20, ?, ?)`,
+      )
+      .bind(now, now, now, now, now, now)
+      .run();
+    await expect(repository.listInvoiceItems(db, [])).resolves.toEqual([]);
+    expect(
+      (await repository.listInvoiceItems(db, ["inv-a", "inv-b"])).map(
+        (row) => row.id,
+      ),
+    ).toEqual(["a1", "a2", "b2"]);
+  });
+});

--- a/apps/worker/tests/features/month-range-routes.test.ts
+++ b/apps/worker/tests/features/month-range-routes.test.ts
@@ -15,6 +15,10 @@ function createDb() {
           calls.push({ sql, values });
           return statement;
         },
+        async raw() {
+          if (!values.length) calls.push({ sql, values });
+          return [];
+        },
         async all() {
           if (!values.length) calls.push({ sql, values });
           return { results: [] };
@@ -39,7 +43,11 @@ describe("month-filtered resource APIs", () => {
       transactions: [],
     });
     expect(
-      calls.some(({ sql }) => sql.includes("COALESCE(txn.authorized_at")),
+      calls.some(
+        ({ sql }) =>
+          sql.includes("COALESCE(txn.authorized_at") ||
+          /authorized_at/.test(sql),
+      ),
     ).toBe(true);
     expect(
       calls.some(({ values }) => values.join(",") === "2026-07-01,2026-08-01"),
@@ -54,9 +62,11 @@ describe("month-filtered resource APIs", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual([]);
-    expect(calls.some(({ sql }) => sql.includes("b.billing_period >="))).toBe(
-      true,
-    );
+    expect(
+      calls.some(
+        ({ sql }) => sql.includes("billing_period") && sql.includes("substr("),
+      ),
+    ).toBe(true);
     expect(
       calls.some(({ values }) => values.join(",") === "2026-07-01,2026-08-01"),
     ).toBe(true);
@@ -112,6 +122,18 @@ describe("month-filtered resource APIs", () => {
         const statement = {
           bind() {
             return statement;
+          },
+          async raw() {
+            return invoiceRows.map((row) => [
+              row.id,
+              row.connectorId,
+              row.sourceId,
+              row.invoiceNumber,
+              row.invoiceDate,
+              row.sellerName,
+              row.amount,
+              row.updatedAt,
+            ]);
           },
           async all() {
             return { results: invoiceRows };

--- a/apps/worker/tests/features/sync/persistence.test.ts
+++ b/apps/worker/tests/features/sync/persistence.test.ts
@@ -52,9 +52,11 @@ class SqliteStatement {
 
   async raw() {
     this.owner.executedSql.push(this.sql);
-    const statement = this.owner.database.prepare(this.sql);
-    statement.setReturnArrays(true);
-    return statement.all(...(this.values as never[]));
+    return (
+      this.owner.database
+        .prepare(this.sql)
+        .all(...(this.values as never[])) as Record<string, unknown>[]
+    ).map((row) => Object.values(row));
   }
 
   async first<T>() {

--- a/apps/worker/tests/features/sync/persistence.test.ts
+++ b/apps/worker/tests/features/sync/persistence.test.ts
@@ -29,6 +29,18 @@ import {
   reconcileSinopacLegacyTransactionStatements,
 } from "../../../src/features/sync/repository";
 
+/** This Node sqlite bind API only accepts anonymous `?`; expand D1 `?1` placeholders. */
+function expandNumberedParams(sql: string, values: unknown[]) {
+  const expanded: unknown[] = [];
+  const rewritten = sql.replace(/\?(\d+)/g, (_, index) => {
+    expanded.push(values[Number(index) - 1]);
+    return "?";
+  });
+  return expanded.length > 0
+    ? { sql: rewritten, values: expanded }
+    : { sql, values };
+}
+
 class SqliteStatement {
   private values: unknown[] = [];
 
@@ -52,36 +64,39 @@ class SqliteStatement {
 
   async raw() {
     this.owner.executedSql.push(this.sql);
+    const query = expandNumberedParams(this.sql, this.values);
     return (
       this.owner.database
-        .prepare(this.sql)
-        .all(...(this.values as never[])) as Record<string, unknown>[]
+        .prepare(query.sql)
+        .all(...(query.values as never[])) as Record<string, unknown>[]
     ).map((row) => Object.values(row));
   }
 
   async first<T>() {
     this.owner.executedSql.push(this.sql);
+    const query = expandNumberedParams(this.sql, this.values);
     return (
       (this.owner.database
-        .prepare(this.sql)
-        .get(...(this.values as never[])) as T) ?? null
+        .prepare(query.sql)
+        .get(...(query.values as never[])) as T) ?? null
     );
   }
 
   execute() {
     this.owner.executedSql.push(this.sql);
-    if (/^\s*(SELECT|WITH)\b/i.test(this.sql)) {
+    const query = expandNumberedParams(this.sql, this.values);
+    if (/^\s*(SELECT|WITH)\b/i.test(query.sql)) {
       return {
         success: true,
         meta: { changes: 0 },
         results: this.owner.database
-          .prepare(this.sql)
-          .all(...(this.values as never[])),
+          .prepare(query.sql)
+          .all(...(query.values as never[])),
       };
     }
     const result = this.owner.database
-      .prepare(this.sql)
-      .run(...(this.values as never[]));
+      .prepare(query.sql)
+      .run(...(query.values as never[]));
     return {
       success: true,
       meta: { changes: Number(result.changes) },

--- a/docs/002-backend-architecture.md
+++ b/docs/002-backend-architecture.md
@@ -250,7 +250,7 @@ Drizzle 型別只留在 DB 與 Worker repository 層。`packages/core`、前端�
 
 Feature-specific 查詢應放在 feature 的 `repository.ts`，而不是持續擴大 `packages/db/src/index.ts`。一般 repository 以 Drizzle 為預設寫法；同步 lease、staging promotion 等尚未轉換的路徑仍使用原生 D1。
 
-分類 repository 已轉換為 Drizzle；規則重排維持單一 batch，保留 NOCASE 分類唯一性、系統規則保護與 override conflict target。
+分類 repository 已轉換為 Drizzle；規則重排維持單一 batch，保留 NOCASE 分類唯一性、系統規則保護與 override conflict target。invoices、investments 與 bank 的一般列表／明細查詢已轉換為 Drizzle，保留游標分頁、LEFT JOIN null、pending／posted 可見性與 TEXT 日期邊界；銀行交易日條件維持可使用 `idx_bank_transactions_transaction_day`。dashboard／activity 聚合與同步 lease／staging 仍使用原生 D1。
 
 資料庫 schema 與預設資料必須透過：
 

--- a/docs/006-drizzle-adoption-plan.md
+++ b/docs/006-drizzle-adoption-plan.md
@@ -1,6 +1,6 @@
 # Drizzle 導入實作計畫
 
-日期：2026-09-12。狀態：階段 1–2 與 3A–3B 已落地（schema／client、exchange-rates、manual-assets、notifications、classification 與 connector settings）；階段 3C–5 待實作。SQL migrations 仍是 schema 權威，正式環境不使用 `drizzle-kit push`。
+日期：2026-09-12。狀態：階段 1–2 與 3A–3C 已落地（schema／client、exchange-rates、manual-assets、notifications、classification、connector settings，以及 invoices／investments／bank 一般列表／明細）；階段 3D–5 待實作。SQL migrations 仍是 schema 權威，正式環境不使用 `drizzle-kit push`。
 
 ## 目標與建議方案
 
@@ -86,6 +86,14 @@
 - 共用 connector settings／cursor 改用 Drizzle；connectors repository 沿用既有委派介面。設定 upsert 不覆蓋既有 ID、created_at 或 sync_cursor，public config 與 cursor 更新僅修改指定欄位。
 - 設定存取邊界使用 sanitizeDatabaseError，避免 Drizzle 綁定參數流入 API log 或同步錯誤紀錄；隔離 D1 測試涵蓋上述保留語意、排序回滾及敏感參數遮罩。
 - 此批未變更 schema、ID 格式、SQL migrations 或部署流程；下一批為 3C。Schema／ID 調整另行規劃 migration。
+
+3C 已完成：
+
+- invoices 列表／區間／明細與 line items 改用 Drizzle，保留 invoice_date／updated_at／id 游標、Taipei 日界與 json_each 批次查詢。
+- investments 最新持倉與交易列表／區間改用 Drizzle，保留 per-connector＋asset_type 的最新 as_of_date、effective_date 游標與 TEXT 日期邊界。
+- bank 帳戶、交易、信用卡帳單的一般列表／明細改用 Drizzle；帳戶 latest snapshot 維持 LEFT JOIN null，pending 僅在未 matching 時可見，使用者 calculation preference 可為 null。
+- 銀行交易日條件維持與 `idx_bank_transactions_transaction_day` 相同的 CASE 運算式；既有 `EXPLAIN QUERY PLAN` 測試繼續驗證索引。
+- dashboard／net-worth／activity 聚合、bank calculation／search 與同步 lease／staging 仍留待 3D／4；此批未變更 schema、ID 格式或 SQL migrations。
 
 保留並延伸 `bank/repository.test.ts` 既有 `EXPLAIN QUERY PLAN` 測試，尤其 `idx_bank_transactions_transaction_day`。不得把可使用 expression index 的條件改寫成無法使用索引的等價運算，或將資料全取回 JavaScript 才篩選。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

延續 `codex/drizzle-stage-3b` @ `3e8b190`（階段 3B），將 `invoices`、`investments` 與 `bank` 的一般列表／明細查詢改為 Drizzle。不重做階段 1–2 或 3A。

## 行為保留

- API shape、排序與游標分頁
- 發票／銀行交易的 Taipei 日界與 TEXT 日期比較
- 帳戶 latest snapshot 的 LEFT JOIN null
- pending 僅在未 matching 時可見；使用者 calculation preference 可為 null
- 銀行交易日條件維持與 `idx_bank_transactions_transaction_day` 相同的 CASE 運算式，既有 `EXPLAIN QUERY PLAN` 繼續驗證索引
- 既有 D1 batch 原子邊界未改寫；此批沒有把 batch 換成逐一 await 或 `Promise.all`

## 文件

- 已更新 `docs/006-drizzle-adoption-plan.md`（3C 完成、下一步 3D／4／5）
- 已更新 `docs/002-backend-architecture.md` 與 `AGENTS.md` 的轉換範圍
- 未改 schema／migrations，因此未重跑 `db:schema:docs`

## 明確非目標

- 階段 3D：dashboard／net-worth／activity／bank calculation／search 聚合
- 階段 4：sync lease／staging
- 階段 5：Drizzle Kit
- Schema migration、UUID／int、ID 前綴、NOT NULL
- 正式 D1 寫入、真實銀行同步、合併到 main

## 驗證

已從 repo root 通過與 CI 相同的檢查：

- `npm run format:check`
- `npm run typecheck`
- `npm run test:backend`：Worker 535、`@taiwan-fin-hub/db` 10、connector self-checks、deployment tests 16

未連線正式 D1，也未執行真實銀行同步。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45390eb9-4030-4ad1-94fe-1ef38fa0ef0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45390eb9-4030-4ad1-94fe-1ef38fa0ef0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

