### PR TITLE
fix(sync): 修正未設定來源被誤判為等待首次同步

### DIFF
--- a/apps/worker/src/features/sync/notification-batch-repository.ts
+++ b/apps/worker/src/features/sync/notification-batch-repository.ts
@@ -2,6 +2,7 @@ import {
   createDrizzle,
   sanitizeDatabaseError,
   syncJobs,
+  syncJobConfiguredJoin,
   syncJobSelection,
   connectorSettings,
   scheduledSyncBatches,
@@ -50,10 +51,10 @@ export async function ensureDefaultScheduleBatch(db: D1Database) {
       connector_id: sql<ConnectorId>`${syncJobs.connectorId}`,
     })
     .from(syncJobs)
+    .innerJoin(connectorSettings, syncJobConfiguredJoin)
     .where(
       and(
         eq(syncJobs.enabled, 1),
-        sql`EXISTS (SELECT 1 FROM ${connectorSettings} WHERE ${connectorSettings.connectorId} = ${syncJobs.connectorId})`,
         eq(syncJobs.scheduleMode, "inherit"),
         or(
           isNull(syncJobs.lastStatus),
@@ -135,12 +136,12 @@ export async function findNextDefaultScheduleBatchJob(
     .select(syncJobSelection)
     .from(scheduledSyncBatchResults)
     .innerJoin(syncJobs, eq(syncJobs.id, scheduledSyncBatchResults.jobId))
+    .innerJoin(connectorSettings, syncJobConfiguredJoin)
     .where(
       and(
         eq(scheduledSyncBatchResults.batchId, batchId),
         isNull(scheduledSyncBatchResults.completedAt),
         eq(syncJobs.enabled, 1),
-        sql`EXISTS (SELECT 1 FROM ${connectorSettings} WHERE ${connectorSettings.connectorId} = ${syncJobs.connectorId})`,
         eq(syncJobs.scheduleMode, "inherit"),
         or(
           isNull(syncJobs.lastStatus),

--- a/apps/worker/src/features/sync/schedule-repository.ts
+++ b/apps/worker/src/features/sync/schedule-repository.ts
@@ -4,6 +4,8 @@ import {
   syncJobs,
   syncScheduleSettings,
   connectorSettings,
+  syncJobConfiguredJoin,
+  syncJobConfiguredSelection,
   syncJobSelection,
 } from "@taiwan-fin-hub/db";
 import { and, asc, eq, sql } from "drizzle-orm";
@@ -109,7 +111,7 @@ export async function listSyncJobs(db: D1Database) {
     .select({
       id: sql<string>`${syncJobs.id}`,
       connectorId: sql<ConnectorId>`${syncJobs.connectorId}`,
-      configured: sql<number>`EXISTS (SELECT 1 FROM ${connectorSettings} WHERE ${connectorSettings.connectorId} = ${syncJobs.connectorId})`,
+      configured: syncJobConfiguredSelection,
       scope: syncJobs.scope,
       enabled: syncJobs.enabled,
       intervalMinutes: syncJobs.intervalMinutes,
@@ -128,6 +130,7 @@ export async function listSyncJobs(db: D1Database) {
       updatedAt: syncJobs.updatedAt,
     })
     .from(syncJobs)
+    .leftJoin(connectorSettings, syncJobConfiguredJoin)
     .orderBy(asc(syncJobs.connectorId), asc(syncJobs.scope))
     .all()
     .catch((error) => {

--- a/apps/worker/tests/features/sync/drizzle-runtime.test.ts
+++ b/apps/worker/tests/features/sync/drizzle-runtime.test.ts
@@ -146,6 +146,23 @@ describe("階段 4：隔離 D1 lease 與 promotion", () => {
       ["tdcc:all", 1],
       ["tdcc:bank", 1],
     ]);
+    await db.prepare("DELETE FROM connector_settings").run();
+    expect((await listSyncJobs(db)).every((row) => !row.configured)).toBe(true);
+    await db
+      .prepare(
+        "INSERT INTO connector_settings (id, connector_id, encrypted_config, created_at, updated_at) VALUES ('tdcc', 'tdcc', 'synthetic', ?, ?)",
+      )
+      .bind(now, now)
+      .run();
+    const configuredJobs = (await listSyncJobs(db)).filter(
+      (row) => row.configured && row.scope === "all",
+    );
+    expect(configuredJobs).toEqual([
+      expect.objectContaining({ connectorId: "tdcc", configured: 1 }),
+    ]);
+    expect(
+      (await listSyncJobs(db)).filter((row) => row.configured).length,
+    ).toBe(2);
     expect(
       (await listInheritedSyncJobs(db)).sort((a, b) =>
         a.id.localeCompare(b.id),

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -115,6 +115,9 @@ function rethrowSettingsError(error: unknown): never {
 }
 
 export {
+  hasConnectorSettings,
+  syncJobConfiguredJoin,
+  syncJobConfiguredSelection,
   syncJobSelection,
   acquireSyncJobLock,
   completeSyncJob,

--- a/packages/db/src/sync-jobs.ts
+++ b/packages/db/src/sync-jobs.ts
@@ -1,4 +1,15 @@
-import { and, asc, eq, isNull, lt, lte, ne, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  exists,
+  isNull,
+  lt,
+  lte,
+  ne,
+  or,
+  sql,
+} from "drizzle-orm";
 import { createDrizzle } from "./client";
 import { sanitizeDatabaseError } from "./errors";
 import { syncJobs, connectorSettings } from "./schema";
@@ -27,6 +38,22 @@ export interface SyncJobRow<TConnectorId extends string = string> {
   last_error: string | null;
   created_at: string;
   updated_at: string;
+}
+
+export const syncJobConfiguredJoin = eq(
+  connectorSettings.connectorId,
+  syncJobs.connectorId,
+);
+
+export const syncJobConfiguredSelection = sql<number>`CASE WHEN ${connectorSettings.connectorId} IS NOT NULL THEN 1 ELSE 0 END`;
+
+export function hasConnectorSettings(db: ReturnType<typeof createDrizzle>) {
+  return exists(
+    db
+      .select({ one: sql`1` })
+      .from(connectorSettings)
+      .where(syncJobConfiguredJoin),
+  );
 }
 
 export const syncJobSelection = {
@@ -107,7 +134,7 @@ export async function findNextDueSyncJob<TConnectorId extends string>(
     .where(
       and(
         eq(syncJobs.enabled, 1),
-        sql`EXISTS (SELECT 1 FROM ${connectorSettings} WHERE ${connectorSettings.connectorId} = ${syncJobs.connectorId})`,
+        hasConnectorSettings(createDrizzle(db)),
         or(
           isNull(syncJobs.lastStatus),
           ne(syncJobs.lastStatus, "needs_user_action"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 問題

Drizzle 階段 4 將 `listSyncJobs` 的 `configured` 判斷改為 Drizzle `sql` 模板中的 `EXISTS` 子查詢後，產生的 SQL 為：

```sql
EXISTS (SELECT 1 FROM "connector_settings" WHERE "connector_id" = "connector_id")
```

兩側欄位皆被展開為未限定的 `"connector_id"`，在 `connector_settings` 有任何一筆資料時，會對**所有** `sync_jobs` 回傳 `configured = true`。前端因此把整個 catalog 的 sync job 都當成「已設定但等待首次同步」，出現「5 / 5 個資料來源等待首次同步」的琥珀色提醒。

## 修正

- `listSyncJobs`：改以 `leftJoin(connectorSettings)` + `CASE WHEN connector_settings.connector_id IS NOT NULL` 計算 `configured`
- `findNextDueSyncJob`、預設排程批次選取：改用 `hasConnectorSettings()`（Drizzle `exists()` 輔助函式）或 `innerJoin(connectorSettings)`，確保正確關聯
- 在 `packages/db` 抽出共用的 `hasConnectorSettings` / `syncJobConfiguredJoin` / `syncJobConfiguredSelection`
- 補上隔離 D1 測試：僅有設定的那一個 connector 會被標為 configured

## 驗證

- `npm run format:check` ✅
- `npm run typecheck` ✅
- `apps/worker/tests/features/sync/drizzle-runtime.test.ts` ✅
- `apps/web/src/data/connectors/sync-status.test.ts` ✅

## 文件

無需更新：行為與 Drizzle 導入前的 SQL 語意一致，屬於 ORM 查詢產生錯誤的修正。

## 殘餘風險

- 其他 Drizzle 階段 4 查詢若仍使用相同模式的 `sql\`EXISTS (... ${table.col} = ${otherTable.col})\`` 模板，可能也有類似關聯問題（例如 report / run repository），本次僅修正 sync job `configured` 與排程選取路徑。
- `notification-batch-repository.test.ts` 使用的 node:sqlite D1 mock 與 Drizzle 不相容，相關測試在 main 上已失敗，需另案改用 Miniflare D1。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e1f41c4-4c0c-5b9d-8ccc-058fc4bfbe40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e1f41c4-4c0c-5b9d-8ccc-058fc4bfbe40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

