### PR TITLE
fix(db): 單欄 TEXT 主鍵補上 NOT NULL

### DIFF
--- a/apps/worker/src/features/activity/repository.ts
+++ b/apps/worker/src/features/activity/repository.ts
@@ -36,7 +36,7 @@ export type MappingTransactionRow = {
 export async function listInvoiceTransactionPreferences(db: D1Database) {
   return createDrizzle(db)
     .select({
-      invoiceId: sql<string>`${invoiceTransactionPreferences.invoiceId}`,
+      invoiceId: invoiceTransactionPreferences.invoiceId,
       transactionId: invoiceTransactionPreferences.transactionId,
       decision: sql<
         "linked" | "separate"
@@ -62,7 +62,7 @@ export async function findMappingInvoice(db: D1Database, invoiceId: string) {
   return (
     (await createDrizzle(db)
       .select({
-        id: sql<string>`${invoices.id}`,
+        id: invoices.id,
         invoiceDate: invoices.invoiceDate,
       })
       .from(invoices)
@@ -78,7 +78,7 @@ export async function findMappingTransaction(
   return (
     (await createDrizzle(db)
       .select({
-        id: sql<string>`${bankTx.id}`,
+        id: bankTx.id,
         postedDate: bankTx.postedDate,
         authorizedAt: bankTx.authorizedAt,
         amount: bankTx.amount,
@@ -103,7 +103,7 @@ export async function findLinkedInvoiceId(
 ) {
   const row = await createDrizzle(db)
     .select({
-      invoiceId: sql<string>`${invoiceTransactionPreferences.invoiceId}`,
+      invoiceId: invoiceTransactionPreferences.invoiceId,
     })
     .from(invoiceTransactionPreferences)
     .where(

--- a/apps/worker/src/features/bank/calculation-repository.ts
+++ b/apps/worker/src/features/bank/calculation-repository.ts
@@ -11,7 +11,7 @@ export async function bankTransactionExists(
 ) {
   return Boolean(
     await createDrizzle(db)
-      .select({ id: sql<string>`${bankTransactions.id}` })
+      .select({ id: bankTransactions.id })
       .from(bankTransactions)
       .where(
         and(

--- a/apps/worker/src/features/bank/repository.ts
+++ b/apps/worker/src/features/bank/repository.ts
@@ -28,6 +28,7 @@ const visibleBankTransactionFilter = and(
   sql`(${txn.status} <> 'pending' OR ${txn.matchedTransactionId} IS NULL)`,
 );
 
+// Alias-join selects keep sql`.as()` so D1 raw() column order matches Drizzle fields.
 const bankTransactionColumns = {
   id: sql<string>`${txn.id}`.as("id"),
   connectorId: sql<string>`${txn.connectorId}`.as("connectorId"),
@@ -139,7 +140,7 @@ function bankTransactionQuery(db: D1Database) {
 export async function listBankAccounts(db: D1Database) {
   return createDrizzle(db)
     .select({
-      id: sql<string>`${account.id}`,
+      id: account.id,
       connectorId: account.connectorId,
       sourceId: account.sourceId,
       institutionName: account.institutionName,

--- a/apps/worker/src/features/classification/repository.ts
+++ b/apps/worker/src/features/classification/repository.ts
@@ -40,7 +40,7 @@ export async function listClassificationOverrides(
 export async function listEnabledClassificationRules(db: D1Database) {
   return createDrizzle(db)
     .select({
-      id: sql<string>`${rules.id}`,
+      id: rules.id,
       category_id: rules.categoryId,
       label: categories.label,
       target_type: rules.targetType,
@@ -60,7 +60,7 @@ export async function listEnabledClassificationRules(db: D1Database) {
 export async function listClassificationCategories(db: D1Database) {
   return createDrizzle(db)
     .select({
-      id: sql<string>`${categories.id}`,
+      id: categories.id,
       label: categories.label,
       sortOrder: categories.sortOrder,
       isSystem: categories.isSystem,
@@ -73,7 +73,7 @@ export async function listClassificationCategories(db: D1Database) {
 export async function findCategoryByLabel(db: D1Database, label: string) {
   return (
     (await createDrizzle(db)
-      .select({ id: sql<string>`${categories.id}` })
+      .select({ id: categories.id })
       .from(categories)
       .where(sql`${categories.label} = ${label} COLLATE NOCASE`)
       .limit(1)
@@ -111,7 +111,7 @@ export async function insertClassificationCategory(
 export async function listClassificationRules(db: D1Database) {
   return createDrizzle(db)
     .select({
-      id: sql<string>`${rules.id}`,
+      id: rules.id,
       categoryId: rules.categoryId,
       targetType: rules.targetType,
       field: rules.field,
@@ -131,7 +131,7 @@ export async function listClassificationRules(db: D1Database) {
 
 export async function listEditableClassificationRuleIds(db: D1Database) {
   const rows = await createDrizzle(db)
-    .select({ id: sql<string>`${rules.id}` })
+    .select({ id: rules.id })
     .from(rules)
     .where(eq(rules.isSystem, 0))
     .orderBy(desc(rules.priority), desc(rules.updatedAt), rules.id)

--- a/apps/worker/src/features/exchange-rates/repository.ts
+++ b/apps/worker/src/features/exchange-rates/repository.ts
@@ -14,8 +14,7 @@ export const SUPPORTED_EXCHANGE_CURRENCIES = ["USD", "JPY", "EUR"] as const;
 export async function listExchangeRates(db: D1Database) {
   return createDrizzle(db)
     .select({
-      // The IN predicate excludes the nullable legacy TEXT primary key.
-      currency: sql<string>`${exchangeRates.currency}`,
+      currency: exchangeRates.currency,
       rateTwd: exchangeRates.rateToTwd,
       updatedAt: exchangeRates.updatedAt,
     })

--- a/apps/worker/src/features/investments/repository.ts
+++ b/apps/worker/src/features/investments/repository.ts
@@ -7,7 +7,7 @@ import { and, asc, desc, eq, sql } from "drizzle-orm";
 import type { MonthDateRange } from "../../platform/month-range";
 
 const investmentTransactionColumns = {
-  id: sql<string>`${investmentTransactions.id}`,
+  id: investmentTransactions.id,
   connectorId: investmentTransactions.connectorId,
   accountId: investmentTransactions.accountId,
   sourceId: investmentTransactions.sourceId,
@@ -61,7 +61,7 @@ export async function listLatestInvestmentPositions(
 ) {
   return createDrizzle(db)
     .select({
-      id: sql<string>`${investmentPositions.id}`,
+      id: investmentPositions.id,
       assetType: investmentPositions.assetType,
       symbol: investmentPositions.symbol,
       name: investmentPositions.name,

--- a/apps/worker/src/features/invoices/repository.ts
+++ b/apps/worker/src/features/invoices/repository.ts
@@ -9,7 +9,7 @@ const invoiceDay = sql`CASE WHEN length(${invoices.invoiceDate}) > 10
   ELSE ${invoices.invoiceDate} END`;
 
 const invoiceSummaryColumns = {
-  id: sql<string>`${invoices.id}`,
+  id: invoices.id,
   connectorId: sql<ConnectorId>`${invoices.connectorId}`,
   sourceId: invoices.sourceId,
   invoiceNumber: invoices.invoiceNumber,
@@ -102,7 +102,7 @@ export async function listInvoiceItems(db: D1Database, invoiceIds: string[]) {
   if (invoiceIds.length === 0) return [];
   return createDrizzle(db)
     .select({
-      id: sql<string>`${invoiceLineItems.id}`,
+      id: invoiceLineItems.id,
       invoiceId: invoiceLineItems.invoiceId,
       sourceId: invoiceLineItems.sourceId,
       lineNumber: invoiceLineItems.lineNumber,

--- a/apps/worker/src/features/manual-assets/repository.ts
+++ b/apps/worker/src/features/manual-assets/repository.ts
@@ -24,7 +24,7 @@ export type ManualAssetHistoryRow = {
 export async function listManualAssets(db: D1Database) {
   return createDrizzle(db)
     .select({
-      id: sql<string>`${manualAssets.id}`,
+      id: manualAssets.id,
       name: manualAssets.name,
       category: manualAssets.category,
       note: manualAssets.note,
@@ -39,7 +39,7 @@ export async function listManualAssets(db: D1Database) {
 export async function listLatestManualAssetValues(db: D1Database) {
   return createDrizzle(db)
     .select({
-      assetId: sql<string>`${netWorthHistory.assetType}`,
+      assetId: netWorthHistory.assetType,
       value: netWorthHistory.netWorth,
       date: netWorthHistory.date,
     })

--- a/apps/worker/src/features/net-worth/repository.ts
+++ b/apps/worker/src/features/net-worth/repository.ts
@@ -63,7 +63,7 @@ export async function listNetWorthHistory(
 ) {
   return createDrizzle(db)
     .select({
-      id: sql<string>`${history.id}`,
+      id: history.id,
       date: history.date,
       netWorth: history.netWorth,
       assetType: history.assetType,

--- a/apps/worker/src/features/notifications/repository.ts
+++ b/apps/worker/src/features/notifications/repository.ts
@@ -27,7 +27,7 @@ const DEFAULT_PREFERENCES: NotificationPreferences = {
 export async function listPushSubscriptions(db: D1Database) {
   const rows = await createDrizzle(db)
     .select({
-      id: sql<string>`${pushSubscriptions.id}`,
+      id: pushSubscriptions.id,
       encryptedSubscription: pushSubscriptions.encryptedSubscription,
       createdAt: pushSubscriptions.createdAt,
       updatedAt: pushSubscriptions.updatedAt,

--- a/apps/worker/src/features/sync/einvoice-run-repository.ts
+++ b/apps/worker/src/features/sync/einvoice-run-repository.ts
@@ -86,7 +86,7 @@ export type MergeEinvoiceRunItemInput = {
 };
 
 const runSelection = {
-  id: sql<EinvoiceRunRow["id"]>`${einvoiceSyncRuns.id}`,
+  id: einvoiceSyncRuns.id,
   connector_id: sql<
     EinvoiceRunRow["connector_id"]
   >`${einvoiceSyncRuns.connectorId}`,
@@ -112,7 +112,7 @@ const runSelection = {
 };
 
 const itemSelection = {
-  id: sql<EinvoiceRunItemRow["id"]>`${einvoiceSyncRunItems.id}`,
+  id: einvoiceSyncRunItems.id,
   run_id: einvoiceSyncRunItems.runId,
   invoice_source_id: einvoiceSyncRunItems.invoiceSourceId,
   header_json: einvoiceSyncRunItems.headerJson,

--- a/apps/worker/src/features/sync/notification-batch-repository.ts
+++ b/apps/worker/src/features/sync/notification-batch-repository.ts
@@ -47,7 +47,7 @@ export async function ensureDefaultScheduleBatch(db: D1Database) {
 
   const jobs = await createDrizzle(db)
     .select({
-      id: sql<string>`${syncJobs.id}`,
+      id: syncJobs.id,
       connector_id: sql<ConnectorId>`${syncJobs.connectorId}`,
     })
     .from(syncJobs)

--- a/apps/worker/src/features/sync/report-repository.ts
+++ b/apps/worker/src/features/sync/report-repository.ts
@@ -89,7 +89,7 @@ export async function recoverLatestScheduledSyncSource(
     .limit(1);
   const latest = await orm
     .select({
-      batchId: sql<string>`${scheduledSyncBatches.id}`,
+      batchId: scheduledSyncBatches.id,
       jobId: scheduledSyncBatchResults.jobId,
     })
     .from(scheduledSyncBatches)
@@ -348,7 +348,7 @@ export async function getLatestScheduledSyncReport(
 ): Promise<ScheduledSyncReport | null> {
   const batch = await createDrizzle(db)
     .select({
-      id: sql<string>`${scheduledSyncBatches.id}`,
+      id: scheduledSyncBatches.id,
       startedAt: scheduledSyncBatches.createdAt,
       completedAt: sql<string>`${scheduledSyncBatches.completedAt}`,
       isBaseline: scheduledSyncBatches.isBaseline,

--- a/apps/worker/src/features/sync/schedule-repository.ts
+++ b/apps/worker/src/features/sync/schedule-repository.ts
@@ -49,7 +49,7 @@ export async function findDefaultSyncSchedule(db: D1Database) {
 
 export async function listInheritedSyncJobs(db: D1Database) {
   return createDrizzle(db)
-    .select({ id: sql<string>`${syncJobs.id}`, nextRunAt: syncJobs.nextRunAt })
+    .select({ id: syncJobs.id, nextRunAt: syncJobs.nextRunAt })
     .from(syncJobs)
     .where(eq(syncJobs.scheduleMode, "inherit"))
     .all()
@@ -109,7 +109,7 @@ export async function saveDefaultSyncSchedule(
 export async function listSyncJobs(db: D1Database) {
   return createDrizzle(db)
     .select({
-      id: sql<string>`${syncJobs.id}`,
+      id: syncJobs.id,
       connectorId: sql<ConnectorId>`${syncJobs.connectorId}`,
       configured: syncJobConfiguredSelection,
       scope: syncJobs.scope,

--- a/apps/worker/src/features/sync/tdcc-run-repository.ts
+++ b/apps/worker/src/features/sync/tdcc-run-repository.ts
@@ -145,7 +145,7 @@ export type TdccRunLeaseInput = {
 };
 
 const runSelection = {
-  id: sql<TdccRunRow["id"]>`${tdccSyncRuns.id}`,
+  id: tdccSyncRuns.id,
   connector_id: sql<TdccRunRow["connector_id"]>`${tdccSyncRuns.connectorId}`,
   trigger: sql<TdccRunRow["trigger"]>`${tdccSyncRuns.trigger}`,
   scope: sql<TdccRunRow["scope"]>`${tdccSyncRuns.scope}`,
@@ -173,7 +173,7 @@ const runSelection = {
 };
 
 const itemSelection = {
-  id: sql<TdccRunItemRow["id"]>`${tdccSyncRunItems.id}`,
+  id: tdccSyncRunItems.id,
   run_id: tdccSyncRunItems.runId,
   task_type: tdccSyncRunItems.taskType,
   task_key: tdccSyncRunItems.taskKey,

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -11,7 +11,7 @@
 - Tables：28
 - Explicit indexes：41
 - Other objects：0
-- Migrations：41
+- Migrations：42
 
 ## Tables
 
@@ -55,7 +55,7 @@
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 系統內部使用的穩定帳戶識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 系統內部使用的穩定帳戶識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `connector_id` | 建立此記錄的外部連接器識別碼。 | TEXT | NO | — | — | — |
 | 3 | `source_id` | 外部銀行或連接器提供的帳戶識別碼。 | TEXT | NO | — | — | — |
 | 4 | `institution_name` | 銀行、發卡機構或金融機構名稱。 | TEXT | YES | — | — | — |
@@ -89,7 +89,7 @@
 
 ```sql
 CREATE TABLE "bank_accounts" (
-  id TEXT PRIMARY KEY,
+  id TEXT NOT NULL PRIMARY KEY,
   connector_id TEXT NOT NULL,
   source_id TEXT NOT NULL,
   institution_name TEXT,
@@ -119,7 +119,7 @@ CREATE TABLE "bank_accounts" (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 餘額快照的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 餘額快照的系統識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `connector_id` | 產生此快照的外部連接器識別碼。 | TEXT | NO | — | — | — |
 | 3 | `account_id` | 所屬 bank_accounts 記錄的識別碼。 | TEXT | NO | — | — | — |
 | 4 | `source_id` | 外部來源對此餘額或帳戶的識別碼。 | TEXT | NO | — | — | — |
@@ -145,14 +145,14 @@ CREATE TABLE "bank_accounts" (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
-| `idx_bank_balance_snapshots_as_of` | 否 | 否 | `as_of_at` | `CREATE INDEX idx_bank_balance_snapshots_as_of<br>  ON bank_balance_snapshots (as_of_at)` |
 | `idx_bank_balance_snapshots_account_as_of` | 否 | 否 | `account_id`, `as_of_at` | `CREATE INDEX idx_bank_balance_snapshots_account_as_of<br>  ON bank_balance_snapshots (account_id, as_of_at)` |
+| `idx_bank_balance_snapshots_as_of` | 否 | 否 | `as_of_at` | `CREATE INDEX idx_bank_balance_snapshots_as_of<br>  ON bank_balance_snapshots (as_of_at)` |
 
 #### DDL
 
 ```sql
 CREATE TABLE "bank_balance_snapshots" (
-  id TEXT PRIMARY KEY,
+  id TEXT NOT NULL PRIMARY KEY,
   connector_id TEXT NOT NULL,
   account_id TEXT NOT NULL REFERENCES "bank_accounts" (id),
   source_id TEXT NOT NULL,
@@ -180,7 +180,7 @@ CREATE TABLE "bank_balance_snapshots" (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `transaction_id` | 套用偏好的 bank_transactions 記錄識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `transaction_id` | 套用偏好的 bank_transactions 記錄識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `excluded_from_calculation` | 是否將此交易排除於計算，0 表示納入、1 表示排除。 | INTEGER | NO | 0 | — | — |
 | 3 | `created_at` | 偏好首次建立的時間。 | TEXT | NO | — | — | — |
 | 4 | `updated_at` | 偏好最後更新的時間。 | TEXT | NO | — | — | — |
@@ -198,8 +198,8 @@ CREATE TABLE "bank_balance_snapshots" (
 #### DDL
 
 ```sql
-CREATE TABLE bank_transaction_preferences (
-  transaction_id TEXT PRIMARY KEY,
+CREATE TABLE "bank_transaction_preferences" (
+  transaction_id TEXT NOT NULL PRIMARY KEY,
   excluded_from_calculation INTEGER NOT NULL DEFAULT 0 CHECK (excluded_from_calculation IN (0, 1)),
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
@@ -215,7 +215,7 @@ CREATE TABLE bank_transaction_preferences (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 交易的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 交易的系統識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `connector_id` | 產生此交易的外部連接器識別碼。 | TEXT | NO | — | — | — |
 | 3 | `account_id` | 所屬 bank_accounts 記錄的識別碼。 | TEXT | NO | — | — | — |
 | 4 | `source_id` | 外部來源系統提供的交易識別碼。 | TEXT | NO | — | — | — |
@@ -243,18 +243,18 @@ CREATE TABLE bank_transaction_preferences (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
-| `idx_bank_transactions_matched_transaction` | 是 | 是 | `matched_transaction_id` | `CREATE UNIQUE INDEX idx_bank_transactions_matched_transaction<br>  ON bank_transactions(matched_transaction_id)<br>  WHERE matched_transaction_id IS NOT NULL` |
-| `idx_bank_transactions_transaction_day` | 否 | 否 | — | `CREATE INDEX idx_bank_transactions_transaction_day<br>  ON bank_transactions (<br>    CASE<br>      WHEN length(authorized_at) > 10<br>        THEN COALESCE(<br>          date(authorized_at, '+8 hours'),<br>          substr(authorized_at, 1, 10)<br>        )<br>      ELSE substr(COALESCE(authorized_at, posted_date), 1, 10)<br>    END<br>  )` |
-| `idx_bank_transactions_status` | 否 | 否 | `connector_id`, `account_id`, `status` | `CREATE INDEX idx_bank_transactions_status<br>  ON bank_transactions (connector_id, account_id, status)` |
-| `idx_bank_transactions_effective_updated` | 否 | 否 | `effective_date`, `updated_at`, `id` | `CREATE INDEX idx_bank_transactions_effective_updated<br>  ON bank_transactions (effective_date DESC, updated_at DESC, id DESC)` |
-| `idx_bank_transactions_posted_date` | 否 | 否 | `posted_date` | `CREATE INDEX idx_bank_transactions_posted_date<br>  ON bank_transactions (posted_date)` |
 | `idx_bank_transactions_account_posted_date` | 否 | 否 | `account_id`, `posted_date` | `CREATE INDEX idx_bank_transactions_account_posted_date<br>  ON bank_transactions (account_id, posted_date)` |
+| `idx_bank_transactions_posted_date` | 否 | 否 | `posted_date` | `CREATE INDEX idx_bank_transactions_posted_date<br>  ON bank_transactions (posted_date)` |
+| `idx_bank_transactions_effective_updated` | 否 | 否 | `effective_date`, `updated_at`, `id` | `CREATE INDEX idx_bank_transactions_effective_updated<br>  ON bank_transactions (effective_date DESC, updated_at DESC, id DESC)` |
+| `idx_bank_transactions_status` | 否 | 否 | `connector_id`, `account_id`, `status` | `CREATE INDEX idx_bank_transactions_status<br>  ON bank_transactions (connector_id, account_id, status)` |
+| `idx_bank_transactions_transaction_day` | 否 | 否 | — | `CREATE INDEX idx_bank_transactions_transaction_day<br>  ON bank_transactions (<br>    CASE<br>      WHEN length(authorized_at) > 10<br>        THEN COALESCE(<br>          date(authorized_at, '+8 hours'),<br>          substr(authorized_at, 1, 10)<br>        )<br>      ELSE substr(COALESCE(authorized_at, posted_date), 1, 10)<br>    END<br>  )` |
+| `idx_bank_transactions_matched_transaction` | 是 | 是 | `matched_transaction_id` | `CREATE UNIQUE INDEX idx_bank_transactions_matched_transaction<br>  ON bank_transactions(matched_transaction_id)<br>  WHERE matched_transaction_id IS NOT NULL` |
 
 #### DDL
 
 ```sql
 CREATE TABLE "bank_transactions" (
-  id TEXT PRIMARY KEY,
+  id TEXT NOT NULL PRIMARY KEY,
   connector_id TEXT NOT NULL,
   account_id TEXT NOT NULL REFERENCES "bank_accounts" (id),
   source_id TEXT NOT NULL,
@@ -281,7 +281,7 @@ CREATE TABLE "bank_transactions" (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 分類的穩定識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 分類的穩定識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `label` | 前端顯示的分類名稱。 | TEXT | NO | — | — | — |
 | 3 | `sort_order` | 分類在介面中的排序順序。 | INTEGER | NO | 0 | — | — |
 | 4 | `is_system` | 是否為系統內建分類；1 表示不可視為一般使用者資料刪除。 | INTEGER | NO | 1 | — | — |
@@ -301,8 +301,8 @@ CREATE TABLE "bank_transactions" (
 #### DDL
 
 ```sql
-CREATE TABLE classification_categories (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "classification_categories" (
+  id TEXT NOT NULL PRIMARY KEY,
   label TEXT NOT NULL,
   sort_order INTEGER NOT NULL DEFAULT 0,
   is_system INTEGER NOT NULL DEFAULT 1,
@@ -320,7 +320,7 @@ CREATE TABLE classification_categories (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 覆寫記錄的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 覆寫記錄的系統識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `target_type` | 被分類資料的類型，例如 bank_transaction。 | TEXT | NO | — | — | — |
 | 3 | `target_id` | 被分類資料的識別碼。 | TEXT | NO | — | — | — |
 | 4 | `category_id` | 指定的 classification_categories 識別碼。 | TEXT | NO | — | — | — |
@@ -342,11 +342,11 @@ CREATE TABLE classification_categories (
 #### DDL
 
 ```sql
-CREATE TABLE classification_overrides (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "classification_overrides" (
+  id TEXT NOT NULL PRIMARY KEY,
   target_type TEXT NOT NULL,
   target_id TEXT NOT NULL,
-  category_id TEXT NOT NULL REFERENCES classification_categories(id),
+  category_id TEXT NOT NULL REFERENCES "classification_categories" (id),
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
   UNIQUE (target_type, target_id)
@@ -362,7 +362,7 @@ CREATE TABLE classification_overrides (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 規則的穩定識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 規則的穩定識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `category_id` | 符合規則時套用的分類識別碼。 | TEXT | NO | — | — | — |
 | 3 | `target_type` | 規則適用的資料類型；NULL 表示可套用於共用目標。 | TEXT | YES | — | — | — |
 | 4 | `field` | 要比對的欄位或欄位集合，例如 any_text。 | TEXT | NO | — | — | — |
@@ -387,15 +387,15 @@ CREATE TABLE classification_overrides (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
-| `idx_classification_rules_category` | 否 | 否 | `category_id` | `CREATE INDEX idx_classification_rules_category<br>  ON classification_rules (category_id)` |
 | `idx_classification_rules_enabled_priority` | 否 | 否 | `enabled`, `target_type`, `priority` | `CREATE INDEX idx_classification_rules_enabled_priority<br>  ON classification_rules (enabled, target_type, priority)` |
+| `idx_classification_rules_category` | 否 | 否 | `category_id` | `CREATE INDEX idx_classification_rules_category<br>  ON classification_rules (category_id)` |
 
 #### DDL
 
 ```sql
-CREATE TABLE classification_rules (
-  id TEXT PRIMARY KEY,
-  category_id TEXT NOT NULL REFERENCES classification_categories(id),
+CREATE TABLE "classification_rules" (
+  id TEXT NOT NULL PRIMARY KEY,
+  category_id TEXT NOT NULL REFERENCES "classification_categories" (id),
   target_type TEXT,
   field TEXT NOT NULL,
   operator TEXT NOT NULL,
@@ -420,7 +420,7 @@ CHECK (excluded_from_calculation IN (0, 1)))
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 設定記錄的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 設定記錄的系統識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `connector_id` | 連接器的穩定識別碼，每個連接器只有一筆設定。 | TEXT | NO | — | — | — |
 | 3 | `encrypted_config` | 使用 Worker 設定的金鑰加密後的認證與私密設定。 | TEXT | NO | — | — | — |
 | 4 | `sync_cursor` | 連接器下次增量同步使用的游標或狀態。 | TEXT | YES | — | — | — |
@@ -439,8 +439,8 @@ CHECK (excluded_from_calculation IN (0, 1)))
 #### DDL
 
 ```sql
-CREATE TABLE connector_settings (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "connector_settings" (
+  id TEXT NOT NULL PRIMARY KEY,
   connector_id TEXT NOT NULL,
   encrypted_config TEXT NOT NULL,
   sync_cursor TEXT,
@@ -459,7 +459,7 @@ CREATE TABLE connector_settings (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 帳單的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 帳單的系統識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `connector_id` | 產生此帳單的外部連接器識別碼。 | TEXT | NO | — | — | — |
 | 3 | `account_id` | 所屬信用卡帳戶的 bank_accounts 識別碼。 | TEXT | NO | — | — | — |
 | 4 | `source_id` | 外部來源系統提供的帳單識別碼。 | TEXT | NO | — | — | — |
@@ -485,14 +485,14 @@ CREATE TABLE connector_settings (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
-| `idx_credit_card_bills_page` | 否 | 否 | `billing_period`, `account_id`, `id` | `CREATE INDEX idx_credit_card_bills_page<br>  ON credit_card_bills (billing_period DESC, account_id ASC, id ASC)` |
 | `idx_credit_card_bills_account_period` | 否 | 否 | `account_id`, `billing_period` | `CREATE INDEX idx_credit_card_bills_account_period<br>  ON credit_card_bills (account_id, billing_period)` |
+| `idx_credit_card_bills_page` | 否 | 否 | `billing_period`, `account_id`, `id` | `CREATE INDEX idx_credit_card_bills_page<br>  ON credit_card_bills (billing_period DESC, account_id ASC, id ASC)` |
 
 #### DDL
 
 ```sql
 CREATE TABLE "credit_card_bills" (
-  id TEXT PRIMARY KEY,
+  id TEXT NOT NULL PRIMARY KEY,
   connector_id TEXT NOT NULL,
   account_id TEXT NOT NULL REFERENCES "bank_accounts" (id),
   source_id TEXT NOT NULL,
@@ -520,7 +520,7 @@ CREATE TABLE "credit_card_bills" (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 發票同步項目的識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 發票同步項目的識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `run_id` | 所屬 einvoice_sync_runs 執行記錄；刪除執行記錄時一併刪除項目。 | TEXT | NO | — | — | — |
 | 3 | `invoice_source_id` | 外部來源的發票識別碼，用於同一輪同步內去重。 | TEXT | NO | — | — | — |
 | 4 | `header_json` | 取得發票清單時保存的發票表頭 JSON。 | TEXT | NO | — | — | — |
@@ -553,9 +553,9 @@ CREATE TABLE "credit_card_bills" (
 #### DDL
 
 ```sql
-CREATE TABLE einvoice_sync_run_items (
-  id TEXT PRIMARY KEY,
-  run_id TEXT NOT NULL REFERENCES einvoice_sync_runs(id) ON DELETE CASCADE,
+CREATE TABLE "einvoice_sync_run_items" (
+  id TEXT NOT NULL PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES "einvoice_sync_runs" (id) ON DELETE CASCADE,
   invoice_source_id TEXT NOT NULL,
   header_json TEXT NOT NULL,
   normalized_invoice_json TEXT NOT NULL,
@@ -584,7 +584,7 @@ CREATE TABLE einvoice_sync_run_items (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 此次電子發票同步執行的識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 此次電子發票同步執行的識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `connector_id` | 連接器識別碼，固定為 einvoice。 | TEXT | NO | 'einvoice' | — | — |
 | 3 | `trigger` | 啟動來源：manual 手動同步或 scheduled 排程同步。 | TEXT | NO | — | — | — |
 | 4 | `sync_job_id` | 對應的 sync_jobs 工作；工作刪除時設為 NULL。 | TEXT | YES | — | — | — |
@@ -617,19 +617,19 @@ CREATE TABLE einvoice_sync_run_items (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
-| `idx_einvoice_sync_runs_completed` | 否 | 否 | `completed_at` | `CREATE INDEX idx_einvoice_sync_runs_completed<br>  ON einvoice_sync_runs (completed_at DESC)` |
 | `idx_einvoice_sync_runs_one_active` | 是 | 是 | `connector_id` | `CREATE UNIQUE INDEX idx_einvoice_sync_runs_one_active<br>  ON einvoice_sync_runs (connector_id)<br>  WHERE status IN ('queued', 'initializing', 'processing')` |
+| `idx_einvoice_sync_runs_completed` | 否 | 否 | `completed_at` | `CREATE INDEX idx_einvoice_sync_runs_completed<br>  ON einvoice_sync_runs (completed_at DESC)` |
 
 #### DDL
 
 ```sql
-CREATE TABLE einvoice_sync_runs (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "einvoice_sync_runs" (
+  id TEXT NOT NULL PRIMARY KEY,
   connector_id TEXT NOT NULL DEFAULT 'einvoice'
     CHECK (connector_id = 'einvoice'),
   trigger TEXT NOT NULL CHECK (trigger IN ('manual', 'scheduled')),
-  sync_job_id TEXT REFERENCES sync_jobs(id) ON DELETE SET NULL,
-  scheduled_batch_id TEXT REFERENCES scheduled_sync_batches(id) ON DELETE SET NULL,
+  sync_job_id TEXT REFERENCES "sync_jobs" (id) ON DELETE SET NULL,
+  scheduled_batch_id TEXT REFERENCES "scheduled_sync_batches" (id) ON DELETE SET NULL,
   settings_version TEXT,
   status TEXT NOT NULL CHECK (status IN (
     'queued', 'initializing', 'processing', 'completed', 'failed', 'needs_user_action'
@@ -660,7 +660,7 @@ CREATE TABLE einvoice_sync_runs (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `currency` | 外幣幣別代碼，也是此表的主鍵。 | TEXT | YES | — | 1 | — |
+| 1 | `currency` | 外幣幣別代碼，也是此表的主鍵。 | TEXT | NO | — | 1 | — |
 | 2 | `rate_to_twd` | 一單位該幣別換算成 TWD 的匯率。 | REAL | NO | — | — | — |
 | 3 | `updated_at` | 匯率最後更新的時間。 | TEXT | NO | — | — | — |
 
@@ -675,8 +675,8 @@ CREATE TABLE einvoice_sync_runs (
 #### DDL
 
 ```sql
-CREATE TABLE exchange_rates (
-  currency TEXT PRIMARY KEY,
+CREATE TABLE "exchange_rates" (
+  currency TEXT NOT NULL PRIMARY KEY,
   rate_to_twd REAL NOT NULL,
   updated_at TEXT NOT NULL
 )
@@ -691,7 +691,7 @@ CREATE TABLE exchange_rates (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 持倉快照的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 持倉快照的系統識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `connector_id` | 產生此持倉的外部連接器識別碼。 | TEXT | NO | — | — | — |
 | 3 | `source_id` | 外部來源系統提供的持倉識別碼。 | TEXT | NO | — | — | — |
 | 4 | `asset_type` | 資產類型，目前限制為 stock、etf 或 fund。 | TEXT | NO | — | — | — |
@@ -714,16 +714,16 @@ CREATE TABLE exchange_rates (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
-| `idx_investment_positions_page` | 否 | 否 | `as_of_date`, `asset_type`, `name`, `id` | `CREATE INDEX idx_investment_positions_page<br>  ON investment_positions (as_of_date DESC, asset_type ASC, name ASC, id ASC)` |
-| `idx_investment_positions_latest_scope` | 否 | 否 | `connector_id`, `asset_type`, `as_of_date` | `CREATE INDEX idx_investment_positions_latest_scope<br>  ON investment_positions (connector_id, asset_type, as_of_date DESC)` |
-| `idx_investment_positions_asset_type` | 否 | 否 | `asset_type` | `CREATE INDEX idx_investment_positions_asset_type<br>  ON investment_positions (asset_type)` |
 | `idx_investment_positions_as_of_date` | 否 | 否 | `as_of_date` | `CREATE INDEX idx_investment_positions_as_of_date<br>  ON investment_positions (as_of_date)` |
+| `idx_investment_positions_asset_type` | 否 | 否 | `asset_type` | `CREATE INDEX idx_investment_positions_asset_type<br>  ON investment_positions (asset_type)` |
+| `idx_investment_positions_latest_scope` | 否 | 否 | `connector_id`, `asset_type`, `as_of_date` | `CREATE INDEX idx_investment_positions_latest_scope<br>  ON investment_positions (connector_id, asset_type, as_of_date DESC)` |
+| `idx_investment_positions_page` | 否 | 否 | `as_of_date`, `asset_type`, `name`, `id` | `CREATE INDEX idx_investment_positions_page<br>  ON investment_positions (as_of_date DESC, asset_type ASC, name ASC, id ASC)` |
 
 #### DDL
 
 ```sql
-CREATE TABLE investment_positions (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "investment_positions" (
+  id TEXT NOT NULL PRIMARY KEY,
   connector_id TEXT NOT NULL,
   source_id TEXT NOT NULL,
   asset_type TEXT NOT NULL CHECK (asset_type IN ('stock', 'etf', 'fund')),
@@ -750,7 +750,7 @@ CREATE TABLE investment_positions (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 投資交易的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 投資交易的系統識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `connector_id` | 產生此交易的外部連接器識別碼。 | TEXT | NO | — | — | — |
 | 3 | `account_id` | 外部券商或投資帳戶識別碼。 | TEXT | NO | — | — | — |
 | 4 | `source_id` | 外部來源系統提供的交易識別碼。 | TEXT | NO | — | — | — |
@@ -781,15 +781,15 @@ CREATE TABLE investment_positions (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
-| `idx_investment_transactions_effective_updated` | 否 | 否 | `effective_date`, `updated_at`, `id` | `CREATE INDEX idx_investment_transactions_effective_updated<br>  ON investment_transactions (effective_date DESC, updated_at DESC, id DESC)` |
-| `idx_investment_transactions_symbol` | 否 | 否 | `symbol` | `CREATE INDEX idx_investment_transactions_symbol<br>  ON investment_transactions (symbol)` |
 | `idx_investment_transactions_trade_date` | 否 | 否 | `trade_date` | `CREATE INDEX idx_investment_transactions_trade_date<br>  ON investment_transactions (trade_date)` |
+| `idx_investment_transactions_symbol` | 否 | 否 | `symbol` | `CREATE INDEX idx_investment_transactions_symbol<br>  ON investment_transactions (symbol)` |
+| `idx_investment_transactions_effective_updated` | 否 | 否 | `effective_date`, `updated_at`, `id` | `CREATE INDEX idx_investment_transactions_effective_updated<br>  ON investment_transactions (effective_date DESC, updated_at DESC, id DESC)` |
 
 #### DDL
 
 ```sql
-CREATE TABLE investment_transactions (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "investment_transactions" (
+  id TEXT NOT NULL PRIMARY KEY,
   connector_id TEXT NOT NULL,
   account_id TEXT NOT NULL,
   source_id TEXT NOT NULL,
@@ -822,7 +822,7 @@ CREATE TABLE investment_transactions (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 發票明細的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 發票明細的系統識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `invoice_id` | 所屬 invoices 記錄的識別碼。 | TEXT | NO | — | — | — |
 | 3 | `connector_id` | 取得此明細的外部連接器識別碼。 | TEXT | NO | — | — | — |
 | 4 | `invoice_source_id` | 外部來源發票識別碼，用於同步比對。 | TEXT | NO | — | — | — |
@@ -846,14 +846,14 @@ CREATE TABLE investment_transactions (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
-| `idx_invoice_line_items_invoice_source` | 否 | 否 | `connector_id`, `invoice_source_id` | `CREATE INDEX idx_invoice_line_items_invoice_source<br>  ON invoice_line_items (connector_id, invoice_source_id)` |
 | `idx_invoice_line_items_invoice_id` | 否 | 否 | `invoice_id` | `CREATE INDEX idx_invoice_line_items_invoice_id<br>  ON invoice_line_items (invoice_id)` |
+| `idx_invoice_line_items_invoice_source` | 否 | 否 | `connector_id`, `invoice_source_id` | `CREATE INDEX idx_invoice_line_items_invoice_source<br>  ON invoice_line_items (connector_id, invoice_source_id)` |
 
 #### DDL
 
 ```sql
-CREATE TABLE invoice_line_items (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "invoice_line_items" (
+  id TEXT NOT NULL PRIMARY KEY,
   invoice_id TEXT NOT NULL,
   connector_id TEXT NOT NULL,
   invoice_source_id TEXT NOT NULL,
@@ -866,7 +866,7 @@ CREATE TABLE invoice_line_items (
   raw_payload TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
-  FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE CASCADE,
+  FOREIGN KEY (invoice_id) REFERENCES "invoices" (id) ON DELETE CASCADE,
   UNIQUE (connector_id, invoice_source_id, source_id)
 )
 ```
@@ -880,7 +880,7 @@ CREATE TABLE invoice_line_items (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `invoice_id` | 套用決策的 invoices 記錄識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `invoice_id` | 套用決策的 invoices 記錄識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `transaction_id` | 被關聯的 bank_transactions 識別碼；separate 時為 NULL。 | TEXT | YES | — | — | — |
 | 3 | `decision` | 關聯決策，目前限制為 linked 或 separate。 | TEXT | NO | — | — | — |
 | 4 | `created_at` | 決策首次建立的時間。 | TEXT | NO | — | — | — |
@@ -899,8 +899,8 @@ CREATE TABLE invoice_line_items (
 #### DDL
 
 ```sql
-CREATE TABLE invoice_transaction_preferences (
-  invoice_id TEXT PRIMARY KEY,
+CREATE TABLE "invoice_transaction_preferences" (
+  invoice_id TEXT NOT NULL PRIMARY KEY,
   transaction_id TEXT,
   decision TEXT NOT NULL CHECK (decision IN ('linked', 'separate')),
   created_at TEXT NOT NULL,
@@ -921,7 +921,7 @@ CREATE TABLE invoice_transaction_preferences (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 發票的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 發票的系統識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `connector_id` | 取得此發票的外部連接器識別碼。 | TEXT | NO | — | — | — |
 | 3 | `source_id` | 外部來源系統提供的發票識別碼。 | TEXT | NO | — | — | — |
 | 4 | `invoice_number` | 發票字軌號碼或發票號碼。 | TEXT | YES | — | — | — |
@@ -940,14 +940,14 @@ CREATE TABLE invoice_transaction_preferences (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
-| `idx_invoices_page` | 否 | 否 | `invoice_date`, `updated_at`, `id` | `CREATE INDEX idx_invoices_page<br>  ON invoices (invoice_date DESC, updated_at DESC, id DESC)` |
 | `idx_invoices_invoice_date` | 否 | 否 | `invoice_date` | `CREATE INDEX idx_invoices_invoice_date<br>  ON invoices (invoice_date)` |
+| `idx_invoices_page` | 否 | 否 | `invoice_date`, `updated_at`, `id` | `CREATE INDEX idx_invoices_page<br>  ON invoices (invoice_date DESC, updated_at DESC, id DESC)` |
 
 #### DDL
 
 ```sql
-CREATE TABLE invoices (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "invoices" (
+  id TEXT NOT NULL PRIMARY KEY,
   connector_id TEXT NOT NULL,
   source_id TEXT NOT NULL,
   invoice_number TEXT,
@@ -970,7 +970,7 @@ CREATE TABLE invoices (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 手動資產的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 手動資產的系統識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `name` | 前端顯示的資產名稱。 | TEXT | NO | — | — | — |
 | 3 | `category` | 資產分類，例如房產、現金或其他。 | TEXT | NO | — | — | — |
 | 4 | `note` | 使用者補充的備註。 | TEXT | YES | — | — | — |
@@ -988,8 +988,8 @@ CREATE TABLE invoices (
 #### DDL
 
 ```sql
-CREATE TABLE manual_assets (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "manual_assets" (
+  id TEXT NOT NULL PRIMARY KEY,
   name TEXT NOT NULL,
   category TEXT NOT NULL,
   note TEXT,
@@ -1006,7 +1006,7 @@ CREATE TABLE manual_assets (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 歷史點的系統識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 歷史點的系統識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `date` | 此數值所代表的日期。 | TEXT | NO | — | — | — |
 | 3 | `net_worth` | 該日期與資產類型的金額；手動資產保留其設定幣別，其餘讀模型通常以 TWD 表示。 | INTEGER | NO | — | — | — |
 | 4 | `asset_type` | 資產類型，例如 total、deposit、stock、fund 或手動資產 id。 | TEXT | NO | 'total' | — | — |
@@ -1021,14 +1021,14 @@ CREATE TABLE manual_assets (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
-| `idx_net_worth_history_page` | 否 | 否 | `date`, `source`, `asset_type`, `id` | `CREATE INDEX idx_net_worth_history_page<br>  ON net_worth_history (date DESC, source ASC, asset_type ASC, id ASC)` |
 | `idx_net_worth_history_date` | 否 | 否 | `date` | `CREATE INDEX idx_net_worth_history_date<br>  ON net_worth_history (date)` |
+| `idx_net_worth_history_page` | 否 | 否 | `date`, `source`, `asset_type`, `id` | `CREATE INDEX idx_net_worth_history_page<br>  ON net_worth_history (date DESC, source ASC, asset_type ASC, id ASC)` |
 
 #### DDL
 
 ```sql
-CREATE TABLE net_worth_history (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "net_worth_history" (
+  id TEXT NOT NULL PRIMARY KEY,
   date TEXT NOT NULL,
   net_worth INTEGER NOT NULL,
   asset_type TEXT NOT NULL DEFAULT 'total',
@@ -1047,7 +1047,7 @@ CREATE TABLE net_worth_history (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 設定識別碼，固定為 default。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 設定識別碼，固定為 default。 | TEXT | NO | — | 1 | — |
 | 2 | `notify_success` | 是否在排程同步成功時顯示推播。 | INTEGER | NO | 0 | — | — |
 | 3 | `notify_failed` | 是否在排程同步失敗時顯示推播。 | INTEGER | NO | 1 | — | — |
 | 4 | `notify_needs_user_action` | 是否在同步需要 OTP、CAPTCHA 或重新登入時顯示推播。 | INTEGER | NO | 1 | — | — |
@@ -1064,8 +1064,8 @@ CREATE TABLE net_worth_history (
 #### DDL
 
 ```sql
-CREATE TABLE notification_preferences (
-  id TEXT PRIMARY KEY CHECK (id = 'default'),
+CREATE TABLE "notification_preferences" (
+  id TEXT NOT NULL PRIMARY KEY CHECK (id = 'default'),
   notify_success INTEGER NOT NULL DEFAULT 0,
   notify_failed INTEGER NOT NULL DEFAULT 1,
   notify_needs_user_action INTEGER NOT NULL DEFAULT 1,
@@ -1082,7 +1082,7 @@ CREATE TABLE notification_preferences (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 由 push endpoint 雜湊產生的裝置訂閱識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 由 push endpoint 雜湊產生的裝置訂閱識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `encrypted_subscription` | 加密保存的 endpoint、p256dh 與 auth 訂閱資料。 | TEXT | NO | — | — | — |
 | 3 | `created_at` | 裝置首次登記的時間。 | TEXT | NO | — | — | — |
 | 4 | `updated_at` | 裝置訂閱最後更新的時間。 | TEXT | NO | — | — | — |
@@ -1100,8 +1100,8 @@ CREATE TABLE notification_preferences (
 #### DDL
 
 ```sql
-CREATE TABLE push_subscriptions (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "push_subscriptions" (
+  id TEXT NOT NULL PRIMARY KEY,
   encrypted_subscription TEXT NOT NULL,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
@@ -1162,7 +1162,7 @@ CREATE TABLE scheduled_sync_batch_results (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 批次識別碼，由 default 與 UUID 組成。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 批次識別碼，由 default 與 UUID 組成。 | TEXT | NO | — | 1 | — |
 | 2 | `schedule_key` | 排程類型識別碼，目前固定為 default。 | TEXT | NO | 'default' | — | — |
 | 3 | `notification_claimed_at` | 彙總推播被 scheduler 取得發送權的時間。 | TEXT | YES | — | — | — |
 | 4 | `created_at` | 批次建立時間。 | TEXT | NO | — | — | — |
@@ -1183,14 +1183,14 @@ CREATE TABLE scheduled_sync_batch_results (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
-| `idx_scheduled_sync_batches_completed` | 否 | 否 | `completed_at` | `CREATE INDEX idx_scheduled_sync_batches_completed<br>  ON scheduled_sync_batches (completed_at DESC)` |
 | `idx_scheduled_sync_batches_open` | 是 | 是 | `schedule_key` | `CREATE UNIQUE INDEX idx_scheduled_sync_batches_open<br>  ON scheduled_sync_batches (schedule_key)<br>  WHERE notification_claimed_at IS NULL` |
+| `idx_scheduled_sync_batches_completed` | 否 | 否 | `completed_at` | `CREATE INDEX idx_scheduled_sync_batches_completed<br>  ON scheduled_sync_batches (completed_at DESC)` |
 
 #### DDL
 
 ```sql
-CREATE TABLE scheduled_sync_batches (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "scheduled_sync_batches" (
+  id TEXT NOT NULL PRIMARY KEY,
   schedule_key TEXT NOT NULL DEFAULT 'default' CHECK (schedule_key = 'default'),
   notification_claimed_at TEXT,
   created_at TEXT NOT NULL
@@ -1206,7 +1206,7 @@ CREATE TABLE scheduled_sync_batches (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 同步工作的系統識別碼，通常由 connector_id 與 scope 組成。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 同步工作的系統識別碼，通常由 connector_id 與 scope 組成。 | TEXT | NO | — | 1 | — |
 | 2 | `connector_id` | 要執行同步的連接器識別碼。 | TEXT | NO | — | — | — |
 | 3 | `scope` | 同步範圍，例如 all 或特定帳戶範圍。 | TEXT | NO | — | — | — |
 | 4 | `enabled` | 是否啟用此同步工作。 | INTEGER | NO | 1 | — | — |
@@ -1239,8 +1239,8 @@ CREATE TABLE scheduled_sync_batches (
 #### DDL
 
 ```sql
-CREATE TABLE sync_jobs (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "sync_jobs" (
+  id TEXT NOT NULL PRIMARY KEY,
   connector_id TEXT NOT NULL,
   scope TEXT NOT NULL,
   enabled INTEGER NOT NULL DEFAULT 1,
@@ -1271,7 +1271,7 @@ CREATE TABLE sync_jobs (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 設定識別碼，固定為 default。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 設定識別碼，固定為 default。 | TEXT | NO | — | 1 | — |
 | 2 | `interval_minutes` | 預設同步間隔，單位為分鐘。 | INTEGER | NO | — | — | — |
 | 3 | `preferred_time` | 預設每日或每週執行時間，使用台北時間。 | TEXT | NO | — | — | — |
 | 4 | `timezone` | 排程使用的時區，目前為 Asia/Taipei。 | TEXT | NO | — | — | — |
@@ -1289,8 +1289,8 @@ CREATE TABLE sync_jobs (
 #### DDL
 
 ```sql
-CREATE TABLE sync_schedule_settings (
-  id TEXT PRIMARY KEY CHECK (id = 'default'),
+CREATE TABLE "sync_schedule_settings" (
+  id TEXT NOT NULL PRIMARY KEY CHECK (id = 'default'),
   interval_minutes INTEGER NOT NULL,
   preferred_time TEXT NOT NULL,
   timezone TEXT NOT NULL,
@@ -1346,7 +1346,7 @@ CREATE TABLE sync_write_staging (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 集保同步工作項目的識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 集保同步工作項目的識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `run_id` | 所屬 tdcc_sync_runs 執行記錄；刪除執行記錄時一併刪除項目。 | TEXT | NO | — | — | — |
 | 3 | `task_type` | 此項目負責的資料擷取任務類型，目前為 bank_page 或 trade_page。 | TEXT | NO | — | — | — |
 | 4 | `task_key` | 同一任務類型內用於區分工作範圍的識別鍵。 | TEXT | NO | '' | — | — |
@@ -1375,15 +1375,15 @@ CREATE TABLE sync_write_staging (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
-| `idx_tdcc_sync_run_items_account` | 否 | 否 | `run_id`, `account_id`, `task_type`, `page_number` | `CREATE INDEX idx_tdcc_sync_run_items_account<br>  ON tdcc_sync_run_items (run_id, account_id, task_type, page_number)` |
 | `idx_tdcc_sync_run_items_claim` | 否 | 否 | `run_id`, `status`, `lease_expires_at`, `created_at` | `CREATE INDEX idx_tdcc_sync_run_items_claim<br>  ON tdcc_sync_run_items (run_id, status, lease_expires_at, created_at)` |
+| `idx_tdcc_sync_run_items_account` | 否 | 否 | `run_id`, `account_id`, `task_type`, `page_number` | `CREATE INDEX idx_tdcc_sync_run_items_account<br>  ON tdcc_sync_run_items (run_id, account_id, task_type, page_number)` |
 
 #### DDL
 
 ```sql
-CREATE TABLE tdcc_sync_run_items (
-  id TEXT PRIMARY KEY,
-  run_id TEXT NOT NULL REFERENCES tdcc_sync_runs(id) ON DELETE CASCADE,
+CREATE TABLE "tdcc_sync_run_items" (
+  id TEXT NOT NULL PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES "tdcc_sync_runs" (id) ON DELETE CASCADE,
   task_type TEXT NOT NULL,
   task_key TEXT NOT NULL DEFAULT '',
   account_id TEXT,
@@ -1414,7 +1414,7 @@ CREATE TABLE tdcc_sync_run_items (
 
 | 順序 | 欄位 | 意義 | SQLite type | 可為 NULL | 預設值 | PK 順序 | Generated |
 | ---: | --- | --- | --- | :---: | --- | ---: | --- |
-| 1 | `id` | 此次集保同步執行的識別碼。 | TEXT | YES | — | 1 | — |
+| 1 | `id` | 此次集保同步執行的識別碼。 | TEXT | NO | — | 1 | — |
 | 2 | `connector_id` | 連接器識別碼，固定為 tdcc。 | TEXT | NO | 'tdcc' | — | — |
 | 3 | `trigger` | 啟動來源：manual 手動同步或 scheduled 排程同步。 | TEXT | NO | — | — | — |
 | 4 | `scope` | 同步範圍：all 全部、investments 持倉、bank 銀行資料或 trades 投資交易。 | TEXT | NO | 'all' | — | — |
@@ -1451,21 +1451,21 @@ CREATE TABLE tdcc_sync_run_items (
 
 | Index | Unique | Partial | 欄位 | 定義 |
 | --- | :---: | :---: | --- | --- |
-| `idx_tdcc_sync_runs_completed` | 否 | 否 | `completed_at` | `CREATE INDEX idx_tdcc_sync_runs_completed<br>  ON tdcc_sync_runs (completed_at DESC)` |
 | `idx_tdcc_sync_runs_one_active` | 是 | 是 | `connector_id` | `CREATE UNIQUE INDEX idx_tdcc_sync_runs_one_active<br>  ON tdcc_sync_runs (connector_id)<br>  WHERE status IN ('queued', 'initializing', 'processing', 'promoting')` |
+| `idx_tdcc_sync_runs_completed` | 否 | 否 | `completed_at` | `CREATE INDEX idx_tdcc_sync_runs_completed<br>  ON tdcc_sync_runs (completed_at DESC)` |
 
 #### DDL
 
 ```sql
-CREATE TABLE tdcc_sync_runs (
-  id TEXT PRIMARY KEY,
+CREATE TABLE "tdcc_sync_runs" (
+  id TEXT NOT NULL PRIMARY KEY,
   connector_id TEXT NOT NULL DEFAULT 'tdcc'
     CHECK (connector_id = 'tdcc'),
   trigger TEXT NOT NULL CHECK (trigger IN ('manual', 'scheduled')),
   scope TEXT NOT NULL DEFAULT 'all'
     CHECK (scope IN ('all', 'investments', 'bank', 'trades')),
-  sync_job_id TEXT REFERENCES sync_jobs(id) ON DELETE SET NULL,
-  scheduled_batch_id TEXT REFERENCES scheduled_sync_batches(id) ON DELETE SET NULL,
+  sync_job_id TEXT REFERENCES "sync_jobs" (id) ON DELETE SET NULL,
+  scheduled_batch_id TEXT REFERENCES "scheduled_sync_batches" (id) ON DELETE SET NULL,
   settings_version TEXT,
   phase TEXT NOT NULL DEFAULT 'initialize'
     CHECK (phase IN (
@@ -1546,6 +1546,7 @@ Migration 是 schema 演進的 source of truth；若要了解某欄位的變更�
 - [`0041_time_deposit_lifecycle.sql`](../packages/db/migrations/0041_time_deposit_lifecycle.sql)
 - [`0042_bank_transaction_lifecycle.sql`](../packages/db/migrations/0042_bank_transaction_lifecycle.sql)
 - [`0043_merge_legacy_invoice_duplicates.sql`](../packages/db/migrations/0043_merge_legacy_invoice_duplicates.sql)
+- [`0044_text_primary_keys_not_null.sql`](../packages/db/migrations/0044_text_primary_keys_not_null.sql)
 
 ## 程式碼導覽
 

--- a/packages/db/migrations/0044_text_primary_keys_not_null.sql
+++ b/packages/db/migrations/0044_text_primary_keys_not_null.sql
@@ -1,0 +1,651 @@
+PRAGMA defer_foreign_keys = ON;
+
+CREATE TABLE _pk_migration_scheduled_sync_batch_results_backup AS
+SELECT * FROM scheduled_sync_batch_results;
+DROP TABLE scheduled_sync_batch_results;
+
+CREATE TABLE bank_accounts_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  institution_name TEXT,
+  account_name TEXT,
+  account_type TEXT CHECK (
+    account_type IS NULL
+    OR account_type IN ('checking', 'savings', 'credit', 'loan', 'settlement_cash', 'time_deposit', 'stored_value', 'unknown')
+  ),
+  currency TEXT NOT NULL DEFAULT 'TWD',
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  bank_code TEXT,
+  account_last4 TEXT,
+  canonical_account_id TEXT REFERENCES bank_accounts_new (id),
+  credit_limit INTEGER, opened_date TEXT, maturity_date TEXT, inactive_at TEXT,
+  UNIQUE (connector_id, source_id)
+);
+
+CREATE TABLE bank_balance_snapshots_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  account_id TEXT NOT NULL REFERENCES bank_accounts_new (id),
+  source_id TEXT NOT NULL,
+  balance INTEGER NOT NULL,
+  available_balance INTEGER,
+  currency TEXT NOT NULL DEFAULT 'TWD',
+  as_of_at TEXT NOT NULL,
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  statement_balance INTEGER,
+  payment_due_date TEXT,
+  no_payment_needed INTEGER,
+  statement_closing_date TEXT,
+  UNIQUE (connector_id, account_id, source_id)
+);
+
+CREATE TABLE bank_transaction_preferences_new (
+  transaction_id TEXT NOT NULL PRIMARY KEY,
+  excluded_from_calculation INTEGER NOT NULL DEFAULT 0 CHECK (excluded_from_calculation IN (0, 1)),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE bank_transactions_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  account_id TEXT NOT NULL REFERENCES bank_accounts_new (id),
+  source_id TEXT NOT NULL,
+  posted_date TEXT,
+  authorized_at TEXT,
+  amount INTEGER NOT NULL,
+  currency TEXT NOT NULL DEFAULT 'TWD',
+  description TEXT,
+  counterparty TEXT,
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  effective_date TEXT AS (COALESCE(posted_date, authorized_at, '')),
+  status TEXT NOT NULL DEFAULT 'posted' CHECK (status IN ('pending', 'posted')), transfer_peer_id TEXT, matched_transaction_id TEXT,
+  UNIQUE (connector_id, account_id, source_id)
+);
+
+CREATE TABLE classification_categories_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  label TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  is_system INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE classification_overrides_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  target_type TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  category_id TEXT NOT NULL REFERENCES classification_categories_new (id),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE (target_type, target_id)
+);
+
+CREATE TABLE classification_rules_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  category_id TEXT NOT NULL REFERENCES classification_categories_new (id),
+  target_type TEXT,
+  field TEXT NOT NULL,
+  operator TEXT NOT NULL,
+  pattern TEXT NOT NULL,
+  priority INTEGER NOT NULL DEFAULT 100,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  is_system INTEGER NOT NULL DEFAULT 0,
+  source TEXT NOT NULL DEFAULT 'user',
+  description TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+, excluded_from_calculation INTEGER NOT NULL DEFAULT 0
+CHECK (excluded_from_calculation IN (0, 1)));
+
+CREATE TABLE connector_settings_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  encrypted_config TEXT NOT NULL,
+  sync_cursor TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL, public_config TEXT,
+  UNIQUE (connector_id)
+);
+
+CREATE TABLE credit_card_bills_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  account_id TEXT NOT NULL REFERENCES bank_accounts_new (id),
+  source_id TEXT NOT NULL,
+  billing_period TEXT NOT NULL,
+  statement_amount INTEGER,
+  minimum_payment INTEGER,
+  paid_amount INTEGER,
+  is_paid INTEGER,
+  payment_due_date TEXT,
+  statement_closing_date TEXT,
+  currency TEXT NOT NULL DEFAULT 'TWD',
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE (connector_id, account_id, billing_period)
+);
+
+CREATE TABLE einvoice_sync_run_items_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES einvoice_sync_runs_new (id) ON DELETE CASCADE,
+  invoice_source_id TEXT NOT NULL,
+  header_json TEXT NOT NULL,
+  normalized_invoice_json TEXT NOT NULL,
+  detail_key TEXT,
+  detail_metadata_json TEXT,
+  detail_items_json TEXT,
+  line_item_count INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'processing', 'done')),
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  lease_token TEXT,
+  lease_expires_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT,
+  UNIQUE (run_id, invoice_source_id)
+);
+
+CREATE TABLE einvoice_sync_runs_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  connector_id TEXT NOT NULL DEFAULT 'einvoice'
+    CHECK (connector_id = 'einvoice'),
+  trigger TEXT NOT NULL CHECK (trigger IN ('manual', 'scheduled')),
+  sync_job_id TEXT REFERENCES sync_jobs_new (id) ON DELETE SET NULL,
+  scheduled_batch_id TEXT REFERENCES scheduled_sync_batches_new (id) ON DELETE SET NULL,
+  settings_version TEXT,
+  status TEXT NOT NULL CHECK (status IN (
+    'queued', 'initializing', 'processing', 'completed', 'failed', 'needs_user_action'
+  )),
+  total_item_count INTEGER NOT NULL DEFAULT 0,
+  pending_item_count INTEGER NOT NULL DEFAULT 0,
+  processing_item_count INTEGER NOT NULL DEFAULT 0,
+  done_item_count INTEGER NOT NULL DEFAULT 0,
+  line_item_count INTEGER NOT NULL DEFAULT 0,
+  new_invoice_count INTEGER NOT NULL DEFAULT 0,
+  session_refresh_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  chunk_lease_owner TEXT,
+  chunk_lease_expires_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  promoted_at TEXT,
+  completed_at TEXT
+);
+
+CREATE TABLE exchange_rates_new (
+  currency TEXT NOT NULL PRIMARY KEY,
+  rate_to_twd REAL NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE investment_positions_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  asset_type TEXT NOT NULL CHECK (asset_type IN ('stock', 'etf', 'fund')),
+  symbol TEXT,
+  name TEXT NOT NULL,
+  quantity REAL,
+  market_value INTEGER,
+  cash_balance INTEGER,
+  currency TEXT NOT NULL DEFAULT 'TWD',
+  as_of_date TEXT NOT NULL,
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE (connector_id, source_id, as_of_date)
+);
+
+CREATE TABLE investment_transactions_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  broker_no TEXT,
+  broker_account TEXT,
+  broker_name TEXT,
+  symbol TEXT,
+  name TEXT,
+  asset_type TEXT CHECK (asset_type IN ('stock', 'etf', 'fund', 'bond', 'unknown')),
+  trade_date TEXT,
+  posted_date TEXT,
+  transaction_code TEXT,
+  transaction_name TEXT,
+  quantity REAL,
+  price REAL,
+  amount INTEGER,
+  currency TEXT NOT NULL DEFAULT 'TWD',
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL, effective_date TEXT AS (COALESCE(trade_date, posted_date, '')),
+  UNIQUE (connector_id, account_id, source_id)
+);
+
+CREATE TABLE invoice_line_items_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  invoice_id TEXT NOT NULL,
+  connector_id TEXT NOT NULL,
+  invoice_source_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  line_number INTEGER NOT NULL,
+  description TEXT NOT NULL,
+  quantity REAL,
+  unit_price INTEGER,
+  amount INTEGER NOT NULL,
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (invoice_id) REFERENCES invoices_new (id) ON DELETE CASCADE,
+  UNIQUE (connector_id, invoice_source_id, source_id)
+);
+
+CREATE TABLE invoice_transaction_preferences_new (
+  invoice_id TEXT NOT NULL PRIMARY KEY,
+  transaction_id TEXT,
+  decision TEXT NOT NULL CHECK (decision IN ('linked', 'separate')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  CHECK (
+    (decision = 'linked' AND transaction_id IS NOT NULL)
+    OR decision = 'separate'
+  )
+);
+
+CREATE TABLE invoices_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  invoice_number TEXT,
+  invoice_date TEXT NOT NULL,
+  seller_name TEXT,
+  amount INTEGER NOT NULL,
+  raw_payload TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE (connector_id, source_id)
+);
+
+CREATE TABLE manual_assets_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  name TEXT NOT NULL,
+  category TEXT NOT NULL,
+  note TEXT,
+  created_at TEXT NOT NULL
+, currency TEXT NOT NULL DEFAULT 'TWD');
+
+CREATE TABLE net_worth_history_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  date TEXT NOT NULL,
+  net_worth INTEGER NOT NULL,
+  asset_type TEXT NOT NULL DEFAULT 'total',
+  source TEXT NOT NULL,
+  snapshotted_at TEXT NOT NULL,
+  UNIQUE (source, asset_type, date)
+);
+
+CREATE TABLE notification_preferences_new (
+  id TEXT NOT NULL PRIMARY KEY CHECK (id = 'default'),
+  notify_success INTEGER NOT NULL DEFAULT 0,
+  notify_failed INTEGER NOT NULL DEFAULT 1,
+  notify_needs_user_action INTEGER NOT NULL DEFAULT 1,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE push_subscriptions_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  encrypted_subscription TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  last_success_at TEXT,
+  consecutive_failures INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE scheduled_sync_batches_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  schedule_key TEXT NOT NULL DEFAULT 'default' CHECK (schedule_key = 'default'),
+  notification_claimed_at TEXT,
+  created_at TEXT NOT NULL
+, completed_at TEXT, is_baseline INTEGER NOT NULL DEFAULT 0, assets_before_twd INTEGER, credit_card_debt_before_twd INTEGER, missing_currencies_before TEXT NOT NULL DEFAULT '[]', assets_after_twd INTEGER, credit_card_debt_after_twd INTEGER, missing_currencies_after TEXT NOT NULL DEFAULT '[]');
+
+CREATE TABLE sync_jobs_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  connector_id TEXT NOT NULL,
+  scope TEXT NOT NULL,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  interval_minutes INTEGER NOT NULL,
+  next_run_at TEXT NOT NULL,
+  locked_until TEXT,
+  locked_by TEXT,
+  lock_trigger TEXT CHECK (lock_trigger IS NULL OR lock_trigger IN ('manual', 'scheduled')),
+  lock_scope TEXT,
+  last_run_at TEXT,
+  last_success_at TEXT,
+  last_status TEXT,
+  last_error TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL, schedule_mode TEXT NOT NULL DEFAULT 'inherit'
+  CHECK (schedule_mode IN ('inherit', 'custom')), preferred_time TEXT NOT NULL DEFAULT '06:00', preferred_weekday INTEGER NOT NULL DEFAULT 1
+  CHECK (preferred_weekday BETWEEN 0 AND 6),
+  UNIQUE (connector_id, scope)
+);
+
+CREATE TABLE sync_schedule_settings_new (
+  id TEXT NOT NULL PRIMARY KEY CHECK (id = 'default'),
+  interval_minutes INTEGER NOT NULL,
+  preferred_time TEXT NOT NULL,
+  timezone TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+, preferred_weekday INTEGER NOT NULL DEFAULT 1
+  CHECK (preferred_weekday BETWEEN 0 AND 6));
+
+CREATE TABLE tdcc_sync_run_items_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES tdcc_sync_runs_new (id) ON DELETE CASCADE,
+  task_type TEXT NOT NULL,
+  task_key TEXT NOT NULL DEFAULT '',
+  account_id TEXT,
+  page_cursor TEXT NOT NULL DEFAULT '',
+  next_page_cursor TEXT,
+  page_number INTEGER NOT NULL DEFAULT 0,
+  task_json TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(task_json)),
+  payload_json TEXT CHECK (payload_json IS NULL OR json_valid(payload_json)),
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'processing', 'done', 'failed')),
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  lease_token TEXT,
+  lease_expires_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT,
+  UNIQUE (run_id, task_type, task_key, page_cursor)
+);
+
+CREATE TABLE tdcc_sync_runs_new (
+  id TEXT NOT NULL PRIMARY KEY,
+  connector_id TEXT NOT NULL DEFAULT 'tdcc'
+    CHECK (connector_id = 'tdcc'),
+  trigger TEXT NOT NULL CHECK (trigger IN ('manual', 'scheduled')),
+  scope TEXT NOT NULL DEFAULT 'all'
+    CHECK (scope IN ('all', 'investments', 'bank', 'trades')),
+  sync_job_id TEXT REFERENCES sync_jobs_new (id) ON DELETE SET NULL,
+  scheduled_batch_id TEXT REFERENCES scheduled_sync_batches_new (id) ON DELETE SET NULL,
+  settings_version TEXT,
+  phase TEXT NOT NULL DEFAULT 'initialize'
+    CHECK (phase IN (
+      'initialize', 'snapshot', 'positions', 'bank', 'investments',
+      'trades', 'promote', 'finalize'
+    )),
+  status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN (
+    'queued', 'initializing', 'processing', 'promoting',
+    'completed', 'failed', 'needs_user_action'
+  )),
+  -- The run retains the encrypted provider state it was initialized with.
+  -- It is never exposed in an API response or log.
+  encrypted_config TEXT,
+  encrypted_session TEXT,
+  session_json TEXT CHECK (session_json IS NULL OR json_valid(session_json)),
+  total_item_count INTEGER NOT NULL DEFAULT 0,
+  pending_item_count INTEGER NOT NULL DEFAULT 0,
+  processing_item_count INTEGER NOT NULL DEFAULT 0,
+  done_item_count INTEGER NOT NULL DEFAULT 0,
+  failed_item_count INTEGER NOT NULL DEFAULT 0,
+  session_refresh_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  lease_owner TEXT,
+  lease_expires_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  promoted_at TEXT,
+  completed_at TEXT
+);
+
+INSERT INTO bank_accounts_new (id, connector_id, source_id, institution_name, account_name, account_type, currency, raw_payload, created_at, updated_at, bank_code, account_last4, canonical_account_id, credit_limit, opened_date, maturity_date, inactive_at)
+SELECT id, connector_id, source_id, institution_name, account_name, account_type, currency, raw_payload, created_at, updated_at, bank_code, account_last4, canonical_account_id, credit_limit, opened_date, maturity_date, inactive_at FROM bank_accounts;
+
+INSERT INTO bank_balance_snapshots_new (id, connector_id, account_id, source_id, balance, available_balance, currency, as_of_at, raw_payload, created_at, updated_at, statement_balance, payment_due_date, no_payment_needed, statement_closing_date)
+SELECT id, connector_id, account_id, source_id, balance, available_balance, currency, as_of_at, raw_payload, created_at, updated_at, statement_balance, payment_due_date, no_payment_needed, statement_closing_date FROM bank_balance_snapshots;
+
+INSERT INTO bank_transaction_preferences_new (transaction_id, excluded_from_calculation, created_at, updated_at)
+SELECT transaction_id, excluded_from_calculation, created_at, updated_at FROM bank_transaction_preferences;
+
+INSERT INTO bank_transactions_new (id, connector_id, account_id, source_id, posted_date, authorized_at, amount, currency, description, counterparty, raw_payload, created_at, updated_at, status, transfer_peer_id, matched_transaction_id)
+SELECT id, connector_id, account_id, source_id, posted_date, authorized_at, amount, currency, description, counterparty, raw_payload, created_at, updated_at, status, transfer_peer_id, matched_transaction_id FROM bank_transactions;
+
+INSERT INTO classification_categories_new (id, label, sort_order, is_system, created_at, updated_at)
+SELECT id, label, sort_order, is_system, created_at, updated_at FROM classification_categories;
+
+INSERT INTO classification_overrides_new (id, target_type, target_id, category_id, created_at, updated_at)
+SELECT id, target_type, target_id, category_id, created_at, updated_at FROM classification_overrides;
+
+INSERT INTO classification_rules_new (id, category_id, target_type, field, operator, pattern, priority, enabled, is_system, source, description, created_at, updated_at, excluded_from_calculation)
+SELECT id, category_id, target_type, field, operator, pattern, priority, enabled, is_system, source, description, created_at, updated_at, excluded_from_calculation FROM classification_rules;
+
+INSERT INTO connector_settings_new (id, connector_id, encrypted_config, sync_cursor, created_at, updated_at, public_config)
+SELECT id, connector_id, encrypted_config, sync_cursor, created_at, updated_at, public_config FROM connector_settings;
+
+INSERT INTO credit_card_bills_new (id, connector_id, account_id, source_id, billing_period, statement_amount, minimum_payment, paid_amount, is_paid, payment_due_date, statement_closing_date, currency, raw_payload, created_at, updated_at)
+SELECT id, connector_id, account_id, source_id, billing_period, statement_amount, minimum_payment, paid_amount, is_paid, payment_due_date, statement_closing_date, currency, raw_payload, created_at, updated_at FROM credit_card_bills;
+
+INSERT INTO einvoice_sync_run_items_new (id, run_id, invoice_source_id, header_json, normalized_invoice_json, detail_key, detail_metadata_json, detail_items_json, line_item_count, status, attempt_count, last_error, lease_token, lease_expires_at, created_at, updated_at, completed_at)
+SELECT id, run_id, invoice_source_id, header_json, normalized_invoice_json, detail_key, detail_metadata_json, detail_items_json, line_item_count, status, attempt_count, last_error, lease_token, lease_expires_at, created_at, updated_at, completed_at FROM einvoice_sync_run_items;
+
+INSERT INTO einvoice_sync_runs_new (id, connector_id, trigger, sync_job_id, scheduled_batch_id, settings_version, status, total_item_count, pending_item_count, processing_item_count, done_item_count, line_item_count, new_invoice_count, session_refresh_count, last_error, chunk_lease_owner, chunk_lease_expires_at, created_at, updated_at, promoted_at, completed_at)
+SELECT id, connector_id, trigger, sync_job_id, scheduled_batch_id, settings_version, status, total_item_count, pending_item_count, processing_item_count, done_item_count, line_item_count, new_invoice_count, session_refresh_count, last_error, chunk_lease_owner, chunk_lease_expires_at, created_at, updated_at, promoted_at, completed_at FROM einvoice_sync_runs;
+
+INSERT INTO exchange_rates_new (currency, rate_to_twd, updated_at)
+SELECT currency, rate_to_twd, updated_at FROM exchange_rates;
+
+INSERT INTO investment_positions_new (id, connector_id, source_id, asset_type, symbol, name, quantity, market_value, cash_balance, currency, as_of_date, raw_payload, created_at, updated_at)
+SELECT id, connector_id, source_id, asset_type, symbol, name, quantity, market_value, cash_balance, currency, as_of_date, raw_payload, created_at, updated_at FROM investment_positions;
+
+INSERT INTO investment_transactions_new (id, connector_id, account_id, source_id, broker_no, broker_account, broker_name, symbol, name, asset_type, trade_date, posted_date, transaction_code, transaction_name, quantity, price, amount, currency, raw_payload, created_at, updated_at)
+SELECT id, connector_id, account_id, source_id, broker_no, broker_account, broker_name, symbol, name, asset_type, trade_date, posted_date, transaction_code, transaction_name, quantity, price, amount, currency, raw_payload, created_at, updated_at FROM investment_transactions;
+
+INSERT INTO invoice_line_items_new (id, invoice_id, connector_id, invoice_source_id, source_id, line_number, description, quantity, unit_price, amount, raw_payload, created_at, updated_at)
+SELECT id, invoice_id, connector_id, invoice_source_id, source_id, line_number, description, quantity, unit_price, amount, raw_payload, created_at, updated_at FROM invoice_line_items;
+
+INSERT INTO invoice_transaction_preferences_new (invoice_id, transaction_id, decision, created_at, updated_at)
+SELECT invoice_id, transaction_id, decision, created_at, updated_at FROM invoice_transaction_preferences;
+
+INSERT INTO invoices_new (id, connector_id, source_id, invoice_number, invoice_date, seller_name, amount, raw_payload, created_at, updated_at)
+SELECT id, connector_id, source_id, invoice_number, invoice_date, seller_name, amount, raw_payload, created_at, updated_at FROM invoices;
+
+INSERT INTO manual_assets_new (id, name, category, note, created_at, currency)
+SELECT id, name, category, note, created_at, currency FROM manual_assets;
+
+INSERT INTO net_worth_history_new (id, date, net_worth, asset_type, source, snapshotted_at)
+SELECT id, date, net_worth, asset_type, source, snapshotted_at FROM net_worth_history;
+
+INSERT INTO notification_preferences_new (id, notify_success, notify_failed, notify_needs_user_action, updated_at)
+SELECT id, notify_success, notify_failed, notify_needs_user_action, updated_at FROM notification_preferences;
+
+INSERT INTO push_subscriptions_new (id, encrypted_subscription, created_at, updated_at, last_success_at, consecutive_failures)
+SELECT id, encrypted_subscription, created_at, updated_at, last_success_at, consecutive_failures FROM push_subscriptions;
+
+INSERT INTO scheduled_sync_batches_new (id, schedule_key, notification_claimed_at, created_at, completed_at, is_baseline, assets_before_twd, credit_card_debt_before_twd, missing_currencies_before, assets_after_twd, credit_card_debt_after_twd, missing_currencies_after)
+SELECT id, schedule_key, notification_claimed_at, created_at, completed_at, is_baseline, assets_before_twd, credit_card_debt_before_twd, missing_currencies_before, assets_after_twd, credit_card_debt_after_twd, missing_currencies_after FROM scheduled_sync_batches;
+
+INSERT INTO sync_jobs_new (id, connector_id, scope, enabled, interval_minutes, next_run_at, locked_until, locked_by, lock_trigger, lock_scope, last_run_at, last_success_at, last_status, last_error, created_at, updated_at, schedule_mode, preferred_time, preferred_weekday)
+SELECT id, connector_id, scope, enabled, interval_minutes, next_run_at, locked_until, locked_by, lock_trigger, lock_scope, last_run_at, last_success_at, last_status, last_error, created_at, updated_at, schedule_mode, preferred_time, preferred_weekday FROM sync_jobs;
+
+INSERT INTO sync_schedule_settings_new (id, interval_minutes, preferred_time, timezone, updated_at, preferred_weekday)
+SELECT id, interval_minutes, preferred_time, timezone, updated_at, preferred_weekday FROM sync_schedule_settings;
+
+INSERT INTO tdcc_sync_run_items_new (id, run_id, task_type, task_key, account_id, page_cursor, next_page_cursor, page_number, task_json, payload_json, status, attempt_count, last_error, lease_token, lease_expires_at, created_at, updated_at, completed_at)
+SELECT id, run_id, task_type, task_key, account_id, page_cursor, next_page_cursor, page_number, task_json, payload_json, status, attempt_count, last_error, lease_token, lease_expires_at, created_at, updated_at, completed_at FROM tdcc_sync_run_items;
+
+INSERT INTO tdcc_sync_runs_new (id, connector_id, trigger, scope, sync_job_id, scheduled_batch_id, settings_version, phase, status, encrypted_config, encrypted_session, session_json, total_item_count, pending_item_count, processing_item_count, done_item_count, failed_item_count, session_refresh_count, last_error, lease_owner, lease_expires_at, created_at, updated_at, promoted_at, completed_at)
+SELECT id, connector_id, trigger, scope, sync_job_id, scheduled_batch_id, settings_version, phase, status, encrypted_config, encrypted_session, session_json, total_item_count, pending_item_count, processing_item_count, done_item_count, failed_item_count, session_refresh_count, last_error, lease_owner, lease_expires_at, created_at, updated_at, promoted_at, completed_at FROM tdcc_sync_runs;
+
+DROP TABLE bank_transaction_preferences;
+DROP TABLE invoice_transaction_preferences;
+DROP TABLE invoice_line_items;
+DROP TABLE einvoice_sync_run_items;
+DROP TABLE tdcc_sync_run_items;
+DROP TABLE bank_balance_snapshots;
+DROP TABLE bank_transactions;
+DROP TABLE credit_card_bills;
+DROP TABLE classification_overrides;
+DROP TABLE classification_rules;
+DROP TABLE einvoice_sync_runs;
+DROP TABLE tdcc_sync_runs;
+DROP TABLE investment_positions;
+DROP TABLE investment_transactions;
+DROP TABLE invoices;
+DROP TABLE bank_accounts;
+DROP TABLE classification_categories;
+DROP TABLE connector_settings;
+DROP TABLE exchange_rates;
+DROP TABLE manual_assets;
+DROP TABLE net_worth_history;
+DROP TABLE notification_preferences;
+DROP TABLE push_subscriptions;
+DROP TABLE scheduled_sync_batches;
+DROP TABLE sync_jobs;
+DROP TABLE sync_schedule_settings;
+ALTER TABLE bank_accounts_new RENAME TO bank_accounts;
+ALTER TABLE bank_balance_snapshots_new RENAME TO bank_balance_snapshots;
+ALTER TABLE bank_transaction_preferences_new RENAME TO bank_transaction_preferences;
+ALTER TABLE bank_transactions_new RENAME TO bank_transactions;
+ALTER TABLE classification_categories_new RENAME TO classification_categories;
+ALTER TABLE classification_overrides_new RENAME TO classification_overrides;
+ALTER TABLE classification_rules_new RENAME TO classification_rules;
+ALTER TABLE connector_settings_new RENAME TO connector_settings;
+ALTER TABLE credit_card_bills_new RENAME TO credit_card_bills;
+ALTER TABLE einvoice_sync_run_items_new RENAME TO einvoice_sync_run_items;
+ALTER TABLE einvoice_sync_runs_new RENAME TO einvoice_sync_runs;
+ALTER TABLE exchange_rates_new RENAME TO exchange_rates;
+ALTER TABLE investment_positions_new RENAME TO investment_positions;
+ALTER TABLE investment_transactions_new RENAME TO investment_transactions;
+ALTER TABLE invoice_line_items_new RENAME TO invoice_line_items;
+ALTER TABLE invoice_transaction_preferences_new RENAME TO invoice_transaction_preferences;
+ALTER TABLE invoices_new RENAME TO invoices;
+ALTER TABLE manual_assets_new RENAME TO manual_assets;
+ALTER TABLE net_worth_history_new RENAME TO net_worth_history;
+ALTER TABLE notification_preferences_new RENAME TO notification_preferences;
+ALTER TABLE push_subscriptions_new RENAME TO push_subscriptions;
+ALTER TABLE scheduled_sync_batches_new RENAME TO scheduled_sync_batches;
+ALTER TABLE sync_jobs_new RENAME TO sync_jobs;
+ALTER TABLE sync_schedule_settings_new RENAME TO sync_schedule_settings;
+ALTER TABLE tdcc_sync_run_items_new RENAME TO tdcc_sync_run_items;
+ALTER TABLE tdcc_sync_runs_new RENAME TO tdcc_sync_runs;
+
+CREATE TABLE scheduled_sync_batch_results (
+  batch_id TEXT NOT NULL,
+  job_id TEXT NOT NULL,
+  connector_id TEXT NOT NULL,
+  status TEXT CHECK (status IN ('success', 'failed', 'needs_user_action')),
+  completed_at TEXT, new_invoices INTEGER NOT NULL DEFAULT 0, new_bank_transactions INTEGER NOT NULL DEFAULT 0, new_investment_transactions INTEGER NOT NULL DEFAULT 0, recovered_at TEXT,
+  PRIMARY KEY (batch_id, job_id),
+  FOREIGN KEY (batch_id) REFERENCES scheduled_sync_batches(id) ON DELETE CASCADE
+);
+INSERT INTO scheduled_sync_batch_results (batch_id, job_id, connector_id, status, completed_at, new_invoices, new_bank_transactions, new_investment_transactions, recovered_at)
+SELECT batch_id, job_id, connector_id, status, completed_at, new_invoices, new_bank_transactions, new_investment_transactions, recovered_at FROM _pk_migration_scheduled_sync_batch_results_backup;
+DROP TABLE _pk_migration_scheduled_sync_batch_results_backup;
+
+CREATE INDEX idx_bank_accounts_match
+  ON bank_accounts (bank_code, account_last4, currency);
+CREATE INDEX idx_bank_balance_snapshots_as_of
+  ON bank_balance_snapshots (as_of_at);
+CREATE INDEX idx_bank_balance_snapshots_account_as_of
+  ON bank_balance_snapshots (account_id, as_of_at);
+CREATE INDEX idx_bank_transaction_preferences_excluded
+  ON bank_transaction_preferences (excluded_from_calculation);
+CREATE UNIQUE INDEX idx_bank_transactions_matched_transaction
+  ON bank_transactions(matched_transaction_id)
+  WHERE matched_transaction_id IS NOT NULL;
+CREATE INDEX idx_bank_transactions_transaction_day
+  ON bank_transactions (
+    CASE
+      WHEN length(authorized_at) > 10
+        THEN COALESCE(
+          date(authorized_at, '+8 hours'),
+          substr(authorized_at, 1, 10)
+        )
+      ELSE substr(COALESCE(authorized_at, posted_date), 1, 10)
+    END
+  );
+CREATE INDEX idx_bank_transactions_status
+  ON bank_transactions (connector_id, account_id, status);
+CREATE INDEX idx_bank_transactions_effective_updated
+  ON bank_transactions (effective_date DESC, updated_at DESC, id DESC);
+CREATE INDEX idx_bank_transactions_posted_date
+  ON bank_transactions (posted_date);
+CREATE INDEX idx_bank_transactions_account_posted_date
+  ON bank_transactions (account_id, posted_date);
+CREATE UNIQUE INDEX idx_classification_categories_label_nocase
+  ON classification_categories (label COLLATE NOCASE);
+CREATE INDEX idx_classification_overrides_category
+  ON classification_overrides (category_id);
+CREATE INDEX idx_classification_rules_category
+  ON classification_rules (category_id);
+CREATE INDEX idx_classification_rules_enabled_priority
+  ON classification_rules (enabled, target_type, priority);
+CREATE INDEX idx_credit_card_bills_page
+  ON credit_card_bills (billing_period DESC, account_id ASC, id ASC);
+CREATE INDEX idx_credit_card_bills_account_period
+  ON credit_card_bills (account_id, billing_period);
+CREATE INDEX idx_einvoice_sync_run_items_claim
+  ON einvoice_sync_run_items (run_id, status, lease_expires_at, created_at);
+CREATE INDEX idx_einvoice_sync_runs_completed
+  ON einvoice_sync_runs (completed_at DESC);
+CREATE UNIQUE INDEX idx_einvoice_sync_runs_one_active
+  ON einvoice_sync_runs (connector_id)
+  WHERE status IN ('queued', 'initializing', 'processing');
+CREATE INDEX idx_investment_positions_page
+  ON investment_positions (as_of_date DESC, asset_type ASC, name ASC, id ASC);
+CREATE INDEX idx_investment_positions_latest_scope
+  ON investment_positions (connector_id, asset_type, as_of_date DESC);
+CREATE INDEX idx_investment_positions_asset_type
+  ON investment_positions (asset_type);
+CREATE INDEX idx_investment_positions_as_of_date
+  ON investment_positions (as_of_date);
+CREATE INDEX idx_investment_transactions_effective_updated
+  ON investment_transactions (effective_date DESC, updated_at DESC, id DESC);
+CREATE INDEX idx_investment_transactions_symbol
+  ON investment_transactions (symbol);
+CREATE INDEX idx_investment_transactions_trade_date
+  ON investment_transactions (trade_date);
+CREATE INDEX idx_invoice_line_items_invoice_source
+  ON invoice_line_items (connector_id, invoice_source_id);
+CREATE INDEX idx_invoice_line_items_invoice_id
+  ON invoice_line_items (invoice_id);
+CREATE UNIQUE INDEX idx_invoice_transaction_preferences_linked_transaction
+  ON invoice_transaction_preferences (transaction_id)
+  WHERE decision = 'linked';
+CREATE INDEX idx_invoices_page
+  ON invoices (invoice_date DESC, updated_at DESC, id DESC);
+CREATE INDEX idx_invoices_invoice_date
+  ON invoices (invoice_date);
+CREATE INDEX idx_net_worth_history_page
+  ON net_worth_history (date DESC, source ASC, asset_type ASC, id ASC);
+CREATE INDEX idx_net_worth_history_date
+  ON net_worth_history (date);
+CREATE INDEX idx_scheduled_sync_batches_completed
+  ON scheduled_sync_batches (completed_at DESC);
+CREATE UNIQUE INDEX idx_scheduled_sync_batches_open
+  ON scheduled_sync_batches (schedule_key)
+  WHERE notification_claimed_at IS NULL;
+CREATE INDEX idx_sync_jobs_due
+  ON sync_jobs (enabled, next_run_at);
+CREATE INDEX idx_tdcc_sync_run_items_account
+  ON tdcc_sync_run_items (run_id, account_id, task_type, page_number);
+CREATE INDEX idx_tdcc_sync_run_items_claim
+  ON tdcc_sync_run_items (run_id, status, lease_expires_at, created_at);
+CREATE INDEX idx_tdcc_sync_runs_completed
+  ON tdcc_sync_runs (completed_at DESC);
+CREATE UNIQUE INDEX idx_tdcc_sync_runs_one_active
+  ON tdcc_sync_runs (connector_id)
+  WHERE status IN ('queued', 'initializing', 'processing', 'promoting');

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -19,7 +19,7 @@ export async function getConnectorSettings(
   return (
     (await createDrizzle(db)
       .select({
-        id: sql<string>`${connectorSettings.id}`,
+        id: connectorSettings.id,
         connector_id: connectorSettings.connectorId,
         encrypted_config: connectorSettings.encryptedConfig,
         public_config: connectorSettings.publicConfig,

--- a/packages/db/src/schema/assets.ts
+++ b/packages/db/src/schema/assets.ts
@@ -8,13 +8,12 @@ import {
   index,
 } from "drizzle-orm/sqlite-core";
 
-// Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
-// SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
+// SQL migrations remain authoritative for schema shape and constraints.
 
 export const manualAssets = sqliteTable(
   "manual_assets",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     name: text("name").notNull(),
     category: text("category").notNull(),
     note: text("note"),
@@ -29,7 +28,7 @@ export const manualAssets = sqliteTable(
 export const netWorthHistory = sqliteTable(
   "net_worth_history",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     date: text("date").notNull(),
     netWorth: integer("net_worth").notNull(),
     assetType: text("asset_type")

--- a/packages/db/src/schema/bank.ts
+++ b/packages/db/src/schema/bank.ts
@@ -11,13 +11,12 @@ import {
   check,
 } from "drizzle-orm/sqlite-core";
 
-// Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
-// SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
+// SQL migrations remain authoritative for schema shape and constraints.
 
 export const bankAccounts = sqliteTable(
   "bank_accounts",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     connectorId: text("connector_id").notNull(),
     sourceId: text("source_id").notNull(),
     institutionName: text("institution_name"),
@@ -62,7 +61,7 @@ export const bankAccounts = sqliteTable(
 export const bankBalanceSnapshots = sqliteTable(
   "bank_balance_snapshots",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     connectorId: text("connector_id").notNull(),
     accountId: text("account_id").notNull(),
     sourceId: text("source_id").notNull(),
@@ -98,7 +97,7 @@ export const bankBalanceSnapshots = sqliteTable(
 export const bankTransactions = sqliteTable(
   "bank_transactions",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     connectorId: text("connector_id").notNull(),
     accountId: text("account_id").notNull(),
     sourceId: text("source_id").notNull(),
@@ -165,7 +164,7 @@ export const bankTransactions = sqliteTable(
 export const bankTransactionPreferences = sqliteTable(
   "bank_transaction_preferences",
   {
-    transactionId: text("transaction_id"),
+    transactionId: text("transaction_id").notNull(),
     excludedFromCalculation: integer("excluded_from_calculation")
       .notNull()
       .default(sql`0`),
@@ -187,7 +186,7 @@ export const bankTransactionPreferences = sqliteTable(
 export const creditCardBills = sqliteTable(
   "credit_card_bills",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     connectorId: text("connector_id").notNull(),
     accountId: text("account_id").notNull(),
     sourceId: text("source_id").notNull(),

--- a/packages/db/src/schema/classification.ts
+++ b/packages/db/src/schema/classification.ts
@@ -11,13 +11,12 @@ import {
   check,
 } from "drizzle-orm/sqlite-core";
 
-// Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
-// SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
+// SQL migrations remain authoritative for schema shape and constraints.
 
 export const classificationCategories = sqliteTable(
   "classification_categories",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     label: text("label").notNull(),
     sortOrder: integer("sort_order")
       .notNull()
@@ -39,7 +38,7 @@ export const classificationCategories = sqliteTable(
 export const classificationOverrides = sqliteTable(
   "classification_overrides",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     targetType: text("target_type").notNull(),
     targetId: text("target_id").notNull(),
     categoryId: text("category_id").notNull(),
@@ -60,7 +59,7 @@ export const classificationOverrides = sqliteTable(
 export const classificationRules = sqliteTable(
   "classification_rules",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     categoryId: text("category_id").notNull(),
     targetType: text("target_type"),
     field: text("field").notNull(),

--- a/packages/db/src/schema/exchange-rates.ts
+++ b/packages/db/src/schema/exchange-rates.ts
@@ -1,12 +1,11 @@
 import { sqliteTable, text, real, primaryKey } from "drizzle-orm/sqlite-core";
 
-// Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
-// SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
+// SQL migrations remain authoritative for schema shape and constraints.
 
 export const exchangeRates = sqliteTable(
   "exchange_rates",
   {
-    currency: text("currency"),
+    currency: text("currency").notNull(),
     rateToTwd: real("rate_to_twd").notNull(),
     updatedAt: text("updated_at").notNull(),
   },

--- a/packages/db/src/schema/investments.ts
+++ b/packages/db/src/schema/investments.ts
@@ -10,13 +10,12 @@ import {
   check,
 } from "drizzle-orm/sqlite-core";
 
-// Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
-// SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
+// SQL migrations remain authoritative for schema shape and constraints.
 
 export const investmentPositions = sqliteTable(
   "investment_positions",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     connectorId: text("connector_id").notNull(),
     sourceId: text("source_id").notNull(),
     assetType: text("asset_type").notNull(),
@@ -59,7 +58,7 @@ export const investmentPositions = sqliteTable(
 export const investmentTransactions = sqliteTable(
   "investment_transactions",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     connectorId: text("connector_id").notNull(),
     accountId: text("account_id").notNull(),
     sourceId: text("source_id").notNull(),

--- a/packages/db/src/schema/invoices.ts
+++ b/packages/db/src/schema/invoices.ts
@@ -12,13 +12,12 @@ import {
   check,
 } from "drizzle-orm/sqlite-core";
 
-// Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
-// SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
+// SQL migrations remain authoritative for schema shape and constraints.
 
 export const invoices = sqliteTable(
   "invoices",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     connectorId: text("connector_id").notNull(),
     sourceId: text("source_id").notNull(),
     invoiceNumber: text("invoice_number"),
@@ -44,7 +43,7 @@ export const invoices = sqliteTable(
 export const invoiceLineItems = sqliteTable(
   "invoice_line_items",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     invoiceId: text("invoice_id").notNull(),
     connectorId: text("connector_id").notNull(),
     invoiceSourceId: text("invoice_source_id").notNull(),
@@ -76,7 +75,7 @@ export const invoiceLineItems = sqliteTable(
 export const invoiceTransactionPreferences = sqliteTable(
   "invoice_transaction_preferences",
   {
-    invoiceId: text("invoice_id"),
+    invoiceId: text("invoice_id").notNull(),
     transactionId: text("transaction_id"),
     decision: text("decision").notNull(),
     createdAt: text("created_at").notNull(),

--- a/packages/db/src/schema/notifications.ts
+++ b/packages/db/src/schema/notifications.ts
@@ -7,13 +7,12 @@ import {
   check,
 } from "drizzle-orm/sqlite-core";
 
-// Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
-// SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
+// SQL migrations remain authoritative for schema shape and constraints.
 
 export const pushSubscriptions = sqliteTable(
   "push_subscriptions",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     encryptedSubscription: text("encrypted_subscription").notNull(),
     createdAt: text("created_at").notNull(),
     updatedAt: text("updated_at").notNull(),
@@ -28,7 +27,7 @@ export const pushSubscriptions = sqliteTable(
 export const notificationPreferences = sqliteTable(
   "notification_preferences",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     notifySuccess: integer("notify_success")
       .notNull()
       .default(sql`0`),

--- a/packages/db/src/schema/settings.ts
+++ b/packages/db/src/schema/settings.ts
@@ -1,12 +1,11 @@
 import { sqliteTable, text, primaryKey, unique } from "drizzle-orm/sqlite-core";
 
-// Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
-// SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
+// SQL migrations remain authoritative for schema shape and constraints.
 
 export const connectorSettings = sqliteTable(
   "connector_settings",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     connectorId: text("connector_id").notNull(),
     encryptedConfig: text("encrypted_config").notNull(),
     syncCursor: text("sync_cursor"),

--- a/packages/db/src/schema/sync.ts
+++ b/packages/db/src/schema/sync.ts
@@ -11,13 +11,12 @@ import {
   check,
 } from "drizzle-orm/sqlite-core";
 
-// Table-level primary keys preserve SQLite's existing nullable TEXT primary keys.
-// SQL migrations remain authoritative; do not add NOT NULL through ORM adoption.
+// SQL migrations remain authoritative for schema shape and constraints.
 
 export const syncJobs = sqliteTable(
   "sync_jobs",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     connectorId: text("connector_id").notNull(),
     scope: text("scope").notNull(),
     enabled: integer("enabled")
@@ -61,7 +60,7 @@ export const syncJobs = sqliteTable(
 export const syncScheduleSettings = sqliteTable(
   "sync_schedule_settings",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     intervalMinutes: integer("interval_minutes").notNull(),
     preferredTime: text("preferred_time").notNull(),
     timezone: text("timezone").notNull(),
@@ -99,7 +98,7 @@ export const syncWriteStaging = sqliteTable(
 export const scheduledSyncBatches = sqliteTable(
   "scheduled_sync_batches",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     scheduleKey: text("schedule_key")
       .notNull()
       .default(sql`'default'`),
@@ -165,7 +164,7 @@ export const scheduledSyncBatchResults = sqliteTable(
 export const einvoiceSyncRuns = sqliteTable(
   "einvoice_sync_runs",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     connectorId: text("connector_id")
       .notNull()
       .default(sql`'einvoice'`),
@@ -234,7 +233,7 @@ export const einvoiceSyncRuns = sqliteTable(
 export const einvoiceSyncRunItems = sqliteTable(
   "einvoice_sync_run_items",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     runId: text("run_id").notNull(),
     invoiceSourceId: text("invoice_source_id").notNull(),
     headerJson: text("header_json").notNull(),
@@ -279,7 +278,7 @@ export const einvoiceSyncRunItems = sqliteTable(
 export const tdccSyncRuns = sqliteTable(
   "tdcc_sync_runs",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     connectorId: text("connector_id")
       .notNull()
       .default(sql`'tdcc'`),
@@ -371,7 +370,7 @@ export const tdccSyncRuns = sqliteTable(
 export const tdccSyncRunItems = sqliteTable(
   "tdcc_sync_run_items",
   {
-    id: text("id"),
+    id: text("id").notNull(),
     runId: text("run_id").notNull(),
     taskType: text("task_type").notNull(),
     taskKey: text("task_key")

--- a/packages/db/src/sync-jobs.ts
+++ b/packages/db/src/sync-jobs.ts
@@ -57,8 +57,8 @@ export function hasConnectorSettings(db: ReturnType<typeof createDrizzle>) {
 }
 
 export const syncJobSelection = {
-  id: sql<SyncJobRow["id"]>`${syncJobs.id}`,
-  connector_id: sql<SyncJobRow["connector_id"]>`${syncJobs.connectorId}`,
+  id: syncJobs.id,
+  connector_id: syncJobs.connectorId,
   scope: syncJobs.scope,
   enabled: syncJobs.enabled,
   interval_minutes: syncJobs.intervalMinutes,

--- a/packages/db/tests/client.test.ts
+++ b/packages/db/tests/client.test.ts
@@ -71,7 +71,7 @@ describe("Drizzle D1 client", () => {
       .all();
     const [rate] = await db
       .select({
-        code: sql<string>`${exchangeRates.currency}`,
+        code: exchangeRates.currency,
         rateTwd: exchangeRates.rateToTwd,
         updatedAt: exchangeRates.updatedAt,
       })
@@ -114,7 +114,7 @@ describe("Drizzle D1 client", () => {
 
     const rows = await db
       .select({
-        currency: sql<string>`${exchangeRates.currency}`,
+        currency: exchangeRates.currency,
         rateTwd: exchangeRates.rateToTwd,
       })
       .from(exchangeRates)

--- a/packages/db/tests/schema.test.ts
+++ b/packages/db/tests/schema.test.ts
@@ -102,6 +102,78 @@ function inspect(database: DatabaseSync) {
   });
 }
 
+const TEXT_PRIMARY_KEY_COLUMNS: Array<{ table: string; column: string }> = [
+  { table: "bank_accounts", column: "id" },
+  { table: "bank_balance_snapshots", column: "id" },
+  { table: "bank_transaction_preferences", column: "transaction_id" },
+  { table: "bank_transactions", column: "id" },
+  { table: "classification_categories", column: "id" },
+  { table: "classification_overrides", column: "id" },
+  { table: "classification_rules", column: "id" },
+  { table: "connector_settings", column: "id" },
+  { table: "credit_card_bills", column: "id" },
+  { table: "einvoice_sync_run_items", column: "id" },
+  { table: "einvoice_sync_runs", column: "id" },
+  { table: "exchange_rates", column: "currency" },
+  { table: "investment_positions", column: "id" },
+  { table: "investment_transactions", column: "id" },
+  { table: "invoice_line_items", column: "id" },
+  { table: "invoice_transaction_preferences", column: "invoice_id" },
+  { table: "invoices", column: "id" },
+  { table: "manual_assets", column: "id" },
+  { table: "net_worth_history", column: "id" },
+  { table: "notification_preferences", column: "id" },
+  { table: "push_subscriptions", column: "id" },
+  { table: "scheduled_sync_batches", column: "id" },
+  { table: "sync_jobs", column: "id" },
+  { table: "sync_schedule_settings", column: "id" },
+  { table: "tdcc_sync_run_items", column: "id" },
+  { table: "tdcc_sync_runs", column: "id" },
+];
+
+describe("TEXT primary key NOT NULL constraints", () => {
+  it("requires NOT NULL on single-column TEXT primary keys after migrations", () => {
+    const database = new DatabaseSync(":memory:");
+    try {
+      for (const migration of readMigrations()) database.exec(migration);
+      for (const { table, column } of TEXT_PRIMARY_KEY_COLUMNS) {
+        const info = database
+          .prepare(`PRAGMA table_xinfo('${table}')`)
+          .all()
+          .find((row) => row.name === column);
+        expect(info, `${table}.${column}`).toBeDefined();
+        expect(info?.pk, `${table}.${column} pk`).toBe(1);
+        expect(info?.notnull, `${table}.${column} notnull`).toBe(1);
+      }
+    } finally {
+      database.close();
+    }
+  });
+
+  it("rejects NULL primary key inserts", () => {
+    const database = new DatabaseSync(":memory:");
+    try {
+      for (const migration of readMigrations()) database.exec(migration);
+      expect(() =>
+        database
+          .prepare(
+            "INSERT INTO bank_accounts (id, connector_id, source_id, created_at, updated_at) VALUES (NULL, 'c', 's', '2020-01-01T00:00:00.000Z', '2020-01-01T00:00:00.000Z')",
+          )
+          .run(),
+      ).toThrow(/NOT NULL/i);
+      expect(() =>
+        database
+          .prepare(
+            "INSERT INTO exchange_rates (currency, rate_to_twd, updated_at) VALUES (NULL, 1.0, '2020-01-01T00:00:00.000Z')",
+          )
+          .run(),
+      ).toThrow(/NOT NULL/i);
+    } finally {
+      database.close();
+    }
+  });
+});
+
 describe("Drizzle schema parity", () => {
   it("preserves the migrated schema, including generated columns and index semantics", async () => {
     const migrated = new DatabaseSync(":memory:");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

依 schema inventory 必須修項目，將 26 個單欄 `TEXT PRIMARY KEY` 改為 `TEXT NOT NULL PRIMARY KEY`；並在 PK 已 `.notNull()` 後，將 repository 中多餘的 `sql<string>\`${column}\`` 改為直接 Drizzle 欄位引用。

## 變更內容

### Migration `0044_text_primary_keys_not_null.sql`
- 以表重建（`_new` swap）更新 26 張表，保留既有 index、FK、generated column、CHECK、default
- `scheduled_sync_batch_results` 以一般備份表還原（複合 PK 已為 NOT NULL）

### Drizzle schema
- 26 個 PK 欄位加上 `.notNull()`

### Repository select 簡化
- 將 `sql<string>\`${column}\``（及多餘 `.as()`）改為直接欄位引用，例如 `invoiceTransactionPreferences.invoiceId`
- **保留 `sql`：** 窄化型別 cast（`ConnectorId`、`"linked" | "separate"`、sync run status 等）、generated 欄位（`effectiveDate`）、可為 null 欄位在輸出型別需收斂時（`completedAt`）、以及 alias 多表 join 的 `bankTransactionColumns` / `creditCardBillColumns`（D1 `raw()` 仍需 `sql\`.as()\`` 對齊欄位順序）

### 文件與測試
- `docs/database-schema.md` 經 `npm run db:schema:docs` 重新產生
- `packages/db/tests/schema.test.ts` 新增 PRAGMA `notnull` parity 與 NULL PK insert 測試

## 驗證

- `npm run format:check`
- `npm run typecheck`
- `npm run test:backend`（512 passed；31 failed 與 `main` 相同）
- `packages/db` vitest（含 Drizzle parity 與 PK NOT NULL 測試）

## D1 上線注意

套用 migration **前**，請在 D1 對各表 PK 欄位執行 `SELECT COUNT(*) FROM <table> WHERE <pk> IS NULL`；若有資料須先修復。D1 不支援 `CREATE TEMP TABLE`，migration 使用一般備份表處理 `scheduled_sync_batch_results`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26b7738b-dd8d-5728-8822-cdc197a4ad34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26b7738b-dd8d-5728-8822-cdc197a4ad34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

